### PR TITLE
Validate description/instrument contradictions during ingestion

### DIFF
--- a/server/db/db.go
+++ b/server/db/db.go
@@ -417,6 +417,21 @@ func TxTypeToInstrumentKind(t apiv1.TxType) string {
 	}
 }
 
+// AssetClassToInstrumentKind returns the instrument kind for an asset class.
+// Returns InstrumentKindCash for CASH, InstrumentKindSecurity for all other
+// non-empty values, and empty string for empty (unidentified instruments are
+// ambiguous — no contradiction can be detected).
+func AssetClassToInstrumentKind(assetClass string) string {
+	switch assetClass {
+	case "":
+		return ""
+	case AssetClassCash:
+		return InstrumentKindCash
+	default:
+		return InstrumentKindSecurity
+	}
+}
+
 // AssetClassToTxTypeStrings returns the tx_type DB strings that map to the given asset class.
 func AssetClassToTxTypeStrings(assetClass string) []string {
 	var strs []string

--- a/server/service/ingestion/worker.go
+++ b/server/service/ingestion/worker.go
@@ -130,7 +130,7 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 	}
 	_ = database.SetJobTotalCount(ctx, j.JobID, int32(len(txsToProcess)))
 	// Extract description hints.
-	cache, extractedHintsCache, err := extractDescHints(ctx, database, descRegistry, counter, source, broker, txsToProcess)
+	cache, extractedHintsCache, descInstruments, descValErrs, err := extractDescHints(ctx, database, descRegistry, counter, source, broker, txsToProcess)
 	if err != nil {
 		log.Printf("ingestion job %s: extract description hints: %v", j.JobID, err)
 		_ = database.AppendValidationErrors(ctx, j.JobID, []*apiv1.ValidationError{
@@ -139,13 +139,23 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 		_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_FAILED)
 		return false, ""
 	}
+	if len(descValErrs) > 0 {
+		_ = database.AppendValidationErrors(ctx, j.JobID, descValErrs)
+		_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_FAILED)
+		return false, ""
+	}
 	// Resolve instruments.
-	instrumentIDs, idErrs, err := resolveInstruments(ctx, database, registry, broker, source, j.JobID, counter, txsToProcess, originalIndices, cache, extractedHintsCache)
+	instrumentIDs, idErrs, resolveValErrs, err := resolveInstruments(ctx, database, registry, broker, source, j.JobID, counter, txsToProcess, originalIndices, cache, extractedHintsCache, descInstruments)
 	if err != nil {
 		log.Printf("ingestion job %s: resolve instrument: %v", j.JobID, err)
 		_ = database.AppendValidationErrors(ctx, j.JobID, []*apiv1.ValidationError{
 			{RowIndex: -1, Field: "instrument_description", Message: err.Error()},
 		})
+		_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_FAILED)
+		return false, ""
+	}
+	if len(resolveValErrs) > 0 {
+		_ = database.AppendValidationErrors(ctx, j.JobID, resolveValErrs)
 		_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_FAILED)
 		return false, ""
 	}
@@ -191,25 +201,71 @@ func filterStoredTxs(txs []*apiv1.Tx, broker string, ignored []db.IgnoredAssetCl
 
 // extractDescHints looks up each distinct (source, description) in DB and runs
 // batch description extraction for misses. Returns a resolve cache pre-populated
-// with DB hits and an extracted hints cache keyed by cacheKey(source, desc).
-func extractDescHints(ctx context.Context, database db.DB, descRegistry *description.Registry, counter telemetry.CounterIncrementer, source, broker string, txs []*apiv1.Tx) (map[string]resolveResult, map[string][]identifier.Identifier, error) {
+// with DB hits, an extracted hints cache keyed by cacheKey(source, desc), a map
+// of instrument rows found via broker description lookup (for later identifier
+// contradiction checks), and any validation errors from contradictions.
+//
+// Contradictions detected:
+//   - Within-batch: same (source, desc) with both CASH and SECURITY InstrumentKinds.
+//   - DB: broker description resolves to an instrument whose asset class contradicts the tx's InstrumentKind.
+func extractDescHints(ctx context.Context, database db.DB, descRegistry *description.Registry, counter telemetry.CounterIncrementer, source, broker string, txs []*apiv1.Tx) (map[string]resolveResult, map[string][]identifier.Identifier, map[string]*db.InstrumentRow, []*apiv1.ValidationError, error) {
 	cache := make(map[string]resolveResult)
+	descInstruments := make(map[string]*db.InstrumentRow)
 	var extractedHintsCache map[string][]identifier.Identifier
 	seen := make(map[string]bool)
+	kindByDesc := make(map[string]string) // first InstrumentKind seen per (source, desc)
+	var valErrs []*apiv1.ValidationError
 	var batchItems []description.BatchItem
 	idByKey := make(map[string]string)
-	for _, tx := range txs {
+	for i, tx := range txs {
 		desc := tx.GetInstrumentDescription()
 		key := cacheKey(source, desc)
+		kind := db.TxTypeToInstrumentKind(tx.GetType())
+
+		// Within-batch kind contradiction check.
+		if prev, ok := kindByDesc[key]; ok {
+			if prev != kind {
+				valErrs = append(valErrs, &apiv1.ValidationError{
+					RowIndex: int32(i),
+					Field:    "instrument_description",
+					Message:  fmt.Sprintf("instrument_description %q appears with conflicting transaction types (both %s and %s); use different descriptions for the cash and security legs", desc, prev, kind),
+				})
+				continue
+			}
+		} else {
+			kindByDesc[key] = kind
+		}
+
 		if seen[key] {
 			continue
 		}
 		seen[key] = true
 		id, err := database.FindInstrumentBySourceDescription(ctx, source, desc)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, nil, err
 		}
 		if id != "" {
+			// DB kind contradiction check.
+			inst, err := database.GetInstrument(ctx, id)
+			if err != nil {
+				return nil, nil, nil, nil, err
+			}
+			if inst != nil {
+				descInstruments[key] = inst
+				var instAC string
+				if inst.AssetClass != nil {
+					instAC = *inst.AssetClass
+				}
+				instKind := db.AssetClassToInstrumentKind(instAC)
+				if instKind != "" && instKind != kind {
+					valErrs = append(valErrs, &apiv1.ValidationError{
+						RowIndex: int32(i),
+						Field:    "instrument_description",
+						Message:  fmt.Sprintf("instrument_description %q was previously identified as a %s instrument but is used here as a %s transaction", desc, instKind, kind),
+					})
+					continue
+				}
+			}
 			cache[key] = resolveResult{InstrumentID: id}
 		} else {
 			batchID := shortHashForBatch(key)
@@ -221,6 +277,9 @@ func extractDescHints(ctx context.Context, database db.DB, descRegistry *descrip
 			})
 		}
 	}
+	if len(valErrs) > 0 {
+		return nil, nil, nil, valErrs, nil
+	}
 	if len(batchItems) > 0 {
 		hintsByID, err := runDescriptionPluginsBatch(ctx, database, descRegistry, counter, broker, source, batchItems)
 		if err == nil && hintsByID != nil {
@@ -230,23 +289,43 @@ func extractDescHints(ctx context.Context, database db.DB, descRegistry *descrip
 			}
 		}
 	}
-	return cache, extractedHintsCache, nil
+	return cache, extractedHintsCache, descInstruments, nil, nil
 }
 
 // resolveInstruments resolves each tx to an instrument ID using the pre-populated
 // cache and extracted hints. Returns the instrument IDs (parallel to txs) and any
-// identification errors collected from the cache.
-func resolveInstruments(ctx context.Context, database db.DB, registry *identifier.Registry, broker, source, jobID string, counter telemetry.CounterIncrementer, txs []*apiv1.Tx, originalIndices []int, cache map[string]resolveResult, extractedHintsCache map[string][]identifier.Identifier) ([]string, []db.IdentificationError, error) {
+// identification errors collected from the cache. descInstruments maps cacheKey(source, desc)
+// to instruments found via broker description lookup; used to detect identifier contradictions.
+func resolveInstruments(ctx context.Context, database db.DB, registry *identifier.Registry, broker, source, jobID string, counter telemetry.CounterIncrementer, txs []*apiv1.Tx, originalIndices []int, cache map[string]resolveResult, extractedHintsCache map[string][]identifier.Identifier, descInstruments map[string]*db.InstrumentRow) ([]string, []db.IdentificationError, []*apiv1.ValidationError, error) {
 	instrumentIDs := make([]string, len(txs))
+	var valErrs []*apiv1.ValidationError
 	for i, tx := range txs {
 		desc := tx.GetInstrumentDescription()
 		rowIndex := int32(originalIndices[i])
-		r, err := Resolve(ctx, database, registry, broker, source, desc, HintsFromTx(tx), identifierHintsFromTx(ctx, tx), cache, rowIndex, counter, extractedHintsCache)
+		txHints := identifierHintsFromTx(ctx, tx)
+
+		// Identifier contradiction check: if the description already maps to a
+		// known instrument, verify that the tx's identifier hints do not conflict
+		// with identifiers stored on that instrument.
+		if len(txHints) > 0 && descInstruments != nil {
+			key := cacheKey(source, desc)
+			if inst, ok := descInstruments[key]; ok {
+				if valErr := checkIdentifierContradiction(inst, txHints, desc, rowIndex); valErr != nil {
+					valErrs = append(valErrs, valErr)
+					continue
+				}
+			}
+		}
+
+		r, err := Resolve(ctx, database, registry, broker, source, desc, HintsFromTx(tx), txHints, cache, rowIndex, counter, extractedHintsCache)
 		if err != nil {
-			return nil, nil, fmt.Errorf("row %d: %w", rowIndex, err)
+			return nil, nil, nil, fmt.Errorf("row %d: %w", rowIndex, err)
 		}
 		instrumentIDs[i] = r.InstrumentID
 		_ = database.IncrJobProcessedCount(ctx, jobID)
+	}
+	if len(valErrs) > 0 {
+		return nil, nil, valErrs, nil
 	}
 	var idErrs []db.IdentificationError
 	for _, r := range cache {
@@ -254,7 +333,33 @@ func resolveInstruments(ctx context.Context, database db.DB, registry *identifie
 			idErrs = append(idErrs, *r.IdErr)
 		}
 	}
-	return instrumentIDs, idErrs, nil
+	return instrumentIDs, idErrs, nil, nil
+}
+
+// checkIdentifierContradiction checks whether any of the tx's identifier hints
+// contradict identifiers stored on the instrument previously resolved for this
+// description. Returns a validation error if a contradiction is found.
+func checkIdentifierContradiction(inst *db.InstrumentRow, txHints []identifier.Identifier, desc string, rowIndex int32) *apiv1.ValidationError {
+	for _, hint := range txHints {
+		if hint.Type == "BROKER_DESCRIPTION" || hint.Type == "" || hint.Value == "" {
+			continue
+		}
+		// Check if the instrument has identifiers of the same type.
+		for _, stored := range inst.Identifiers {
+			if stored.Type != hint.Type {
+				continue
+			}
+			// Same type exists — values must match.
+			if stored.Value != hint.Value {
+				return &apiv1.ValidationError{
+					RowIndex: rowIndex,
+					Field:    "identifier_hints",
+					Message:  fmt.Sprintf("identifier hint %s:%s contradicts the instrument previously identified for description %q (has %s:%s)", hint.Type, hint.Value, desc, stored.Type, stored.Value),
+				}
+			}
+		}
+	}
+	return nil
 }
 
 // brokerToStr converts a proto Broker enum to its string representation.

--- a/server/service/ingestion/worker_test.go
+++ b/server/service/ingestion/worker_test.go
@@ -240,3 +240,224 @@ func TestProcessSingle_DropsTxTypeSplitTransaction(t *testing.T) {
 
 	processJob(ctx, database, registry, nil, nil, j, nil)
 }
+
+func TestExtractDescHints_SameDescDifferentKinds_Error(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	database := mock.NewMockDB(ctrl)
+
+	ctx := context.Background()
+	source := "Fidelity:web:standard"
+	txs := []*apiv1.Tx{
+		{Timestamp: timestamppb.Now(), InstrumentDescription: "EQQQ ETF", Type: apiv1.TxType_BUYSTOCK, Quantity: 10},
+		{Timestamp: timestamppb.Now(), InstrumentDescription: "EQQQ ETF", Type: apiv1.TxType_INCOME, Quantity: 5, TradingCurrency: "GBP"},
+	}
+
+	// Only the first tx triggers a DB lookup; the second triggers the kind contradiction.
+	database.EXPECT().
+		FindInstrumentBySourceDescription(gomock.Any(), source, "EQQQ ETF").
+		Return("", nil)
+
+	_, _, _, valErrs, err := extractDescHints(ctx, database, nil, nil, source, "Fidelity", txs)
+	if err != nil {
+		t.Fatalf("extractDescHints: %v", err)
+	}
+	if len(valErrs) != 1 {
+		t.Fatalf("expected 1 validation error, got %d", len(valErrs))
+	}
+	if valErrs[0].RowIndex != 1 {
+		t.Errorf("RowIndex = %d, want 1", valErrs[0].RowIndex)
+	}
+}
+
+func TestExtractDescHints_DBKindContradiction_Error(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	database := mock.NewMockDB(ctrl)
+
+	ctx := context.Background()
+	source := "Fidelity:web:standard"
+	txs := []*apiv1.Tx{
+		{Timestamp: timestamppb.Now(), InstrumentDescription: "EQQQ ETF", Type: apiv1.TxType_INCOME, Quantity: 5, TradingCurrency: "GBP"},
+	}
+	acETF := "ETF"
+	database.EXPECT().
+		FindInstrumentBySourceDescription(gomock.Any(), source, "EQQQ ETF").
+		Return("inst-1", nil)
+	database.EXPECT().
+		GetInstrument(gomock.Any(), "inst-1").
+		Return(&db.InstrumentRow{ID: "inst-1", AssetClass: &acETF}, nil)
+
+	_, _, _, valErrs, err := extractDescHints(ctx, database, nil, nil, source, "Fidelity", txs)
+	if err != nil {
+		t.Fatalf("extractDescHints: %v", err)
+	}
+	if len(valErrs) != 1 {
+		t.Fatalf("expected 1 validation error, got %d", len(valErrs))
+	}
+	if valErrs[0].RowIndex != 0 {
+		t.Errorf("RowIndex = %d, want 0", valErrs[0].RowIndex)
+	}
+}
+
+func TestExtractDescHints_DBUnidentified_NoError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	database := mock.NewMockDB(ctrl)
+
+	ctx := context.Background()
+	source := "Fidelity:web:standard"
+	txs := []*apiv1.Tx{
+		{Timestamp: timestamppb.Now(), InstrumentDescription: "MYSTERY", Type: apiv1.TxType_INCOME, Quantity: 5, TradingCurrency: "GBP"},
+	}
+	// Instrument exists but has nil asset class (unidentified).
+	database.EXPECT().
+		FindInstrumentBySourceDescription(gomock.Any(), source, "MYSTERY").
+		Return("inst-1", nil)
+	database.EXPECT().
+		GetInstrument(gomock.Any(), "inst-1").
+		Return(&db.InstrumentRow{ID: "inst-1"}, nil)
+
+	_, _, _, valErrs, err := extractDescHints(ctx, database, nil, nil, source, "Fidelity", txs)
+	if err != nil {
+		t.Fatalf("extractDescHints: %v", err)
+	}
+	if len(valErrs) != 0 {
+		t.Errorf("expected no validation errors, got %d: %+v", len(valErrs), valErrs)
+	}
+}
+
+func TestResolveInstruments_IdentifierContradiction_Error(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	database := mock.NewMockDB(ctrl)
+	registry := identifier.NewRegistry()
+
+	ctx := context.Background()
+	source := "Fidelity:web:standard"
+	desc := "APPLE INC"
+	txs := []*apiv1.Tx{
+		{
+			Timestamp:             timestamppb.Now(),
+			InstrumentDescription: desc,
+			Type:                  apiv1.TxType_BUYSTOCK,
+			Quantity:              10,
+			IdentifierHints: []*apiv1.InstrumentIdentifier{
+				{Type: apiv1.IdentifierType_ISIN, Value: "US9999999999"},
+			},
+		},
+	}
+	cache := map[string]resolveResult{
+		cacheKey(source, desc): {InstrumentID: "inst-1"},
+	}
+	descInstruments := map[string]*db.InstrumentRow{
+		cacheKey(source, desc): {
+			ID:          "inst-1",
+			Identifiers: []db.IdentifierInput{{Type: "ISIN", Value: "US0378331005"}},
+		},
+	}
+
+	_, _, valErrs, err := resolveInstruments(ctx, database, registry, "Fidelity", source, "job-1", nil, txs, []int{0}, cache, nil, descInstruments)
+	if err != nil {
+		t.Fatalf("resolveInstruments: %v", err)
+	}
+	if len(valErrs) != 1 {
+		t.Fatalf("expected 1 validation error, got %d", len(valErrs))
+	}
+	if valErrs[0].RowIndex != 0 {
+		t.Errorf("RowIndex = %d, want 0", valErrs[0].RowIndex)
+	}
+}
+
+func TestResolveInstruments_IdentifierMatch_NoError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	database := mock.NewMockDB(ctrl)
+	registry := identifier.NewRegistry()
+
+	ctx := context.Background()
+	source := "Fidelity:web:standard"
+	desc := "APPLE INC"
+	txs := []*apiv1.Tx{
+		{
+			Timestamp:             timestamppb.Now(),
+			InstrumentDescription: desc,
+			Type:                  apiv1.TxType_BUYSTOCK,
+			Quantity:              10,
+			IdentifierHints: []*apiv1.InstrumentIdentifier{
+				{Type: apiv1.IdentifierType_ISIN, Value: "US0378331005"},
+			},
+		},
+	}
+	cache := map[string]resolveResult{
+		cacheKey(source, desc): {InstrumentID: "inst-1"},
+	}
+	descInstruments := map[string]*db.InstrumentRow{
+		cacheKey(source, desc): {
+			ID:          "inst-1",
+			Identifiers: []db.IdentifierInput{{Type: "ISIN", Value: "US0378331005"}},
+		},
+	}
+
+	// Path A: Resolve looks up by identifier hint.
+	database.EXPECT().FindInstrumentByIdentifier(gomock.Any(), "ISIN", "", "US0378331005").Return("inst-1", nil)
+	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-1").Return(nil)
+
+	ids, _, valErrs, err := resolveInstruments(ctx, database, registry, "Fidelity", source, "job-1", nil, txs, []int{0}, cache, nil, descInstruments)
+	if err != nil {
+		t.Fatalf("resolveInstruments: %v", err)
+	}
+	if len(valErrs) != 0 {
+		t.Errorf("expected no validation errors, got %d: %+v", len(valErrs), valErrs)
+	}
+	if ids[0] != "inst-1" {
+		t.Errorf("instrumentID = %q, want inst-1", ids[0])
+	}
+}
+
+func TestResolveInstruments_NewIdentifierType_NoError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	database := mock.NewMockDB(ctrl)
+	registry := identifier.NewRegistry()
+
+	ctx := context.Background()
+	source := "Fidelity:web:standard"
+	desc := "APPLE INC"
+	txs := []*apiv1.Tx{
+		{
+			Timestamp:             timestamppb.Now(),
+			InstrumentDescription: desc,
+			Type:                  apiv1.TxType_BUYSTOCK,
+			Quantity:              10,
+			IdentifierHints: []*apiv1.InstrumentIdentifier{
+				{Type: apiv1.IdentifierType_MIC_TICKER, Value: "AAPL", Domain: "XNAS"},
+			},
+		},
+	}
+	cache := map[string]resolveResult{
+		cacheKey(source, desc): {InstrumentID: "inst-1"},
+	}
+	// Instrument has ISIN but tx supplies MIC_TICKER — different type, no contradiction.
+	descInstruments := map[string]*db.InstrumentRow{
+		cacheKey(source, desc): {
+			ID:          "inst-1",
+			Identifiers: []db.IdentifierInput{{Type: "ISIN", Value: "US0378331005"}},
+		},
+	}
+
+	// Path A: Resolve looks up by identifier hint.
+	database.EXPECT().FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").Return("inst-1", nil)
+	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-1").Return(nil)
+
+	ids, _, valErrs, err := resolveInstruments(ctx, database, registry, "Fidelity", source, "job-1", nil, txs, []int{0}, cache, nil, descInstruments)
+	if err != nil {
+		t.Fatalf("resolveInstruments: %v", err)
+	}
+	if len(valErrs) != 0 {
+		t.Errorf("expected no validation errors, got %d: %+v", len(valErrs), valErrs)
+	}
+	if ids[0] != "inst-1" {
+		t.Errorf("instrumentID = %q, want inst-1", ids[0])
+	}
+}


### PR DESCRIPTION
## Summary
- Detect and reject uploads where the same `instrument_description` maps to contradictory instruments
- **InstrumentKind contradiction**: same description used for both CASH (e.g. INCOME) and SECURITY (e.g. BUYSTOCK) tx types, either within the same upload or against a previously stored broker description
- **Identifier contradiction**: tx supplies an identifier hint (e.g. ISIN:X) that conflicts with an identifier of the same type already stored on the instrument resolved for that description
- Both are fatal validation errors that fail the job

## Test plan
- [x] `TestExtractDescHints_SameDescDifferentKinds_Error` — BUYSTOCK + INCOME with same description
- [x] `TestExtractDescHints_DBKindContradiction_Error` — DB instrument is SECURITY, tx is INCOME
- [x] `TestExtractDescHints_DBUnidentified_NoError` — unidentified instrument (nil asset class) is ambiguous, no error
- [x] `TestResolveInstruments_IdentifierContradiction_Error` — ISIN mismatch
- [x] `TestResolveInstruments_IdentifierMatch_NoError` — matching ISIN, no error
- [x] `TestResolveInstruments_NewIdentifierType_NoError` — different identifier type, no contradiction
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)