### PR TITLE
Add Splits tab with import/export and standardize button layout

### DIFF
--- a/client/app/admin/corporate-events/import-modal.tsx
+++ b/client/app/admin/corporate-events/import-modal.tsx
@@ -14,9 +14,7 @@ import {
   getHoldings,
   getJob,
   importCorporateEventSplits,
-  listPortfolios,
   type GetJobResult,
-  type Portfolio,
 } from "@/lib/portfolio-api";
 import { prefillFromPosition, validateRatio } from "@/lib/splits";
 import type { Holding } from "@/gen/api/v1/api_pb";
@@ -48,8 +46,6 @@ export function ImportCorporateEventsModal({
   const [extractorId, setExtractorId] = useState<string>("");
   const [parseResult, setParseResult] = useState<SplitParseResult | null>(null);
   const [rows, setRows] = useState<PreviewRow[]>([]);
-  const [portfolios, setPortfolios] = useState<Portfolio[]>([]);
-  const [prefillPortfolioId, setPrefillPortfolioId] = useState<string>("");
   const [prefilling, setPrefilling] = useState(false);
   const [file, setFile] = useState<File | null>(null);
   const [fileInputActive, setFileInputActive] = useState(false);
@@ -66,12 +62,6 @@ export function ImportCorporateEventsModal({
     () => extractors.find((e) => e.id === extractorId) ?? extractors[0],
     [extractors, extractorId],
   );
-  // Schwab-style flow: when no row carries an embedded ratio, the prefill
-  // portfolio selector is meaningful. IBKR-style files already carry ratios.
-  const prefillUseful = useMemo(
-    () => rows.some((r) => !r.splitFromInput || !r.splitToInput),
-    [rows],
-  );
 
   const reset = useCallback(() => {
     setPhase("idle");
@@ -79,7 +69,6 @@ export function ImportCorporateEventsModal({
     setExtractorId("");
     setParseResult(null);
     setRows([]);
-    setPrefillPortfolioId("");
     setPrefilling(false);
     setFile(null);
     setFileInputActive(false);
@@ -89,78 +78,32 @@ export function ImportCorporateEventsModal({
     if (fileRef.current) fileRef.current.value = "";
   }, []);
 
-  // Load portfolios on first open so prefill is available immediately.
-  useEffect(() => {
-    if (!open) return;
-    let cancelled = false;
-    listPortfolios()
-      .then((res) => {
-        if (!cancelled) setPortfolios(res.portfolios);
-      })
-      .catch(() => {
-        // Non-fatal: prefill stays disabled.
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [open]);
-
   // Reset on close.
   useEffect(() => {
     if (!open) reset();
   }, [open, reset]);
 
-  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const f = e.target.files?.[0];
-    if (!f || !selectedExtractor) return;
-    setFile(f);
-    const file = f;
-    const reader = new FileReader();
-    reader.onload = (ev) => {
-      const text = (ev.target?.result as string) ?? "";
-      const result = selectedExtractor.extract(text);
-      setParseResult(result);
-      setRows(
-        result.splits.map((s) => ({
-          ...s,
-          splitFromInput: s.splitFrom ?? "",
-          splitToInput: s.splitTo ?? "",
-          prefilled: false,
-        })),
-      );
-      setPhase("preview");
-    };
-    reader.readAsText(file);
-  }
+  // Auto-prefill ratios from admin holdings after file parse.
+  const autoPrefill = useCallback(async (parsed: PreviewRow[], selectedBroker: Broker | undefined) => {
+    const needsPrefill = parsed.some((r) => !r.splitFromInput || !r.splitToInput);
+    if (!needsPrefill) return parsed;
 
-  function updateRow(index: number, patch: Partial<PreviewRow>) {
-    setRows((prev) => prev.map((r, i) => (i === index ? { ...r, ...patch } : r)));
-  }
-
-  // Prefill ratios from a holder portfolio. Only fills empty rows.
-  const handlePrefill = useCallback(async () => {
-    if (!prefillPortfolioId || rows.length === 0) return;
     setPrefilling(true);
-    setSubmitError(null);
     try {
-      // Cache holdings per ex date.
       const cache = new Map<string, Holding[]>();
       const next: PreviewRow[] = [];
-      for (const row of rows) {
+      for (const row of parsed) {
         if (row.splitFromInput && row.splitToInput) {
           next.push(row);
           continue;
         }
         let holdings = cache.get(row.exDate);
         if (!holdings) {
-          const res = await getHoldings({
-            portfolioId: prefillPortfolioId,
-            asOf: dayBefore(row.exDate),
-          });
+          const res = await getHoldings({ asOf: dayBefore(row.exDate) });
           holdings = res.holdings;
           cache.set(row.exDate, holdings);
         }
-        const pre = sumMatchingHoldingQty(holdings, row);
+        const pre = sumMatchingHoldingQty(holdings, row, selectedBroker);
         const delta = parseFloat(row.deltaShares ?? "");
         if (!Number.isFinite(pre) || !Number.isFinite(delta)) {
           next.push(row);
@@ -178,13 +121,43 @@ export function ImportCorporateEventsModal({
           prefilled: true,
         });
       }
-      setRows(next);
-    } catch (e) {
-      setSubmitError(e instanceof Error ? e.message : String(e));
+      return next;
+    } catch {
+      // Non-fatal: prefill just doesn't happen.
+      return parsed;
     } finally {
       setPrefilling(false);
     }
-  }, [prefillPortfolioId, rows]);
+  }, []);
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const f = e.target.files?.[0];
+    if (!f || !selectedExtractor) return;
+    setFile(f);
+    const file = f;
+    const reader = new FileReader();
+    reader.onload = async (ev) => {
+      const text = (ev.target?.result as string) ?? "";
+      const result = selectedExtractor.extract(text);
+      setParseResult(result);
+      const preview = result.splits.map((s) => ({
+        ...s,
+        splitFromInput: s.splitFrom ?? "",
+        splitToInput: s.splitTo ?? "",
+        prefilled: false,
+      }));
+      setRows(preview);
+      setPhase("preview");
+      // Auto-prefill rows missing ratios.
+      const prefilled = await autoPrefill(preview, broker);
+      setRows(prefilled);
+    };
+    reader.readAsText(file);
+  }
+
+  function updateRow(index: number, patch: Partial<PreviewRow>) {
+    setRows((prev) => prev.map((r, i) => (i === index ? { ...r, ...patch } : r)));
+  }
 
   // Validate every row before allowing submit.
   const rowValidation = useMemo(
@@ -195,7 +168,8 @@ export function ImportCorporateEventsModal({
     rows.length > 0 &&
     rowValidation.every((v) => v.ok) &&
     phase === "preview" &&
-    !jobId;
+    !jobId &&
+    !prefilling;
 
   async function handleSubmit() {
     if (!canSubmit) return;
@@ -363,35 +337,8 @@ export function ImportCorporateEventsModal({
               </p>
             ) : (
               <>
-                {prefillUseful && portfolios.length > 0 && (
-                  <div className="flex items-end gap-2 rounded-md border border-border bg-background p-3">
-                    <div className="flex-1 space-y-1">
-                      <label htmlFor="ce-prefill" className="block text-xs font-medium text-text-muted">
-                        Prefill ratios from holder portfolio
-                      </label>
-                      <select
-                        id="ce-prefill"
-                        value={prefillPortfolioId}
-                        onChange={(e) => setPrefillPortfolioId(e.target.value)}
-                        className="block w-full rounded-md border border-border bg-surface px-2 py-1.5 text-sm text-text-primary focus:border-primary focus:outline-none"
-                      >
-                        <option value="">(none)</option>
-                        {portfolios.map((p) => (
-                          <option key={p.id} value={p.id}>
-                            {p.name}
-                          </option>
-                        ))}
-                      </select>
-                    </div>
-                    <button
-                      type="button"
-                      onClick={handlePrefill}
-                      disabled={!prefillPortfolioId || prefilling}
-                      className="rounded-md border border-border bg-surface px-3 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-primary-light/15 disabled:cursor-not-allowed disabled:opacity-50"
-                    >
-                      {prefilling ? "Prefilling\u2026" : "Prefill"}
-                    </button>
-                  </div>
+                {prefilling && (
+                  <p className="text-sm text-text-muted">Prefilling ratios from your holdings...</p>
                 )}
 
                 <div className="overflow-x-auto rounded-md border border-border">
@@ -538,14 +485,19 @@ function dayBefore(ymd: string): Date {
  * instrument. We match on identifier value (case-insensitive), falling
  * back to instrument description equality. When the row has an account,
  * holdings outside that account are ignored; otherwise all matching
- * holdings are summed.
+ * holdings are summed. Holdings are also filtered by broker when provided.
  */
-function sumMatchingHoldingQty(holdings: Holding[], row: ExtractedSplit): number {
+function sumMatchingHoldingQty(
+  holdings: Holding[],
+  row: ExtractedSplit,
+  selectedBroker?: Broker,
+): number {
   const idValue = row.identifier.value.toUpperCase();
   const desc = row.instrumentDescription.toUpperCase();
   let total = 0;
   let any = false;
   for (const h of holdings) {
+    if (selectedBroker != null && h.broker !== selectedBroker) continue;
     if (row.account && h.account !== row.account) continue;
     const matchesId = h.instrument?.identifiers.some(
       (id) => id.value.toUpperCase() === idValue,

--- a/client/app/admin/corporate-events/page.tsx
+++ b/client/app/admin/corporate-events/page.tsx
@@ -7,6 +7,9 @@ import {
   resolveUnhandledCorporateEvent,
   type UnhandledCorporateEvent,
 } from "@/lib/portfolio-api";
+import { SplitsTab } from "./splits-tab";
+
+type Tab = "unhandled" | "splits" | "dividends";
 
 function eventTypeBadge(eventType: string): string {
   switch (eventType.toLowerCase()) {
@@ -19,7 +22,35 @@ function eventTypeBadge(eventType: string): string {
   }
 }
 
+function TabButton({
+  active,
+  disabled,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  disabled?: boolean;
+  onClick?: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      className={
+        active
+          ? "border-b-2 border-accent px-4 py-2 text-sm font-medium text-accent"
+          : "px-4 py-2 text-sm font-medium text-text-muted hover:text-text-primary"
+      }
+      disabled={disabled}
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+}
+
 export default function AdminCorporateEventsPage() {
+  const [tab, setTab] = useState<Tab>("unhandled");
   const [events, setEvents] = useState<UnhandledCorporateEvent[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -55,28 +86,9 @@ export default function AdminCorporateEventsPage() {
     load();
   }, [load]);
 
-  if (loading && events.length === 0) {
-    return (
-      <div>
-        <h1 className="font-display text-xl font-bold text-text-primary">Corporate Events</h1>
-        <p className="mt-2 text-text-muted">Loading corporate events...</p>
-      </div>
-    );
-  }
-
   return (
     <div data-testid="page-corporate-events">
-      <div className="flex items-center justify-between gap-4">
-        <h1 className="font-display text-xl font-bold text-text-primary">Corporate Events</h1>
-        <button
-          type="button"
-          onClick={load}
-          disabled={loading}
-          className="rounded bg-primary px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-dark disabled:opacity-50"
-        >
-          {loading ? "Refreshing..." : "Refresh"}
-        </button>
-      </div>
+      <h1 className="font-display text-xl font-bold text-text-primary">Corporate Events</h1>
       {error && (
         <div className="mt-2">
           <ErrorAlert>{error}</ErrorAlert>
@@ -84,75 +96,72 @@ export default function AdminCorporateEventsPage() {
       )}
 
       <div className="mt-4 flex gap-0 border-b border-border">
-        <button
-          type="button"
-          className="border-b-2 border-accent px-4 py-2 text-sm font-medium text-accent"
-        >
+        <TabButton active={tab === "unhandled"} onClick={() => setTab("unhandled")}>
           Unhandled
-        </button>
-        <button
-          type="button"
-          className="px-4 py-2 text-sm font-medium text-text-muted hover:text-text-primary"
-          disabled
-        >
-          Splits (coming soon)
-        </button>
-        <button
-          type="button"
-          className="px-4 py-2 text-sm font-medium text-text-muted hover:text-text-primary"
-          disabled
-        >
+        </TabButton>
+        <TabButton active={tab === "splits"} onClick={() => setTab("splits")}>
+          Splits
+        </TabButton>
+        <TabButton active={false} disabled>
           Dividends (coming soon)
-        </button>
+        </TabButton>
       </div>
 
-      {events.length === 0 && !error ? (
-        <p className="mt-4 text-text-muted">No unhandled corporate events.</p>
-      ) : (
-        <table data-testid="corporate-events-table" className="mt-4 w-full text-left text-sm">
-          <thead>
-            <tr className="border-b border-border text-text-muted">
-              <th className="py-2 pr-4 font-medium">Instrument</th>
-              <th className="py-2 pr-4 font-medium">Type</th>
-              <th className="py-2 pr-4 font-medium">Ex Date</th>
-              <th className="py-2 pr-4 font-medium">Detail</th>
-              <th className="py-2 pr-4 font-medium">Created</th>
-              <th className="py-2 font-medium" />
-            </tr>
-          </thead>
-          <tbody>
-            {events.map((ev) => (
-              <tr key={ev.id} data-testid="corporate-event-row" className="border-b border-border">
-                <td className="py-2 pr-4 font-mono text-text-primary">
-                  {ev.instrumentName || ev.instrumentId}
-                </td>
-                <td className="py-2 pr-4">
-                  <span
-                    className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${eventTypeBadge(ev.eventType)}`}
-                  >
-                    {ev.eventType}
-                  </span>
-                </td>
-                <td className="py-2 pr-4 text-text-muted">{ev.exDate || "\u2014"}</td>
-                <td className="py-2 pr-4 text-text-muted">{ev.detail || "\u2014"}</td>
-                <td className="py-2 pr-4 text-text-muted">
-                  {ev.createdAt ? ev.createdAt.toLocaleDateString() : "\u2014"}
-                </td>
-                <td className="py-2 text-right">
-                  <button
-                    type="button"
-                    onClick={() => handleResolve(ev.id)}
-                    disabled={resolving !== null}
-                    className="rounded border border-border px-3 py-1 text-xs hover:bg-background disabled:opacity-50"
-                  >
-                    {resolving === ev.id ? "Resolving..." : "Resolve"}
-                  </button>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+      {tab === "unhandled" && (
+        <>
+          {loading && events.length === 0 ? (
+            <p className="mt-4 text-text-muted">Loading corporate events...</p>
+          ) : events.length === 0 && !error ? (
+            <p className="mt-4 text-text-muted">No unhandled corporate events.</p>
+          ) : (
+            <table data-testid="corporate-events-table" className="mt-4 w-full text-left text-sm">
+              <thead>
+                <tr className="border-b border-border text-text-muted">
+                  <th className="py-2 pr-4 font-medium">Instrument</th>
+                  <th className="py-2 pr-4 font-medium">Type</th>
+                  <th className="py-2 pr-4 font-medium">Ex Date</th>
+                  <th className="py-2 pr-4 font-medium">Detail</th>
+                  <th className="py-2 pr-4 font-medium">Created</th>
+                  <th className="py-2 font-medium" />
+                </tr>
+              </thead>
+              <tbody>
+                {events.map((ev) => (
+                  <tr key={ev.id} data-testid="corporate-event-row" className="border-b border-border">
+                    <td className="py-2 pr-4 font-mono text-text-primary">
+                      {ev.instrumentName || ev.instrumentId}
+                    </td>
+                    <td className="py-2 pr-4">
+                      <span
+                        className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium ${eventTypeBadge(ev.eventType)}`}
+                      >
+                        {ev.eventType}
+                      </span>
+                    </td>
+                    <td className="py-2 pr-4 text-text-muted">{ev.exDate || "\u2014"}</td>
+                    <td className="py-2 pr-4 text-text-muted">{ev.detail || "\u2014"}</td>
+                    <td className="py-2 pr-4 text-text-muted">
+                      {ev.createdAt ? ev.createdAt.toLocaleDateString() : "\u2014"}
+                    </td>
+                    <td className="py-2 text-right">
+                      <button
+                        type="button"
+                        onClick={() => handleResolve(ev.id)}
+                        disabled={resolving !== null}
+                        className="rounded border border-border px-3 py-1 text-xs hover:bg-background disabled:opacity-50"
+                      >
+                        {resolving === ev.id ? "Resolving..." : "Resolve"}
+                      </button>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          )}
+        </>
       )}
+
+      {tab === "splits" && <SplitsTab />}
     </div>
   );
 }

--- a/client/app/admin/corporate-events/splits-tab.tsx
+++ b/client/app/admin/corporate-events/splits-tab.tsx
@@ -1,0 +1,259 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ErrorAlert } from "@/app/components/error-alert";
+import type { ExportCorporateEventRow } from "@/gen/api/v1/api_pb";
+import {
+  exportCorporateEvents,
+  importCorporateEventSplits,
+  getJob,
+  type GetJobResult,
+} from "@/lib/portfolio-api";
+import { JobStatus } from "@/gen/api/v1/api_pb";
+import { splitsToJson, parseSplitsJson } from "@/lib/json/corporate-events";
+import { ImportCorporateEventsModal } from "./import-modal";
+
+interface SplitDisplay {
+  identifierType: string;
+  identifierValue: string;
+  identifierDomain: string;
+  exDate: string;
+  splitFrom: string;
+  splitTo: string;
+  dataProvider: string;
+}
+
+export function SplitsTab() {
+  const [splits, setSplits] = useState<SplitDisplay[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [exportLoading, setExportLoading] = useState(false);
+  const [importOpen, setImportOpen] = useState(false);
+  const [importJsonError, setImportJsonError] = useState<string | null>(null);
+  const [importJobId, setImportJobId] = useState<string | null>(null);
+  const [importJobStatus, setImportJobStatus] = useState<GetJobResult | null>(null);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  const loadSplits = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const rows: SplitDisplay[] = [];
+      for await (const row of exportCorporateEvents()) {
+        if (row.event.case === "split") {
+          rows.push({
+            identifierType: row.identifierType,
+            identifierValue: row.identifierValue,
+            identifierDomain: row.identifierDomain,
+            exDate: row.event.value.exDate,
+            splitFrom: row.event.value.splitFrom,
+            splitTo: row.event.value.splitTo,
+            dataProvider: row.dataProvider,
+          });
+        }
+      }
+      rows.sort((a, b) => b.exDate.localeCompare(a.exDate));
+      setSplits(rows);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to load splits");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    loadSplits();
+  }, [loadSplits]);
+
+  async function handleExport() {
+    setExportLoading(true);
+    setError(null);
+    try {
+      const rows: ExportCorporateEventRow[] = [];
+      for await (const row of exportCorporateEvents()) {
+        if (row.event.case === "split") rows.push(row);
+      }
+      const json = splitsToJson(rows);
+      const blob = new Blob([json], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "splits.json";
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Export failed");
+    } finally {
+      setExportLoading(false);
+    }
+  }
+
+  function handleJsonFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const f = e.target.files?.[0];
+    if (!f) return;
+    setImportJsonError(null);
+    const reader = new FileReader();
+    reader.onload = async (ev) => {
+      const text = (ev.target?.result as string) ?? "";
+      const result = parseSplitsJson(text);
+      if (result.errors.length > 0) {
+        setImportJsonError(result.errors.map((e) => `Row ${e.rowIndex}: ${e.field} - ${e.message}`).join("\n"));
+        if (fileRef.current) fileRef.current.value = "";
+        return;
+      }
+      if (result.splits.length === 0) {
+        setImportJsonError("No splits found in file.");
+        if (fileRef.current) fileRef.current.value = "";
+        return;
+      }
+      try {
+        const jobId = await importCorporateEventSplits(result.splits);
+        setImportJobId(jobId);
+      } catch (err) {
+        setImportJsonError(err instanceof Error ? err.message : String(err));
+      }
+      if (fileRef.current) fileRef.current.value = "";
+    };
+    reader.readAsText(f);
+  }
+
+  // Poll JSON import job.
+  useEffect(() => {
+    if (!importJobId) return;
+    let cancelled = false;
+    const poll = async () => {
+      try {
+        const result = await getJob(importJobId);
+        if (cancelled) return;
+        setImportJobStatus(result);
+        if (result.status === JobStatus.SUCCESS || result.status === JobStatus.FAILED) {
+          if (result.status === JobStatus.SUCCESS) loadSplits();
+          setImportJobId(null);
+        }
+      } catch {
+        // Ignore transient poll errors.
+      }
+    };
+    poll();
+    const t = setInterval(poll, 2000);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, [importJobId, loadSplits]);
+
+  function dismissJobStatus() {
+    setImportJobStatus(null);
+  }
+
+  return (
+    <div className="mt-4 space-y-4">
+      <div className="flex flex-wrap items-end gap-3">
+        <div className="ml-auto flex gap-2">
+          <button
+            type="button"
+            onClick={handleExport}
+            disabled={exportLoading}
+            className="rounded-md border border-border bg-surface px-3 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-primary-light/15 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {exportLoading ? "Exporting..." : "Export JSON"}
+          </button>
+          <label className="cursor-pointer rounded-md border border-border bg-surface px-3 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-primary-light/15">
+            Import JSON
+            <input
+              ref={fileRef}
+              type="file"
+              accept=".json"
+              onChange={handleJsonFileChange}
+              className="sr-only"
+            />
+          </label>
+          <button
+            type="button"
+            onClick={() => setImportOpen(true)}
+            className="rounded-md border border-border bg-surface px-3 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-primary-light/15"
+          >
+            Import from Broker
+          </button>
+        </div>
+      </div>
+
+      {error && (
+        <div className="mt-2">
+          <ErrorAlert>{error}</ErrorAlert>
+        </div>
+      )}
+
+      {importJsonError && (
+        <div className="mt-2">
+          <ErrorAlert>{importJsonError}</ErrorAlert>
+        </div>
+      )}
+
+      {importJobId && (
+        <p className="mt-2 text-sm text-text-muted">
+          Importing...{importJobStatus && importJobStatus.totalCount > 0
+            ? ` ${importJobStatus.processedCount} of ${importJobStatus.totalCount}`
+            : ""}
+        </p>
+      )}
+
+      {importJobStatus && !importJobId && (
+        <div className="mt-2 flex items-center gap-2 text-sm">
+          {importJobStatus.status === JobStatus.SUCCESS ? (
+            <span className="text-text-primary">
+              Import complete: {importJobStatus.processedCount} event{importJobStatus.processedCount !== 1 ? "s" : ""} processed.
+            </span>
+          ) : (
+            <span className="text-accent-dark">Import failed.</span>
+          )}
+          <button
+            type="button"
+            onClick={dismissJobStatus}
+            className="text-xs text-text-muted underline hover:text-text-primary"
+          >
+            Dismiss
+          </button>
+        </div>
+      )}
+
+      {loading ? (
+        <p className="mt-4 text-text-muted">Loading splits...</p>
+      ) : splits.length === 0 ? (
+        <p className="mt-4 text-text-muted">No stock splits.</p>
+      ) : (
+        <table className="mt-4 w-full text-left text-sm">
+          <thead>
+            <tr className="border-b border-border text-text-muted">
+              <th className="py-2 pr-4 font-medium">Instrument</th>
+              <th className="py-2 pr-4 font-medium">Ex Date</th>
+              <th className="py-2 pr-4 font-medium">From</th>
+              <th className="py-2 pr-4 font-medium">To</th>
+              <th className="py-2 pr-4 font-medium">Provider</th>
+            </tr>
+          </thead>
+          <tbody>
+            {splits.map((s) => (
+              <tr key={`${s.identifierValue}-${s.exDate}`} className="border-b border-border">
+                <td className="py-2 pr-4 font-mono text-text-primary">
+                  {s.identifierDomain ? `${s.identifierDomain}:` : ""}
+                  {s.identifierValue}
+                </td>
+                <td className="py-2 pr-4 text-text-muted">{s.exDate}</td>
+                <td className="py-2 pr-4 text-text-muted">{s.splitFrom}</td>
+                <td className="py-2 pr-4 text-text-muted">{s.splitTo}</td>
+                <td className="py-2 pr-4 text-text-muted">{s.dataProvider}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      <ImportCorporateEventsModal
+        open={importOpen}
+        onClose={() => setImportOpen(false)}
+        onComplete={() => loadSplits()}
+      />
+    </div>
+  );
+}

--- a/client/app/admin/instruments/page.tsx
+++ b/client/app/admin/instruments/page.tsx
@@ -125,10 +125,19 @@ export default function AdminInstrumentsPage() {
 
   return (
     <div className="space-y-5">
-      <div className="flex flex-wrap items-baseline gap-3">
-        <h2 className="font-display text-2xl font-bold tracking-tight text-text-primary">
-          Instruments
-        </h2>
+      <h2 className="font-display text-2xl font-bold tracking-tight text-text-primary">
+        Instruments
+      </h2>
+
+      {/* Filters and action buttons */}
+      <div className="flex flex-wrap items-end gap-3">
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          placeholder="Search by name or ticker..."
+          className="w-full max-w-sm rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-primary placeholder:text-text-muted focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary/30"
+        />
         {!loading && (
           <span className="font-mono text-xs text-text-muted">
             {totalCount} total
@@ -154,15 +163,7 @@ export default function AdminInstrumentsPage() {
       </div>
       {exportError && <ErrorAlert>{exportError}</ErrorAlert>}
 
-      {/* Search and filters */}
       <div className="space-y-3">
-        <input
-          type="text"
-          value={search}
-          onChange={(e) => setSearch(e.target.value)}
-          placeholder="Search by name or ticker..."
-          className="w-full max-w-sm rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-primary placeholder:text-text-muted focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary/30"
-        />
         <div className="flex flex-wrap gap-1.5">
           {ALL_ASSET_CLASSES.map((cls) => {
             const active = activeClasses.has(cls);

--- a/client/app/admin/layout.tsx
+++ b/client/app/admin/layout.tsx
@@ -30,12 +30,6 @@ const adminNav: NavItem[] = [
     ],
   },
   {
-    section: "Events",
-    children: [
-      { href: "/admin/corporate-events", label: "Corporate Events" },
-    ],
-  },
-  {
     section: "Diagnostics",
     children: [
       { href: "/admin/logs", label: "Logs", disabled: true },

--- a/client/lib/json/corporate-events.ts
+++ b/client/lib/json/corporate-events.ts
@@ -1,0 +1,125 @@
+/**
+ * JSON serialization for corporate event (split) export/import.
+ * Format: array of split objects with identifier context.
+ */
+
+import { AssetClass } from "@/gen/api/v1/api_pb";
+import type { ExportCorporateEventRow } from "@/gen/api/v1/api_pb";
+import type { CorporateSplitImportRow } from "@/lib/portfolio-api";
+import { assetClassToStr, assetClassFromStr } from "@/lib/asset-class";
+import type { ParseError } from "@/lib/csv/standard";
+
+interface SerializedSplit {
+  identifier_type: string;
+  identifier_value: string;
+  identifier_domain?: string;
+  asset_class?: string;
+  ex_date: string;
+  split_from: string;
+  split_to: string;
+}
+
+/** Serialize split export rows to JSON string. */
+export function splitsToJson(rows: ExportCorporateEventRow[]): string {
+  const serialized: SerializedSplit[] = rows
+    .filter((r) => r.event.case === "split")
+    .map((r) => {
+      const split = r.event.value!;
+      const obj: SerializedSplit = {
+        identifier_type: r.identifierType,
+        identifier_value: r.identifierValue,
+        ex_date: split.exDate,
+        split_from: split.splitFrom,
+        split_to: split.splitTo,
+      };
+      if (r.identifierDomain) obj.identifier_domain = r.identifierDomain;
+      const ac = assetClassToStr(r.assetClass);
+      if (ac) obj.asset_class = ac;
+      return obj;
+    });
+  return JSON.stringify(serialized, null, 2) + "\n";
+}
+
+export interface SplitParseResult {
+  splits: CorporateSplitImportRow[];
+  errors: ParseError[];
+}
+
+/** Parse splits JSON back into importable rows. */
+export function parseSplitsJson(json: string): SplitParseResult {
+  const errors: ParseError[] = [];
+  let parsed: unknown;
+
+  try {
+    parsed = JSON.parse(json);
+  } catch (e) {
+    return {
+      splits: [],
+      errors: [{ rowIndex: 0, field: "file", message: `Invalid JSON: ${e instanceof Error ? e.message : String(e)}` }],
+    };
+  }
+
+  if (!Array.isArray(parsed)) {
+    return {
+      splits: [],
+      errors: [{ rowIndex: 0, field: "file", message: "Expected a JSON array" }],
+    };
+  }
+
+  const splits: CorporateSplitImportRow[] = [];
+
+  for (let i = 0; i < parsed.length; i++) {
+    const item = parsed[i];
+    if (typeof item !== "object" || item === null) {
+      errors.push({ rowIndex: i, field: "item", message: "Expected an object" });
+      continue;
+    }
+    const obj = item as Record<string, unknown>;
+
+    const identifierType = String(obj.identifier_type ?? "");
+    const identifierValue = String(obj.identifier_value ?? "");
+    if (!identifierType) {
+      errors.push({ rowIndex: i, field: "identifier_type", message: "Required" });
+      continue;
+    }
+    if (!identifierValue) {
+      errors.push({ rowIndex: i, field: "identifier_value", message: "Required" });
+      continue;
+    }
+
+    const exDate = String(obj.ex_date ?? "");
+    if (!exDate || !/^\d{4}-\d{2}-\d{2}$/.test(exDate)) {
+      errors.push({ rowIndex: i, field: "ex_date", message: "Required, format YYYY-MM-DD" });
+      continue;
+    }
+
+    const splitFrom = String(obj.split_from ?? "");
+    const splitTo = String(obj.split_to ?? "");
+    if (!splitFrom || !splitTo) {
+      errors.push({ rowIndex: i, field: "split_from/split_to", message: "Both split_from and split_to are required" });
+      continue;
+    }
+    const fromNum = parseFloat(splitFrom);
+    const toNum = parseFloat(splitTo);
+    if (!Number.isFinite(fromNum) || fromNum <= 0 || !Number.isFinite(toNum) || toNum <= 0) {
+      errors.push({ rowIndex: i, field: "split_from/split_to", message: "Must be positive numbers" });
+      continue;
+    }
+
+    const row: CorporateSplitImportRow = {
+      identifierType,
+      identifierValue,
+      exDate,
+      splitFrom,
+      splitTo,
+    };
+    const domain = String(obj.identifier_domain ?? "");
+    if (domain) row.identifierDomain = domain;
+    const ac = assetClassFromStr(String(obj.asset_class ?? ""));
+    if (ac !== AssetClass.UNSPECIFIED) row.assetClass = ac;
+
+    splits.push(row);
+  }
+
+  return { splits, errors };
+}

--- a/client/lib/portfolio-api.ts
+++ b/client/lib/portfolio-api.ts
@@ -7,6 +7,8 @@ import { timestampDate, timestampFromDate } from "@bufbuild/protobuf/wkt";
 import { DateSchema } from "@/gen/google/type/date_pb";
 import type { Date as ProtoDate } from "@/gen/google/type/date_pb";
 import {
+  ExportCorporateEventRowSchema,
+  ExportCorporateEventsRequestSchema,
   ExportInstrumentsRequestSchema,
   ExportPriceRowSchema,
   ExportPricesRequestSchema,
@@ -107,6 +109,7 @@ import {
 import type {
   DescriptionPluginConfig,
   EODPriceProto,
+  ExportCorporateEventRow,
   InflationIndexProto,
   InflationPluginConfig,
   ExportPriceRow,
@@ -686,6 +689,15 @@ export async function importCorporateEventSplits(rows: CorporateSplitImportRow[]
   );
   const res = fromBinary(ImportCorporateEventsResponseSchema, resBytes);
   return res.jobId;
+}
+
+/** Stream all exported corporate events (admin only). */
+export async function* exportCorporateEvents(): AsyncGenerator<ExportCorporateEventRow> {
+  const base = getBaseUrl();
+  const req = create(ExportCorporateEventsRequestSchema, {});
+  for await (const bytes of streamingFetch(base, ApiServicePrefix + "ExportCorporateEvents", toBinary(ExportCorporateEventsRequestSchema, req), { credentials: "include" })) {
+    yield fromBinary(ExportCorporateEventRowSchema, bytes);
+  }
 }
 
 /** A single day's portfolio value point. */


### PR DESCRIPTION
## Summary

- Enable the Splits tab on the Corporate Events admin page with a table of all stock splits, JSON export/import, and broker-specific import via the existing modal
- Change broker import modal from manual portfolio-based prefill to automatic holdings-based prefill (queries admin holdings at each split's ex-date, filters by broker/account)
- Remove duplicate "Events" nav section and unnecessary refresh button
- Standardize admin page button layout: filters left, action buttons right (matching Prices page pattern) across Instruments and Corporate Events pages

## Test plan

- [ ] Navigate to Admin > Reference Data > Corporate Events, verify Splits tab is enabled and clickable
- [ ] On Splits tab, verify table loads and displays existing splits (or shows empty state)
- [ ] Click Export JSON, verify `splits.json` downloads with correct format
- [ ] Import the exported JSON file back, verify job completes and table refreshes
- [ ] Click Import from Broker, verify modal opens with broker/format selection
- [ ] Upload a Schwab CSV with split rows, verify auto-prefill populates ratios when admin has holdings
- [ ] Verify ratios left blank when admin has no holdings for the instrument
- [ ] Verify editable fields work and validation blocks submission of invalid ratios
- [ ] Confirm "Events" section no longer appears in admin sidebar nav
- [ ] Confirm Instruments page buttons are right-justified alongside filters
- [ ] Run `make test` to verify no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)