### PR TITLE
Fix split E2E test failures caused by VCR date matching

### DIFF
--- a/server/db/postgres/corporate_events.go
+++ b/server/db/postgres/corporate_events.go
@@ -494,7 +494,8 @@ func (p *Postgres) SplitsByUnderlyingTicker(ctx context.Context, ticker string) 
 	return out, rows.Err()
 }
 
-// InstrumentsWithSplits implements db.CorporateEventDB.
+// InstrumentsWithSplits implements db.CorporateEventDB. Returns instruments
+// that have splits directly or via their underlying (for derivatives).
 func (p *Postgres) InstrumentsWithSplits(ctx context.Context, instrumentIDs []string) ([]string, error) {
 	if len(instrumentIDs) == 0 {
 		return nil, nil
@@ -508,8 +509,14 @@ func (p *Postgres) InstrumentsWithSplits(ctx context.Context, instrumentIDs []st
 		uuids = append(uuids, u)
 	}
 	rows, err := p.q.QueryContext(ctx, `
-		SELECT DISTINCT instrument_id FROM stock_splits
-		WHERE instrument_id = ANY($1::uuid[])
+		SELECT DISTINCT id FROM (
+			SELECT instrument_id AS id FROM stock_splits
+			WHERE instrument_id = ANY($1::uuid[])
+			UNION
+			SELECT i.id FROM instruments i
+			JOIN stock_splits s ON s.instrument_id = i.underlying_id
+			WHERE i.id = ANY($1::uuid[])
+		) t
 	`, pq.Array(uuids))
 	if err != nil {
 		return nil, fmt.Errorf("instruments with splits: %w", err)

--- a/server/db/postgres/instruments.go
+++ b/server/db/postgres/instruments.go
@@ -355,18 +355,18 @@ func (p *Postgres) EnsureInstrument(ctx context.Context, assetClass, exchangeMIC
 					return err
 				}
 			}
-			// Update identified_at and option fields on survivor.
-			return updateIdentifiedAt(ctx, exec, survivor, optionFields)
+			// Update identified_at, underlying, and option fields on survivor.
+			return updateIdentifiedAt(ctx, exec, survivor, underlyingUUID, optionFields)
 		})
 		if err != nil {
 			return "", err
 		}
 		return survivor.String(), nil
 	}
-	// Exactly one instrument: update identified_at and option fields.
+	// Exactly one instrument: update identified_at, underlying, and option fields.
 	if len(distinctIDs) == 1 {
 		id := distinctIDs[0]
-		if err := updateIdentifiedAt(ctx, p.q, id, optionFields); err != nil {
+		if err := updateIdentifiedAt(ctx, p.q, id, underlyingUUID, optionFields); err != nil {
 			return "", err
 		}
 		return id.String(), nil
@@ -414,17 +414,17 @@ func (p *Postgres) EnsureInstrument(ctx context.Context, assetClass, exchangeMIC
 	return newID.String(), nil
 }
 
-// updateIdentifiedAt sets identified_at = now() and optionally updates option
-// fields on an existing instrument.
-func updateIdentifiedAt(ctx context.Context, exec queryable, id uuid.UUID, optionFields *db.OptionFields) error {
+// updateIdentifiedAt sets identified_at = now(), optionally sets underlying_id,
+// and optionally updates option fields on an existing instrument.
+func updateIdentifiedAt(ctx context.Context, exec queryable, id uuid.UUID, underlyingID *uuid.UUID, optionFields *db.OptionFields) error {
 	if optionFields != nil {
 		_, err := exec.ExecContext(ctx, `
-			UPDATE instruments SET identified_at = now(), strike = $2, expiry = $3, put_call = $4
+			UPDATE instruments SET identified_at = now(), underlying_id = COALESCE($2, underlying_id), strike = $3, expiry = $4, put_call = $5
 			WHERE id = $1
-		`, id, optionFields.Strike, optionFields.Expiry, optionFields.PutCall)
+		`, id, nullUUID(underlyingID), optionFields.Strike, optionFields.Expiry, optionFields.PutCall)
 		return err
 	}
-	_, err := exec.ExecContext(ctx, `UPDATE instruments SET identified_at = now() WHERE id = $1`, id)
+	_, err := exec.ExecContext(ctx, `UPDATE instruments SET identified_at = now(), underlying_id = COALESCE($2, underlying_id) WHERE id = $1`, id, nullUUID(underlyingID))
 	return err
 }
 

--- a/server/testutil/vcr/vcr.go
+++ b/server/testutil/vcr/vcr.go
@@ -154,15 +154,23 @@ func EnvOrSkip(t *testing.T, name string, suite string) string {
 // replay correctly on subsequent days.
 var dateRe = regexp.MustCompile(`\d{4}-\d{2}-\d{2}`)
 
-// normalizeURL replaces ISO date segments in the URL path with a fixed
-// placeholder so that date-dependent URLs (e.g. Massive DailyBars) match
-// cassette entries regardless of when the test runs.
+// normalizeURL replaces ISO date segments in both the URL path and query
+// parameter values with a fixed placeholder so that date-dependent URLs
+// match cassette entries regardless of when the test runs.
 func normalizeURL(raw string) string {
 	u, err := url.Parse(raw)
 	if err != nil {
 		return raw
 	}
 	u.Path = dateRe.ReplaceAllString(u.Path, "DATE")
+	q := u.Query()
+	for key, vals := range q {
+		for i, v := range vals {
+			vals[i] = dateRe.ReplaceAllString(v, "DATE")
+		}
+		q[key] = vals
+	}
+	u.RawQuery = q.Encode()
 	return u.String()
 }
 

--- a/server/testutil/vcr/vcr_test.go
+++ b/server/testutil/vcr/vcr_test.go
@@ -63,12 +63,12 @@ func TestNormalizeURL(t *testing.T) {
 			want: "https://api.massive.com/v2/aggs/ticker/TSLA/range/1/day/DATE/DATE?adjusted=false&apiKey=REDACTED&sort=asc",
 		},
 		{
-			name: "no dates in path",
+			name: "no dates in path or query",
 			in:   "https://api.massive.com/v3/reference/tickers/AAPL?apiKey=REDACTED",
 			want: "https://api.massive.com/v3/reference/tickers/AAPL?apiKey=REDACTED",
 		},
 		{
-			name: "eodhd search",
+			name: "eodhd search no dates",
 			in:   "https://eodhd.com/api/search/US0378331005?api_token=REDACTED&fmt=json&limit=10&type=stock",
 			want: "https://eodhd.com/api/search/US0378331005?api_token=REDACTED&fmt=json&limit=10&type=stock",
 		},
@@ -76,6 +76,16 @@ func TestNormalizeURL(t *testing.T) {
 			name: "different end dates match after normalization",
 			in:   "https://api.massive.com/v2/aggs/ticker/AMZN/range/1/day/2024-01-27/2026-03-27?adjusted=false&apiKey=REDACTED&sort=asc",
 			want: "https://api.massive.com/v2/aggs/ticker/AMZN/range/1/day/DATE/DATE?adjusted=false&apiKey=REDACTED&sort=asc",
+		},
+		{
+			name: "eodhd splits with date query params",
+			in:   "https://eodhd.com/api/splits/AAPL.US?api_token=REDACTED&fmt=json&from=2024-06-15&to=2026-05-11",
+			want: "https://eodhd.com/api/splits/AAPL.US?api_token=REDACTED&fmt=json&from=DATE&to=DATE",
+		},
+		{
+			name: "eodhd dividends with date query params",
+			in:   "https://eodhd.com/api/div/AAPL.US?api_token=REDACTED&fmt=json&from=2024-06-15&to=2026-05-11",
+			want: "https://eodhd.com/api/div/AAPL.US?api_token=REDACTED&fmt=json&from=DATE&to=DATE",
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

- **Root cause**: VCR `E2EMatcher` normalized ISO dates in URL paths but not query parameter values. The corporate event fetcher's `to` date (`CURRENT_DATE + 30 days`) drifted from the cassette recording, causing EODHD requests to silently fail. This prevented the fetcher from discovering splits and recomputing option split adjustments.
- **VCR fix**: Extend `normalizeURL` to also replace dates in query param values, so cassettes replay regardless of when the test runs.
- **InstrumentsWithSplits**: Also return derivatives whose underlying has splits, so option adj quantities are computed during ingestion (not just by the fetcher).
- **updateIdentifiedAt**: Set `underlying_id` on re-identification to close a gap where instruments created via fallback never got their underlying populated.

## Test plan

- [x] All unit tests pass (`make test`)
- [x] All DB functional tests pass (`make db-test`)
- [x] All 27 E2E tests pass (`make e2e-test`), including both stock-split scenarios

🤖 Generated with [Claude Code](https://claude.com/claude-code)