### PR TITLE
Extract shared plugin utilities and fix logger bug

### DIFF
--- a/server/corporateevents/worker.go
+++ b/server/corporateevents/worker.go
@@ -2,14 +2,13 @@ package corporateevents
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
-	"strings"
 	"time"
 
 	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/pluginutil"
 	"github.com/leedenison/portfoliodb/server/telemetry"
 	"github.com/leedenison/portfoliodb/server/worker"
 )
@@ -174,15 +173,15 @@ func processInstrument(ctx context.Context, database db.DB, plugins []pluginEntr
 			if blocked[pe.id] {
 				continue
 			}
-			if !pluginAccepts(pe.plugin, inst) {
+			if !pluginutil.PluginAccepts(pe.plugin.AcceptableAssetClasses(), pe.plugin.AcceptableExchanges(), pe.plugin.AcceptableCurrencies(), inst) {
 				continue
 			}
-			ids := filterIdentifiers(pe.plugin.SupportedIdentifierTypes(), inst.Identifiers)
+			ids := pluginutil.FilterIdentifiers(pe.plugin.SupportedIdentifierTypes(), inst.Identifiers)
 			if len(ids) == 0 {
 				continue
 			}
 
-			callCtx, callCancel := context.WithTimeout(ctx, timeoutFromConfig(pe.config))
+			callCtx, callCancel := context.WithTimeout(ctx, pluginutil.TimeoutFromConfig(pe.config, DefaultPluginTimeout))
 			result, err := pe.plugin.FetchEvents(callCtx, pe.config, toPluginIdentifiers(ids), assetClass, gap.From, gap.To)
 			callCancel()
 			if err != nil {
@@ -300,39 +299,6 @@ func computeMissingIntervals(earliestTxDate, endDate time.Time, coverage []db.Co
 	return out
 }
 
-// pluginAccepts checks whether a plugin can handle the given instrument.
-func pluginAccepts(p Plugin, inst *db.InstrumentRow) bool {
-	if ac := p.AcceptableAssetClasses(); len(ac) > 0 && inst.AssetClass != nil && *inst.AssetClass != "" {
-		if !ac[*inst.AssetClass] {
-			return false
-		}
-	}
-	if ex := p.AcceptableExchanges(); len(ex) > 0 && inst.ExchangeMIC != nil && *inst.ExchangeMIC != "" {
-		if !ex[*inst.ExchangeMIC] {
-			return false
-		}
-	}
-	if cu := p.AcceptableCurrencies(); len(cu) > 0 && inst.Currency != nil && *inst.Currency != "" {
-		if !cu[strings.ToUpper(*inst.Currency)] {
-			return false
-		}
-	}
-	return true
-}
-
-func filterIdentifiers(supported []string, ids []db.IdentifierInput) []db.IdentifierInput {
-	set := make(map[string]bool, len(supported))
-	for _, t := range supported {
-		set[t] = true
-	}
-	var out []db.IdentifierInput
-	for _, id := range ids {
-		if set[id.Type] {
-			out = append(out, id)
-		}
-	}
-	return out
-}
 
 func toPluginIdentifiers(ids []db.IdentifierInput) []Identifier {
 	out := make([]Identifier, len(ids))
@@ -384,34 +350,3 @@ func dividendsToDB(instrumentID, provider string, dividends []CashDividend) []db
 	return out
 }
 
-type pluginConfigJSON struct {
-	TimeoutSeconds *int `json:"timeout_seconds"`
-}
-
-// timeoutFromConfig parses timeout_seconds from plugin config JSON and falls
-// back to DefaultPluginTimeout when missing or invalid.
-func timeoutFromConfig(config []byte) time.Duration {
-	if len(config) == 0 {
-		return DefaultPluginTimeout
-	}
-	var c pluginConfigJSON
-	if err := json.Unmarshal(config, &c); err != nil {
-		return DefaultPluginTimeout
-	}
-	if c.TimeoutSeconds == nil || *c.TimeoutSeconds <= 0 {
-		return DefaultPluginTimeout
-	}
-	return time.Duration(*c.TimeoutSeconds) * time.Second
-}
-
-// Trigger sends a non-blocking signal on a corporate event trigger channel.
-// Safe to call with a nil channel.
-func Trigger(ch chan<- struct{}) {
-	if ch == nil {
-		return
-	}
-	select {
-	case ch <- struct{}{}:
-	default:
-	}
-}

--- a/server/corporateevents/worker_test.go
+++ b/server/corporateevents/worker_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/leedenison/portfoliodb/server/db"
 	"github.com/leedenison/portfoliodb/server/db/mock"
+	"github.com/leedenison/portfoliodb/server/pluginutil"
 	"go.uber.org/mock/gomock"
 )
 
@@ -94,7 +95,7 @@ func TestPluginAccepts(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			if got := pluginAccepts(tc.p, tc.inst); got != tc.want {
+			if got := pluginutil.PluginAccepts(tc.p.AcceptableAssetClasses(), tc.p.AcceptableExchanges(), tc.p.AcceptableCurrencies(), tc.inst); got != tc.want {
 				t.Errorf("got %v want %v", got, tc.want)
 			}
 		})
@@ -107,32 +108,32 @@ func TestFilterIdentifiers(t *testing.T) {
 		{Type: "ISIN", Value: "US0378331005"},
 		{Type: "OPENFIGI_TICKER", Value: "BBG000B9XRY4"},
 	}
-	got := filterIdentifiers([]string{"MIC_TICKER", "OPENFIGI_TICKER"}, ids)
+	got := pluginutil.FilterIdentifiers([]string{"MIC_TICKER", "OPENFIGI_TICKER"}, ids)
 	if len(got) != 2 {
 		t.Fatalf("expected 2, got %d", len(got))
 	}
 }
 
 func TestTimeoutFromConfig(t *testing.T) {
-	if timeoutFromConfig(nil) != DefaultPluginTimeout {
+	if pluginutil.TimeoutFromConfig(nil, DefaultPluginTimeout) != DefaultPluginTimeout {
 		t.Error("nil config")
 	}
-	if timeoutFromConfig([]byte(`{"timeout_seconds": 30}`)) != 30*time.Second {
+	if pluginutil.TimeoutFromConfig([]byte(`{"timeout_seconds": 30}`), DefaultPluginTimeout) != 30*time.Second {
 		t.Error("explicit 30s")
 	}
-	if timeoutFromConfig([]byte(`{"timeout_seconds": -5}`)) != DefaultPluginTimeout {
+	if pluginutil.TimeoutFromConfig([]byte(`{"timeout_seconds": -5}`), DefaultPluginTimeout) != DefaultPluginTimeout {
 		t.Error("negative")
 	}
-	if timeoutFromConfig([]byte(`not json`)) != DefaultPluginTimeout {
+	if pluginutil.TimeoutFromConfig([]byte(`not json`), DefaultPluginTimeout) != DefaultPluginTimeout {
 		t.Error("invalid json")
 	}
 }
 
 func TestTrigger(t *testing.T) {
-	t.Run("nil channel", func(t *testing.T) { Trigger(nil) })
+	t.Run("nil channel", func(t *testing.T) { pluginutil.Trigger(nil) })
 	t.Run("sends signal", func(t *testing.T) {
 		ch := make(chan struct{}, 1)
-		Trigger(ch)
+		pluginutil.Trigger(ch)
 		select {
 		case <-ch:
 		default:
@@ -142,7 +143,7 @@ func TestTrigger(t *testing.T) {
 	t.Run("non-blocking when full", func(t *testing.T) {
 		ch := make(chan struct{}, 1)
 		ch <- struct{}{}
-		Trigger(ch)
+		pluginutil.Trigger(ch)
 	})
 }
 

--- a/server/pluginutil/pluginutil.go
+++ b/server/pluginutil/pluginutil.go
@@ -1,0 +1,76 @@
+package pluginutil
+
+import (
+	"encoding/json"
+	"strings"
+	"time"
+
+	"github.com/leedenison/portfoliodb/server/db"
+)
+
+// PluginAccepts checks whether an instrument matches the given asset class,
+// exchange, and currency filter maps. Empty or nil maps accept all values.
+func PluginAccepts(ac, ex, cu map[string]bool, inst *db.InstrumentRow) bool {
+	if len(ac) > 0 && inst.AssetClass != nil && *inst.AssetClass != "" {
+		if !ac[*inst.AssetClass] {
+			return false
+		}
+	}
+	if len(ex) > 0 && inst.ExchangeMIC != nil && *inst.ExchangeMIC != "" {
+		if !ex[*inst.ExchangeMIC] {
+			return false
+		}
+	}
+	if len(cu) > 0 && inst.Currency != nil && *inst.Currency != "" {
+		if !cu[strings.ToUpper(*inst.Currency)] {
+			return false
+		}
+	}
+	return true
+}
+
+// FilterIdentifiers returns identifiers whose type is in the supported set.
+func FilterIdentifiers(supported []string, ids []db.IdentifierInput) []db.IdentifierInput {
+	set := make(map[string]bool, len(supported))
+	for _, t := range supported {
+		set[t] = true
+	}
+	var out []db.IdentifierInput
+	for _, id := range ids {
+		if set[id.Type] {
+			out = append(out, id)
+		}
+	}
+	return out
+}
+
+type pluginConfigJSON struct {
+	TimeoutSeconds *int `json:"timeout_seconds"`
+}
+
+// TimeoutFromConfig parses timeout_seconds from plugin config JSON and falls
+// back to defaultTimeout when missing or invalid.
+func TimeoutFromConfig(config []byte, defaultTimeout time.Duration) time.Duration {
+	if len(config) == 0 {
+		return defaultTimeout
+	}
+	var c pluginConfigJSON
+	if err := json.Unmarshal(config, &c); err != nil {
+		return defaultTimeout
+	}
+	if c.TimeoutSeconds == nil || *c.TimeoutSeconds <= 0 {
+		return defaultTimeout
+	}
+	return time.Duration(*c.TimeoutSeconds) * time.Second
+}
+
+// Trigger sends a non-blocking signal on a trigger channel. Nil-safe.
+func Trigger(ch chan<- struct{}) {
+	if ch == nil {
+		return
+	}
+	select {
+	case ch <- struct{}{}:
+	default:
+	}
+}

--- a/server/pluginutil/pluginutil_test.go
+++ b/server/pluginutil/pluginutil_test.go
@@ -1,0 +1,153 @@
+package pluginutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/leedenison/portfoliodb/server/db"
+)
+
+func strPtr(s string) *string { return &s }
+
+func TestPluginAccepts(t *testing.T) {
+	tests := []struct {
+		name string
+		ac   map[string]bool
+		ex   map[string]bool
+		cu   map[string]bool
+		inst *db.InstrumentRow
+		want bool
+	}{
+		{
+			name: "nil filters accept anything",
+			inst: &db.InstrumentRow{AssetClass: strPtr("STOCK"), ExchangeMIC: strPtr("XNAS"), Currency: strPtr("USD")},
+			want: true,
+		},
+		{
+			name: "asset class mismatch",
+			ac:   map[string]bool{"STOCK": true},
+			inst: &db.InstrumentRow{AssetClass: strPtr("OPTION")},
+			want: false,
+		},
+		{
+			name: "asset class match",
+			ac:   map[string]bool{"STOCK": true, "ETF": true},
+			inst: &db.InstrumentRow{AssetClass: strPtr("ETF")},
+			want: true,
+		},
+		{
+			name: "nil asset class passes filter",
+			ac:   map[string]bool{"STOCK": true},
+			inst: &db.InstrumentRow{},
+			want: true,
+		},
+		{
+			name: "empty asset class passes filter",
+			ac:   map[string]bool{"STOCK": true},
+			inst: &db.InstrumentRow{AssetClass: strPtr("")},
+			want: true,
+		},
+		{
+			name: "currency case insensitive",
+			cu:   map[string]bool{"USD": true},
+			inst: &db.InstrumentRow{Currency: strPtr("usd")},
+			want: true,
+		},
+		{
+			name: "currency mismatch",
+			cu:   map[string]bool{"USD": true},
+			inst: &db.InstrumentRow{Currency: strPtr("EUR")},
+			want: false,
+		},
+		{
+			name: "nil currency passes filter",
+			cu:   map[string]bool{"USD": true},
+			inst: &db.InstrumentRow{},
+			want: true,
+		},
+		{
+			name: "exchange mismatch",
+			ex:   map[string]bool{"XNAS": true},
+			inst: &db.InstrumentRow{ExchangeMIC: strPtr("XNYS")},
+			want: false,
+		},
+		{
+			name: "nil exchange passes filter",
+			ex:   map[string]bool{"XNAS": true},
+			inst: &db.InstrumentRow{},
+			want: true,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := PluginAccepts(tc.ac, tc.ex, tc.cu, tc.inst); got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFilterIdentifiers(t *testing.T) {
+	ids := []db.IdentifierInput{
+		{Type: "MIC_TICKER", Value: "AAPL"},
+		{Type: "ISIN", Value: "US0378331005"},
+		{Type: "OCC", Value: "AAPL250321C00150000"},
+	}
+	got := FilterIdentifiers([]string{"MIC_TICKER", "OCC"}, ids)
+	if len(got) != 2 {
+		t.Fatalf("expected 2, got %d", len(got))
+	}
+	if got[0].Type != "MIC_TICKER" || got[1].Type != "OCC" {
+		t.Errorf("unexpected types: %s, %s", got[0].Type, got[1].Type)
+	}
+}
+
+func TestFilterIdentifiers_NoMatch(t *testing.T) {
+	ids := []db.IdentifierInput{{Type: "ISIN", Value: "US0378331005"}}
+	got := FilterIdentifiers([]string{"MIC_TICKER"}, ids)
+	if len(got) != 0 {
+		t.Fatalf("expected 0, got %d", len(got))
+	}
+}
+
+func TestTimeoutFromConfig(t *testing.T) {
+	def := 45 * time.Second
+	if TimeoutFromConfig(nil, def) != def {
+		t.Error("nil config should return default")
+	}
+	if TimeoutFromConfig([]byte(`{"timeout_seconds": 30}`), def) != 30*time.Second {
+		t.Error("explicit 30s")
+	}
+	if TimeoutFromConfig([]byte(`{"timeout_seconds": -5}`), def) != def {
+		t.Error("negative should return default")
+	}
+	if TimeoutFromConfig([]byte(`{"timeout_seconds": 0}`), def) != def {
+		t.Error("zero should return default")
+	}
+	if TimeoutFromConfig([]byte(`not json`), def) != def {
+		t.Error("invalid json should return default")
+	}
+	if TimeoutFromConfig([]byte(`{}`), def) != def {
+		t.Error("missing key should return default")
+	}
+}
+
+func TestTrigger(t *testing.T) {
+	t.Run("nil channel", func(t *testing.T) {
+		Trigger(nil) // should not panic
+	})
+	t.Run("sends signal", func(t *testing.T) {
+		ch := make(chan struct{}, 1)
+		Trigger(ch)
+		select {
+		case <-ch:
+		default:
+			t.Error("expected signal")
+		}
+	})
+	t.Run("non-blocking when full", func(t *testing.T) {
+		ch := make(chan struct{}, 1)
+		ch <- struct{}{}
+		Trigger(ch) // should not block
+	})
+}

--- a/server/pricefetcher/worker.go
+++ b/server/pricefetcher/worker.go
@@ -2,14 +2,13 @@ package pricefetcher
 
 import (
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
-	"strings"
 	"time"
 
 	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/pluginutil"
 	"github.com/leedenison/portfoliodb/server/telemetry"
 	"github.com/leedenison/portfoliodb/server/worker"
 )
@@ -155,13 +154,13 @@ func processGaps(ctx context.Context, database db.DB, plugins []pluginEntry, gap
 
 		fetchedByPlugin := false
 		for _, pe := range plugins {
-			if !pluginAccepts(pe.plugin, inst) {
+			if !pluginutil.PluginAccepts(pe.plugin.AcceptableAssetClasses(), pe.plugin.AcceptableExchanges(), pe.plugin.AcceptableCurrencies(), inst) {
 				continue
 			}
 			if blocked[ig.InstrumentID][pe.id] {
 				continue
 			}
-			ids := filterIdentifiers(pe.plugin.SupportedIdentifierTypes(), inst.Identifiers)
+			ids := pluginutil.FilterIdentifiers(pe.plugin.SupportedIdentifierTypes(), inst.Identifiers)
 			if len(ids) == 0 {
 				continue
 			}
@@ -183,7 +182,7 @@ func processGaps(ctx context.Context, database db.DB, plugins []pluginEntry, gap
 				if inst.AssetClass != nil {
 					assetClass = *inst.AssetClass
 				}
-					callCtx, callCancel := context.WithTimeout(ctx, timeoutFromConfig(pe.config))
+					callCtx, callCancel := context.WithTimeout(ctx, pluginutil.TimeoutFromConfig(pe.config, DefaultPricePluginTimeout))
 				result, err := pe.plugin.FetchPrices(callCtx, pe.config, pfIDs, assetClass, gap.From, gap.To)
 				callCancel()
 				if err != nil {
@@ -236,41 +235,6 @@ func extractInstrumentIDs(gaps []db.InstrumentDateRanges) []string {
 	return out
 }
 
-// pluginAccepts checks whether a plugin can handle the given instrument
-// based on asset class, exchange, and currency filters.
-func pluginAccepts(p Plugin, inst *db.InstrumentRow) bool {
-	if ac := p.AcceptableAssetClasses(); len(ac) > 0 && inst.AssetClass != nil && *inst.AssetClass != "" {
-		if !ac[*inst.AssetClass] {
-			return false
-		}
-	}
-	if ex := p.AcceptableExchanges(); len(ex) > 0 && inst.ExchangeMIC != nil && *inst.ExchangeMIC != "" {
-		if !ex[*inst.ExchangeMIC] {
-			return false
-		}
-	}
-	if cu := p.AcceptableCurrencies(); len(cu) > 0 && inst.Currency != nil && *inst.Currency != "" {
-		if !cu[strings.ToUpper(*inst.Currency)] {
-			return false
-		}
-	}
-	return true
-}
-
-// filterIdentifiers returns identifiers whose type is in the supported set.
-func filterIdentifiers(supported []string, ids []db.IdentifierInput) []db.IdentifierInput {
-	set := make(map[string]bool, len(supported))
-	for _, t := range supported {
-		set[t] = true
-	}
-	var out []db.IdentifierInput
-	for _, id := range ids {
-		if set[id.Type] {
-			out = append(out, id)
-		}
-	}
-	return out
-}
 
 func toPricefetcherIDs(ids []db.IdentifierInput) []Identifier {
 	out := make([]Identifier, len(ids))
@@ -297,33 +261,3 @@ func barsToEODPrices(instrumentID, provider string, bars []DailyBar) []db.EODPri
 	return out
 }
 
-type pluginConfigJSON struct {
-	TimeoutSeconds *int `json:"timeout_seconds"`
-}
-
-// timeoutFromConfig parses timeout_seconds from plugin config JSON; defaults to DefaultPricePluginTimeout.
-func timeoutFromConfig(config []byte) time.Duration {
-	if len(config) == 0 {
-		return DefaultPricePluginTimeout
-	}
-	var c pluginConfigJSON
-	if err := json.Unmarshal(config, &c); err != nil {
-		return DefaultPricePluginTimeout
-	}
-	if c.TimeoutSeconds == nil || *c.TimeoutSeconds <= 0 {
-		return DefaultPricePluginTimeout
-	}
-	return time.Duration(*c.TimeoutSeconds) * time.Second
-}
-
-// Trigger sends a non-blocking signal on a price trigger channel.
-// Safe to call with a nil channel.
-func Trigger(ch chan<- struct{}) {
-	if ch == nil {
-		return
-	}
-	select {
-	case ch <- struct{}{}:
-	default:
-	}
-}

--- a/server/pricefetcher/worker_test.go
+++ b/server/pricefetcher/worker_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/leedenison/portfoliodb/server/db"
 	"github.com/leedenison/portfoliodb/server/db/mock"
+	"github.com/leedenison/portfoliodb/server/pluginutil"
 	"github.com/leedenison/portfoliodb/server/telemetry"
 	"go.uber.org/mock/gomock"
 )
@@ -78,7 +79,7 @@ func TestPluginAccepts(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := pluginAccepts(tc.plugin, tc.inst)
+			got := pluginutil.PluginAccepts(tc.plugin.AcceptableAssetClasses(), tc.plugin.AcceptableExchanges(), tc.plugin.AcceptableCurrencies(), tc.inst)
 			if got != tc.want {
 				t.Errorf("pluginAccepts = %v, want %v", got, tc.want)
 			}
@@ -92,7 +93,7 @@ func TestFilterIdentifiers(t *testing.T) {
 		{Type: "ISIN", Value: "US0378331005"},
 		{Type: "OCC", Value: "AAPL250321C00150000"},
 	}
-	got := filterIdentifiers([]string{"MIC_TICKER", "OCC"}, ids)
+	got := pluginutil.FilterIdentifiers([]string{"MIC_TICKER", "OCC"}, ids)
 	if len(got) != 2 {
 		t.Fatalf("expected 2, got %d", len(got))
 	}
@@ -103,11 +104,11 @@ func TestFilterIdentifiers(t *testing.T) {
 
 func TestTrigger(t *testing.T) {
 	t.Run("nil channel", func(t *testing.T) {
-		Trigger(nil) // should not panic
+		pluginutil.Trigger(nil) // should not panic
 	})
 	t.Run("sends signal", func(t *testing.T) {
 		ch := make(chan struct{}, 1)
-		Trigger(ch)
+		pluginutil.Trigger(ch)
 		select {
 		case <-ch:
 		default:
@@ -117,7 +118,7 @@ func TestTrigger(t *testing.T) {
 	t.Run("non-blocking when full", func(t *testing.T) {
 		ch := make(chan struct{}, 1)
 		ch <- struct{}{}
-		Trigger(ch) // should not block
+		pluginutil.Trigger(ch) // should not block
 	})
 }
 
@@ -428,8 +429,8 @@ func TestRunWorker_DebounceCollapsesTriggers(t *testing.T) {
 
 	// Send 2 more triggers while cycle 1 is in-flight.
 	// Buffer holds 1, so one is queued and one is dropped.
-	Trigger(trigger)
-	Trigger(trigger)
+	pluginutil.Trigger(trigger)
+	pluginutil.Trigger(trigger)
 
 	// Release both cycles.
 	close(gate)

--- a/server/service/api/display_currency.go
+++ b/server/service/api/display_currency.go
@@ -5,7 +5,7 @@ import (
 	"regexp"
 
 	"github.com/leedenison/portfoliodb/server/auth"
-	"github.com/leedenison/portfoliodb/server/pricefetcher"
+	"github.com/leedenison/portfoliodb/server/pluginutil"
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -40,6 +40,6 @@ func (s *Server) SetDisplayCurrency(ctx context.Context, req *apiv1.SetDisplayCu
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	// Trigger a price fetch cycle so FX rates for the new display currency are fetched.
-	pricefetcher.Trigger(s.priceTrigger)
+	pluginutil.Trigger(s.priceTrigger)
 	return &apiv1.SetDisplayCurrencyResponse{DisplayCurrency: cc}, nil
 }

--- a/server/service/api/instruments.go
+++ b/server/service/api/instruments.go
@@ -195,5 +195,8 @@ func (s *Server) ImportInstruments(ctx context.Context, req *apiv1.ImportInstrum
 		}
 		ensuredCount++
 	}
+	// No fetcher triggers here. Imported instruments have no holdings yet, so
+	// there are no price gaps to fill. Corporate events (splits, dividends)
+	// are picked up by the daily corporate event fetch cycle.
 	return &apiv1.ImportInstrumentsResponse{EnsuredCount: ensuredCount, Errors: errs}, nil
 }

--- a/server/service/ingestion/corporate_event_worker.go
+++ b/server/service/ingestion/corporate_event_worker.go
@@ -153,7 +153,7 @@ func processCorporateEventImport(ctx context.Context, database db.DB, pluginRegi
 		if err != nil {
 			log.Printf("corporate event import job %s: list splits %s: %v", j.JobID, instID, err)
 		} else {
-			options := corporateevents.ProcessOptionSplits(ctx, database, instID, allSplits, nil, nil)
+			options := corporateevents.ProcessOptionSplits(ctx, database, instID, allSplits, ingestionLog, nil)
 			for _, opt := range options {
 				_ = database.RecomputeSplitAdjustments(ctx, opt.ID)
 			}

--- a/server/service/ingestion/worker.go
+++ b/server/service/ingestion/worker.go
@@ -9,11 +9,10 @@ import (
 
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
 	ingestionv1 "github.com/leedenison/portfoliodb/proto/ingestion/v1"
-	"github.com/leedenison/portfoliodb/server/corporateevents"
 	"github.com/leedenison/portfoliodb/server/db"
 	"github.com/leedenison/portfoliodb/server/identifier"
 	"github.com/leedenison/portfoliodb/server/identifier/description"
-	"github.com/leedenison/portfoliodb/server/pricefetcher"
+	"github.com/leedenison/portfoliodb/server/pluginutil"
 	"github.com/leedenison/portfoliodb/server/telemetry"
 	"github.com/leedenison/portfoliodb/server/worker"
 	"google.golang.org/protobuf/proto"
@@ -99,15 +98,23 @@ func processJob(ctx context.Context, opts WorkerOptions, j *JobRequest) {
 			if err := recalcAfterIngestion(ctx, opts.DB, userID); err != nil {
 				log.Printf("ingestion job %s: recalc INITIALIZE txs: %v", j.JobID, err)
 			}
-			pricefetcher.Trigger(opts.PriceTrigger)
+			// Only the price fetcher is triggered here. The corporate event
+			// fetcher is not nudged because splits are not time-critical --
+			// the daily corporate event fetch cycle is sufficient for any
+			// newly resolved instruments.
+			pluginutil.Trigger(opts.PriceTrigger)
 		}
 	case db.JobTypePrice:
 		if processPriceImport(ctx, opts.DB, opts.IdentifierRegistry, j) {
-			pricefetcher.Trigger(opts.PriceTrigger)
+			pluginutil.Trigger(opts.PriceTrigger)
 		}
 	case db.JobTypeCorporateEvent:
 		if processCorporateEventImport(ctx, opts.DB, opts.IdentifierRegistry, j) {
-			corporateevents.Trigger(opts.CorporateEventTrigger)
+			// Only the corporate event fetcher is triggered here. The price
+			// fetcher is not nudged because instruments resolved during
+			// corporate event import cannot by definition create new holding
+			// gaps that would require price data.
+			pluginutil.Trigger(opts.CorporateEventTrigger)
 		}
 	default:
 		log.Printf("ingestion job %s: unknown job type %q", j.JobID, j.JobType)


### PR DESCRIPTION
## Summary

- Extract duplicated `pluginAccepts`, `filterIdentifiers`, `timeoutFromConfig`, and `Trigger` functions from `pricefetcher` and `corporateevents` into a new `server/pluginutil` package
- Fix `ProcessOptionSplits` receiving `nil` logger in the corporate event import path (silenced all warnings/errors)
- Add comments documenting why each import workflow triggers only specific downstream fetchers (e.g. tx import triggers price fetcher but not corp event fetcher)

## Test plan

- [x] `make test` passes -- all existing tests updated to call `pluginutil.*`
- [x] New `pluginutil_test.go` covers `PluginAccepts`, `FilterIdentifiers`, `TimeoutFromConfig`, and `Trigger` edge cases
- [ ] Verify no behavioral changes: existing pricefetcher and corporateevents worker tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)