### PR TITLE
Refactor splits import to use modal with spinner progress

### DIFF
--- a/client/app/admin/corporate-events/import-splits-modal.tsx
+++ b/client/app/admin/corporate-events/import-splits-modal.tsx
@@ -1,0 +1,298 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { Modal } from "@/app/components/modal";
+import { ErrorAlert } from "@/app/components/error-alert";
+import { parseSplitsJson } from "@/lib/json/corporate-events";
+import { importCorporateEventSplits, getJob } from "@/lib/portfolio-api";
+import { JobStatus } from "@/gen/api/v1/api_pb";
+import type { SplitParseResult } from "@/lib/json/corporate-events";
+import type { GetJobResult } from "@/lib/portfolio-api";
+
+type Phase = "idle" | "preview" | "processing" | "result";
+
+export function ImportSplitsModal({
+  open,
+  onClose,
+  onComplete,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onComplete?: () => void;
+}) {
+  const [phase, setPhase] = useState<Phase>("idle");
+  const [parseResult, setParseResult] = useState<SplitParseResult | null>(null);
+  const [jobId, setJobId] = useState<string | null>(null);
+  const [jobStatus, setJobStatus] = useState<GetJobResult | null>(null);
+  const [importError, setImportError] = useState<string | null>(null);
+  const [file, setFile] = useState<File | null>(null);
+  const [fileInputActive, setFileInputActive] = useState(false);
+  const fileRef = useRef<HTMLInputElement>(null);
+
+  function reset() {
+    setPhase("idle");
+    setParseResult(null);
+    setJobId(null);
+    setJobStatus(null);
+    setImportError(null);
+    setFile(null);
+    setFileInputActive(false);
+    if (fileRef.current) fileRef.current.value = "";
+  }
+
+  const processing = phase === "processing";
+
+  function handleClose() {
+    if (processing) return;
+    reset();
+    onClose();
+  }
+
+  function handleFileChange(e: React.ChangeEvent<HTMLInputElement>) {
+    const f = e.target.files?.[0];
+    if (!f) return;
+    setFile(f);
+    const reader = new FileReader();
+    reader.onload = (ev) => {
+      const text = ev.target?.result as string;
+      const result = parseSplitsJson(text);
+      setParseResult(result);
+      setPhase("preview");
+    };
+    reader.readAsText(f);
+  }
+
+  async function handleImport() {
+    if (!parseResult || parseResult.splits.length === 0) return;
+    setPhase("processing");
+    setImportError(null);
+    try {
+      const id = await importCorporateEventSplits(parseResult.splits);
+      setJobId(id);
+    } catch (err) {
+      setImportError(err instanceof Error ? err.message : String(err));
+      setPhase("preview");
+    }
+  }
+
+  // Poll job status.
+  useEffect(() => {
+    if (!jobId || phase !== "processing") return;
+    let cancelled = false;
+    const poll = async () => {
+      try {
+        const result = await getJob(jobId);
+        if (cancelled) return;
+        setJobStatus(result);
+        if (result.status === JobStatus.SUCCESS || result.status === JobStatus.FAILED) {
+          setPhase("result");
+        }
+      } catch {
+        // Ignore transient poll errors.
+      }
+    };
+    poll();
+    const t = setInterval(poll, 2000);
+    return () => {
+      cancelled = true;
+      clearInterval(t);
+    };
+  }, [jobId, phase]);
+
+  function handleDone() {
+    onComplete?.();
+    reset();
+    onClose();
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={handleClose}
+      title="Import splits"
+      closable={!processing}
+    >
+      <div className="flex flex-col gap-4 overflow-y-auto p-5">
+        {phase === "idle" && (
+          <div className="space-y-3">
+            <p className="text-sm text-text-muted">
+              Select a JSON file to import splits.
+            </p>
+            <input
+              ref={fileRef}
+              type="file"
+              accept=".json"
+              onChange={handleFileChange}
+              className="sr-only"
+              aria-label="Choose JSON file"
+            />
+            <button
+              type="button"
+              onClick={() => {
+                setFileInputActive(true);
+                fileRef.current?.click();
+                setTimeout(() => setFileInputActive(false), 400);
+              }}
+              className={`rounded-md border px-4 py-2 text-sm font-semibold transition-colors ${
+                fileInputActive
+                  ? "border-primary bg-primary text-white"
+                  : "border-border bg-primary-light/20 text-text-primary hover:bg-primary-light/40 active:border-primary active:bg-primary active:text-white"
+              }`}
+            >
+              {fileInputActive ? "Opening\u2026" : "Choose file"}
+            </button>
+            {file && (
+              <p className="text-sm text-text-muted">
+                Selected: {file.name}
+              </p>
+            )}
+          </div>
+        )}
+
+        {phase === "preview" && parseResult && (
+          <div className="space-y-4">
+            {parseResult.errors.length > 0 ? (
+              <div className="space-y-2">
+                <p className="text-sm font-medium text-text-primary">
+                  Parse errors ({parseResult.errors.length})
+                </p>
+                <div className="max-h-48 overflow-y-auto rounded-md border border-border bg-surface">
+                  <table className="w-full border-collapse text-xs">
+                    <thead>
+                      <tr className="border-b border-border bg-primary-dark/[0.03]">
+                        <th className="px-3 py-2 text-left font-semibold uppercase tracking-wider text-text-muted">Row</th>
+                        <th className="px-3 py-2 text-left font-semibold uppercase tracking-wider text-text-muted">Field</th>
+                        <th className="px-3 py-2 text-left font-semibold uppercase tracking-wider text-text-muted">Error</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {parseResult.errors.map((e, i) => (
+                        <tr key={i} className="border-b border-border/40 last:border-0">
+                          <td className="px-3 py-1.5 font-mono text-text-muted">{e.rowIndex}</td>
+                          <td className="px-3 py-1.5 font-mono text-text-primary">{e.field}</td>
+                          <td className="px-3 py-1.5 text-accent-dark">{e.message}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+                {parseResult.splits.length > 0 && (
+                  <p className="text-xs text-text-muted">
+                    {parseResult.splits.length} split{parseResult.splits.length !== 1 ? "s" : ""} parsed successfully (with errors above).
+                  </p>
+                )}
+              </div>
+            ) : (
+              <p className="text-sm text-text-primary">
+                Ready to import{" "}
+                <span className="font-semibold">{parseResult.splits.length}</span>{" "}
+                split{parseResult.splits.length !== 1 ? "s" : ""}.
+              </p>
+            )}
+
+            {importError && <ErrorAlert>{importError}</ErrorAlert>}
+
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={handleImport}
+                disabled={parseResult.splits.length === 0}
+                className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-dark disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Import
+              </button>
+              <button
+                type="button"
+                onClick={reset}
+                className="rounded-md border border-border px-4 py-2 text-sm font-medium text-text-primary transition-colors hover:bg-primary-light/15 disabled:opacity-50"
+              >
+                Cancel
+              </button>
+            </div>
+          </div>
+        )}
+
+        {phase === "processing" && (
+          <div className="flex flex-col items-center gap-3 py-6">
+            <svg
+              className="h-8 w-8 animate-spin text-primary"
+              viewBox="0 0 24 24"
+              fill="none"
+            >
+              <circle
+                className="opacity-25"
+                cx="12"
+                cy="12"
+                r="10"
+                stroke="currentColor"
+                strokeWidth="3"
+              />
+              <path
+                className="opacity-75"
+                fill="currentColor"
+                d="M4 12a8 8 0 018-8v3a5 5 0 00-5 5H4z"
+              />
+            </svg>
+            <p className="text-sm text-text-muted">
+              {jobStatus && jobStatus.totalCount > 0
+                ? `Processed ${jobStatus.processedCount.toLocaleString()} of ${jobStatus.totalCount.toLocaleString()} splits\u2026`
+                : "Processing\u2026"}
+            </p>
+          </div>
+        )}
+
+        {phase === "result" && jobStatus && (
+          <div className="space-y-4">
+            {jobStatus.status === JobStatus.SUCCESS ? (
+              <p className="text-sm text-text-primary">
+                Import complete:{" "}
+                <span className="font-semibold">{jobStatus.processedCount.toLocaleString()}</span>{" "}
+                split{jobStatus.processedCount !== 1 ? "s" : ""} processed.
+              </p>
+            ) : (
+              <p className="text-sm text-accent-dark font-medium">
+                Import failed.
+              </p>
+            )}
+
+            {jobStatus.validationErrors.length > 0 && (
+              <div className="space-y-2">
+                <p className="text-sm font-medium text-accent-dark">
+                  {jobStatus.validationErrors.length} error{jobStatus.validationErrors.length !== 1 ? "s" : ""}
+                </p>
+                <div className="max-h-48 overflow-y-auto rounded-md border border-border bg-surface">
+                  <table className="w-full border-collapse text-xs">
+                    <thead>
+                      <tr className="border-b border-border bg-primary-dark/[0.03]">
+                        <th className="px-3 py-2 text-left font-semibold uppercase tracking-wider text-text-muted">Row</th>
+                        <th className="px-3 py-2 text-left font-semibold uppercase tracking-wider text-text-muted">Field</th>
+                        <th className="px-3 py-2 text-left font-semibold uppercase tracking-wider text-text-muted">Error</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {jobStatus.validationErrors.map((e, i) => (
+                        <tr key={i} className="border-b border-border/40 last:border-0">
+                          <td className="px-3 py-1.5 font-mono text-text-muted">{e.rowIndex}</td>
+                          <td className="px-3 py-1.5 font-mono text-text-primary">{e.field}</td>
+                          <td className="px-3 py-1.5 text-accent-dark">{e.message}</td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            )}
+
+            <button
+              type="button"
+              onClick={handleDone}
+              className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-dark"
+            >
+              Done
+            </button>
+          </div>
+        )}
+      </div>
+    </Modal>
+  );
+}

--- a/client/app/admin/corporate-events/splits-tab.tsx
+++ b/client/app/admin/corporate-events/splits-tab.tsx
@@ -1,16 +1,11 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { ErrorAlert } from "@/app/components/error-alert";
+import { exportCorporateEvents } from "@/lib/portfolio-api";
+import { splitsToJson } from "@/lib/json/corporate-events";
 import type { ExportCorporateEventRow } from "@/gen/api/v1/api_pb";
-import {
-  exportCorporateEvents,
-  importCorporateEventSplits,
-  getJob,
-  type GetJobResult,
-} from "@/lib/portfolio-api";
-import { JobStatus } from "@/gen/api/v1/api_pb";
-import { splitsToJson, parseSplitsJson } from "@/lib/json/corporate-events";
+import { ImportSplitsModal } from "./import-splits-modal";
 
 interface SplitDisplay {
   identifierType: string;
@@ -27,10 +22,7 @@ export function SplitsTab() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [exportLoading, setExportLoading] = useState(false);
-  const [importJsonError, setImportJsonError] = useState<string | null>(null);
-  const [importJobId, setImportJobId] = useState<string | null>(null);
-  const [importJobStatus, setImportJobStatus] = useState<GetJobResult | null>(null);
-  const fileRef = useRef<HTMLInputElement>(null);
+  const [importOpen, setImportOpen] = useState(false);
 
   const loadSplits = useCallback(async () => {
     setLoading(true);
@@ -86,64 +78,6 @@ export function SplitsTab() {
     }
   }
 
-  function handleJsonFileChange(e: React.ChangeEvent<HTMLInputElement>) {
-    const f = e.target.files?.[0];
-    if (!f) return;
-    setImportJsonError(null);
-    const reader = new FileReader();
-    reader.onload = async (ev) => {
-      const text = (ev.target?.result as string) ?? "";
-      const result = parseSplitsJson(text);
-      if (result.errors.length > 0) {
-        setImportJsonError(result.errors.map((e) => `Row ${e.rowIndex}: ${e.field} - ${e.message}`).join("\n"));
-        if (fileRef.current) fileRef.current.value = "";
-        return;
-      }
-      if (result.splits.length === 0) {
-        setImportJsonError("No splits found in file.");
-        if (fileRef.current) fileRef.current.value = "";
-        return;
-      }
-      try {
-        const jobId = await importCorporateEventSplits(result.splits);
-        setImportJobId(jobId);
-      } catch (err) {
-        setImportJsonError(err instanceof Error ? err.message : String(err));
-      }
-      if (fileRef.current) fileRef.current.value = "";
-    };
-    reader.readAsText(f);
-  }
-
-  // Poll JSON import job.
-  useEffect(() => {
-    if (!importJobId) return;
-    let cancelled = false;
-    const poll = async () => {
-      try {
-        const result = await getJob(importJobId);
-        if (cancelled) return;
-        setImportJobStatus(result);
-        if (result.status === JobStatus.SUCCESS || result.status === JobStatus.FAILED) {
-          if (result.status === JobStatus.SUCCESS) loadSplits();
-          setImportJobId(null);
-        }
-      } catch {
-        // Ignore transient poll errors.
-      }
-    };
-    poll();
-    const t = setInterval(poll, 2000);
-    return () => {
-      cancelled = true;
-      clearInterval(t);
-    };
-  }, [importJobId, loadSplits]);
-
-  function dismissJobStatus() {
-    setImportJobStatus(null);
-  }
-
   return (
     <div className="mt-4 space-y-4">
       <div className="flex flex-wrap items-end gap-3">
@@ -156,16 +90,13 @@ export function SplitsTab() {
           >
             {exportLoading ? "Exporting..." : "Export JSON"}
           </button>
-          <label className="cursor-pointer rounded-md border border-border bg-surface px-3 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-primary-light/15">
+          <button
+            type="button"
+            onClick={() => setImportOpen(true)}
+            className="rounded-md border border-border bg-surface px-3 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-primary-light/15"
+          >
             Import JSON
-            <input
-              ref={fileRef}
-              type="file"
-              accept=".json"
-              onChange={handleJsonFileChange}
-              className="sr-only"
-            />
-          </label>
+          </button>
         </div>
       </div>
 
@@ -175,38 +106,11 @@ export function SplitsTab() {
         </div>
       )}
 
-      {importJsonError && (
-        <div className="mt-2">
-          <ErrorAlert>{importJsonError}</ErrorAlert>
-        </div>
-      )}
-
-      {importJobId && (
-        <p className="mt-2 text-sm text-text-muted">
-          Importing...{importJobStatus && importJobStatus.totalCount > 0
-            ? ` ${importJobStatus.processedCount} of ${importJobStatus.totalCount}`
-            : ""}
-        </p>
-      )}
-
-      {importJobStatus && !importJobId && (
-        <div className="mt-2 flex items-center gap-2 text-sm">
-          {importJobStatus.status === JobStatus.SUCCESS ? (
-            <span className="text-text-primary">
-              Import complete: {importJobStatus.processedCount} event{importJobStatus.processedCount !== 1 ? "s" : ""} processed.
-            </span>
-          ) : (
-            <span className="text-accent-dark">Import failed.</span>
-          )}
-          <button
-            type="button"
-            onClick={dismissJobStatus}
-            className="text-xs text-text-muted underline hover:text-text-primary"
-          >
-            Dismiss
-          </button>
-        </div>
-      )}
+      <ImportSplitsModal
+        open={importOpen}
+        onClose={() => setImportOpen(false)}
+        onComplete={loadSplits}
+      />
 
       {loading ? (
         <p className="mt-4 text-text-muted">Loading splits...</p>
@@ -239,7 +143,6 @@ export function SplitsTab() {
           </tbody>
         </table>
       )}
-
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Extract splits import flow from inline UI into a dedicated `ImportSplitsModal` component
- Follow the same phased modal pattern used by price and transaction imports (idle → preview → processing → result)
- Add animated spinner with "Processed X of Y splits" progress text during processing
- Show parse errors in a scrollable table and validation errors on result, matching price import style
- Simplify `SplitsTab` by removing inline import state, polling logic, and dismiss UI

## Test plan
- [ ] Open Corporate Events > Splits tab
- [ ] Click "Import JSON" — verify modal opens with file chooser
- [ ] Select a valid splits JSON file — verify preview shows split count with Import/Cancel buttons
- [ ] Select an invalid JSON file — verify parse errors display in table format
- [ ] Click Import — verify spinner and progress text appear, modal cannot be closed during processing
- [ ] On success — verify result message with Done button, clicking Done refreshes the splits table
- [ ] On failure — verify error message and validation error table display
- [ ] Verify Export JSON still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)