### PR TITLE
Add exported_at to price export/import for split adjustment

### DIFF
--- a/client/app/admin/prices/import-modal.tsx
+++ b/client/app/admin/prices/import-modal.tsx
@@ -68,7 +68,7 @@ export function ImportPricesModal({
     setPhase("processing");
     setImportError(null);
     try {
-      const id = await importPrices(parseResult.prices);
+      const id = await importPrices(parseResult.prices, parseResult.exportedAt);
       setJobId(id);
     } catch (err) {
       setImportError(err instanceof Error ? err.message : String(err));

--- a/client/app/admin/prices/page.tsx
+++ b/client/app/admin/prices/page.tsx
@@ -94,10 +94,14 @@ function PriceListTab() {
     setExportError(null);
     try {
       const rows: ExportPriceRow[] = [];
+      let exportedAt: Date | undefined;
       for await (const row of exportPrices()) {
+        if (!exportedAt && row.exportedAt) {
+          exportedAt = timestampDate(row.exportedAt);
+        }
         rows.push(row);
       }
-      const csv = pricesToCsv(rows);
+      const csv = pricesToCsv(rows, exportedAt);
       const blob = new Blob([csv], { type: "text/csv" });
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");

--- a/client/lib/csv/prices.test.ts
+++ b/client/lib/csv/prices.test.ts
@@ -29,6 +29,21 @@ describe("pricesToCsv", () => {
     expect(lines[1]).toContain("185.9");
   });
 
+  it("prepends exported_at comment line when date provided", () => {
+    const exportedAt = new Date("2025-07-15T10:30:00.000Z");
+    const csv = pricesToCsv([makeRow()], exportedAt);
+    const lines = csv.split("\n");
+    expect(lines[0]).toBe("# exported_at=2025-07-15T10:30:00.000Z");
+    expect(lines[1]).toBe(
+      "identifier_type,identifier_value,identifier_domain,price_date,open,high,low,close,adjusted_close,volume,asset_class"
+    );
+  });
+
+  it("omits comment line when no exportedAt provided", () => {
+    const csv = pricesToCsv([makeRow()]);
+    expect(csv.startsWith("#")).toBe(false);
+  });
+
   it("includes optional fields when present", () => {
     const csv = pricesToCsv([
       makeRow({ open: 185.5, high: 186.2, low: 184.8, adjustedClose: 185.9, volume: 50000000n, assetClass: AssetClass.STOCK }),
@@ -170,10 +185,12 @@ describe("csvToPrices", () => {
       makeRow({ open: 185.5, high: 186.2, low: 184.8, adjustedClose: 185.9, volume: 50000000n }),
       makeRow({ identifierType: "MIC_TICKER", identifierValue: "AAPL", identifierDomain: "XNAS", priceDate: "2024-01-16", close: 186.5 }),
     ];
-    const csv = pricesToCsv(original);
+    const exportedAt = new Date("2025-07-15T10:30:00.000Z");
+    const csv = pricesToCsv(original, exportedAt);
     const result = csvToPrices(csv);
     expect(result.errors).toHaveLength(0);
     expect(result.prices).toHaveLength(2);
+    expect(result.exportedAt).toEqual(exportedAt);
     expect(result.prices[0].identifierType).toBe("ISIN");
     expect(result.prices[0].close).toBe(185.9);
     expect(result.prices[0].open).toBe(185.5);
@@ -182,6 +199,28 @@ describe("csvToPrices", () => {
     expect(result.prices[1].identifierDomain).toBe("XNAS");
     expect(result.prices[1].close).toBe(186.5);
     expect(result.prices[1].open).toBeUndefined();
+  });
+
+  it("extracts exported_at from comment line", () => {
+    const csv = `# exported_at=2025-07-15T10:30:00.000Z\n${HEADER}\nISIN,US0378331005,,2024-01-15,,,,185.9,,`;
+    const result = csvToPrices(csv);
+    expect(result.errors).toHaveLength(0);
+    expect(result.prices).toHaveLength(1);
+    expect(result.exportedAt).toEqual(new Date("2025-07-15T10:30:00.000Z"));
+  });
+
+  it("returns undefined exportedAt when no comment line", () => {
+    const csv = `${HEADER}\nISIN,US0378331005,,2024-01-15,,,,185.9,,`;
+    const result = csvToPrices(csv);
+    expect(result.exportedAt).toBeUndefined();
+  });
+
+  it("ignores unknown comment lines", () => {
+    const csv = `# some other comment\n${HEADER}\nISIN,US0378331005,,2024-01-15,,,,185.9,,`;
+    const result = csvToPrices(csv);
+    expect(result.errors).toHaveLength(0);
+    expect(result.prices).toHaveLength(1);
+    expect(result.exportedAt).toBeUndefined();
   });
 
   it("handles empty input", () => {

--- a/client/lib/csv/prices.ts
+++ b/client/lib/csv/prices.ts
@@ -29,7 +29,7 @@ function fmtOptBigint(v: bigint | undefined): string {
 }
 
 /** Serialize ExportPriceRow[] to CSV text. */
-export function pricesToCsv(rows: ExportPriceRow[]): string {
+export function pricesToCsv(rows: ExportPriceRow[], exportedAt?: Date): string {
   const data = rows.map((r) => [
     r.identifierType,
     r.identifierValue,
@@ -43,12 +43,17 @@ export function pricesToCsv(rows: ExportPriceRow[]): string {
     fmtOptBigint(r.volume),
     assetClassToStr(r.assetClass),
   ]);
-  return Papa.unparse({ fields: HEADER.split(","), data }, { newline: "\n" }) + "\n";
+  const csv = Papa.unparse({ fields: HEADER.split(","), data }, { newline: "\n" }) + "\n";
+  if (exportedAt) {
+    return `# exported_at=${exportedAt.toISOString()}\n${csv}`;
+  }
+  return csv;
 }
 
 export interface PriceParseResult {
   prices: ImportPriceRow[];
   errors: ParseError[];
+  exportedAt?: Date;
 }
 
 /** Parse CSV text into ImportPriceRow[] with validation. */
@@ -56,10 +61,26 @@ export function csvToPrices(text: string): PriceParseResult {
   const prices: ImportPriceRow[] = [];
   const errors: ParseError[] = [];
 
-  const parsed = Papa.parse<string[]>(text, { header: false, skipEmptyLines: true });
+  // Extract metadata from comment lines and strip them before parsing.
+  let exportedAt: Date | undefined;
+  const dataLines: string[] = [];
+  for (const line of text.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("# exported_at=")) {
+      const d = new Date(trimmed.slice("# exported_at=".length));
+      if (!isNaN(d.getTime())) exportedAt = d;
+    } else if (trimmed.startsWith("#")) {
+      continue;
+    } else {
+      dataLines.push(line);
+    }
+  }
+  const csvText = dataLines.join("\n");
+
+  const parsed = Papa.parse<string[]>(csvText, { header: false, skipEmptyLines: true });
   const rows = parsed.data;
   if (rows.length === 0) {
-    return { prices, errors };
+    return { prices, errors, exportedAt };
   }
 
   const headerFields = rows[0].map((h) => h.trim().toLowerCase());
@@ -75,7 +96,7 @@ export function csvToPrices(text: string): PriceParseResult {
     }
   }
   if (errors.length > 0) {
-    return { prices, errors };
+    return { prices, errors, exportedAt };
   }
 
   for (let i = 1; i < rows.length; i++) {
@@ -181,5 +202,5 @@ export function csvToPrices(text: string): PriceParseResult {
     prices.push(row);
   }
 
-  return { prices, errors };
+  return { prices, errors, exportedAt };
 }

--- a/client/lib/portfolio-api.ts
+++ b/client/lib/portfolio-api.ts
@@ -638,9 +638,12 @@ export async function* exportPrices(): AsyncGenerator<ExportPriceRow> {
 }
 
 /** Import (upsert) prices (admin only). Returns a job ID for async processing. */
-export async function importPrices(prices: ImportPriceRow[]): Promise<string> {
+export async function importPrices(prices: ImportPriceRow[], exportedAt?: Date): Promise<string> {
   const base = getBaseUrl();
-  const req = create(ImportPricesRequestSchema, { prices });
+  const req = create(ImportPricesRequestSchema, {
+    prices,
+    exportedAt: exportedAt ? timestampFromDate(exportedAt) : undefined,
+  });
   const resBytes = await unaryFetch(base, ApiServicePrefix + "ImportPrices", toBinary(ImportPricesRequestSchema, req), { credentials: "include" });
   const res = fromBinary(ImportPricesResponseSchema, resBytes);
   return res.jobId;

--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -673,6 +673,7 @@ message ExportPriceRow {
   optional double adjusted_close = 9;
   optional int64 volume = 10;
   AssetClass asset_class = 11;   // denormalized from instrument
+  google.protobuf.Timestamp exported_at = 12; // when the export was generated
 }
 
 // ImportPriceRow is one price row to import. When the instrument is unknown, asset_class
@@ -698,6 +699,10 @@ message ImportPricesRequest {
   // UpsertPricesWithFill to generate synthetic LOCF prices for non-trading
   // days within each range. When absent, prices are upserted as-is.
   repeated ImportCoverage coverage = 2;
+  // When set, used as hintsValidAt for split adjustment during instrument
+  // resolution. OCC symbols in the file are assumed valid as of this time;
+  // any splits with ex_date after this and on or before today are applied.
+  google.protobuf.Timestamp exported_at = 3;
 }
 
 // ImportCoverage declares that the caller intends to cover a date range for

--- a/server/service/api/prices.go
+++ b/server/service/api/prices.go
@@ -81,8 +81,10 @@ func (s *Server) ExportPrices(req *apiv1.ExportPricesRequest, stream apiv1.ApiSe
 	if err != nil {
 		return status.Error(codes.Internal, err.Error())
 	}
+	now := timestamppb.Now()
 	for _, r := range rows {
 		row := &apiv1.ExportPriceRow{
+			ExportedAt:       now,
 			IdentifierType:   r.IdentifierType,
 			IdentifierValue:  r.IdentifierValue,
 			IdentifierDomain: r.IdentifierDomain,

--- a/server/service/ingestion/corporate_event_worker.go
+++ b/server/service/ingestion/corporate_event_worker.go
@@ -176,7 +176,7 @@ func resolveCorporateEventRow(ctx context.Context, database db.DB, pluginRegistr
 	}
 	acStr := db.AssetClassToStr(row.GetAssetClass())
 	instID, err := resolveOrIdentifyInstrument(ctx, database, pluginRegistry,
-		row.GetIdentifierType(), row.GetIdentifierDomain(), row.GetIdentifierValue(), acStr)
+		row.GetIdentifierType(), row.GetIdentifierDomain(), row.GetIdentifierValue(), acStr, nil)
 	cache[key] = &resolveEntry{instID: instID, err: err}
 	return instID, err
 }
@@ -290,7 +290,7 @@ func writeImportCoverage(ctx context.Context, database db.DB, coverage []*apiv1.
 			// plugin registry is passed through so the resolution rules
 			// match the per-event resolution above.
 			instID, rerr := resolveOrIdentifyInstrument(ctx, database, pluginRegistry,
-				c.GetIdentifierType(), c.GetIdentifierDomain(), c.GetIdentifierValue(), "")
+				c.GetIdentifierType(), c.GetIdentifierDomain(), c.GetIdentifierValue(), "", nil)
 			entry = &resolveEntry{instID: instID, err: rerr}
 			cache[key] = entry
 		}

--- a/server/service/ingestion/price_worker.go
+++ b/server/service/ingestion/price_worker.go
@@ -42,6 +42,14 @@ func processPriceImport(ctx context.Context, database db.DB, pluginRegistry *ide
 		return false
 	}
 
+	var hintsValidAt *time.Time
+	if req.GetExportedAt() != nil {
+		t := req.GetExportedAt().AsTime()
+		hintsValidAt = &t
+	} else {
+		slog.Warn("price import missing exported_at; OCC symbols will not be split-adjusted", "job_id", j.JobID)
+	}
+
 	rows := req.GetPrices()
 	_ = database.SetJobTotalCount(ctx, j.JobID, int32(len(rows)))
 
@@ -78,7 +86,7 @@ func processPriceImport(ctx context.Context, database db.DB, pluginRegistry *ide
 		entry, cached := resolveCache[cacheKey]
 		if !cached {
 			acStr := db.AssetClassToStr(row.GetAssetClass())
-			instID, resolveErr := resolveOrIdentifyInstrument(ctx, database, pluginRegistry, row.GetIdentifierType(), row.GetIdentifierDomain(), row.GetIdentifierValue(), acStr)
+			instID, resolveErr := resolveOrIdentifyInstrument(ctx, database, pluginRegistry, row.GetIdentifierType(), row.GetIdentifierDomain(), row.GetIdentifierValue(), acStr, hintsValidAt)
 			entry = &resolveEntry{instID: instID, err: resolveErr}
 			resolveCache[cacheKey] = entry
 		}
@@ -215,7 +223,7 @@ func upsertWithCoverage(ctx context.Context, database db.DB, prices []db.EODPric
 }
 
 // resolveOrIdentifyInstrument finds an instrument by identifier, or creates one.
-func resolveOrIdentifyInstrument(ctx context.Context, database db.DB, pluginRegistry *identifier.Registry, idType, domain, value, assetClass string) (string, error) {
+func resolveOrIdentifyInstrument(ctx context.Context, database db.DB, pluginRegistry *identifier.Registry, idType, domain, value, assetClass string, hintsValidAt *time.Time) (string, error) {
 	hint := identifier.Identifier{Type: idType, Domain: domain, Value: value}
 
 	if assetClass != "" && pluginRegistry != nil {
@@ -226,7 +234,7 @@ func resolveOrIdentifyInstrument(ctx context.Context, database db.DB, pluginRegi
 		result, err := identification.ResolveWithPlugins(ctx, database, pluginRegistry,
 			"", "", "", hints,
 			[]identifier.Identifier{hint},
-			false, fallback, nil, nil, 0, nil)
+			false, fallback, nil, nil, 0, hintsValidAt)
 		if err != nil {
 			return "", fmt.Errorf("identification error for %s %q: %v", idType, value, err)
 		}


### PR DESCRIPTION
## Summary

- Price CSV exports now include a `# exported_at=<ISO8601>` comment line with the export timestamp
- On import, `exported_at` is threaded through as `hintsValidAt` to `AdjustOCCForKnownSplits()`, so OCC option symbols are split-adjusted for any splits with ex_date after the export time
- Imports without `exported_at` log a server warning and skip split adjustment (backward compatible with existing CSV files)

## Test plan

- [x] Server unit tests pass (`make server-test`)
- [x] Client unit tests pass (`make client-test`) — 3 new CSV tests for comment line serialization, parsing, and round-trip
- [ ] Manual: export prices, verify `# exported_at=` line appears in CSV
- [ ] Manual: import CSV with OCC option where a split exists after `exported_at` — verify OCC is adjusted
- [ ] Manual: import CSV without `# exported_at=` — verify existing behavior (no adjustment, warning logged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)