### PR TITLE
Exclude CASH and FX instruments from export

### DIFF
--- a/server/db/db.go
+++ b/server/db/db.go
@@ -567,7 +567,7 @@ type InstrumentDB interface {
 	GetInstrument(ctx context.Context, instrumentID string) (*InstrumentRow, error)
 	// ListInstrumentsByIDs returns instruments by ID slice (for batch underlying lookup). Missing IDs are omitted; order not guaranteed.
 	ListInstrumentsByIDs(ctx context.Context, ids []string) ([]*InstrumentRow, error)
-	// ListInstrumentsForExport returns all instruments that have at least one identifier with canonical = true. If exchangeFilter != "", filter by instruments.exchange_mic. Order by instruments.id.
+	// ListInstrumentsForExport returns all instruments that have at least one identifier with canonical = true. Excludes CASH and FX asset classes (reference data). If exchangeFilter != "", filter by instruments.exchange_mic. Order by instruments.id.
 	ListInstrumentsForExport(ctx context.Context, exchangeFilter string) ([]*InstrumentRow, error)
 	// ValidateMIC checks whether the given MIC code exists in the exchanges reference table.
 	ValidateMIC(ctx context.Context, mic string) (bool, error)

--- a/server/db/postgres/instruments.go
+++ b/server/db/postgres/instruments.go
@@ -227,6 +227,7 @@ func (p *Postgres) ListInstrumentsForExport(ctx context.Context, exchangeFilter 
 			FROM instruments i
 			LEFT JOIN exchanges e ON e.mic = i.exchange_mic
 			WHERE EXISTS (SELECT 1 FROM instrument_identifiers ii WHERE ii.instrument_id = i.id AND ii.canonical = true)
+			AND i.asset_class NOT IN ('CASH', 'FX')
 			AND i.exchange_mic = $1
 			ORDER BY i.id
 		`, exchangeFilter)
@@ -237,6 +238,7 @@ func (p *Postgres) ListInstrumentsForExport(ctx context.Context, exchangeFilter 
 			FROM instruments i
 			LEFT JOIN exchanges e ON e.mic = i.exchange_mic
 			WHERE EXISTS (SELECT 1 FROM instrument_identifiers ii WHERE ii.instrument_id = i.id AND ii.canonical = true)
+			AND i.asset_class NOT IN ('CASH', 'FX')
 			ORDER BY i.id
 		`)
 	}

--- a/server/db/postgres/instruments_test.go
+++ b/server/db/postgres/instruments_test.go
@@ -131,7 +131,7 @@ func TestListInstrumentsForExport_ExcludesBrokerDescriptionOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListInstrumentsForExport: %v", err)
 	}
-	// List includes seeded CASH instruments (migration 002) plus any we create; broker-only must be excluded.
+	// List excludes seeded CASH/FX instruments (reference data); broker-only must also be excluded.
 	var foundApple bool
 	for _, row := range list {
 		if row.ID == brokerOnlyID {
@@ -164,7 +164,7 @@ func TestListInstrumentsForExport_ExchangeFilter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListInstrumentsForExport: %v", err)
 	}
-	// XNAS filter: seeded CASH instruments have exchange NULL so only our Nasdaq instrument matches.
+	// XNAS filter: only our Nasdaq STOCK instrument matches (CASH/FX excluded).
 	if len(list) != 1 || list[0].ExchangeMIC == nil || *list[0].ExchangeMIC != "XNAS" {
 		var ex string
 		if len(list) > 0 && list[0].ExchangeMIC != nil {
@@ -176,9 +176,9 @@ func TestListInstrumentsForExport_ExchangeFilter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ListInstrumentsForExport all: %v", err)
 	}
-	// No filter: seeded CASH instruments (canonical CURRENCY) plus our 2 STOCK instruments.
-	if len(listAll) < 2 {
-		t.Fatalf("expected at least 2 instruments with no filter, got %d", len(listAll))
+	// No filter: CASH/FX excluded, so only our 2 STOCK instruments.
+	if len(listAll) != 2 {
+		t.Fatalf("expected 2 instruments with no filter, got %d", len(listAll))
 	}
 	var foundNasdaq, foundNYSE bool
 	for _, row := range listAll {


### PR DESCRIPTION
## Summary
- Exclude instruments with asset class CASH or FX from `ListInstrumentsForExport` since they are populated by reference data (seed migrations)
- Added `NOT IN ('CASH', 'FX')` filter to both SQL queries (with and without exchange filter)
- Updated DB integration tests to reflect the exclusion

## Test plan
- [x] Unit tests pass (`make server-test`)
- [x] DB integration tests pass (`make db-test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)