### PR TITLE
Restrict Air watch directories to server and proto

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -6,7 +6,7 @@ tmp_dir = "tmp"
   cmd = "buf generate --template buf.gen.go.yaml && go build -o /tmp/portfoliodb ./server/cmd/portfoliodb"
   entrypoint = ["/tmp/portfoliodb", "-grpc-addr", ":50051", "-db-url", "postgres://portfoliodb:portfoliodb@postgres:5432/portfoliodb?sslmode=disable"]
   include_ext = ["go", "proto", "mod", "sum", "yaml", "yml"]
-  include_dir = [".", "server", "proto"]
+  include_dir = ["server", "proto"]
   exclude_dir = ["tmp", "vendor", "testdata", ".git", "client"]
   exclude_regex = ["_test\\.go", "\\.pb\\.go$"]
   delay = 1000


### PR DESCRIPTION
## Summary
- Remove `"."` from Air's `include_dir` config, keeping only `server` and `proto`
- Prevents Air from recursively watching irrelevant directories (e2e/node_modules, docs, local, etc.) on dev server start

## Test plan
- [ ] Start dev server and verify Air only watches server/ and proto/ subdirectories
- [ ] Verify live-reload still triggers on Go and proto file changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)