### PR TITLE
Use exported_at as fetched_at for imported prices

### DIFF
--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -699,9 +699,10 @@ message ImportPricesRequest {
   // UpsertPricesWithFill to generate synthetic LOCF prices for non-trading
   // days within each range. When absent, prices are upserted as-is.
   repeated ImportCoverage coverage = 2;
-  // When set, used as hintsValidAt for split adjustment during instrument
-  // resolution. OCC symbols in the file are assumed valid as of this time;
-  // any splits with ex_date after this and on or before today are applied.
+  // When set, used as pricesAsOf: prices and identifiers in the file are
+  // assumed current as of this time. OCC symbols are split-adjusted during
+  // instrument resolution, and imported price rows use this as fetched_at
+  // so that splits with ex_date after this timestamp are applied.
   google.protobuf.Timestamp exported_at = 3;
 }
 

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -91,7 +91,8 @@ type EODPrice struct {
 	Close        float64
 	Volume       *int64
 	DataProvider string
-	Synthetic    bool // true for forward-filled non-trading day prices
+	Synthetic    bool       // true for forward-filled non-trading day prices
+	FetchedAt    *time.Time // when the price data was current; nil defaults to now()
 }
 
 // PriceCacheDB provides price cache management.
@@ -114,7 +115,7 @@ type PriceCacheDB interface {
 	// UpsertPricesWithFill inserts real bars and generates synthetic LOCF prices
 	// for every date in [from, to) that has no real bar, all in a single SQL
 	// statement. The last non-synthetic close before `from` seeds the forward-fill.
-	UpsertPricesWithFill(ctx context.Context, instrumentID, provider string, bars []EODPrice, from, to time.Time) error
+	UpsertPricesWithFill(ctx context.Context, instrumentID, provider string, bars []EODPrice, from, to time.Time, fetchedAt *time.Time) error
 }
 
 // PluginConfigDB provides unified plugin config CRUD for all categories.

--- a/server/db/postgres/price_cache.go
+++ b/server/db/postgres/price_cache.go
@@ -414,6 +414,8 @@ func (p *Postgres) UpsertPrices(ctx context.Context, prices []db.EODPrice) error
 	volumes := make([]*int64, len(prices))
 	providers := make([]string, len(prices))
 	synthetics := make([]bool, len(prices))
+	fetchedAts := make([]time.Time, len(prices))
+	now := time.Now()
 
 	for i, pr := range prices {
 		instIDs[i] = pr.InstrumentID
@@ -425,6 +427,11 @@ func (p *Postgres) UpsertPrices(ctx context.Context, prices []db.EODPrice) error
 		volumes[i] = pr.Volume
 		providers[i] = pr.DataProvider
 		synthetics[i] = pr.Synthetic
+		if pr.FetchedAt != nil {
+			fetchedAts[i] = *pr.FetchedAt
+		} else {
+			fetchedAts[i] = now
+		}
 	}
 
 	_, err := p.q.ExecContext(ctx, `
@@ -432,7 +439,8 @@ func (p *Postgres) UpsertPrices(ctx context.Context, prices []db.EODPrice) error
 		SELECT unnest($1::uuid[]), unnest($2::date[]), unnest($3::double precision[]),
 			unnest($4::double precision[]), unnest($5::double precision[]),
 			unnest($6::double precision[]), unnest($7::bigint[]),
-			unnest($8::text[]), unnest($9::boolean[]), now()
+			unnest($8::text[]), unnest($9::boolean[]),
+			unnest($10::timestamptz[])
 		ON CONFLICT (instrument_id, price_date) DO UPDATE SET
 			open = EXCLUDED.open,
 			high = EXCLUDED.high,
@@ -445,7 +453,8 @@ func (p *Postgres) UpsertPrices(ctx context.Context, prices []db.EODPrice) error
 		WHERE eod_prices.synthetic = true OR EXCLUDED.synthetic = false
 	`, pq.Array(instIDs), pq.Array(dates), pq.Array(opens),
 		pq.Array(highs), pq.Array(lows), pq.Array(closes),
-		pq.Array(volumes), pq.Array(providers), pq.Array(synthetics))
+		pq.Array(volumes), pq.Array(providers), pq.Array(synthetics),
+		pq.Array(fetchedAts))
 	if err != nil {
 		return fmt.Errorf("upsert prices: %w", err)
 	}
@@ -457,10 +466,15 @@ func (p *Postgres) UpsertPrices(ctx context.Context, prices []db.EODPrice) error
 // [from, to) that has no real bar, all in a single SQL round-trip. The last
 // non-synthetic close price before `from` seeds the forward-fill for dates
 // preceding the first real bar.
-func (p *Postgres) UpsertPricesWithFill(ctx context.Context, instrumentID, provider string, bars []db.EODPrice, from, to time.Time) error {
+func (p *Postgres) UpsertPricesWithFill(ctx context.Context, instrumentID, provider string, bars []db.EODPrice, from, to time.Time, fetchedAt *time.Time) error {
 	id, err := uuid.Parse(instrumentID)
 	if err != nil {
 		return fmt.Errorf("upsert prices with fill: invalid id %q: %w", instrumentID, err)
+	}
+
+	if fetchedAt == nil {
+		now := time.Now()
+		fetchedAt = &now
 	}
 
 	// Deduplicate bars by date, keeping the last occurrence.
@@ -534,7 +548,7 @@ func (p *Postgres) UpsertPricesWithFill(ctx context.Context, instrumentID, provi
 			FROM grouped
 		)
 		INSERT INTO eod_prices (instrument_id, price_date, open, high, low, close, volume, data_provider, synthetic, fetched_at)
-		SELECT $1::uuid, price_date, open, high, low, close, volume, $10::text, synthetic, now()
+		SELECT $1::uuid, price_date, open, high, low, close, volume, $10::text, synthetic, $11::timestamptz
 		FROM locf
 		WHERE price_date >= $2::date AND close IS NOT NULL
 		ON CONFLICT (instrument_id, price_date) DO UPDATE SET
@@ -544,7 +558,7 @@ func (p *Postgres) UpsertPricesWithFill(ctx context.Context, instrumentID, provi
 			fetched_at = EXCLUDED.fetched_at
 		WHERE eod_prices.synthetic = true OR EXCLUDED.synthetic = false
 	`, id, from, to, pq.Array(dates), pq.Array(opens), pq.Array(highs),
-		pq.Array(lows), pq.Array(closes), pq.Array(volumes), provider)
+		pq.Array(lows), pq.Array(closes), pq.Array(volumes), provider, fetchedAt)
 	if err != nil {
 		return fmt.Errorf("upsert prices with fill: %w", err)
 	}

--- a/server/db/postgres/price_cache_test.go
+++ b/server/db/postgres/price_cache_test.go
@@ -718,7 +718,7 @@ func TestUpsertPricesWithFill_BasicWeekend(t *testing.T) {
 		{InstrumentID: instID, PriceDate: mon.AddDate(0, 0, 4), Close: 106.0}, // Fri
 	}
 	to := mon.AddDate(0, 0, 7)
-	err := p.UpsertPricesWithFill(ctx, instID, "test", bars, mon, to)
+	err := p.UpsertPricesWithFill(ctx, instID, "test", bars, mon, to, nil)
 	if err != nil {
 		t.Fatalf("upsert with fill: %v", err)
 	}
@@ -773,7 +773,7 @@ func TestUpsertPricesWithFill_SeedFromDB(t *testing.T) {
 	// Gap fill Sat-Mon with no new bars (seed from Friday's close).
 	from := d(2024, 1, 6) // Sat
 	to := d(2024, 1, 9)   // Tue (exclusive)
-	err := p.UpsertPricesWithFill(ctx, instID, "test", nil, from, to)
+	err := p.UpsertPricesWithFill(ctx, instID, "test", nil, from, to, nil)
 	if err != nil {
 		t.Fatalf("upsert with fill: %v", err)
 	}
@@ -803,7 +803,7 @@ func TestUpsertPricesWithFill_NoSeedNoBars(t *testing.T) {
 	instID := setupInstrument(t, p, "FILL3")
 
 	// No seed, no bars — nothing should be inserted.
-	err := p.UpsertPricesWithFill(ctx, instID, "test", nil, d(2024, 1, 1), d(2024, 1, 4))
+	err := p.UpsertPricesWithFill(ctx, instID, "test", nil, d(2024, 1, 1), d(2024, 1, 4), nil)
 	if err != nil {
 		t.Fatalf("upsert with fill: %v", err)
 	}
@@ -825,7 +825,7 @@ func TestUpsertPricesWithFill_NoSeedAtStart(t *testing.T) {
 	bars := []db.EODPrice{
 		{InstrumentID: instID, PriceDate: d(2024, 1, 3), Close: 50.0},
 	}
-	err := p.UpsertPricesWithFill(ctx, instID, "test", bars, d(2024, 1, 1), d(2024, 1, 5))
+	err := p.UpsertPricesWithFill(ctx, instID, "test", bars, d(2024, 1, 1), d(2024, 1, 5), nil)
 	if err != nil {
 		t.Fatalf("upsert with fill: %v", err)
 	}
@@ -865,7 +865,7 @@ func TestUpsertPricesWithFill_DuplicateDates(t *testing.T) {
 		{InstrumentID: instID, PriceDate: mon.AddDate(0, 0, 1), Close: 102.0},
 	}
 	to := mon.AddDate(0, 0, 2)
-	err := p.UpsertPricesWithFill(ctx, instID, "test", bars, mon, to)
+	err := p.UpsertPricesWithFill(ctx, instID, "test", bars, mon, to, nil)
 	if err != nil {
 		t.Fatalf("upsert with fill: %v", err)
 	}

--- a/server/pricefetcher/worker.go
+++ b/server/pricefetcher/worker.go
@@ -208,7 +208,7 @@ func processGaps(ctx context.Context, database db.DB, plugins []pluginEntry, gap
 				}
 
 				prices := barsToEODPrices(ig.InstrumentID, pe.id, result.Bars)
-				if err := database.UpsertPricesWithFill(ctx, ig.InstrumentID, pe.id, prices, gap.From, gap.To); err != nil {
+				if err := database.UpsertPricesWithFill(ctx, ig.InstrumentID, pe.id, prices, gap.From, gap.To, nil); err != nil {
 					if log != nil {
 						log.ErrorContext(ctx, "price fetch: upsert", "instrument", ig.InstrumentID, "err", err)
 					}

--- a/server/pricefetcher/worker_test.go
+++ b/server/pricefetcher/worker_test.go
@@ -159,7 +159,7 @@ func TestRunCycle_FXGapsProcessed(t *testing.T) {
 			},
 		},
 	}, nil)
-	mockDB.EXPECT().UpsertPricesWithFill(gomock.Any(), fxInstID, pluginID, gomock.Any(), from, to).Return(nil)
+	mockDB.EXPECT().UpsertPricesWithFill(gomock.Any(), fxInstID, pluginID, gomock.Any(), from, to, gomock.Any()).Return(nil)
 
 	runCycle(ctx, mockDB, reg, nil, nil, nil)
 
@@ -329,7 +329,7 @@ func TestRunCycle_MaxHistoryTruncation(t *testing.T) {
 			},
 		},
 	}, nil)
-	mockDB.EXPECT().UpsertPricesWithFill(gomock.Any(), instID, pluginID, gomock.Any(), gomock.Any(), to).Return(nil)
+	mockDB.EXPECT().UpsertPricesWithFill(gomock.Any(), instID, pluginID, gomock.Any(), gomock.Any(), to, gomock.Any()).Return(nil)
 
 	runCycle(ctx, mockDB, reg, nil, nil, nil)
 

--- a/server/service/ingestion/price_worker.go
+++ b/server/service/ingestion/price_worker.go
@@ -42,10 +42,10 @@ func processPriceImport(ctx context.Context, database db.DB, pluginRegistry *ide
 		return false
 	}
 
-	var hintsValidAt *time.Time
+	var pricesAsOf *time.Time
 	if req.GetExportedAt() != nil {
 		t := req.GetExportedAt().AsTime()
-		hintsValidAt = &t
+		pricesAsOf = &t
 	} else {
 		slog.Warn("price import missing exported_at; OCC symbols will not be split-adjusted", "job_id", j.JobID)
 	}
@@ -86,7 +86,7 @@ func processPriceImport(ctx context.Context, database db.DB, pluginRegistry *ide
 		entry, cached := resolveCache[cacheKey]
 		if !cached {
 			acStr := db.AssetClassToStr(row.GetAssetClass())
-			instID, resolveErr := resolveOrIdentifyInstrument(ctx, database, pluginRegistry, row.GetIdentifierType(), row.GetIdentifierDomain(), row.GetIdentifierValue(), acStr, hintsValidAt)
+			instID, resolveErr := resolveOrIdentifyInstrument(ctx, database, pluginRegistry, row.GetIdentifierType(), row.GetIdentifierDomain(), row.GetIdentifierValue(), acStr, pricesAsOf)
 			entry = &resolveEntry{instID: instID, err: resolveErr}
 			resolveCache[cacheKey] = entry
 		}
@@ -105,6 +105,7 @@ func processPriceImport(ctx context.Context, database db.DB, pluginRegistry *ide
 			PriceDate:    priceDate,
 			Close:        row.GetClose(),
 			DataProvider: "import",
+			FetchedAt:    pricesAsOf,
 		}
 		if row.Open != nil {
 			p.Open = row.Open
@@ -203,7 +204,11 @@ func upsertWithCoverage(ctx context.Context, database db.DB, prices []db.EODPric
 			if len(inRange) > 0 {
 				provider = inRange[0].DataProvider
 			}
-			if err := database.UpsertPricesWithFill(ctx, instID, provider, inRange, r.from, r.to); err != nil {
+			var fetchedAt *time.Time
+			if len(inRange) > 0 {
+				fetchedAt = inRange[0].FetchedAt
+			}
+			if err := database.UpsertPricesWithFill(ctx, instID, provider, inRange, r.from, r.to, fetchedAt); err != nil {
 				return err
 			}
 		}

--- a/server/service/ingestion/price_worker_test.go
+++ b/server/service/ingestion/price_worker_test.go
@@ -156,7 +156,7 @@ func TestProcessPriceImport_WithCoverage_UsesUpsertWithFill(t *testing.T) {
 	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-price-cov").Return(nil)
 	// Expect UpsertPricesWithFill (not UpsertPrices) because coverage was provided.
 	database.EXPECT().
-		UpsertPricesWithFill(gomock.Any(), "inst-aapl", "import", gomock.Any(), gomock.Any(), gomock.Any()).
+		UpsertPricesWithFill(gomock.Any(), "inst-aapl", "import", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil)
 	database.EXPECT().
 		SetJobStatus(gomock.Any(), "job-price-cov", apiv1.JobStatus_SUCCESS).


### PR DESCRIPTION
## Summary

- Imported prices now use the `exported_at` timestamp from the CSV header as `fetched_at` instead of `now()`, so `split_factor_at` correctly adjusts prices for splits that occurred between export and import
- Added `FetchedAt` field to `EODPrice` struct; `UpsertPrices` reads it per-row and `UpsertPricesWithFill` accepts it as a parameter (both default to `now()` when nil)
- Renamed `hintsValidAt` to `pricesAsOf` in the price import path to reflect its dual role (OCC identifier resolution + price fetched_at)

## Test plan

- [x] All existing unit tests pass
- [ ] Import a price CSV with `exported_at` header predating a known split; verify `fetched_at` in `eod_prices` matches the exported_at value
- [ ] Import a price CSV without `exported_at` header; verify `fetched_at` defaults to approximately now
- [ ] Verify live price fetcher still uses `now()` for `fetched_at`
- [ ] Run `RecomputeSplitAdjustments` after import and verify split-adjusted prices are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)