### PR TITLE
Log differences between hints and resolved instruments

### DIFF
--- a/server/identifier/hints.go
+++ b/server/identifier/hints.go
@@ -57,6 +57,14 @@ func ShouldAttemptPlugin(acceptableKinds, acceptableTypes map[string]bool, kind,
 	return true
 }
 
+// HintDiff records a single difference between a supplied hint and the
+// resolved instrument value.
+type HintDiff struct {
+	Field         string // "Currency", "SecurityType", "Exchange", or identifier type e.g. "ISIN"
+	HintValue     string
+	ResolvedValue string
+}
+
 // AllowedIdentifierTypes is the controlled vocabulary for identifier hint types (proto IdentifierType names).
 // Description plugins must return hints whose Type is in this set; invalid types are discarded at debug log.
 var AllowedIdentifierTypes = map[string]bool{

--- a/server/service/identification/resolve.go
+++ b/server/service/identification/resolve.go
@@ -30,6 +30,7 @@ type ResolveResult struct {
 	HadTimeout   bool // at least one plugin timed out
 	HadError     bool // at least one plugin returned a non-ErrNotIdentified error
 	Identified   bool // a plugin successfully identified the instrument
+	HintDiffs    []identifier.HintDiff // differences between supplied hints and resolved instrument
 }
 
 // FallbackFunc is called when no identifier plugin resolves the instrument.
@@ -142,6 +143,58 @@ func consistentWith(ctx context.Context, l *slog.Logger, winnerPlugin, otherPlug
 		}
 	}
 	return true
+}
+
+// CompareHints compares supplied hints and identifier hints against the
+// resolved instrument and its identifiers, returning any differences.
+// Fields are skipped when either side is empty or UNKNOWN.
+func CompareHints(hints identifier.Hints, identifierHints []identifier.Identifier, inst *identifier.Instrument, resolvedIDs []identifier.Identifier) []identifier.HintDiff {
+	if inst == nil {
+		return nil
+	}
+	var diffs []identifier.HintDiff
+
+	// Currency.
+	if hints.Currency != "" && inst.Currency != "" &&
+		!strings.EqualFold(hints.Currency, inst.Currency) {
+		diffs = append(diffs, identifier.HintDiff{Field: "Currency", HintValue: hints.Currency, ResolvedValue: inst.Currency})
+	}
+
+	// SecurityType (same vocabulary as AssetClass).
+	if hints.SecurityTypeHint != "" && hints.SecurityTypeHint != identifier.SecurityTypeHintUnknown &&
+		inst.AssetClass != "" && inst.AssetClass != identifier.SecurityTypeHintUnknown &&
+		!strings.EqualFold(hints.SecurityTypeHint, inst.AssetClass) {
+		diffs = append(diffs, identifier.HintDiff{Field: "SecurityType", HintValue: hints.SecurityTypeHint, ResolvedValue: inst.AssetClass})
+	}
+
+	// Exchange: compare MIC_TICKER hint domain (the MIC code) against inst.Exchange.
+	if inst.Exchange != "" {
+		for _, h := range identifierHints {
+			if h.Type == "MIC_TICKER" && h.Domain != "" &&
+				!strings.EqualFold(h.Domain, inst.Exchange) {
+				diffs = append(diffs, identifier.HintDiff{Field: "Exchange", HintValue: h.Domain, ResolvedValue: inst.Exchange})
+				break
+			}
+		}
+	}
+
+	// Identifier values: compare client-supplied hints against resolved identifiers.
+	resolvedByType := make(map[string]string, len(resolvedIDs))
+	for _, id := range resolvedIDs {
+		if id.Value != "" {
+			resolvedByType[id.Type] = id.Value
+		}
+	}
+	for _, h := range identifierHints {
+		if h.Value == "" {
+			continue
+		}
+		if rv, ok := resolvedByType[h.Type]; ok && rv != h.Value {
+			diffs = append(diffs, identifier.HintDiff{Field: h.Type, HintValue: h.Value, ResolvedValue: rv})
+		}
+	}
+
+	return diffs
 }
 
 // ResolveWithPlugins calls enabled identifier plugins with the given hints, merges results, and ensures the instrument.
@@ -310,11 +363,12 @@ func ResolveWithPlugins(
 		if inst.AssetClass == db.AssetClassOption {
 			optFields = optionFieldsFromIdentifiers(mergedIds)
 		}
+		diffs := CompareHints(hints, identifierHints, inst, mergedIds)
 		id, err := database.EnsureInstrument(ctx, inst.AssetClass, inst.Exchange, inst.Currency, inst.Name, inst.CIK, inst.SICCode, identifiers, underlyingID, validFrom, validTo, optFields)
 		if err != nil {
 			return ResolveResult{}, err
 		}
-		return ResolveResult{InstrumentID: id, Identified: true}, nil
+		return ResolveResult{InstrumentID: id, Identified: true, HintDiffs: diffs}, nil
 	}
 
 	// Unresolved: call fallback if provided.

--- a/server/service/identification/resolve_test.go
+++ b/server/service/identification/resolve_test.go
@@ -693,6 +693,170 @@ func TestResolveWithPlugins_InconsistentPluginExcluded(t *testing.T) {
 	}
 }
 
+// --- CompareHints tests ---
+
+func TestCompareHints_NoDiffs(t *testing.T) {
+	hints := identifier.Hints{Currency: "USD", SecurityTypeHint: "STOCK"}
+	inst := &identifier.Instrument{Currency: "USD", AssetClass: "STOCK"}
+	idnHints := []identifier.Identifier{{Type: "ISIN", Value: "US0378331005"}}
+	resolvedIDs := []identifier.Identifier{{Type: "ISIN", Value: "US0378331005"}}
+
+	diffs := CompareHints(hints, idnHints, inst, resolvedIDs)
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs, got %v", diffs)
+	}
+}
+
+func TestCompareHints_CurrencyMismatch(t *testing.T) {
+	hints := identifier.Hints{Currency: "USD"}
+	inst := &identifier.Instrument{Currency: "EUR"}
+
+	diffs := CompareHints(hints, nil, inst, nil)
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+	if diffs[0].Field != "Currency" || diffs[0].HintValue != "USD" || diffs[0].ResolvedValue != "EUR" {
+		t.Errorf("unexpected diff: %+v", diffs[0])
+	}
+}
+
+func TestCompareHints_CurrencyCaseInsensitive(t *testing.T) {
+	hints := identifier.Hints{Currency: "usd"}
+	inst := &identifier.Instrument{Currency: "USD"}
+
+	diffs := CompareHints(hints, nil, inst, nil)
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs for case-insensitive match, got %v", diffs)
+	}
+}
+
+func TestCompareHints_EmptyCurrencySkipped(t *testing.T) {
+	// Empty hint currency.
+	diffs := CompareHints(identifier.Hints{}, nil, &identifier.Instrument{Currency: "USD"}, nil)
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs when hint currency empty, got %v", diffs)
+	}
+	// Empty resolved currency.
+	diffs = CompareHints(identifier.Hints{Currency: "USD"}, nil, &identifier.Instrument{}, nil)
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs when resolved currency empty, got %v", diffs)
+	}
+}
+
+func TestCompareHints_SecurityTypeMismatch(t *testing.T) {
+	hints := identifier.Hints{SecurityTypeHint: "STOCK"}
+	inst := &identifier.Instrument{AssetClass: "ETF"}
+
+	diffs := CompareHints(hints, nil, inst, nil)
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+	if diffs[0].Field != "SecurityType" || diffs[0].HintValue != "STOCK" || diffs[0].ResolvedValue != "ETF" {
+		t.Errorf("unexpected diff: %+v", diffs[0])
+	}
+}
+
+func TestCompareHints_SecurityTypeUnknownSkipped(t *testing.T) {
+	// UNKNOWN hint should not produce a diff.
+	diffs := CompareHints(identifier.Hints{SecurityTypeHint: "UNKNOWN"}, nil, &identifier.Instrument{AssetClass: "STOCK"}, nil)
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs when hint is UNKNOWN, got %v", diffs)
+	}
+	// UNKNOWN resolved should not produce a diff.
+	diffs = CompareHints(identifier.Hints{SecurityTypeHint: "STOCK"}, nil, &identifier.Instrument{AssetClass: "UNKNOWN"}, nil)
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs when resolved is UNKNOWN, got %v", diffs)
+	}
+}
+
+func TestCompareHints_ExchangeViaMICTickerDomain(t *testing.T) {
+	hints := identifier.Hints{}
+	idnHints := []identifier.Identifier{{Type: "MIC_TICKER", Domain: "XNAS", Value: "AAPL"}}
+	inst := &identifier.Instrument{Exchange: "XNYS"}
+
+	diffs := CompareHints(hints, idnHints, inst, nil)
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+	if diffs[0].Field != "Exchange" || diffs[0].HintValue != "XNAS" || diffs[0].ResolvedValue != "XNYS" {
+		t.Errorf("unexpected diff: %+v", diffs[0])
+	}
+}
+
+func TestCompareHints_ExchangeViaMICTickerMatch(t *testing.T) {
+	idnHints := []identifier.Identifier{{Type: "MIC_TICKER", Domain: "XNAS", Value: "AAPL"}}
+	inst := &identifier.Instrument{Exchange: "XNAS"}
+
+	diffs := CompareHints(identifier.Hints{}, idnHints, inst, nil)
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs, got %v", diffs)
+	}
+}
+
+func TestCompareHints_ExchangeEmptyDomainSkipped(t *testing.T) {
+	idnHints := []identifier.Identifier{{Type: "MIC_TICKER", Domain: "", Value: "AAPL"}}
+	inst := &identifier.Instrument{Exchange: "XNAS"}
+
+	diffs := CompareHints(identifier.Hints{}, idnHints, inst, nil)
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs when MIC_TICKER domain empty, got %v", diffs)
+	}
+}
+
+func TestCompareHints_IdentifierValueMismatch(t *testing.T) {
+	idnHints := []identifier.Identifier{{Type: "ISIN", Value: "US0378331005"}}
+	resolvedIDs := []identifier.Identifier{{Type: "ISIN", Value: "GB0002634946"}}
+
+	diffs := CompareHints(identifier.Hints{}, idnHints, &identifier.Instrument{}, resolvedIDs)
+	if len(diffs) != 1 {
+		t.Fatalf("expected 1 diff, got %d", len(diffs))
+	}
+	if diffs[0].Field != "ISIN" || diffs[0].HintValue != "US0378331005" || diffs[0].ResolvedValue != "GB0002634946" {
+		t.Errorf("unexpected diff: %+v", diffs[0])
+	}
+}
+
+func TestCompareHints_IdentifierTypeNotInResolved(t *testing.T) {
+	idnHints := []identifier.Identifier{{Type: "CUSIP", Value: "037833100"}}
+	resolvedIDs := []identifier.Identifier{{Type: "ISIN", Value: "US0378331005"}}
+
+	diffs := CompareHints(identifier.Hints{}, idnHints, &identifier.Instrument{}, resolvedIDs)
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs when hint type not in resolved, got %v", diffs)
+	}
+}
+
+func TestCompareHints_MultipleDiffs(t *testing.T) {
+	hints := identifier.Hints{Currency: "USD", SecurityTypeHint: "STOCK"}
+	idnHints := []identifier.Identifier{
+		{Type: "MIC_TICKER", Domain: "XNAS", Value: "AAPL"},
+		{Type: "ISIN", Value: "US0378331005"},
+	}
+	inst := &identifier.Instrument{Currency: "EUR", AssetClass: "ETF", Exchange: "XNYS"}
+	resolvedIDs := []identifier.Identifier{{Type: "ISIN", Value: "GB0002634946"}}
+
+	diffs := CompareHints(hints, idnHints, inst, resolvedIDs)
+	if len(diffs) != 4 {
+		t.Fatalf("expected 4 diffs, got %d: %v", len(diffs), diffs)
+	}
+	fields := make(map[string]bool)
+	for _, d := range diffs {
+		fields[d.Field] = true
+	}
+	for _, f := range []string{"Currency", "SecurityType", "Exchange", "ISIN"} {
+		if !fields[f] {
+			t.Errorf("expected diff for %s", f)
+		}
+	}
+}
+
+func TestCompareHints_NilInstrument(t *testing.T) {
+	diffs := CompareHints(identifier.Hints{Currency: "USD"}, nil, nil, nil)
+	if diffs != nil {
+		t.Errorf("expected nil diffs for nil instrument, got %v", diffs)
+	}
+}
+
 func TestResolveWithPlugins_ConsistentPluginsMerged(t *testing.T) {
 	saved := PluginRetryBackoff
 	PluginRetryBackoff = time.Millisecond

--- a/server/service/ingestion/resolve.go
+++ b/server/service/ingestion/resolve.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
+	"strings"
 	"time"
 
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
@@ -280,6 +281,22 @@ func Resolve(ctx context.Context, database db.DB, registry *identifier.Registry,
 	return resolveWithIdentifierPlugins(ctx, database, registry, broker, source, instrumentDescription, hints, hintsToUse, cache, key, rowIndex, counter, true, hintsValidAt)
 }
 
+// hintDiffsSummary formats hint diffs as a readable string (e.g. "Currency: USD->EUR, ISIN: US037->US038").
+func hintDiffsSummary(diffs []identifier.HintDiff) string {
+	var b strings.Builder
+	for i, d := range diffs {
+		if i > 0 {
+			b.WriteString(", ")
+		}
+		b.WriteString(d.Field)
+		b.WriteString(": ")
+		b.WriteString(d.HintValue)
+		b.WriteString("->")
+		b.WriteString(d.ResolvedValue)
+	}
+	return b.String()
+}
+
 // hintsByType returns hints whose Type equals typ (e.g. "MIC_TICKER", "OPENFIGI_SHARE_CLASS").
 func hintsByType(hints []identifier.Identifier, typ string) []identifier.Identifier {
 	var out []identifier.Identifier
@@ -304,6 +321,14 @@ func resolveWithIdentifierPlugins(ctx context.Context, database db.DB, registry 
 	result, err := identification.ResolveWithPlugins(ctx, database, registry, broker, source, instrumentDescription, hints, identifierHints, storeSourceDescription, fallback, counter, ingestionLogger(), 0, hintsValidAt)
 	if err != nil {
 		return resolveResult{}, err
+	}
+	if len(result.HintDiffs) > 0 {
+		ingestionLogger().InfoContext(ctx, "instrument resolved with hint differences",
+			"source", source,
+			"instrument_description", instrumentDescription,
+			"instrument_id", result.InstrumentID,
+			"diffs", hintDiffsSummary(result.HintDiffs),
+		)
 	}
 
 	r := resolveResult{InstrumentID: result.InstrumentID, FirstRowIndex: rowIndex}


### PR DESCRIPTION
## Summary

- Add `HintDiff` type and `CompareHints` function to detect differences between supplied resolution hints and the resolved instrument (currency, security type, exchange via MIC_TICKER domain, and identifier values)
- Return diffs via `ResolveResult.HintDiffs` from `ResolveWithPlugins`
- Log at info level during ingestion when differences are found, with a readable summary format (e.g. `Currency: USD->EUR, ISIN: US037->US038`)

## Test plan

- [x] 13 unit tests for `CompareHints` covering all comparison branches (currency, security type, exchange, identifiers, edge cases)
- [x] Full test suite passes (`make test`)
- [ ] Manual: ingest transactions with hints that differ from resolved instruments, verify info log appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)