### PR TITLE
Fail on hint diffs during admin price and corporate event imports

### DIFF
--- a/server/service/ingestion/corporate_event_worker.go
+++ b/server/service/ingestion/corporate_event_worker.go
@@ -11,6 +11,7 @@ import (
 	"github.com/leedenison/portfoliodb/server/corporateevents"
 	"github.com/leedenison/portfoliodb/server/db"
 	"github.com/leedenison/portfoliodb/server/identifier"
+	"github.com/leedenison/portfoliodb/server/service/identification"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -60,7 +61,7 @@ func processCorporateEventImport(ctx context.Context, database db.DB, pluginRegi
 			continue
 		}
 
-		instID, err := resolveCorporateEventRow(ctx, database, pluginRegistry, resolveCache, row)
+		result, err := resolveCorporateEventRow(ctx, database, pluginRegistry, resolveCache, row)
 		if err != nil {
 			valErrs = append(valErrs, &apiv1.ValidationError{
 				RowIndex: int32(i),
@@ -70,6 +71,16 @@ func processCorporateEventImport(ctx context.Context, database db.DB, pluginRegi
 			_ = database.IncrJobProcessedCount(ctx, j.JobID)
 			continue
 		}
+		if len(result.HintDiffs) > 0 {
+			valErrs = append(valErrs, &apiv1.ValidationError{
+				RowIndex: int32(i),
+				Field:    "identifier",
+				Message:  fmt.Sprintf("resolved instrument differs from import data: %s", hintDiffsSummary(result.HintDiffs)),
+			})
+			_ = database.IncrJobProcessedCount(ctx, j.JobID)
+			continue
+		}
+		instID := result.InstrumentID
 
 		switch ev := row.GetEvent().(type) {
 		case *apiv1.ImportCorporateEventRow_Split:
@@ -164,21 +175,21 @@ func processCorporateEventImport(ctx context.Context, database db.DB, pluginRegi
 	return persisted
 }
 
-// resolveCorporateEventRow resolves an instrument id for one import row,
+// resolveCorporateEventRow resolves an instrument for one import row,
 // caching the result so a CSV with thousands of dividends for the same
 // ticker invokes the identifier plugins at most once. The asset class
 // passed to the resolver is the row's declared asset class -- the same
 // hint used by the price import path.
-func resolveCorporateEventRow(ctx context.Context, database db.DB, pluginRegistry *identifier.Registry, cache map[string]*resolveEntry, row *apiv1.ImportCorporateEventRow) (string, error) {
+func resolveCorporateEventRow(ctx context.Context, database db.DB, pluginRegistry *identifier.Registry, cache map[string]*resolveEntry, row *apiv1.ImportCorporateEventRow) (identification.ResolveResult, error) {
 	key := row.GetIdentifierType() + "\x00" + row.GetIdentifierDomain() + "\x00" + row.GetIdentifierValue()
 	if entry, ok := cache[key]; ok {
-		return entry.instID, entry.err
+		return entry.result, entry.err
 	}
 	acStr := db.AssetClassToStr(row.GetAssetClass())
-	instID, err := resolveOrIdentifyInstrument(ctx, database, pluginRegistry,
-		row.GetIdentifierType(), row.GetIdentifierDomain(), row.GetIdentifierValue(), acStr, nil)
-	cache[key] = &resolveEntry{instID: instID, err: err}
-	return instID, err
+	result, err := resolveOrIdentifyInstrument(ctx, database, pluginRegistry,
+		row.GetIdentifierType(), row.GetIdentifierDomain(), row.GetIdentifierValue(), acStr, "", nil)
+	cache[key] = &resolveEntry{result: result, err: err}
+	return result, err
 }
 
 // buildSplit converts a proto SplitRow into a db.StockSplit. ex_date is
@@ -289,12 +300,12 @@ func writeImportCoverage(ctx context.Context, database db.DB, coverage []*apiv1.
 			// touch; resolve it now (cached for sibling coverage rows). The
 			// plugin registry is passed through so the resolution rules
 			// match the per-event resolution above.
-			instID, rerr := resolveOrIdentifyInstrument(ctx, database, pluginRegistry,
-				c.GetIdentifierType(), c.GetIdentifierDomain(), c.GetIdentifierValue(), "", nil)
-			entry = &resolveEntry{instID: instID, err: rerr}
+			result, rerr := resolveOrIdentifyInstrument(ctx, database, pluginRegistry,
+				c.GetIdentifierType(), c.GetIdentifierDomain(), c.GetIdentifierValue(), "", "", nil)
+			entry = &resolveEntry{result: result, err: rerr}
 			cache[key] = entry
 		}
-		if entry.err != nil || entry.instID == "" {
+		if entry.err != nil || entry.result.InstrumentID == "" {
 			msg := fmt.Sprintf("could not resolve instrument for %s %q", c.GetIdentifierType(), c.GetIdentifierValue())
 			if entry.err != nil {
 				msg = entry.err.Error()
@@ -306,7 +317,7 @@ func writeImportCoverage(ctx context.Context, database db.DB, coverage []*apiv1.
 			})
 			continue
 		}
-		if err := database.UpsertCorporateEventCoverage(ctx, entry.instID, db.CorporateEventProviderImport, from, to); err != nil {
+		if err := database.UpsertCorporateEventCoverage(ctx, entry.result.InstrumentID, db.CorporateEventProviderImport, from, to); err != nil {
 			return written, errs, err
 		}
 		written++

--- a/server/service/ingestion/corporate_event_worker_test.go
+++ b/server/service/ingestion/corporate_event_worker_test.go
@@ -2,6 +2,7 @@ package ingestion
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -70,14 +71,13 @@ func TestProcessCorporateEventImport_HappyPath(t *testing.T) {
 	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-ce-1", int32(2)).Return(nil)
 
 	// Resolution: only one cache miss because both events share the same
-	// (type, domain, value). With asset_class set and no plugins registered,
-	// resolveOrIdentifyInstrument falls back to ensureWithSuppliedIdentifier.
-	// The path is "asset class set + plugins registry empty" -- the registry
-	// in this test is empty so the plugin path is skipped and we hit the
-	// DB-only lookup branch.
+	// (type, domain, value). The plugin path's fast DB lookup resolves
+	// the instrument; GetInstrument is called to compare hints.
 	database.EXPECT().
 		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").
 		Return("inst-aapl", nil)
+	database.EXPECT().GetInstrument(gomock.Any(), "inst-aapl").
+		Return(stubInstrument("inst-aapl", "STOCK", "XNAS", "USD"), nil)
 
 	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-ce-1").Return(nil).Times(2)
 
@@ -154,6 +154,8 @@ func TestProcessCorporateEventImport_RejectsBadSplitRatio(t *testing.T) {
 	database.EXPECT().ClearJobPayload(gomock.Any(), "job-ce-2").Return(nil)
 	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-ce-2", int32(1)).Return(nil)
 	database.EXPECT().FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").Return("inst-aapl", nil)
+	database.EXPECT().GetInstrument(gomock.Any(), "inst-aapl").
+		Return(stubInstrument("inst-aapl", "STOCK", "XNAS", "USD"), nil)
 	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-ce-2").Return(nil)
 
 	var capturedErrs []*apiv1.ValidationError
@@ -206,6 +208,8 @@ func TestProcessCorporateEventImport_DividendOnlyDoesNotRecompute(t *testing.T) 
 	database.EXPECT().ClearJobPayload(gomock.Any(), "job-ce-3").Return(nil)
 	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-ce-3", int32(1)).Return(nil)
 	database.EXPECT().FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "MSFT").Return("inst-msft", nil)
+	database.EXPECT().GetInstrument(gomock.Any(), "inst-msft").
+		Return(stubInstrument("inst-msft", "STOCK", "XNAS", "USD"), nil)
 	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-ce-3").Return(nil)
 	database.EXPECT().UpsertCashDividends(gomock.Any(), gomock.Any()).Return(nil)
 	// Critically: NO RecomputeSplitAdjustments call.
@@ -298,6 +302,8 @@ func TestProcessCorporateEventImport_AcceptsHighPrecisionDecimal(t *testing.T) {
 	database.EXPECT().ClearJobPayload(gomock.Any(), "job-ce-prec").Return(nil)
 	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-ce-prec", int32(1)).Return(nil)
 	database.EXPECT().FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "MSFT").Return("inst-msft", nil)
+	database.EXPECT().GetInstrument(gomock.Any(), "inst-msft").
+		Return(stubInstrument("inst-msft", "STOCK", "XNAS", "USD"), nil)
 	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-ce-prec").Return(nil)
 	database.EXPECT().UpsertCashDividends(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, divs []db.CashDividend) error {
@@ -341,6 +347,8 @@ func TestProcessCorporateEventImport_RejectsInvalidDecimal(t *testing.T) {
 	database.EXPECT().ClearJobPayload(gomock.Any(), "job-ce-bad").Return(nil)
 	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-ce-bad", int32(1)).Return(nil)
 	database.EXPECT().FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "MSFT").Return("inst-msft", nil)
+	database.EXPECT().GetInstrument(gomock.Any(), "inst-msft").
+		Return(stubInstrument("inst-msft", "STOCK", "XNAS", "USD"), nil)
 	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-ce-bad").Return(nil)
 
 	var capturedErrs []*apiv1.ValidationError
@@ -356,5 +364,62 @@ func TestProcessCorporateEventImport_RejectsInvalidDecimal(t *testing.T) {
 	}
 	if len(capturedErrs) != 1 || capturedErrs[0].Field != "amount" {
 		t.Fatalf("expected one validation error on field=amount, got %+v", capturedErrs)
+	}
+}
+
+// TestProcessCorporateEventImport_RejectsHintDiff verifies that when the
+// resolved instrument's asset class differs from the import row's declared
+// asset class, the row is rejected with a validation error.
+func TestProcessCorporateEventImport_RejectsHintDiff(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	database := mock.NewMockDB(ctrl)
+	registry := identifier.NewRegistry()
+
+	req := &apiv1.ImportCorporateEventsRequest{
+		Events: []*apiv1.ImportCorporateEventRow{
+			{
+				IdentifierType:   "MIC_TICKER",
+				IdentifierDomain: "XNAS",
+				IdentifierValue:  "AAPL",
+				AssetClass:       apiv1.AssetClass_ASSET_CLASS_STOCK,
+				Event: &apiv1.ImportCorporateEventRow_Split{Split: &apiv1.SplitRow{
+					ExDate: "2020-08-31", SplitFrom: "1", SplitTo: "4",
+				}},
+			},
+		},
+	}
+	payload, _ := proto.Marshal(req)
+	j := &JobRequest{JobID: "job-ce-diff", JobType: db.JobTypeCorporateEvent}
+
+	database.EXPECT().LoadJobPayload(gomock.Any(), "job-ce-diff").Return(payload, nil)
+	database.EXPECT().ClearJobPayload(gomock.Any(), "job-ce-diff").Return(nil)
+	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-ce-diff", int32(1)).Return(nil)
+
+	// Instrument found but has asset class ETF, not STOCK.
+	database.EXPECT().FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").Return("inst-aapl", nil)
+	database.EXPECT().GetInstrument(gomock.Any(), "inst-aapl").
+		Return(stubInstrument("inst-aapl", "ETF", "XNAS", "USD"), nil) // asset class mismatch
+	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-ce-diff").Return(nil)
+
+	var capturedErrs []*apiv1.ValidationError
+	database.EXPECT().AppendValidationErrors(gomock.Any(), "job-ce-diff", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, errs []*apiv1.ValidationError) error {
+			capturedErrs = errs
+			return nil
+		})
+	database.EXPECT().SetJobStatus(gomock.Any(), "job-ce-diff", apiv1.JobStatus_SUCCESS).Return(nil)
+
+	if processCorporateEventImport(context.Background(), database, registry, j) {
+		t.Error("expected persisted=false when row was rejected for hint diff")
+	}
+	if len(capturedErrs) != 1 {
+		t.Fatalf("expected 1 validation error, got %d", len(capturedErrs))
+	}
+	if capturedErrs[0].Field != "identifier" {
+		t.Errorf("expected field=identifier, got %s", capturedErrs[0].Field)
+	}
+	if !strings.Contains(capturedErrs[0].Message, "SecurityType") {
+		t.Errorf("expected message to mention SecurityType, got %s", capturedErrs[0].Message)
 	}
 }

--- a/server/service/ingestion/price_worker.go
+++ b/server/service/ingestion/price_worker.go
@@ -16,7 +16,7 @@ import (
 
 // resolveEntry caches the result of instrument resolution for a given identifier.
 type resolveEntry struct {
-	instID string
+	result identification.ResolveResult
 	err    error
 }
 
@@ -86,8 +86,8 @@ func processPriceImport(ctx context.Context, database db.DB, pluginRegistry *ide
 		entry, cached := resolveCache[cacheKey]
 		if !cached {
 			acStr := db.AssetClassToStr(row.GetAssetClass())
-			instID, resolveErr := resolveOrIdentifyInstrument(ctx, database, pluginRegistry, row.GetIdentifierType(), row.GetIdentifierDomain(), row.GetIdentifierValue(), acStr, pricesAsOf)
-			entry = &resolveEntry{instID: instID, err: resolveErr}
+			result, resolveErr := resolveOrIdentifyInstrument(ctx, database, pluginRegistry, row.GetIdentifierType(), row.GetIdentifierDomain(), row.GetIdentifierValue(), acStr, "", pricesAsOf)
+			entry = &resolveEntry{result: result, err: resolveErr}
 			resolveCache[cacheKey] = entry
 		}
 		if entry.err != nil {
@@ -99,9 +99,18 @@ func processPriceImport(ctx context.Context, database db.DB, pluginRegistry *ide
 			_ = database.IncrJobProcessedCount(ctx, j.JobID)
 			continue
 		}
+		if len(entry.result.HintDiffs) > 0 {
+			valErrs = append(valErrs, &apiv1.ValidationError{
+				RowIndex: int32(i),
+				Field:    "identifier",
+				Message:  fmt.Sprintf("resolved instrument differs from import data: %s", hintDiffsSummary(entry.result.HintDiffs)),
+			})
+			_ = database.IncrJobProcessedCount(ctx, j.JobID)
+			continue
+		}
 
 		p := db.EODPrice{
-			InstrumentID: entry.instID,
+			InstrumentID: entry.result.InstrumentID,
 			PriceDate:    priceDate,
 			Close:        row.GetClose(),
 			DataProvider: "import",
@@ -170,10 +179,10 @@ func upsertWithCoverage(ctx context.Context, database db.DB, prices []db.EODPric
 		}
 		key := coverageKey(c.GetIdentifierType(), c.GetIdentifierDomain(), c.GetIdentifierValue())
 		entry, ok := resolveCache[key]
-		if !ok || entry.err != nil || entry.instID == "" {
+		if !ok || entry.err != nil || entry.result.InstrumentID == "" {
 			continue
 		}
-		instCoverage[entry.instID] = append(instCoverage[entry.instID], dateRange{from, to})
+		instCoverage[entry.result.InstrumentID] = append(instCoverage[entry.result.InstrumentID], dateRange{from, to})
 	}
 
 	// Group prices by instrument ID.
@@ -228,35 +237,73 @@ func upsertWithCoverage(ctx context.Context, database db.DB, prices []db.EODPric
 }
 
 // resolveOrIdentifyInstrument finds an instrument by identifier, or creates one.
-func resolveOrIdentifyInstrument(ctx context.Context, database db.DB, pluginRegistry *identifier.Registry, idType, domain, value, assetClass string, hintsValidAt *time.Time) (string, error) {
+// When the resolved instrument's metadata differs from the supplied hints, the
+// returned ResolveResult.HintDiffs will be non-empty.
+func resolveOrIdentifyInstrument(ctx context.Context, database db.DB, pluginRegistry *identifier.Registry, idType, domain, value, assetClass, currency string, hintsValidAt *time.Time) (identification.ResolveResult, error) {
 	hint := identifier.Identifier{Type: idType, Domain: domain, Value: value}
+	hints := identifier.Hints{SecurityTypeHint: assetClass, Currency: currency}
 
 	if assetClass != "" && pluginRegistry != nil {
 		fallback := func(ctx context.Context, database db.DB) (string, error) {
 			return ensureWithSuppliedIdentifier(ctx, database, idType, domain, value)
 		}
-		hints := identifier.Hints{SecurityTypeHint: assetClass}
 		result, err := identification.ResolveWithPlugins(ctx, database, pluginRegistry,
 			"", "", "", hints,
 			[]identifier.Identifier{hint},
 			false, fallback, nil, nil, 0, hintsValidAt)
 		if err != nil {
-			return "", fmt.Errorf("identification error for %s %q: %v", idType, value, err)
+			return identification.ResolveResult{}, fmt.Errorf("identification error for %s %q: %v", idType, value, err)
 		}
-		return result.InstrumentID, nil
+		// ResolveWithPlugins' fast DB path skips CompareHints; fill in
+		// diffs from the persisted instrument so admin imports still validate.
+		if len(result.HintDiffs) == 0 && result.InstrumentID != "" {
+			result.HintDiffs = compareHintsForDBInstrument(ctx, database, hints, []identifier.Identifier{hint}, result.InstrumentID)
+		}
+		return result, nil
 	}
 
 	ids, err := identification.ResolveByHintsDBOnly(ctx, database, []identifier.Identifier{hint})
 	if err != nil {
-		return "", fmt.Errorf("lookup error for %s %q: %v", idType, value, err)
+		return identification.ResolveResult{}, fmt.Errorf("lookup error for %s %q: %v", idType, value, err)
 	}
 	if len(ids) > 1 {
-		return "", fmt.Errorf("ambiguous: multiple instruments match %s %q", idType, value)
+		return identification.ResolveResult{}, fmt.Errorf("ambiguous: multiple instruments match %s %q", idType, value)
 	}
 	if len(ids) == 1 {
-		return ids[0], nil
+		diffs := compareHintsForDBInstrument(ctx, database, hints, []identifier.Identifier{hint}, ids[0])
+		return identification.ResolveResult{InstrumentID: ids[0], Identified: true, HintDiffs: diffs}, nil
 	}
-	return ensureWithSuppliedIdentifier(ctx, database, idType, domain, value)
+	id, err := ensureWithSuppliedIdentifier(ctx, database, idType, domain, value)
+	if err != nil {
+		return identification.ResolveResult{}, err
+	}
+	return identification.ResolveResult{InstrumentID: id}, nil
+}
+
+// compareHintsForDBInstrument fetches an instrument from the DB and compares
+// it against the supplied hints. Returns nil on any fetch error (best-effort).
+func compareHintsForDBInstrument(ctx context.Context, database db.DB, hints identifier.Hints, idHints []identifier.Identifier, instID string) []identifier.HintDiff {
+	row, err := database.GetInstrument(ctx, instID)
+	if err != nil || row == nil {
+		return nil
+	}
+	inst := &identifier.Instrument{
+		AssetClass: derefStr(row.AssetClass),
+		Exchange:   row.Exchange,
+		Currency:   derefStr(row.Currency),
+	}
+	var resolvedIDs []identifier.Identifier
+	for _, id := range row.Identifiers {
+		resolvedIDs = append(resolvedIDs, identifier.Identifier{Type: id.Type, Domain: id.Domain, Value: id.Value})
+	}
+	return identification.CompareHints(hints, idHints, inst, resolvedIDs)
+}
+
+func derefStr(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
 }
 
 func ensureWithSuppliedIdentifier(ctx context.Context, database db.DB, idType, domain, value string) (string, error) {

--- a/server/service/ingestion/price_worker_test.go
+++ b/server/service/ingestion/price_worker_test.go
@@ -2,14 +2,28 @@ package ingestion
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	"github.com/leedenison/portfoliodb/server/db"
 	"github.com/leedenison/portfoliodb/server/db/mock"
 	"github.com/leedenison/portfoliodb/server/identifier"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/proto"
 )
+
+// stubInstrument returns a minimal InstrumentRow for GetInstrument mocks.
+func stubInstrument(id, assetClass, exchange, currency string) *db.InstrumentRow {
+	row := &db.InstrumentRow{ID: id, Exchange: exchange}
+	if assetClass != "" {
+		row.AssetClass = &assetClass
+	}
+	if currency != "" {
+		row.Currency = &currency
+	}
+	return row
+}
 
 func TestProcessPriceImport_RejectsUnknownIdentifierType(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -100,6 +114,8 @@ func TestProcessPriceImport_AcceptsValidIdentifierType(t *testing.T) {
 	database.EXPECT().
 		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").
 		Return("inst-aapl", nil)
+	database.EXPECT().GetInstrument(gomock.Any(), "inst-aapl").
+		Return(stubInstrument("inst-aapl", "", "XNAS", ""), nil)
 	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-price-2").Return(nil)
 	database.EXPECT().
 		UpsertPrices(gomock.Any(), gomock.Any()).
@@ -153,6 +169,8 @@ func TestProcessPriceImport_WithCoverage_UsesUpsertWithFill(t *testing.T) {
 	database.EXPECT().
 		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").
 		Return("inst-aapl", nil)
+	database.EXPECT().GetInstrument(gomock.Any(), "inst-aapl").
+		Return(stubInstrument("inst-aapl", "", "XNAS", ""), nil)
 	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-price-cov").Return(nil)
 	// Expect UpsertPricesWithFill (not UpsertPrices) because coverage was provided.
 	database.EXPECT().
@@ -207,6 +225,8 @@ func TestProcessPriceImport_WithCoverage_NoCoverageForInstrument_UsesPlanUpsert(
 	database.EXPECT().
 		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").
 		Return("inst-aapl", nil)
+	database.EXPECT().GetInstrument(gomock.Any(), "inst-aapl").
+		Return(stubInstrument("inst-aapl", "", "XNAS", ""), nil)
 	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-price-nocov").Return(nil)
 	// No coverage match for AAPL, so expect plain UpsertPrices.
 	database.EXPECT().
@@ -218,5 +238,71 @@ func TestProcessPriceImport_WithCoverage_NoCoverageForInstrument_UsesPlanUpsert(
 
 	if !processPriceImport(ctx, database, registry, j) {
 		t.Error("expected persisted=true after a successful upsert")
+	}
+}
+
+// TestProcessPriceImport_RejectsHintDiff verifies that when the resolved
+// instrument's exchange differs from the import identifier domain, the row
+// is rejected with a validation error.
+func TestProcessPriceImport_RejectsHintDiff(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	database := mock.NewMockDB(ctrl)
+	registry := identifier.NewRegistry()
+
+	ctx := context.Background()
+	req := &apiv1.ImportPricesRequest{
+		Prices: []*apiv1.ImportPriceRow{
+			{
+				IdentifierType:   "MIC_TICKER",
+				IdentifierValue:  "AAPL",
+				IdentifierDomain: "XNAS",
+				PriceDate:        "2024-01-15",
+				Close:            185.90,
+			},
+		},
+	}
+	payload, err := proto.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	j := &JobRequest{JobID: "job-price-diff", JobType: "price"}
+
+	database.EXPECT().LoadJobPayload(gomock.Any(), "job-price-diff").Return(payload, nil)
+	database.EXPECT().ClearJobPayload(gomock.Any(), "job-price-diff").Return(nil)
+	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-price-diff", int32(1)).Return(nil)
+
+	// DB-only lookup succeeds, but the instrument has a different exchange.
+	database.EXPECT().
+		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").
+		Return("inst-aapl", nil)
+	database.EXPECT().GetInstrument(gomock.Any(), "inst-aapl").
+		Return(stubInstrument("inst-aapl", "", "XNYS", ""), nil) // exchange mismatch: XNYS != XNAS
+	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-price-diff").Return(nil)
+
+	var capturedErrs []*apiv1.ValidationError
+	database.EXPECT().
+		AppendValidationErrors(gomock.Any(), "job-price-diff", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, errs []*apiv1.ValidationError) error {
+			capturedErrs = errs
+			return nil
+		})
+	database.EXPECT().
+		SetJobStatus(gomock.Any(), "job-price-diff", apiv1.JobStatus_SUCCESS).
+		Return(nil)
+
+	if processPriceImport(ctx, database, registry, j) {
+		t.Error("expected persisted=false when row was rejected for hint diff")
+	}
+
+	if len(capturedErrs) != 1 {
+		t.Fatalf("expected 1 validation error, got %d", len(capturedErrs))
+	}
+	if capturedErrs[0].Field != "identifier" {
+		t.Errorf("expected field=identifier, got %s", capturedErrs[0].Field)
+	}
+	if !strings.Contains(capturedErrs[0].Message, "Exchange") {
+		t.Errorf("expected message to mention Exchange, got %s", capturedErrs[0].Message)
 	}
 }


### PR DESCRIPTION
## Summary

- When instruments are resolved during price or corporate event import, the resolved instrument's metadata (asset class, exchange, currency, identifiers) is now compared against the import data using `CompareHints`
- Rows with mismatches are rejected with validation errors instead of being silently accepted
- Transaction imports continue to log diffs at INFO level (unchanged)
- Both the plugin resolution path and the DB-only lookup path now validate hints
- Foundation for PR 2 which will add currency to price exports/imports so it can be validated

## Test plan

- [x] Existing price and corporate event import tests updated and passing
- [x] New `TestProcessPriceImport_RejectsHintDiff` — exchange mismatch produces validation error
- [x] New `TestProcessCorporateEventImport_RejectsHintDiff` — asset class mismatch produces validation error
- [x] `make test` passes
- [ ] Manual: import prices with a MIC_TICKER whose domain differs from the instrument's exchange — verify validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)