### PR TITLE
Add currency to price export/import for hint validation

### DIFF
--- a/client/lib/csv/prices.test.ts
+++ b/client/lib/csv/prices.test.ts
@@ -21,7 +21,7 @@ describe("pricesToCsv", () => {
     const lines = csv.trim().split("\n");
     expect(lines).toHaveLength(2);
     expect(lines[0]).toBe(
-      "identifier_type,identifier_value,identifier_domain,price_date,open,high,low,close,adjusted_close,volume,asset_class"
+      "identifier_type,identifier_value,identifier_domain,price_date,open,high,low,close,adjusted_close,volume,asset_class,currency"
     );
     expect(lines[1]).toContain("ISIN");
     expect(lines[1]).toContain("US0378331005");
@@ -35,7 +35,7 @@ describe("pricesToCsv", () => {
     const lines = csv.split("\n");
     expect(lines[0]).toBe("# exported_at=2025-07-15T10:30:00.000Z");
     expect(lines[1]).toBe(
-      "identifier_type,identifier_value,identifier_domain,price_date,open,high,low,close,adjusted_close,volume,asset_class"
+      "identifier_type,identifier_value,identifier_domain,price_date,open,high,low,close,adjusted_close,volume,asset_class,currency"
     );
   });
 
@@ -46,7 +46,7 @@ describe("pricesToCsv", () => {
 
   it("includes optional fields when present", () => {
     const csv = pricesToCsv([
-      makeRow({ open: 185.5, high: 186.2, low: 184.8, adjustedClose: 185.9, volume: 50000000n, assetClass: AssetClass.STOCK }),
+      makeRow({ open: 185.5, high: 186.2, low: 184.8, adjustedClose: 185.9, volume: 50000000n, assetClass: AssetClass.STOCK, currency: "USD" }),
     ]);
     const lines = csv.trim().split("\n");
     const fields = lines[1].split(",");
@@ -56,6 +56,7 @@ describe("pricesToCsv", () => {
     expect(fields[8]).toBe("185.9"); // adjusted_close
     expect(fields[9]).toBe("50000000"); // volume
     expect(fields[10]).toBe("STOCK"); // asset_class
+    expect(fields[11]).toBe("USD"); // currency
   });
 
   it("leaves optional fields empty when absent", () => {
@@ -81,7 +82,7 @@ describe("pricesToCsv", () => {
 });
 
 describe("csvToPrices", () => {
-  const HEADER = "identifier_type,identifier_value,identifier_domain,price_date,open,high,low,close,adjusted_close,volume,asset_class";
+  const HEADER = "identifier_type,identifier_value,identifier_domain,price_date,open,high,low,close,adjusted_close,volume,asset_class,currency";
 
   it("parses valid CSV", () => {
     const csv = `${HEADER}\nISIN,US0378331005,,2024-01-15,185.5,186.2,184.8,185.9,185.9,50000000`;
@@ -180,10 +181,24 @@ describe("csvToPrices", () => {
     expect(result.prices[0].assetClass).toBe(AssetClass.UNSPECIFIED);
   });
 
+  it("parses currency column", () => {
+    const csv = `${HEADER}\nMIC_TICKER,AAPL,XNAS,2024-01-15,,,,185.9,,,STOCK,USD`;
+    const result = csvToPrices(csv);
+    expect(result.errors).toHaveLength(0);
+    expect(result.prices[0].currency).toBe("USD");
+  });
+
+  it("handles empty currency", () => {
+    const csv = `${HEADER}\nMIC_TICKER,AAPL,XNAS,2024-01-15,,,,185.9,,`;
+    const result = csvToPrices(csv);
+    expect(result.errors).toHaveLength(0);
+    expect(result.prices[0].currency).toBe("");
+  });
+
   it("round-trips through pricesToCsv and csvToPrices", () => {
     const original = [
-      makeRow({ open: 185.5, high: 186.2, low: 184.8, adjustedClose: 185.9, volume: 50000000n }),
-      makeRow({ identifierType: "MIC_TICKER", identifierValue: "AAPL", identifierDomain: "XNAS", priceDate: "2024-01-16", close: 186.5 }),
+      makeRow({ open: 185.5, high: 186.2, low: 184.8, adjustedClose: 185.9, volume: 50000000n, currency: "USD" }),
+      makeRow({ identifierType: "MIC_TICKER", identifierValue: "AAPL", identifierDomain: "XNAS", priceDate: "2024-01-16", close: 186.5, currency: "GBP" }),
     ];
     const exportedAt = new Date("2025-07-15T10:30:00.000Z");
     const csv = pricesToCsv(original, exportedAt);
@@ -195,10 +210,12 @@ describe("csvToPrices", () => {
     expect(result.prices[0].close).toBe(185.9);
     expect(result.prices[0].open).toBe(185.5);
     expect(result.prices[0].volume).toBe(50000000n);
+    expect(result.prices[0].currency).toBe("USD");
     expect(result.prices[1].identifierType).toBe("MIC_TICKER");
     expect(result.prices[1].identifierDomain).toBe("XNAS");
     expect(result.prices[1].close).toBe(186.5);
     expect(result.prices[1].open).toBeUndefined();
+    expect(result.prices[1].currency).toBe("GBP");
   });
 
   it("extracts exported_at from comment line", () => {

--- a/client/lib/csv/prices.ts
+++ b/client/lib/csv/prices.ts
@@ -16,7 +16,7 @@ const VALID_IDENTIFIER_TYPES = new Set(
     .map((v) => v.name),
 );
 
-const HEADER = "identifier_type,identifier_value,identifier_domain,price_date,open,high,low,close,adjusted_close,volume,asset_class";
+const HEADER = "identifier_type,identifier_value,identifier_domain,price_date,open,high,low,close,adjusted_close,volume,asset_class,currency";
 
 const REQUIRED_COLUMNS = new Set(["identifier_type", "identifier_value", "price_date", "close"]);
 
@@ -42,6 +42,7 @@ export function pricesToCsv(rows: ExportPriceRow[], exportedAt?: Date): string {
     fmtOptNum(r.adjustedClose),
     fmtOptBigint(r.volume),
     assetClassToStr(r.assetClass),
+    r.currency,
   ]);
   const csv = Papa.unparse({ fields: HEADER.split(","), data }, { newline: "\n" }) + "\n";
   if (exportedAt) {
@@ -147,6 +148,7 @@ export function csvToPrices(text: string): PriceParseResult {
       priceDate,
       close,
       assetClass: assetClassFromStr(get("asset_class")),
+      currency: get("currency"),
     });
 
     const openStr = get("open");

--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -674,6 +674,7 @@ message ExportPriceRow {
   optional int64 volume = 10;
   AssetClass asset_class = 11;   // denormalized from instrument
   google.protobuf.Timestamp exported_at = 12; // when the export was generated
+  string currency = 13;          // ISO 4217 currency code; denormalized from instrument
 }
 
 // ImportPriceRow is one price row to import. When the instrument is unknown, asset_class
@@ -691,6 +692,7 @@ message ImportPriceRow {
   optional double adjusted_close = 9;
   optional int64 volume = 10;
   AssetClass asset_class = 11;   // optional; security type hint for plugin routing on unknown instruments
+  string currency = 12;          // optional; ISO 4217 currency code used as hint for validation
 }
 
 message ImportPricesRequest {

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -339,6 +339,7 @@ type ExportPriceRow struct {
 	IdentifierValue  string
 	IdentifierDomain string
 	AssetClass       string
+	Currency         string
 	PriceDate        time.Time
 	Open             *float64
 	High             *float64

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -561,6 +561,8 @@ type InstrumentDB interface {
 	EnsureInstrument(ctx context.Context, assetClass, exchangeMIC, currency, name, cik, sicCode string, identifiers []IdentifierInput, underlyingID string, validFrom, validTo *time.Time, optionFields *OptionFields) (string, error)
 	// FindInstrumentByIdentifier looks up instrument_id by (identifier_type, domain, value). Returns "" if not found. Use empty domain for no domain.
 	FindInstrumentByIdentifier(ctx context.Context, identifierType, domain, value string) (string, error)
+	// FindInstrumentWithMetaByIdentifier is like FindInstrumentByIdentifier but also returns asset_class, exchange, and currency from the instruments table in one query.
+	FindInstrumentWithMetaByIdentifier(ctx context.Context, identifierType, domain, value string) (instrumentID, assetClass, exchange, currency string, err error)
 	// FindInstrumentByTypeAndValue looks up instrument_id by (identifier_type, value) with any domain. Returns "" if not found or if multiple instruments match (ambiguous).
 	FindInstrumentByTypeAndValue(ctx context.Context, identifierType, value string) (string, error)
 	// FindInstrumentBySourceDescription looks up instrument_id by (source, NULL domain, instrument_description). Returns "" if not found.

--- a/server/db/postgres/eod_prices.go
+++ b/server/db/postgres/eod_prices.go
@@ -115,6 +115,7 @@ type exportPriceRow struct {
 	IdentifierValue  string    `db:"value"`
 	IdentifierDomain string    `db:"domain"`
 	AssetClass       string    `db:"asset_class"`
+	Currency         string    `db:"currency"`
 	PriceDate        time.Time `db:"price_date"`
 	Open             *float64  `db:"open"`
 	High             *float64  `db:"high"`
@@ -129,6 +130,7 @@ func (p *Postgres) ListPricesForExport(ctx context.Context) ([]db.ExportPriceRow
 	q := `
 		SELECT best_id.identifier_type, best_id.value, COALESCE(best_id.domain, '') AS domain,
 			COALESCE(i.asset_class, '') AS asset_class,
+			COALESCE(i.currency, '') AS currency,
 			ep.price_date, ep.open, ep.high, ep.low, ep.close,
 			ep.adjusted_close, ep.volume
 		FROM eod_prices ep
@@ -148,6 +150,7 @@ func (p *Postgres) ListPricesForExport(ctx context.Context) ([]db.ExportPriceRow
 			IdentifierValue:  r.IdentifierValue,
 			IdentifierDomain: r.IdentifierDomain,
 			AssetClass:       r.AssetClass,
+			Currency:         r.Currency,
 			PriceDate:        r.PriceDate,
 			Open:             r.Open,
 			High:             r.High,

--- a/server/db/postgres/instruments.go
+++ b/server/db/postgres/instruments.go
@@ -147,6 +147,35 @@ func (p *Postgres) FindInstrumentByIdentifier(ctx context.Context, identifierTyp
 	return id.String(), nil
 }
 
+// FindInstrumentWithMetaByIdentifier implements db.InstrumentDB.
+func (p *Postgres) FindInstrumentWithMetaByIdentifier(ctx context.Context, identifierType, domain, value string) (string, string, string, string, error) {
+	var id uuid.UUID
+	var ac, exch, cur string
+	var err error
+	if domain == "" {
+		err = p.q.QueryRowContext(ctx, `
+			SELECT ii.instrument_id, COALESCE(i.asset_class, ''), i.exchange, COALESCE(i.currency, '')
+			FROM instrument_identifiers ii
+			JOIN instruments i ON i.id = ii.instrument_id
+			WHERE ii.identifier_type = $1 AND ii.domain IS NULL AND ii.value = $2
+		`, identifierType, value).Scan(&id, &ac, &exch, &cur)
+	} else {
+		err = p.q.QueryRowContext(ctx, `
+			SELECT ii.instrument_id, COALESCE(i.asset_class, ''), i.exchange, COALESCE(i.currency, '')
+			FROM instrument_identifiers ii
+			JOIN instruments i ON i.id = ii.instrument_id
+			WHERE ii.identifier_type = $1 AND ii.domain = $2 AND ii.value = $3
+		`, identifierType, domain, value).Scan(&id, &ac, &exch, &cur)
+	}
+	if err == sql.ErrNoRows {
+		return "", "", "", "", nil
+	}
+	if err != nil {
+		return "", "", "", "", fmt.Errorf("find instrument with meta by identifier: %w", err)
+	}
+	return id.String(), ac, exch, cur, nil
+}
+
 // FindInstrumentByTypeAndValue implements db.InstrumentDB.
 // Returns "" if no row matches or if more than one instrument has the same (type, value) with different domains (ambiguous).
 func (p *Postgres) FindInstrumentByTypeAndValue(ctx context.Context, identifierType, value string) (string, error) {

--- a/server/service/api/export_import_prices_test.go
+++ b/server/service/api/export_import_prices_test.go
@@ -29,6 +29,7 @@ func TestExportPrices_Success(t *testing.T) {
 			IdentifierValue:  "AAPL",
 			IdentifierDomain: "US",
 			AssetClass:       "STOCK",
+			Currency:         "USD",
 			PriceDate:        time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
 			Open:             &open,
 			Close:            185.90,
@@ -64,6 +65,9 @@ func TestExportPrices_Success(t *testing.T) {
 	}
 	if row.Volume == nil || *row.Volume != 50000000 {
 		t.Fatalf("expected volume=50000000, got %v", row.Volume)
+	}
+	if row.GetCurrency() != "USD" {
+		t.Fatalf("expected currency=USD, got %s", row.GetCurrency())
 	}
 }
 

--- a/server/service/api/prices.go
+++ b/server/service/api/prices.go
@@ -89,6 +89,7 @@ func (s *Server) ExportPrices(req *apiv1.ExportPricesRequest, stream apiv1.ApiSe
 			IdentifierValue:  r.IdentifierValue,
 			IdentifierDomain: r.IdentifierDomain,
 			AssetClass:       db.StrToAssetClass(r.AssetClass),
+			Currency:         r.Currency,
 			PriceDate:        r.PriceDate.Format("2006-01-02"),
 			Close:            r.Close,
 		}

--- a/server/service/identification/resolve.go
+++ b/server/service/identification/resolve.go
@@ -82,7 +82,10 @@ func ResolveByHintsDBOnly(ctx context.Context, database db.InstrumentDB, hints [
 			if err != nil {
 				return nil, err
 			}
-			// TypeAndValue fallback doesn't return metadata; leave fields empty.
+			// TypeAndValue fallback doesn't return metadata. Empty fields
+			// cause CompareHints to skip currency/exchange/assetClass
+			// checks, so hint validation is not performed for instruments
+			// matched by type+value without an exact domain match.
 			ac, exch, cur = "", "", ""
 		}
 		if id != "" && !seen[id] {
@@ -91,6 +94,41 @@ func ResolveByHintsDBOnly(ctx context.Context, database db.InstrumentDB, hints [
 		}
 	}
 	return resolved, nil
+}
+
+// ResolveIDsByHintsDBOnly is a lightweight variant of ResolveByHintsDBOnly that
+// returns only instrument IDs (no metadata). It uses FindInstrumentByIdentifier
+// (index-only lookup) instead of FindInstrumentWithMetaByIdentifier (JOIN),
+// making it cheaper for callers that don't need hint comparison.
+func ResolveIDsByHintsDBOnly(ctx context.Context, database db.InstrumentDB, hints []identifier.Identifier) ([]string, error) {
+	seen := make(map[string]bool)
+	var ids []string
+	for _, h := range hints {
+		if h.Type == "" || h.Value == "" {
+			continue
+		}
+		value := h.Value
+		if h.Type == "OCC" {
+			if compact, ok := derivative.OCCCompact(value); ok {
+				value = compact
+			}
+		}
+		id, err := database.FindInstrumentByIdentifier(ctx, h.Type, h.Domain, value)
+		if err != nil {
+			return nil, err
+		}
+		if id == "" && h.Domain == "" {
+			id, err = database.FindInstrumentByTypeAndValue(ctx, h.Type, value)
+			if err != nil {
+				return nil, err
+			}
+		}
+		if id != "" && !seen[id] {
+			seen[id] = true
+			ids = append(ids, id)
+		}
+	}
+	return ids, nil
 }
 
 // FilterIdentifierHints keeps only hints whose Type is in the controlled vocabulary (identifier.AllowedIdentifierTypes).

--- a/server/service/identification/resolve.go
+++ b/server/service/identification/resolve.go
@@ -33,6 +33,15 @@ type ResolveResult struct {
 	HintDiffs    []identifier.HintDiff // differences between supplied hints and resolved instrument
 }
 
+// ResolvedInstrument holds an instrument ID plus the metadata needed for
+// hint comparison, as returned by ResolveByHintsDBOnly.
+type ResolvedInstrument struct {
+	ID         string
+	AssetClass string
+	Exchange   string
+	Currency   string
+}
+
 // FallbackFunc is called when no identifier plugin resolves the instrument.
 // It must return an instrument ID, typically by calling EnsureInstrument.
 type FallbackFunc func(ctx context.Context, database db.DB) (string, error)
@@ -50,9 +59,9 @@ type FallbackFunc func(ctx context.Context, database db.DB) (string, error)
 //     fallback FindInstrumentByTypeAndValue(type, value) matches any domain; if exactly one instrument has that
 //     (type, value), we use it. If multiple instruments match (same ticker on different exchanges), the fallback
 //     returns "" and we do not resolve (ambiguous).
-func ResolveByHintsDBOnly(ctx context.Context, database db.InstrumentDB, hints []identifier.Identifier) ([]string, error) {
+func ResolveByHintsDBOnly(ctx context.Context, database db.InstrumentDB, hints []identifier.Identifier) ([]ResolvedInstrument, error) {
 	seen := make(map[string]bool)
-	var ids []string
+	var resolved []ResolvedInstrument
 	for _, h := range hints {
 		if h.Type == "" || h.Value == "" {
 			continue
@@ -64,7 +73,7 @@ func ResolveByHintsDBOnly(ctx context.Context, database db.InstrumentDB, hints [
 				value = compact
 			}
 		}
-		id, err := database.FindInstrumentByIdentifier(ctx, h.Type, h.Domain, value)
+		id, ac, exch, cur, err := database.FindInstrumentWithMetaByIdentifier(ctx, h.Type, h.Domain, value)
 		if err != nil {
 			return nil, err
 		}
@@ -73,13 +82,15 @@ func ResolveByHintsDBOnly(ctx context.Context, database db.InstrumentDB, hints [
 			if err != nil {
 				return nil, err
 			}
+			// TypeAndValue fallback doesn't return metadata; leave fields empty.
+			ac, exch, cur = "", "", ""
 		}
 		if id != "" && !seen[id] {
 			seen[id] = true
-			ids = append(ids, id)
+			resolved = append(resolved, ResolvedInstrument{ID: id, AssetClass: ac, Exchange: exch, Currency: cur})
 		}
 	}
-	return ids, nil
+	return resolved, nil
 }
 
 // FilterIdentifierHints keeps only hints whose Type is in the controlled vocabulary (identifier.AllowedIdentifierTypes).
@@ -221,12 +232,18 @@ func ResolveWithPlugins(
 	identifierHints = AdjustOCCForKnownSplits(ctx, database, identifierHints, hintsValidAt, nil)
 
 	// If all hints already resolve to one instrument in DB, use it (avoids plugin call).
-	ids, err := ResolveByHintsDBOnly(ctx, database, identifierHints)
+	resolved, err := ResolveByHintsDBOnly(ctx, database, identifierHints)
 	if err != nil {
 		return ResolveResult{}, err
 	}
-	if len(ids) == 1 {
-		return ResolveResult{InstrumentID: ids[0], Identified: true}, nil
+	if len(resolved) == 1 {
+		inst := &identifier.Instrument{
+			AssetClass: resolved[0].AssetClass,
+			Exchange:   resolved[0].Exchange,
+			Currency:   resolved[0].Currency,
+		}
+		diffs := CompareHints(hints, identifierHints, inst, nil)
+		return ResolveResult{InstrumentID: resolved[0].ID, Identified: true, HintDiffs: diffs}, nil
 	}
 
 	configs, err := database.ListEnabledPluginConfigs(ctx, db.PluginCategoryIdentifier)

--- a/server/service/identification/resolve_test.go
+++ b/server/service/identification/resolve_test.go
@@ -33,8 +33,8 @@ func TestResolveByHintsDBOnly_ExactMatch(t *testing.T) {
 	database := mock.NewMockDB(ctrl)
 
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "OPENFIGI_TICKER", "US", "AAPL").
-		Return("inst-1", nil)
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "OPENFIGI_TICKER", "US", "AAPL").
+		Return("inst-1", "", "", "", nil)
 
 	ids, err := ResolveByHintsDBOnly(context.Background(), database, []identifier.Identifier{
 		{Type: "OPENFIGI_TICKER", Domain: "US", Value: "AAPL"},
@@ -42,7 +42,7 @@ func TestResolveByHintsDBOnly_ExactMatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResolveByHintsDBOnly: %v", err)
 	}
-	if len(ids) != 1 || ids[0] != "inst-1" {
+	if len(ids) != 1 || ids[0].ID != "inst-1" {
 		t.Errorf("got %v, want [inst-1]", ids)
 	}
 }
@@ -54,8 +54,8 @@ func TestResolveByHintsDBOnly_FallbackByTypeAndValue(t *testing.T) {
 
 	// Exact match fails (domain is empty, stored domain is "US")
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "", "AAPL").
-		Return("", nil)
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "AAPL").
+		Return("", "", "", "", nil)
 	// Fallback by (type, value) finds it
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "AAPL").
@@ -67,7 +67,7 @@ func TestResolveByHintsDBOnly_FallbackByTypeAndValue(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResolveByHintsDBOnly: %v", err)
 	}
-	if len(ids) != 1 || ids[0] != "inst-1" {
+	if len(ids) != 1 || ids[0].ID != "inst-1" {
 		t.Errorf("got %v, want [inst-1]", ids)
 	}
 }
@@ -97,11 +97,11 @@ func TestResolveByHintsDBOnly_Deduplicates(t *testing.T) {
 
 	// Two hints resolve to the same instrument
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "OPENFIGI_TICKER", "US", "AAPL").
-		Return("inst-1", nil)
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "OPENFIGI_TICKER", "US", "AAPL").
+		Return("inst-1", "", "", "", nil)
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "ISIN", "", "US0378331005").
-		Return("inst-1", nil)
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "ISIN", "", "US0378331005").
+		Return("inst-1", "", "", "", nil)
 
 	ids, err := ResolveByHintsDBOnly(context.Background(), database, []identifier.Identifier{
 		{Type: "OPENFIGI_TICKER", Domain: "US", Value: "AAPL"},
@@ -122,8 +122,8 @@ func TestResolveByHintsDBOnly_NormalizesOCCToCompact(t *testing.T) {
 
 	// Padded OCC "NVDA  240315P00420000" should be normalized to compact "NVDA240315P00420000" for lookup.
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "OCC", "", "NVDA240315P00420000").
-		Return("inst-1", nil)
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "OCC", "", "NVDA240315P00420000").
+		Return("inst-1", "", "", "", nil)
 
 	ids, err := ResolveByHintsDBOnly(context.Background(), database, []identifier.Identifier{
 		{Type: "OCC", Value: "NVDA  240315P00420000"},
@@ -131,7 +131,7 @@ func TestResolveByHintsDBOnly_NormalizesOCCToCompact(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResolveByHintsDBOnly: %v", err)
 	}
-	if len(ids) != 1 || ids[0] != "inst-1" {
+	if len(ids) != 1 || ids[0].ID != "inst-1" {
 		t.Errorf("got %v, want [inst-1]", ids)
 	}
 }
@@ -166,8 +166,8 @@ func TestResolveWithPlugins_DBHit(t *testing.T) {
 	registry := identifier.NewRegistry()
 
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "", "AAPL").
-		Return("", nil)
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "AAPL").
+		Return("", "", "", "", nil)
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "AAPL").
 		Return("existing-id", nil)
@@ -198,8 +198,8 @@ func TestResolveWithPlugins_PluginSuccess(t *testing.T) {
 	})
 
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "", "AAPL").
-		Return("", nil)
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "AAPL").
+		Return("", "", "", "", nil)
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "AAPL").
 		Return("", nil)
@@ -233,8 +233,8 @@ func TestResolveWithPlugins_AllPluginsFail_Fallback(t *testing.T) {
 	registry.Register("test", &fakePlugin{err: identifier.ErrNotIdentified})
 
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "", "XYZ").
-		Return("", nil)
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "XYZ").
+		Return("", "", "", "", nil)
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "XYZ").
 		Return("", nil)
@@ -278,8 +278,8 @@ func TestResolveWithPlugins_Timeout_SetsHadTimeout(t *testing.T) {
 	registry.Register("slow", &fakePlugin{err: context.DeadlineExceeded})
 
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "", "SLOW").
-		Return("", nil)
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "SLOW").
+		Return("", "", "", "", nil)
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "SLOW").
 		Return("", nil)
@@ -314,8 +314,8 @@ func TestResolveWithPlugins_NilFallback_ReturnsEmpty(t *testing.T) {
 	registry.Register("test", &fakePlugin{err: identifier.ErrNotIdentified})
 
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "", "XYZ").
-		Return("", nil)
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "XYZ").
+		Return("", "", "", "", nil)
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "XYZ").
 		Return("", nil)
@@ -348,8 +348,8 @@ func TestResolveWithPlugins_StoreSourceDescription(t *testing.T) {
 	})
 
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "", desc).
-		Return("", nil)
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", desc).
+		Return("", "", "", "", nil)
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", desc).
 		Return("", nil)
@@ -392,8 +392,8 @@ func TestResolveWithPlugins_PluginError_SetsHadError(t *testing.T) {
 	registry.Register("bad", &fakePlugin{err: errors.New("connection refused")})
 
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "", "BAD").
-		Return("", nil)
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "BAD").
+		Return("", "", "", "", nil)
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "BAD").
 		Return("", nil)
@@ -662,8 +662,8 @@ func TestResolveWithPlugins_InconsistentPluginExcluded(t *testing.T) {
 	})
 
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "", "AAPL").
-		Return("", nil)
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "AAPL").
+		Return("", "", "", "", nil)
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "AAPL").
 		Return("", nil)
@@ -879,8 +879,8 @@ func TestResolveWithPlugins_ConsistentPluginsMerged(t *testing.T) {
 	})
 
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "", "AAPL").
-		Return("", nil)
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "AAPL").
+		Return("", "", "", "", nil)
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "AAPL").
 		Return("", nil)

--- a/server/service/ingestion/corporate_event_worker.go
+++ b/server/service/ingestion/corporate_event_worker.go
@@ -317,6 +317,14 @@ func writeImportCoverage(ctx context.Context, database db.DB, coverage []*apiv1.
 			})
 			continue
 		}
+		if len(entry.result.HintDiffs) > 0 {
+			errs = append(errs, &apiv1.ValidationError{
+				RowIndex: -1,
+				Field:    "coverage.identifier",
+				Message:  fmt.Sprintf("resolved instrument differs from import data: %s", hintDiffsSummary(entry.result.HintDiffs)),
+			})
+			continue
+		}
 		if err := database.UpsertCorporateEventCoverage(ctx, entry.result.InstrumentID, db.CorporateEventProviderImport, from, to); err != nil {
 			return written, errs, err
 		}

--- a/server/service/ingestion/corporate_event_worker_test.go
+++ b/server/service/ingestion/corporate_event_worker_test.go
@@ -72,12 +72,10 @@ func TestProcessCorporateEventImport_HappyPath(t *testing.T) {
 
 	// Resolution: only one cache miss because both events share the same
 	// (type, domain, value). The plugin path's fast DB lookup resolves
-	// the instrument; GetInstrument is called to compare hints.
+	// the instrument with metadata for hint comparison.
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").
-		Return("inst-aapl", nil)
-	database.EXPECT().GetInstrument(gomock.Any(), "inst-aapl").
-		Return(stubInstrument("inst-aapl", "STOCK", "XNAS", "USD"), nil)
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").
+		Return("inst-aapl", "STOCK", "XNAS", "USD", nil)
 
 	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-ce-1").Return(nil).Times(2)
 
@@ -153,9 +151,7 @@ func TestProcessCorporateEventImport_RejectsBadSplitRatio(t *testing.T) {
 	database.EXPECT().LoadJobPayload(gomock.Any(), "job-ce-2").Return(payload, nil)
 	database.EXPECT().ClearJobPayload(gomock.Any(), "job-ce-2").Return(nil)
 	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-ce-2", int32(1)).Return(nil)
-	database.EXPECT().FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").Return("inst-aapl", nil)
-	database.EXPECT().GetInstrument(gomock.Any(), "inst-aapl").
-		Return(stubInstrument("inst-aapl", "STOCK", "XNAS", "USD"), nil)
+	database.EXPECT().FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").Return("inst-aapl", "STOCK", "XNAS", "USD", nil)
 	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-ce-2").Return(nil)
 
 	var capturedErrs []*apiv1.ValidationError
@@ -207,9 +203,7 @@ func TestProcessCorporateEventImport_DividendOnlyDoesNotRecompute(t *testing.T) 
 	database.EXPECT().LoadJobPayload(gomock.Any(), "job-ce-3").Return(payload, nil)
 	database.EXPECT().ClearJobPayload(gomock.Any(), "job-ce-3").Return(nil)
 	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-ce-3", int32(1)).Return(nil)
-	database.EXPECT().FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "MSFT").Return("inst-msft", nil)
-	database.EXPECT().GetInstrument(gomock.Any(), "inst-msft").
-		Return(stubInstrument("inst-msft", "STOCK", "XNAS", "USD"), nil)
+	database.EXPECT().FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "MSFT").Return("inst-msft", "STOCK", "XNAS", "USD", nil)
 	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-ce-3").Return(nil)
 	database.EXPECT().UpsertCashDividends(gomock.Any(), gomock.Any()).Return(nil)
 	// Critically: NO RecomputeSplitAdjustments call.
@@ -301,9 +295,7 @@ func TestProcessCorporateEventImport_AcceptsHighPrecisionDecimal(t *testing.T) {
 	database.EXPECT().LoadJobPayload(gomock.Any(), "job-ce-prec").Return(payload, nil)
 	database.EXPECT().ClearJobPayload(gomock.Any(), "job-ce-prec").Return(nil)
 	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-ce-prec", int32(1)).Return(nil)
-	database.EXPECT().FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "MSFT").Return("inst-msft", nil)
-	database.EXPECT().GetInstrument(gomock.Any(), "inst-msft").
-		Return(stubInstrument("inst-msft", "STOCK", "XNAS", "USD"), nil)
+	database.EXPECT().FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "MSFT").Return("inst-msft", "STOCK", "XNAS", "USD", nil)
 	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-ce-prec").Return(nil)
 	database.EXPECT().UpsertCashDividends(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, divs []db.CashDividend) error {
@@ -346,9 +338,7 @@ func TestProcessCorporateEventImport_RejectsInvalidDecimal(t *testing.T) {
 	database.EXPECT().LoadJobPayload(gomock.Any(), "job-ce-bad").Return(payload, nil)
 	database.EXPECT().ClearJobPayload(gomock.Any(), "job-ce-bad").Return(nil)
 	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-ce-bad", int32(1)).Return(nil)
-	database.EXPECT().FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "MSFT").Return("inst-msft", nil)
-	database.EXPECT().GetInstrument(gomock.Any(), "inst-msft").
-		Return(stubInstrument("inst-msft", "STOCK", "XNAS", "USD"), nil)
+	database.EXPECT().FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "MSFT").Return("inst-msft", "STOCK", "XNAS", "USD", nil)
 	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-ce-bad").Return(nil)
 
 	var capturedErrs []*apiv1.ValidationError
@@ -397,9 +387,8 @@ func TestProcessCorporateEventImport_RejectsHintDiff(t *testing.T) {
 	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-ce-diff", int32(1)).Return(nil)
 
 	// Instrument found but has asset class ETF, not STOCK.
-	database.EXPECT().FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").Return("inst-aapl", nil)
-	database.EXPECT().GetInstrument(gomock.Any(), "inst-aapl").
-		Return(stubInstrument("inst-aapl", "ETF", "XNAS", "USD"), nil) // asset class mismatch
+	database.EXPECT().FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").
+		Return("inst-aapl", "ETF", "XNAS", "USD", nil) // asset class mismatch
 	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-ce-diff").Return(nil)
 
 	var capturedErrs []*apiv1.ValidationError

--- a/server/service/ingestion/price_worker.go
+++ b/server/service/ingestion/price_worker.go
@@ -86,7 +86,7 @@ func processPriceImport(ctx context.Context, database db.DB, pluginRegistry *ide
 		entry, cached := resolveCache[cacheKey]
 		if !cached {
 			acStr := db.AssetClassToStr(row.GetAssetClass())
-			result, resolveErr := resolveOrIdentifyInstrument(ctx, database, pluginRegistry, row.GetIdentifierType(), row.GetIdentifierDomain(), row.GetIdentifierValue(), acStr, "", pricesAsOf)
+			result, resolveErr := resolveOrIdentifyInstrument(ctx, database, pluginRegistry, row.GetIdentifierType(), row.GetIdentifierDomain(), row.GetIdentifierValue(), acStr, row.GetCurrency(), pricesAsOf)
 			entry = &resolveEntry{result: result, err: resolveErr}
 			resolveCache[cacheKey] = entry
 		}

--- a/server/service/ingestion/price_worker.go
+++ b/server/service/ingestion/price_worker.go
@@ -254,56 +254,30 @@ func resolveOrIdentifyInstrument(ctx context.Context, database db.DB, pluginRegi
 		if err != nil {
 			return identification.ResolveResult{}, fmt.Errorf("identification error for %s %q: %v", idType, value, err)
 		}
-		// ResolveWithPlugins' fast DB path skips CompareHints; fill in
-		// diffs from the persisted instrument so admin imports still validate.
-		if len(result.HintDiffs) == 0 && result.InstrumentID != "" {
-			result.HintDiffs = compareHintsForDBInstrument(ctx, database, hints, []identifier.Identifier{hint}, result.InstrumentID)
-		}
 		return result, nil
 	}
 
-	ids, err := identification.ResolveByHintsDBOnly(ctx, database, []identifier.Identifier{hint})
+	resolved, err := identification.ResolveByHintsDBOnly(ctx, database, []identifier.Identifier{hint})
 	if err != nil {
 		return identification.ResolveResult{}, fmt.Errorf("lookup error for %s %q: %v", idType, value, err)
 	}
-	if len(ids) > 1 {
+	if len(resolved) > 1 {
 		return identification.ResolveResult{}, fmt.Errorf("ambiguous: multiple instruments match %s %q", idType, value)
 	}
-	if len(ids) == 1 {
-		diffs := compareHintsForDBInstrument(ctx, database, hints, []identifier.Identifier{hint}, ids[0])
-		return identification.ResolveResult{InstrumentID: ids[0], Identified: true, HintDiffs: diffs}, nil
+	if len(resolved) == 1 {
+		inst := &identifier.Instrument{
+			AssetClass: resolved[0].AssetClass,
+			Exchange:   resolved[0].Exchange,
+			Currency:   resolved[0].Currency,
+		}
+		diffs := identification.CompareHints(hints, []identifier.Identifier{hint}, inst, nil)
+		return identification.ResolveResult{InstrumentID: resolved[0].ID, Identified: true, HintDiffs: diffs}, nil
 	}
 	id, err := ensureWithSuppliedIdentifier(ctx, database, idType, domain, value)
 	if err != nil {
 		return identification.ResolveResult{}, err
 	}
 	return identification.ResolveResult{InstrumentID: id}, nil
-}
-
-// compareHintsForDBInstrument fetches an instrument from the DB and compares
-// it against the supplied hints. Returns nil on any fetch error (best-effort).
-func compareHintsForDBInstrument(ctx context.Context, database db.DB, hints identifier.Hints, idHints []identifier.Identifier, instID string) []identifier.HintDiff {
-	row, err := database.GetInstrument(ctx, instID)
-	if err != nil || row == nil {
-		return nil
-	}
-	inst := &identifier.Instrument{
-		AssetClass: derefStr(row.AssetClass),
-		Exchange:   row.Exchange,
-		Currency:   derefStr(row.Currency),
-	}
-	var resolvedIDs []identifier.Identifier
-	for _, id := range row.Identifiers {
-		resolvedIDs = append(resolvedIDs, identifier.Identifier{Type: id.Type, Domain: id.Domain, Value: id.Value})
-	}
-	return identification.CompareHints(hints, idHints, inst, resolvedIDs)
-}
-
-func derefStr(p *string) string {
-	if p == nil {
-		return ""
-	}
-	return *p
 }
 
 func ensureWithSuppliedIdentifier(ctx context.Context, database db.DB, idType, domain, value string) (string, error) {

--- a/server/service/ingestion/price_worker_test.go
+++ b/server/service/ingestion/price_worker_test.go
@@ -306,3 +306,66 @@ func TestProcessPriceImport_RejectsHintDiff(t *testing.T) {
 		t.Errorf("expected message to mention Exchange, got %s", capturedErrs[0].Message)
 	}
 }
+
+// TestProcessPriceImport_RejectsCurrencyHintDiff verifies that when the
+// import row carries a currency that differs from the resolved instrument's
+// currency, the row is rejected with a validation error.
+func TestProcessPriceImport_RejectsCurrencyHintDiff(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	database := mock.NewMockDB(ctrl)
+	registry := identifier.NewRegistry()
+
+	ctx := context.Background()
+	req := &apiv1.ImportPricesRequest{
+		Prices: []*apiv1.ImportPriceRow{
+			{
+				IdentifierType:   "MIC_TICKER",
+				IdentifierValue:  "AAPL",
+				IdentifierDomain: "XNAS",
+				PriceDate:        "2024-01-15",
+				Close:            185.90,
+				Currency:         "GBP",
+			},
+		},
+	}
+	payload, err := proto.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	j := &JobRequest{JobID: "job-price-curdiff", JobType: "price"}
+
+	database.EXPECT().LoadJobPayload(gomock.Any(), "job-price-curdiff").Return(payload, nil)
+	database.EXPECT().ClearJobPayload(gomock.Any(), "job-price-curdiff").Return(nil)
+	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-price-curdiff", int32(1)).Return(nil)
+
+	database.EXPECT().
+		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").
+		Return("inst-aapl", nil)
+	database.EXPECT().GetInstrument(gomock.Any(), "inst-aapl").
+		Return(stubInstrument("inst-aapl", "", "XNAS", "USD"), nil) // currency mismatch: USD != GBP
+	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-price-curdiff").Return(nil)
+
+	var capturedErrs []*apiv1.ValidationError
+	database.EXPECT().
+		AppendValidationErrors(gomock.Any(), "job-price-curdiff", gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, errs []*apiv1.ValidationError) error {
+			capturedErrs = errs
+			return nil
+		})
+	database.EXPECT().
+		SetJobStatus(gomock.Any(), "job-price-curdiff", apiv1.JobStatus_SUCCESS).
+		Return(nil)
+
+	if processPriceImport(ctx, database, registry, j) {
+		t.Error("expected persisted=false when row was rejected for currency hint diff")
+	}
+
+	if len(capturedErrs) != 1 {
+		t.Fatalf("expected 1 validation error, got %d", len(capturedErrs))
+	}
+	if !strings.Contains(capturedErrs[0].Message, "Currency") {
+		t.Errorf("expected message to mention Currency, got %s", capturedErrs[0].Message)
+	}
+}

--- a/server/service/ingestion/price_worker_test.go
+++ b/server/service/ingestion/price_worker_test.go
@@ -6,24 +6,11 @@ import (
 	"testing"
 
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
-	"github.com/leedenison/portfoliodb/server/db"
 	"github.com/leedenison/portfoliodb/server/db/mock"
 	"github.com/leedenison/portfoliodb/server/identifier"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/proto"
 )
-
-// stubInstrument returns a minimal InstrumentRow for GetInstrument mocks.
-func stubInstrument(id, assetClass, exchange, currency string) *db.InstrumentRow {
-	row := &db.InstrumentRow{ID: id, Exchange: exchange}
-	if assetClass != "" {
-		row.AssetClass = &assetClass
-	}
-	if currency != "" {
-		row.Currency = &currency
-	}
-	return row
-}
 
 func TestProcessPriceImport_RejectsUnknownIdentifierType(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -112,10 +99,8 @@ func TestProcessPriceImport_AcceptsValidIdentifierType(t *testing.T) {
 	// Valid type passes validation, so resolveOrIdentifyInstrument is called.
 	// With no asset_class and no plugins, it does DB-only lookup.
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").
-		Return("inst-aapl", nil)
-	database.EXPECT().GetInstrument(gomock.Any(), "inst-aapl").
-		Return(stubInstrument("inst-aapl", "", "XNAS", ""), nil)
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").
+		Return("inst-aapl", "", "XNAS", "", nil)
 	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-price-2").Return(nil)
 	database.EXPECT().
 		UpsertPrices(gomock.Any(), gomock.Any()).
@@ -167,10 +152,8 @@ func TestProcessPriceImport_WithCoverage_UsesUpsertWithFill(t *testing.T) {
 	database.EXPECT().ClearJobPayload(gomock.Any(), "job-price-cov").Return(nil)
 	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-price-cov", int32(1)).Return(nil)
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").
-		Return("inst-aapl", nil)
-	database.EXPECT().GetInstrument(gomock.Any(), "inst-aapl").
-		Return(stubInstrument("inst-aapl", "", "XNAS", ""), nil)
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").
+		Return("inst-aapl", "", "XNAS", "", nil)
 	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-price-cov").Return(nil)
 	// Expect UpsertPricesWithFill (not UpsertPrices) because coverage was provided.
 	database.EXPECT().
@@ -223,10 +206,8 @@ func TestProcessPriceImport_WithCoverage_NoCoverageForInstrument_UsesPlanUpsert(
 	database.EXPECT().ClearJobPayload(gomock.Any(), "job-price-nocov").Return(nil)
 	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-price-nocov", int32(1)).Return(nil)
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").
-		Return("inst-aapl", nil)
-	database.EXPECT().GetInstrument(gomock.Any(), "inst-aapl").
-		Return(stubInstrument("inst-aapl", "", "XNAS", ""), nil)
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").
+		Return("inst-aapl", "", "XNAS", "", nil)
 	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-price-nocov").Return(nil)
 	// No coverage match for AAPL, so expect plain UpsertPrices.
 	database.EXPECT().
@@ -275,10 +256,8 @@ func TestProcessPriceImport_RejectsHintDiff(t *testing.T) {
 
 	// DB-only lookup succeeds, but the instrument has a different exchange.
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").
-		Return("inst-aapl", nil)
-	database.EXPECT().GetInstrument(gomock.Any(), "inst-aapl").
-		Return(stubInstrument("inst-aapl", "", "XNYS", ""), nil) // exchange mismatch: XNYS != XNAS
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").
+		Return("inst-aapl", "", "XNYS", "", nil) // exchange mismatch: XNYS != XNAS
 	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-price-diff").Return(nil)
 
 	var capturedErrs []*apiv1.ValidationError
@@ -341,10 +320,8 @@ func TestProcessPriceImport_RejectsCurrencyHintDiff(t *testing.T) {
 	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-price-curdiff", int32(1)).Return(nil)
 
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").
-		Return("inst-aapl", nil)
-	database.EXPECT().GetInstrument(gomock.Any(), "inst-aapl").
-		Return(stubInstrument("inst-aapl", "", "XNAS", "USD"), nil) // currency mismatch: USD != GBP
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").
+		Return("inst-aapl", "", "XNAS", "USD", nil) // currency mismatch: USD != GBP
 	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-price-curdiff").Return(nil)
 
 	var capturedErrs []*apiv1.ValidationError

--- a/server/service/ingestion/resolve.go
+++ b/server/service/ingestion/resolve.go
@@ -207,15 +207,15 @@ func Resolve(ctx context.Context, database db.DB, registry *identifier.Registry,
 	// The in-memory batch cache above is still used to avoid repeated DB
 	// lookups within the same upload.
 	if len(identifierHints) > 0 {
-		resolved, err := identification.ResolveByHintsDBOnly(ctx, database, identifierHints)
+		ids, err := identification.ResolveIDsByHintsDBOnly(ctx, database, identifierHints)
 		if err != nil {
 			return resolveResult{}, err
 		}
-		if len(resolved) > 1 {
+		if len(ids) > 1 {
 			return resolveResult{}, fmt.Errorf("conflicting identifier hints resolve to different instruments")
 		}
-		if len(resolved) == 1 {
-			r := resolveResult{InstrumentID: resolved[0].ID, FirstRowIndex: rowIndex}
+		if len(ids) == 1 {
+			r := resolveResult{InstrumentID: ids[0], FirstRowIndex: rowIndex}
 			if cache != nil {
 				cache[key] = r
 			}

--- a/server/service/ingestion/resolve.go
+++ b/server/service/ingestion/resolve.go
@@ -207,15 +207,15 @@ func Resolve(ctx context.Context, database db.DB, registry *identifier.Registry,
 	// The in-memory batch cache above is still used to avoid repeated DB
 	// lookups within the same upload.
 	if len(identifierHints) > 0 {
-		ids, err := identification.ResolveByHintsDBOnly(ctx, database, identifierHints)
+		resolved, err := identification.ResolveByHintsDBOnly(ctx, database, identifierHints)
 		if err != nil {
 			return resolveResult{}, err
 		}
-		if len(ids) > 1 {
+		if len(resolved) > 1 {
 			return resolveResult{}, fmt.Errorf("conflicting identifier hints resolve to different instruments")
 		}
-		if len(ids) == 1 {
-			r := resolveResult{InstrumentID: ids[0], FirstRowIndex: rowIndex}
+		if len(resolved) == 1 {
+			r := resolveResult{InstrumentID: resolved[0].ID, FirstRowIndex: rowIndex}
 			if cache != nil {
 				cache[key] = r
 			}

--- a/server/service/ingestion/resolve_test.go
+++ b/server/service/ingestion/resolve_test.go
@@ -757,8 +757,8 @@ func TestResolve_SameDescription_DifferentHints_NoCacheConflict(t *testing.T) {
 
 	// First: resolve the security transaction (CUSIP hint).
 	database.EXPECT().
-		FindInstrumentWithMetaByIdentifier(gomock.Any(), "CUSIP", "", "594918104").
-		Return("msft-inst-id", "", "", "", nil)
+		FindInstrumentByIdentifier(gomock.Any(), "CUSIP", "", "594918104").
+		Return("msft-inst-id", nil)
 
 	r1, err := Resolve(ctx, database, registry, "IBKR", source, desc,
 		identifier.Hints{}, []identifier.Identifier{{Type: "CUSIP", Value: "594918104"}},
@@ -772,8 +772,8 @@ func TestResolve_SameDescription_DifferentHints_NoCacheConflict(t *testing.T) {
 
 	// Second: resolve the cash transaction (CURRENCY hint) with the same description.
 	database.EXPECT().
-		FindInstrumentWithMetaByIdentifier(gomock.Any(), "CURRENCY", "", "USD").
-		Return("usd-inst-id", "", "", "", nil)
+		FindInstrumentByIdentifier(gomock.Any(), "CURRENCY", "", "USD").
+		Return("usd-inst-id", nil)
 
 	r2, err := Resolve(ctx, database, registry, "IBKR", source, desc,
 		identifier.Hints{}, []identifier.Identifier{{Type: "CURRENCY", Value: "USD"}},

--- a/server/service/ingestion/resolve_test.go
+++ b/server/service/ingestion/resolve_test.go
@@ -78,8 +78,8 @@ func TestResolve_TickerOnlyFallback_ResolvesByTypeAndValue(t *testing.T) {
 	source := "IBKR:test:statement"
 	// Exact (TICKER, "", "AAPL") misses because DB has (TICKER, "US", "AAPL").
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "", "AAPL").
-		Return("", nil)
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "AAPL").
+		Return("", "", "", "", nil)
 	// Fallback by (type, value) finds the instrument.
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "AAPL").
@@ -156,8 +156,8 @@ func TestResolve_AllPluginsErrNotIdentified_BrokerDescriptionOnly(t *testing.T) 
 	ctx := context.Background()
 	source := "IBKR:test:statement"
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "", "UNKNOWN").
-		Return("", nil)
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "UNKNOWN").
+		Return("", "", "", "", nil)
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "UNKNOWN").
 		Return("", nil)
@@ -191,8 +191,8 @@ func TestResolve_OnePluginSuccess_EnsureInstrumentWithResult(t *testing.T) {
 
 	ctx := context.Background()
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "", "AAPL").
-		Return("", nil)
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "AAPL").
+		Return("", "", "", "", nil)
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "AAPL").
 		Return("", nil)
@@ -239,8 +239,8 @@ func TestResolve_BrokerDescriptionAlwaysStored(t *testing.T) {
 
 	ctx := context.Background()
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "", desc).
-		Return("", nil)
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", desc).
+		Return("", "", "", "", nil)
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", desc).
 		Return("", nil)
@@ -299,8 +299,8 @@ func TestResolve_PluginReturnsUnderlying_ResolvesUnderlyingThenDerivative(t *tes
 	ctx := context.Background()
 	// Top-level resolve: DB lookup for the option description.
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "", desc).
-		Return("", nil)
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", desc).
+		Return("", "", "", "", nil)
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", desc).
 		Return("", nil)
@@ -311,8 +311,8 @@ func TestResolve_PluginReturnsUnderlying_ResolvesUnderlyingThenDerivative(t *tes
 	// Recursive underlying resolution: DB lookup finds the underlying already exists.
 	// The underlying hint from plugin uses MIC_TICKER with empty domain.
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "", "AAPL").
-		Return("underlying-uuid", nil)
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "AAPL").
+		Return("underlying-uuid", "", "", "", nil)
 	// Ensure derivative (OPTION) with underlying_id from recursive resolution.
 	database.EXPECT().
 		EnsureInstrument(gomock.Any(), "OPTION", "SMART", "USD", "AAPL Call 20250117 200 C", gomock.Any(), gomock.Any(), gomock.Any(), "underlying-uuid", nil, nil, nil).
@@ -349,8 +349,8 @@ func TestResolve_TwoPlugins_HigherPrecedenceWins(t *testing.T) {
 
 	ctx := context.Background()
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "", "X").
-		Return("", nil)
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "X").
+		Return("", "", "", "", nil)
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "X").
 		Return("", nil)
@@ -395,8 +395,8 @@ func TestResolve_TwoPlugins_MergedIdentifiersByPrecedence(t *testing.T) {
 
 	ctx := context.Background()
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "", "Y").
-		Return("", nil)
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "Y").
+		Return("", "", "", "", nil)
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "Y").
 		Return("", nil)
@@ -449,8 +449,8 @@ func TestResolve_TwoPlugins_SameType_HighPrecedenceWins(t *testing.T) {
 
 	ctx := context.Background()
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "", "Z").
-		Return("", nil)
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "Z").
+		Return("", "", "", "", nil)
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "Z").
 		Return("", nil)
@@ -492,8 +492,8 @@ func TestResolve_PluginTimeout_FallbackAndMessage(t *testing.T) {
 
 	ctx := context.Background()
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "", "SLOW").
-		Return("", nil)
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "SLOW").
+		Return("", "", "", "", nil)
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "SLOW").
 		Return("", nil)
@@ -527,8 +527,8 @@ func TestResolve_PluginUnavailable_FallbackAndMessage(t *testing.T) {
 
 	ctx := context.Background()
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "", "BAD").
-		Return("", nil)
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "BAD").
+		Return("", "", "", "", nil)
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "BAD").
 		Return("", nil)
@@ -757,8 +757,8 @@ func TestResolve_SameDescription_DifferentHints_NoCacheConflict(t *testing.T) {
 
 	// First: resolve the security transaction (CUSIP hint).
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "CUSIP", "", "594918104").
-		Return("msft-inst-id", nil)
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "CUSIP", "", "594918104").
+		Return("msft-inst-id", "", "", "", nil)
 
 	r1, err := Resolve(ctx, database, registry, "IBKR", source, desc,
 		identifier.Hints{}, []identifier.Identifier{{Type: "CUSIP", Value: "594918104"}},
@@ -772,8 +772,8 @@ func TestResolve_SameDescription_DifferentHints_NoCacheConflict(t *testing.T) {
 
 	// Second: resolve the cash transaction (CURRENCY hint) with the same description.
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "CURRENCY", "", "USD").
-		Return("usd-inst-id", nil)
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "CURRENCY", "", "USD").
+		Return("usd-inst-id", "", "", "", nil)
 
 	r2, err := Resolve(ctx, database, registry, "IBKR", source, desc,
 		identifier.Hints{}, []identifier.Identifier{{Type: "CURRENCY", Value: "USD"}},
@@ -843,8 +843,8 @@ func TestResolve_PluginFailsThenRetrySucceeds(t *testing.T) {
 
 	ctx := context.Background()
 	database.EXPECT().
-		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "", "RETRY").
-		Return("", nil)
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "RETRY").
+		Return("", "", "", "", nil)
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "RETRY").
 		Return("", nil)


### PR DESCRIPTION
## Summary

- Add `currency` field to `ExportPriceRow` and `ImportPriceRow` proto messages
- Price exports now include the instrument's ISO 4217 currency code
- Price imports pass the currency as a hint to `resolveOrIdentifyInstrument`, which validates it against the resolved instrument (via hint diff validation from #215)
- Client CSV serializer/parser updated to include the `currency` column

Depends on #215.

## Test plan

- [x] `make generate` succeeds
- [x] `make test` passes (all Go and client tests)
- [x] New `TestProcessPriceImport_RejectsCurrencyHintDiff` — currency mismatch produces validation error
- [x] Price CSV tests updated for currency column (27 tests, including round-trip)
- [x] Export API test verifies currency is mapped to proto field
- [ ] Manual: export prices, verify CSV has currency column
- [ ] Manual: modify currency in CSV, re-import, verify validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)