### PR TITLE
Fix FindInstrumentWithMetaByIdentifier returning exchange acronym instead of MIC

### DIFF
--- a/server/db/db.go
+++ b/server/db/db.go
@@ -561,8 +561,8 @@ type InstrumentDB interface {
 	EnsureInstrument(ctx context.Context, assetClass, exchangeMIC, currency, name, cik, sicCode string, identifiers []IdentifierInput, underlyingID string, validFrom, validTo *time.Time, optionFields *OptionFields) (string, error)
 	// FindInstrumentByIdentifier looks up instrument_id by (identifier_type, domain, value). Returns "" if not found. Use empty domain for no domain.
 	FindInstrumentByIdentifier(ctx context.Context, identifierType, domain, value string) (string, error)
-	// FindInstrumentWithMetaByIdentifier is like FindInstrumentByIdentifier but also returns asset_class, exchange, and currency from the instruments table in one query.
-	FindInstrumentWithMetaByIdentifier(ctx context.Context, identifierType, domain, value string) (instrumentID, assetClass, exchange, currency string, err error)
+	// FindInstrumentWithMetaByIdentifier is like FindInstrumentByIdentifier but also returns asset_class, exchange_mic (ISO 10383 MIC code), and currency from the instruments table in one query.
+	FindInstrumentWithMetaByIdentifier(ctx context.Context, identifierType, domain, value string) (instrumentID, assetClass, exchangeMIC, currency string, err error)
 	// FindInstrumentByTypeAndValue looks up instrument_id by (identifier_type, value) with any domain. Returns "" if not found or if multiple instruments match (ambiguous).
 	FindInstrumentByTypeAndValue(ctx context.Context, identifierType, value string) (string, error)
 	// FindInstrumentBySourceDescription looks up instrument_id by (source, NULL domain, instrument_description). Returns "" if not found.

--- a/server/db/postgres/instruments.go
+++ b/server/db/postgres/instruments.go
@@ -154,14 +154,14 @@ func (p *Postgres) FindInstrumentWithMetaByIdentifier(ctx context.Context, ident
 	var err error
 	if domain == "" {
 		err = p.q.QueryRowContext(ctx, `
-			SELECT ii.instrument_id, COALESCE(i.asset_class, ''), i.exchange, COALESCE(i.currency, '')
+			SELECT ii.instrument_id, COALESCE(i.asset_class, ''), COALESCE(i.exchange_mic, ''), COALESCE(i.currency, '')
 			FROM instrument_identifiers ii
 			JOIN instruments i ON i.id = ii.instrument_id
 			WHERE ii.identifier_type = $1 AND ii.domain IS NULL AND ii.value = $2
 		`, identifierType, value).Scan(&id, &ac, &exch, &cur)
 	} else {
 		err = p.q.QueryRowContext(ctx, `
-			SELECT ii.instrument_id, COALESCE(i.asset_class, ''), i.exchange, COALESCE(i.currency, '')
+			SELECT ii.instrument_id, COALESCE(i.asset_class, ''), COALESCE(i.exchange_mic, ''), COALESCE(i.currency, '')
 			FROM instrument_identifiers ii
 			JOIN instruments i ON i.id = ii.instrument_id
 			WHERE ii.identifier_type = $1 AND ii.domain = $2 AND ii.value = $3

--- a/server/db/postgres/instruments_test.go
+++ b/server/db/postgres/instruments_test.go
@@ -384,6 +384,45 @@ func TestListInstruments_NullAssetClassMatchesUnknown(t *testing.T) {
 	}
 }
 
+// TestFindInstrumentWithMetaByIdentifier_ReturnsMIC verifies that FindInstrumentWithMetaByIdentifier
+// returns the exchange_mic column (e.g. "XNAS"), not the denormalized exchange acronym (e.g. "NASDAQ").
+func TestFindInstrumentWithMetaByIdentifier_ReturnsMIC(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	// Create instrument with exchange_mic = "XNAS". The DB trigger sets the
+	// denormalized exchange column to "NASDAQ" (the acronym from the exchanges table).
+	_, err := p.EnsureInstrument(ctx, "STOCK", "XNAS", "USD", "TestCo", "", "", []db.IdentifierInput{
+		{Type: "MIC_TICKER", Domain: "XNAS", Value: "TEST", Canonical: true},
+	}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+
+	// Look up by exact (type, domain, value).
+	_, _, exch, _, err := p.FindInstrumentWithMetaByIdentifier(ctx, "MIC_TICKER", "XNAS", "TEST")
+	if err != nil {
+		t.Fatalf("FindInstrumentWithMetaByIdentifier: %v", err)
+	}
+	if exch != "XNAS" {
+		t.Errorf("exchange = %q, want %q (must be MIC code, not acronym)", exch, "XNAS")
+	}
+
+	// Also verify the domain-less path returns MIC.
+	_, err = p.EnsureInstrument(ctx, "STOCK", "XNYS", "USD", "TestCo2", "", "", []db.IdentifierInput{
+		{Type: "ISIN", Value: "US9999999999", Canonical: true},
+	}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure XNYS: %v", err)
+	}
+	_, _, exch2, _, err := p.FindInstrumentWithMetaByIdentifier(ctx, "ISIN", "", "US9999999999")
+	if err != nil {
+		t.Fatalf("FindInstrumentWithMetaByIdentifier domain-less: %v", err)
+	}
+	if exch2 != "XNYS" {
+		t.Errorf("exchange (domain-less) = %q, want %q", exch2, "XNYS")
+	}
+}
+
 func TestListInstruments_PaginationPastEnd(t *testing.T) {
 	p := testDBTx(t)
 	ctx := context.Background()

--- a/server/identifier/types.go
+++ b/server/identifier/types.go
@@ -11,7 +11,7 @@ import "time"
 type Instrument struct {
 	ID         string // UUID; may be empty when creating new
 	AssetClass string // one of STOCK, ETF, FIXED_INCOME, MUTUAL_FUND, OPTION, FUTURE, CASH, UNKNOWN
-	Exchange   string
+	Exchange   string // ISO 10383 MIC code (e.g. "XNAS")
 	Currency   string
 	Name       string // optional display name
 

--- a/server/service/identification/resolve.go
+++ b/server/service/identification/resolve.go
@@ -38,7 +38,7 @@ type ResolveResult struct {
 type ResolvedInstrument struct {
 	ID         string
 	AssetClass string
-	Exchange   string
+	Exchange   string // ISO 10383 MIC code (e.g. "XNAS")
 	Currency   string
 }
 


### PR DESCRIPTION
## Summary

- `FindInstrumentWithMetaByIdentifier` was selecting the denormalized `i.exchange` column (acronym, e.g. "NASDAQ") instead of `i.exchange_mic` (MIC code, e.g. "XNAS")
- This caused ~13,800 false-positive hint validation errors like `Exchange: XNAS->NASDAQ` during price import (introduced in #216)
- Added integration test covering both SQL query paths (with and without domain)

## Test plan

- [x] `make test` passes (unit + integration)
- [ ] Re-import `local/standard-format/prices.csv` and verify `XNAS->NASDAQ` class of errors is eliminated

🤖 Generated with [Claude Code](https://claude.com/claude-code)