### PR TITLE
Add provider_instrument_identifiers table and LookupOperatingMIC

### DIFF
--- a/server/db/db.go
+++ b/server/db/db.go
@@ -282,6 +282,16 @@ type IdentifierInput struct {
 	Canonical bool   // default true when not set for backward compat
 }
 
+// ProviderIdentifierInput is a provider-specific identifier for an instrument.
+// Identifier types are free-form strings specific to the provider (e.g.
+// "SEGMENT_MIC_TICKER", "EODHD_EXCH_CODE", "FIGI").
+type ProviderIdentifierInput struct {
+	Provider string
+	Type     string
+	Domain   string
+	Value    string
+}
+
 // OptionFields carries denormalized OCC components for option instruments.
 // Nil when the instrument is not an option.
 type OptionFields struct {
@@ -516,9 +526,10 @@ type InstrumentRow struct {
 	ContractMultiplier  float64    // deliverable multiplier; 1 = standard
 	IdentifiedAt        *time.Time // last identification timestamp
 	Identifiers         []IdentifierInput
-	ExchangeName        *string // read-only; from exchanges JOIN
-	ExchangeAcronym     *string // read-only; from exchanges JOIN
-	ExchangeCountryCode *string // read-only; from exchanges JOIN
+	ProviderIdentifiers []ProviderIdentifierInput // provider-specific identifiers
+	ExchangeName        *string                   // read-only; from exchanges JOIN
+	ExchangeAcronym     *string                   // read-only; from exchanges JOIN
+	ExchangeCountryCode *string                   // read-only; from exchanges JOIN
 }
 
 // HoldingDeclarationRow is a single holding declaration for API responses.
@@ -592,6 +603,14 @@ type InstrumentDB interface {
 	UpdateInstrumentName(ctx context.Context, instrumentID, name string) error
 	// UpdateIdentifiedAt sets identified_at = now() on an existing instrument.
 	UpdateIdentifiedAt(ctx context.Context, instrumentID string) error
+	// SaveProviderIdentifiers inserts provider-specific identifiers for an instrument.
+	// Duplicates (same instrument, provider, type, domain, value) are silently ignored.
+	SaveProviderIdentifiers(ctx context.Context, instrumentID string, ids []ProviderIdentifierInput) error
+	// FindProviderIdentifiers returns provider-specific identifiers for an instrument and provider.
+	FindProviderIdentifiers(ctx context.Context, instrumentID, provider string) ([]ProviderIdentifierInput, error)
+	// LookupOperatingMIC returns the operating MIC for the given MIC code.
+	// If mic is already an operating MIC it returns itself. Returns ("", error) if not found.
+	LookupOperatingMIC(ctx context.Context, mic string) (string, error)
 }
 
 // IgnoredAssetClass is one ignore rule: skip tx types mapping to this asset class for

--- a/server/db/postgres/instruments.go
+++ b/server/db/postgres/instruments.go
@@ -239,8 +239,13 @@ func (p *Postgres) GetInstrument(ctx context.Context, instrumentID string) (*db.
 		return nil, fmt.Errorf("get instrument: %w", err)
 	}
 	row := r.toDBRow()
-	if err := loadIdentifiers(ctx, p.q, []uuid.UUID{r.ID}, []*db.InstrumentRow{row}); err != nil {
+	instIDs := []uuid.UUID{r.ID}
+	instRows := []*db.InstrumentRow{row}
+	if err := loadIdentifiers(ctx, p.q, instIDs, instRows); err != nil {
 		return nil, fmt.Errorf("get instrument identifiers: %w", err)
+	}
+	if err := loadProviderIdentifiers(ctx, p.q, instIDs, instRows); err != nil {
+		return nil, fmt.Errorf("get instrument provider identifiers: %w", err)
 	}
 	return row, nil
 }
@@ -282,6 +287,9 @@ func (p *Postgres) ListInstrumentsForExport(ctx context.Context, exchangeFilter 
 	}
 	if err := loadIdentifiers(ctx, p.q, ids, results); err != nil {
 		return nil, fmt.Errorf("list identifiers for export: %w", err)
+	}
+	if err := loadProviderIdentifiers(ctx, p.q, ids, results); err != nil {
+		return nil, fmt.Errorf("list provider identifiers for export: %w", err)
 	}
 	return results, nil
 }
@@ -329,6 +337,9 @@ func (p *Postgres) ListInstrumentsByIDs(ctx context.Context, ids []string) ([]*d
 	}
 	if err := loadIdentifiers(ctx, p.q, resultIDs, results); err != nil {
 		return nil, fmt.Errorf("list identifiers for instruments: %w", err)
+	}
+	if err := loadProviderIdentifiers(ctx, p.q, resultIDs, results); err != nil {
+		return nil, fmt.Errorf("list provider identifiers for instruments: %w", err)
 	}
 	return results, nil
 }
@@ -539,6 +550,9 @@ func (p *Postgres) ListInstruments(ctx context.Context, search string, assetClas
 	if err := loadIdentifiers(ctx, p.q, ids, results); err != nil {
 		return nil, 0, "", fmt.Errorf("list instrument identifiers: %w", err)
 	}
+	if err := loadProviderIdentifiers(ctx, p.q, ids, results); err != nil {
+		return nil, 0, "", fmt.Errorf("list instrument provider identifiers: %w", err)
+	}
 	return results, total, nextToken, nil
 }
 
@@ -583,6 +597,9 @@ func (p *Postgres) ListOptionsByUnderlying(ctx context.Context, underlyingID str
 	}
 	if err := loadIdentifiers(ctx, p.q, ids, results); err != nil {
 		return nil, fmt.Errorf("list options by underlying identifiers: %w", err)
+	}
+	if err := loadProviderIdentifiers(ctx, p.q, ids, results); err != nil {
+		return nil, fmt.Errorf("list options by underlying provider identifiers: %w", err)
 	}
 	return results, nil
 }
@@ -656,4 +673,70 @@ func (p *Postgres) UpdateIdentifiedAt(ctx context.Context, instrumentID string) 
 		return fmt.Errorf("update identified_at: %w", err)
 	}
 	return nil
+}
+
+// SaveProviderIdentifiers implements db.InstrumentDB.
+func (p *Postgres) SaveProviderIdentifiers(ctx context.Context, instrumentID string, ids []db.ProviderIdentifierInput) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	uid, err := uuid.Parse(instrumentID)
+	if err != nil {
+		return fmt.Errorf("save provider identifiers: invalid id: %w", err)
+	}
+	for _, id := range ids {
+		_, err := p.q.ExecContext(ctx, `
+			INSERT INTO provider_instrument_identifiers (instrument_id, provider, identifier_type, domain, value)
+			VALUES ($1, $2, $3, $4, $5)
+			ON CONFLICT DO NOTHING
+		`, uid, id.Provider, id.Type, nullStr(id.Domain), id.Value)
+		if err != nil {
+			return fmt.Errorf("save provider identifier (%s/%s): %w", id.Provider, id.Type, err)
+		}
+	}
+	return nil
+}
+
+// FindProviderIdentifiers implements db.InstrumentDB.
+func (p *Postgres) FindProviderIdentifiers(ctx context.Context, instrumentID, provider string) ([]db.ProviderIdentifierInput, error) {
+	uid, err := uuid.Parse(instrumentID)
+	if err != nil {
+		return nil, fmt.Errorf("find provider identifiers: invalid id: %w", err)
+	}
+	rows, err := p.q.QueryContext(ctx, `
+		SELECT provider, identifier_type, domain, value
+		FROM provider_instrument_identifiers
+		WHERE instrument_id = $1 AND provider = $2
+		ORDER BY identifier_type, value
+	`, uid, provider)
+	if err != nil {
+		return nil, fmt.Errorf("find provider identifiers: %w", err)
+	}
+	defer rows.Close()
+	var result []db.ProviderIdentifierInput
+	for rows.Next() {
+		var pi db.ProviderIdentifierInput
+		var domain sql.NullString
+		if err := rows.Scan(&pi.Provider, &pi.Type, &domain, &pi.Value); err != nil {
+			return nil, err
+		}
+		if domain.Valid {
+			pi.Domain = domain.String
+		}
+		result = append(result, pi)
+	}
+	return result, rows.Err()
+}
+
+// LookupOperatingMIC implements db.InstrumentDB.
+func (p *Postgres) LookupOperatingMIC(ctx context.Context, mic string) (string, error) {
+	var opMIC string
+	err := p.q.QueryRowContext(ctx, `SELECT operating_mic FROM exchanges WHERE mic = $1`, mic).Scan(&opMIC)
+	if err == sql.ErrNoRows {
+		return "", fmt.Errorf("lookup operating mic: unknown MIC %q", mic)
+	}
+	if err != nil {
+		return "", fmt.Errorf("lookup operating mic: %w", err)
+	}
+	return opMIC, nil
 }

--- a/server/db/postgres/instruments_test.go
+++ b/server/db/postgres/instruments_test.go
@@ -444,3 +444,109 @@ func TestListInstruments_PaginationPastEnd(t *testing.T) {
 		t.Fatalf("past-end page: expected total=3, got %d", total)
 	}
 }
+
+func TestLookupOperatingMIC(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+
+	// Operating MIC returns itself.
+	mic, err := p.LookupOperatingMIC(ctx, "XNAS")
+	if err != nil {
+		t.Fatalf("lookup XNAS: %v", err)
+	}
+	if mic != "XNAS" {
+		t.Fatalf("expected XNAS, got %s", mic)
+	}
+
+	// Segment MIC returns its operating MIC.
+	// XNGS (NASDAQ/NGS Global Select Market) is a segment of XNAS.
+	mic, err = p.LookupOperatingMIC(ctx, "XNGS")
+	if err != nil {
+		t.Fatalf("lookup XNGS: %v", err)
+	}
+	if mic != "XNAS" {
+		t.Fatalf("expected XNAS for segment XNGS, got %s", mic)
+	}
+
+	// Unknown MIC returns error.
+	_, err = p.LookupOperatingMIC(ctx, "ZZZZ")
+	if err == nil {
+		t.Fatal("expected error for unknown MIC")
+	}
+}
+
+func TestSaveAndFindProviderIdentifiers(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+
+	// Create an instrument to attach provider identifiers to.
+	instID, err := p.EnsureInstrument(ctx, "STOCK", "XNAS", "USD", "AAPL", "", "",
+		[]db.IdentifierInput{{Type: "MIC_TICKER", Domain: "XNAS", Value: "AAPL", Canonical: true}},
+		"", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+
+	// Save provider identifiers.
+	err = p.SaveProviderIdentifiers(ctx, instID, []db.ProviderIdentifierInput{
+		{Provider: "massive", Type: "SEGMENT_MIC_TICKER", Domain: "XNGS", Value: "AAPL"},
+		{Provider: "eodhd", Type: "EODHD_EXCH_CODE", Value: "US"},
+		{Provider: "openfigi", Type: "FIGI", Value: "BBG000B9XRY4"},
+	})
+	if err != nil {
+		t.Fatalf("save provider identifiers: %v", err)
+	}
+
+	// Find by provider.
+	ids, err := p.FindProviderIdentifiers(ctx, instID, "massive")
+	if err != nil {
+		t.Fatalf("find massive: %v", err)
+	}
+	if len(ids) != 1 {
+		t.Fatalf("expected 1 massive identifier, got %d", len(ids))
+	}
+	if ids[0].Type != "SEGMENT_MIC_TICKER" || ids[0].Domain != "XNGS" || ids[0].Value != "AAPL" {
+		t.Fatalf("unexpected massive identifier: %+v", ids[0])
+	}
+
+	ids, err = p.FindProviderIdentifiers(ctx, instID, "eodhd")
+	if err != nil {
+		t.Fatalf("find eodhd: %v", err)
+	}
+	if len(ids) != 1 || ids[0].Type != "EODHD_EXCH_CODE" || ids[0].Value != "US" {
+		t.Fatalf("unexpected eodhd identifiers: %+v", ids)
+	}
+
+	// Duplicate insert is idempotent.
+	err = p.SaveProviderIdentifiers(ctx, instID, []db.ProviderIdentifierInput{
+		{Provider: "massive", Type: "SEGMENT_MIC_TICKER", Domain: "XNGS", Value: "AAPL"},
+	})
+	if err != nil {
+		t.Fatalf("duplicate save: %v", err)
+	}
+	ids, err = p.FindProviderIdentifiers(ctx, instID, "massive")
+	if err != nil {
+		t.Fatalf("find after dup: %v", err)
+	}
+	if len(ids) != 1 {
+		t.Fatalf("expected 1 after dup, got %d", len(ids))
+	}
+
+	// Provider identifiers are loaded by GetInstrument.
+	inst, err := p.GetInstrument(ctx, instID)
+	if err != nil {
+		t.Fatalf("get instrument: %v", err)
+	}
+	if len(inst.ProviderIdentifiers) != 3 {
+		t.Fatalf("expected 3 provider identifiers on instrument, got %d", len(inst.ProviderIdentifiers))
+	}
+
+	// Unknown provider returns empty.
+	ids, err = p.FindProviderIdentifiers(ctx, instID, "unknown")
+	if err != nil {
+		t.Fatalf("find unknown: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Fatalf("expected 0 for unknown provider, got %d", len(ids))
+	}
+}

--- a/server/db/postgres/postgres.go
+++ b/server/db/postgres/postgres.go
@@ -379,3 +379,40 @@ func loadIdentifiers(ctx context.Context, q queryable, ids []uuid.UUID, rows []*
 	}
 	return idRows.Err()
 }
+
+// loadProviderIdentifiers batch-loads provider-specific identifiers for the given instrument IDs.
+func loadProviderIdentifiers(ctx context.Context, q queryable, ids []uuid.UUID, rows []*db.InstrumentRow) error {
+	if len(ids) == 0 {
+		return nil
+	}
+	inClause, args := inClauseUUIDs(ids)
+	piRows, err := q.QueryContext(ctx, fmt.Sprintf(`
+		SELECT instrument_id, provider, identifier_type, domain, value
+		FROM provider_instrument_identifiers
+		WHERE instrument_id IN (%s)
+		ORDER BY instrument_id
+	`, inClause), args...)
+	if err != nil {
+		return err
+	}
+	defer piRows.Close()
+	byID := make(map[string]*db.InstrumentRow, len(rows))
+	for _, r := range rows {
+		byID[r.ID] = r
+	}
+	for piRows.Next() {
+		var instID uuid.UUID
+		var pi db.ProviderIdentifierInput
+		var domain sql.NullString
+		if err := piRows.Scan(&instID, &pi.Provider, &pi.Type, &domain, &pi.Value); err != nil {
+			return err
+		}
+		if domain.Valid {
+			pi.Domain = domain.String
+		}
+		if r := byID[instID.String()]; r != nil {
+			r.ProviderIdentifiers = append(r.ProviderIdentifiers, pi)
+		}
+	}
+	return piRows.Err()
+}

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -224,6 +224,24 @@ CREATE TRIGGER trg_recompute_instrument_name_on_inst
   AFTER INSERT OR UPDATE OF exchange_mic ON instruments
   FOR EACH ROW EXECUTE FUNCTION recompute_instrument_name();
 
+-- Provider-specific instrument identifiers. Mirrors instrument_identifiers but
+-- scoped to a data provider. Identifier types are free-form strings specific to
+-- the provider (e.g. "SEGMENT_MIC_TICKER", "EODHD_EXCH_CODE", "FIGI").
+CREATE TABLE provider_instrument_identifiers (
+  id              UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+  instrument_id   UUID NOT NULL REFERENCES instruments (id) ON DELETE CASCADE,
+  provider        TEXT NOT NULL,
+  identifier_type TEXT NOT NULL,
+  domain          TEXT,
+  value           TEXT NOT NULL
+);
+
+-- Per-instrument per-provider uniqueness.
+CREATE UNIQUE INDEX idx_prov_instr_ident_unique_null_domain ON provider_instrument_identifiers (instrument_id, provider, identifier_type, value) WHERE domain IS NULL;
+CREATE UNIQUE INDEX idx_prov_instr_ident_unique_non_null_domain ON provider_instrument_identifiers (instrument_id, provider, identifier_type, domain, value) WHERE domain IS NOT NULL;
+-- Reverse lookup by provider + identifier.
+CREATE INDEX idx_prov_instr_ident_lookup ON provider_instrument_identifiers (provider, identifier_type, value);
+
 -- Plugin config: which plugins are enabled, precedence (unique per category), plugin-specific config.
 -- category: 'identifier', 'description', 'price'.
 -- Precedence constraints are DEFERRABLE so that two plugins' precedences can be swapped


### PR DESCRIPTION
## Summary
- Adds `provider_instrument_identifiers` table to store provider-specific instrument identifiers (segment MICs, EODHD exchange codes, venue FIGIs) separate from the canonical `instrument_identifiers` table
- Adds `LookupOperatingMIC` DB method to map any MIC (segment or operating) to its operating MIC via the exchanges table
- Adds `SaveProviderIdentifiers` and `FindProviderIdentifiers` DB methods for CRUD on the new table
- Adds `ProviderIdentifierInput` struct and `ProviderIdentifiers` field on `InstrumentRow`
- Provider identifiers are loaded alongside canonical identifiers in `GetInstrument`, `ListInstrumentsByIDs`, etc.

This is PR 1 of 5 for the exchange code normalization feature. Subsequent PRs will:
- PR 2: Normalize MIC_TICKER domains to operating MICs on storage
- PR 3: Store provider identifiers from identifier plugins
- PR 4: Use provider identifiers in price/corporate event fetchers
- PR 5: Documentation

## Test plan
- [x] `make server-test` passes (unit tests)
- [x] `make db-test` passes (DB integration tests)
- [x] New `TestLookupOperatingMIC` -- verifies operating MIC self-lookup, segment-to-operating mapping, and unknown MIC error
- [x] New `TestSaveAndFindProviderIdentifiers` -- verifies save, find by provider, idempotent duplicates, loading via GetInstrument, and empty result for unknown provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)