### PR TITLE
Normalize MIC_TICKER domains to operating MICs and relax consistency checks

### DIFF
--- a/server/db/postgres/instruments.go
+++ b/server/db/postgres/instruments.go
@@ -358,6 +358,13 @@ func (p *Postgres) EnsureInstrument(ctx context.Context, assetClass, exchangeMIC
 	if (assetClass == db.AssetClassOption || assetClass == db.AssetClassFuture) && underlyingID == "" {
 		return "", fmt.Errorf("underlying_id required when asset_class is %s", assetClass)
 	}
+	// Normalize MIC_TICKER domains and exchangeMIC to operating MICs.
+	exchangeMIC = p.normalizeToOperatingMIC(ctx, exchangeMIC)
+	for i := range identifiers {
+		if identifiers[i].Type == "MIC_TICKER" && identifiers[i].Domain != "" {
+			identifiers[i].Domain = p.normalizeToOperatingMIC(ctx, identifiers[i].Domain)
+		}
+	}
 	var underlyingUUID *uuid.UUID
 	if underlyingID != "" {
 		parsed, err := uuid.Parse(underlyingID)
@@ -626,6 +633,9 @@ func (p *Postgres) InsertInstrumentIdentifier(ctx context.Context, instrumentID 
 	if err != nil {
 		return fmt.Errorf("insert instrument identifier: invalid id: %w", err)
 	}
+	if input.Type == "MIC_TICKER" && input.Domain != "" {
+		input.Domain = p.normalizeToOperatingMIC(ctx, input.Domain)
+	}
 	_, err = p.q.ExecContext(ctx, `
 		INSERT INTO instrument_identifiers (instrument_id, identifier_type, domain, value, canonical)
 		VALUES ($1, $2, $3, $4, $5)
@@ -726,6 +736,19 @@ func (p *Postgres) FindProviderIdentifiers(ctx context.Context, instrumentID, pr
 		result = append(result, pi)
 	}
 	return result, rows.Err()
+}
+
+// normalizeToOperatingMIC maps a MIC to its operating MIC. If the lookup fails
+// (unknown MIC or DB error), returns the original value unchanged.
+func (p *Postgres) normalizeToOperatingMIC(ctx context.Context, mic string) string {
+	if mic == "" {
+		return mic
+	}
+	opMIC, err := p.LookupOperatingMIC(ctx, mic)
+	if err != nil {
+		return mic
+	}
+	return opMIC
 }
 
 // LookupOperatingMIC implements db.InstrumentDB.

--- a/server/db/postgres/instruments_test.go
+++ b/server/db/postgres/instruments_test.go
@@ -589,3 +589,90 @@ func TestSaveAndFindProviderIdentifiers(t *testing.T) {
 		t.Fatalf("expected 0 for unknown provider, got %d", len(ids))
 	}
 }
+
+func TestEnsureInstrument_NormalizesSegmentMIC(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+
+	// Create instrument with segment MIC XNGS (segment of XNAS).
+	instID, err := p.EnsureInstrument(ctx, "STOCK", "XNGS", "USD", "AAPL", "", "",
+		[]db.IdentifierInput{{Type: "MIC_TICKER", Domain: "XNGS", Value: "AAPL", Canonical: true}},
+		"", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+
+	// Verify exchangeMIC was normalized to operating MIC.
+	inst, err := p.GetInstrument(ctx, instID)
+	if err != nil {
+		t.Fatalf("get instrument: %v", err)
+	}
+	if inst.ExchangeMIC == nil || *inst.ExchangeMIC != "XNAS" {
+		t.Fatalf("expected exchangeMIC XNAS, got %v", inst.ExchangeMIC)
+	}
+
+	// Verify MIC_TICKER domain was normalized to operating MIC.
+	var found bool
+	for _, id := range inst.Identifiers {
+		if id.Type == "MIC_TICKER" {
+			if id.Domain != "XNAS" {
+				t.Fatalf("expected MIC_TICKER domain XNAS, got %s", id.Domain)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("MIC_TICKER identifier not found")
+	}
+
+	// Ensure same instrument is found when looking up with segment MIC.
+	// The domain was normalized, so direct lookup with segment MIC should NOT match.
+	id, err := p.FindInstrumentByIdentifier(ctx, "MIC_TICKER", "XNGS", "AAPL")
+	if err != nil {
+		t.Fatalf("find by segment MIC: %v", err)
+	}
+	if id != "" {
+		t.Fatal("expected no match for segment MIC domain (was normalized)")
+	}
+
+	// But lookup with operating MIC should find it.
+	id, err = p.FindInstrumentByIdentifier(ctx, "MIC_TICKER", "XNAS", "AAPL")
+	if err != nil {
+		t.Fatalf("find by operating MIC: %v", err)
+	}
+	if id != instID {
+		t.Fatalf("expected %s, got %s", instID, id)
+	}
+}
+
+func TestInsertInstrumentIdentifier_NormalizesSegmentMIC(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+
+	// Create instrument with operating MIC.
+	instID, err := p.EnsureInstrument(ctx, "STOCK", "XNAS", "USD", "AAPL", "", "",
+		[]db.IdentifierInput{{Type: "ISIN", Value: "US0378331005", Canonical: true}},
+		"", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+
+	// Insert MIC_TICKER with segment MIC.
+	err = p.InsertInstrumentIdentifier(ctx, instID, db.IdentifierInput{
+		Type: "MIC_TICKER", Domain: "XNGS", Value: "AAPL", Canonical: true,
+	})
+	if err != nil {
+		t.Fatalf("insert identifier: %v", err)
+	}
+
+	// Verify domain was normalized.
+	inst, err := p.GetInstrument(ctx, instID)
+	if err != nil {
+		t.Fatalf("get instrument: %v", err)
+	}
+	for _, id := range inst.Identifiers {
+		if id.Type == "MIC_TICKER" && id.Domain != "XNAS" {
+			t.Fatalf("expected MIC_TICKER domain XNAS, got %s", id.Domain)
+		}
+	}
+}

--- a/server/service/identification/resolve.go
+++ b/server/service/identification/resolve.go
@@ -160,10 +160,42 @@ type pluginResult struct {
 	err  error
 }
 
+// MICNormalizer maps a MIC to its operating MIC. Returns the input unchanged
+// if normalization fails (unknown MIC, DB error, etc.).
+type MICNormalizer func(ctx context.Context, mic string) string
+
+// MICLookup is the subset of db.InstrumentDB needed to build a MICNormalizer.
+type MICLookup interface {
+	LookupOperatingMIC(ctx context.Context, mic string) (string, error)
+}
+
+// NewDBMICNormalizer returns a MICNormalizer backed by a database lookup.
+func NewDBMICNormalizer(db MICLookup) MICNormalizer {
+	return func(ctx context.Context, mic string) string {
+		if mic == "" {
+			return mic
+		}
+		op, err := db.LookupOperatingMIC(ctx, mic)
+		if err != nil {
+			return mic
+		}
+		return op
+	}
+}
+
+// normalizeMICValue applies the normalizer if non-nil, otherwise returns mic unchanged.
+func normalizeMICValue(ctx context.Context, normalizeMIC MICNormalizer, mic string) string {
+	if normalizeMIC == nil || mic == "" {
+		return mic
+	}
+	return normalizeMIC(ctx, mic)
+}
+
 // consistentWith returns true if other's instrument metadata is consistent with
 // winner's. Checks Currency, Exchange, and overlapping identifier values.
-// Logs a warning and returns false on mismatch.
-func consistentWith(ctx context.Context, l *slog.Logger, winnerPlugin, otherPlugin string, winner, other *pluginResult) bool {
+// Logs a warning and returns false on mismatch. Exchange comparison normalizes
+// both sides to operating MICs via normalizeMIC (if non-nil).
+func consistentWith(ctx context.Context, l *slog.Logger, winnerPlugin, otherPlugin string, winner, other *pluginResult, normalizeMIC MICNormalizer) bool {
 	l = resolveLogger(l)
 	if winner.inst.Currency != "" && other.inst.Currency != "" &&
 		!strings.EqualFold(winner.inst.Currency, other.inst.Currency) {
@@ -172,8 +204,10 @@ func consistentWith(ctx context.Context, l *slog.Logger, winnerPlugin, otherPlug
 			"field", "Currency", "winner_value", winner.inst.Currency, "other_value", other.inst.Currency)
 		return false
 	}
-	if winner.inst.Exchange != "" && other.inst.Exchange != "" &&
-		!strings.EqualFold(winner.inst.Exchange, other.inst.Exchange) {
+	winnerExch := normalizeMICValue(ctx, normalizeMIC, winner.inst.Exchange)
+	otherExch := normalizeMICValue(ctx, normalizeMIC, other.inst.Exchange)
+	if winnerExch != "" && otherExch != "" &&
+		!strings.EqualFold(winnerExch, otherExch) {
 		l.WarnContext(ctx, "identifier plugin mismatch, excluding from merge",
 			"winner_plugin", winnerPlugin, "other_plugin", otherPlugin,
 			"field", "Exchange", "winner_value", winner.inst.Exchange, "other_value", other.inst.Exchange)
@@ -196,8 +230,10 @@ func consistentWith(ctx context.Context, l *slog.Logger, winnerPlugin, otherPlug
 
 // CompareHints compares supplied hints and identifier hints against the
 // resolved instrument and its identifiers, returning any differences.
-// Fields are skipped when either side is empty or UNKNOWN.
-func CompareHints(hints identifier.Hints, identifierHints []identifier.Identifier, inst *identifier.Instrument, resolvedIDs []identifier.Identifier) []identifier.HintDiff {
+// Fields are skipped when either side is empty or UNKNOWN. normalizeMIC
+// (if non-nil) maps both sides of the exchange comparison to operating MICs
+// so that segment-vs-operating differences are not flagged.
+func CompareHints(ctx context.Context, hints identifier.Hints, identifierHints []identifier.Identifier, inst *identifier.Instrument, resolvedIDs []identifier.Identifier, normalizeMIC MICNormalizer) []identifier.HintDiff {
 	if inst == nil {
 		return nil
 	}
@@ -217,11 +253,15 @@ func CompareHints(hints identifier.Hints, identifierHints []identifier.Identifie
 	}
 
 	// Exchange: compare MIC_TICKER hint domain (the MIC code) against inst.Exchange.
+	// Both sides are normalized to operating MICs before comparison.
 	if inst.Exchange != "" {
+		instExch := normalizeMICValue(ctx, normalizeMIC, inst.Exchange)
 		for _, h := range identifierHints {
-			if h.Type == "MIC_TICKER" && h.Domain != "" &&
-				!strings.EqualFold(h.Domain, inst.Exchange) {
-				diffs = append(diffs, identifier.HintDiff{Field: "Exchange", HintValue: h.Domain, ResolvedValue: inst.Exchange})
+			if h.Type == "MIC_TICKER" && h.Domain != "" {
+				hintExch := normalizeMICValue(ctx, normalizeMIC, h.Domain)
+				if !strings.EqualFold(hintExch, instExch) {
+					diffs = append(diffs, identifier.HintDiff{Field: "Exchange", HintValue: h.Domain, ResolvedValue: inst.Exchange})
+				}
 				break
 			}
 		}
@@ -265,6 +305,7 @@ func ResolveWithPlugins(
 	hintsValidAt *time.Time,
 ) (ResolveResult, error) {
 	l := resolveLogger(logger)
+	normMIC := NewDBMICNormalizer(database)
 
 	// Adjust OCC hints for known stock splits before any lookups.
 	identifierHints = AdjustOCCForKnownSplits(ctx, database, identifierHints, hintsValidAt, nil)
@@ -280,7 +321,7 @@ func ResolveWithPlugins(
 			Exchange:   resolved[0].Exchange,
 			Currency:   resolved[0].Currency,
 		}
-		diffs := CompareHints(hints, identifierHints, inst, nil)
+		diffs := CompareHints(ctx, hints, identifierHints, inst, nil, normMIC)
 		return ResolveResult{InstrumentID: resolved[0].ID, Identified: true, HintDiffs: diffs}, nil
 	}
 
@@ -370,7 +411,7 @@ func ResolveWithPlugins(
 			if r.err != nil || r.inst == nil {
 				continue
 			}
-			if i != winnerIdx && !consistentWith(ctx, l, inputs[winnerIdx].config.PluginID, inputs[i].config.PluginID, winner, r) {
+			if i != winnerIdx && !consistentWith(ctx, l, inputs[winnerIdx].config.PluginID, inputs[i].config.PluginID, winner, r, normMIC) {
 				continue
 			}
 			for _, idn := range r.ids {
@@ -418,7 +459,7 @@ func ResolveWithPlugins(
 		if inst.AssetClass == db.AssetClassOption {
 			optFields = optionFieldsFromIdentifiers(mergedIds)
 		}
-		diffs := CompareHints(hints, identifierHints, inst, mergedIds)
+		diffs := CompareHints(ctx, hints, identifierHints, inst, mergedIds, normMIC)
 		id, err := database.EnsureInstrument(ctx, inst.AssetClass, inst.Exchange, inst.Currency, inst.Name, inst.CIK, inst.SICCode, identifiers, underlyingID, validFrom, validTo, optFields)
 		if err != nil {
 			return ResolveResult{}, err

--- a/server/service/identification/resolve_test.go
+++ b/server/service/identification/resolve_test.go
@@ -163,6 +163,7 @@ func TestResolveWithPlugins_DBHit(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 
 	database.EXPECT().
@@ -191,6 +192,7 @@ func TestResolveWithPlugins_PluginSuccess(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 	registry.Register("test", &fakePlugin{
 		inst: &identifier.Instrument{AssetClass: "STOCK", Exchange: "XNAS", Currency: "USD", Name: "Apple Inc."},
@@ -229,6 +231,7 @@ func TestResolveWithPlugins_AllPluginsFail_Fallback(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 	registry.Register("test", &fakePlugin{err: identifier.ErrNotIdentified})
 
@@ -274,6 +277,7 @@ func TestResolveWithPlugins_Timeout_SetsHadTimeout(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 	registry.Register("slow", &fakePlugin{err: context.DeadlineExceeded})
 
@@ -310,6 +314,7 @@ func TestResolveWithPlugins_NilFallback_ReturnsEmpty(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 	registry.Register("test", &fakePlugin{err: identifier.ErrNotIdentified})
 
@@ -339,6 +344,7 @@ func TestResolveWithPlugins_StoreSourceDescription(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 	source := "IBKR:test:statement"
 	desc := "APPLE INC COM"
@@ -388,6 +394,7 @@ func TestResolveWithPlugins_PluginError_SetsHadError(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 	registry.Register("bad", &fakePlugin{err: errors.New("connection refused")})
 
@@ -569,7 +576,7 @@ func TestConsistentWith_AllMatch(t *testing.T) {
 		inst: &identifier.Instrument{Exchange: "XNAS", Currency: "USD"},
 		ids:  []identifier.Identifier{{Type: "OPENFIGI_GLOBAL", Value: "BBG000B9XRY4"}},
 	}
-	if !consistentWith(context.Background(), nil, "a", "b", w, o) {
+	if !consistentWith(context.Background(), nil, "a", "b", w, o, nil) {
 		t.Error("expected consistent")
 	}
 }
@@ -581,7 +588,7 @@ func TestConsistentWith_CurrencyMismatch(t *testing.T) {
 	o := &pluginResult{
 		inst: &identifier.Instrument{Currency: "EUR"},
 	}
-	if consistentWith(context.Background(), nil, "a", "b", w, o) {
+	if consistentWith(context.Background(), nil, "a", "b", w, o, nil) {
 		t.Error("expected inconsistent on currency mismatch")
 	}
 }
@@ -593,7 +600,7 @@ func TestConsistentWith_ExchangeMismatch(t *testing.T) {
 	o := &pluginResult{
 		inst: &identifier.Instrument{Exchange: "XNYS", Currency: "USD"},
 	}
-	if consistentWith(context.Background(), nil, "a", "b", w, o) {
+	if consistentWith(context.Background(), nil, "a", "b", w, o, nil) {
 		t.Error("expected inconsistent on exchange mismatch")
 	}
 }
@@ -607,7 +614,7 @@ func TestConsistentWith_EmptyFieldsSkipped(t *testing.T) {
 		inst: &identifier.Instrument{Exchange: "", Currency: ""},
 		ids:  []identifier.Identifier{{Type: "OPENFIGI_GLOBAL", Value: "BBG000B9XRY4"}},
 	}
-	if !consistentWith(context.Background(), nil, "a", "b", w, o) {
+	if !consistentWith(context.Background(), nil, "a", "b", w, o, nil) {
 		t.Error("expected consistent when other has empty exchange/currency")
 	}
 }
@@ -621,7 +628,7 @@ func TestConsistentWith_IdentifierValueMismatch(t *testing.T) {
 		inst: &identifier.Instrument{},
 		ids:  []identifier.Identifier{{Type: "ISIN", Value: "GB1234567890"}},
 	}
-	if consistentWith(context.Background(), nil, "a", "b", w, o) {
+	if consistentWith(context.Background(), nil, "a", "b", w, o, nil) {
 		t.Error("expected inconsistent on ISIN value mismatch")
 	}
 }
@@ -635,7 +642,7 @@ func TestConsistentWith_IdentifierValueMatch(t *testing.T) {
 		inst: &identifier.Instrument{},
 		ids:  []identifier.Identifier{{Type: "ISIN", Value: "US0378331005"}, {Type: "OPENFIGI_GLOBAL", Value: "BBG000B9XRY4"}},
 	}
-	if !consistentWith(context.Background(), nil, "a", "b", w, o) {
+	if !consistentWith(context.Background(), nil, "a", "b", w, o, nil) {
 		t.Error("expected consistent when ISIN values match")
 	}
 }
@@ -648,6 +655,7 @@ func TestResolveWithPlugins_InconsistentPluginExcluded(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 
 	// Plugin A (higher precedence): XNAS/USD with ISIN
@@ -701,7 +709,7 @@ func TestCompareHints_NoDiffs(t *testing.T) {
 	idnHints := []identifier.Identifier{{Type: "ISIN", Value: "US0378331005"}}
 	resolvedIDs := []identifier.Identifier{{Type: "ISIN", Value: "US0378331005"}}
 
-	diffs := CompareHints(hints, idnHints, inst, resolvedIDs)
+	diffs := CompareHints(context.Background(), hints, idnHints, inst, resolvedIDs, nil)
 	if len(diffs) != 0 {
 		t.Errorf("expected no diffs, got %v", diffs)
 	}
@@ -711,7 +719,7 @@ func TestCompareHints_CurrencyMismatch(t *testing.T) {
 	hints := identifier.Hints{Currency: "USD"}
 	inst := &identifier.Instrument{Currency: "EUR"}
 
-	diffs := CompareHints(hints, nil, inst, nil)
+	diffs := CompareHints(context.Background(), hints, nil, inst, nil, nil)
 	if len(diffs) != 1 {
 		t.Fatalf("expected 1 diff, got %d", len(diffs))
 	}
@@ -724,7 +732,7 @@ func TestCompareHints_CurrencyCaseInsensitive(t *testing.T) {
 	hints := identifier.Hints{Currency: "usd"}
 	inst := &identifier.Instrument{Currency: "USD"}
 
-	diffs := CompareHints(hints, nil, inst, nil)
+	diffs := CompareHints(context.Background(), hints, nil, inst, nil, nil)
 	if len(diffs) != 0 {
 		t.Errorf("expected no diffs for case-insensitive match, got %v", diffs)
 	}
@@ -732,12 +740,12 @@ func TestCompareHints_CurrencyCaseInsensitive(t *testing.T) {
 
 func TestCompareHints_EmptyCurrencySkipped(t *testing.T) {
 	// Empty hint currency.
-	diffs := CompareHints(identifier.Hints{}, nil, &identifier.Instrument{Currency: "USD"}, nil)
+	diffs := CompareHints(context.Background(), identifier.Hints{}, nil, &identifier.Instrument{Currency: "USD"}, nil, nil)
 	if len(diffs) != 0 {
 		t.Errorf("expected no diffs when hint currency empty, got %v", diffs)
 	}
 	// Empty resolved currency.
-	diffs = CompareHints(identifier.Hints{Currency: "USD"}, nil, &identifier.Instrument{}, nil)
+	diffs = CompareHints(context.Background(), identifier.Hints{Currency: "USD"}, nil, &identifier.Instrument{}, nil, nil)
 	if len(diffs) != 0 {
 		t.Errorf("expected no diffs when resolved currency empty, got %v", diffs)
 	}
@@ -747,7 +755,7 @@ func TestCompareHints_SecurityTypeMismatch(t *testing.T) {
 	hints := identifier.Hints{SecurityTypeHint: "STOCK"}
 	inst := &identifier.Instrument{AssetClass: "ETF"}
 
-	diffs := CompareHints(hints, nil, inst, nil)
+	diffs := CompareHints(context.Background(), hints, nil, inst, nil, nil)
 	if len(diffs) != 1 {
 		t.Fatalf("expected 1 diff, got %d", len(diffs))
 	}
@@ -758,12 +766,12 @@ func TestCompareHints_SecurityTypeMismatch(t *testing.T) {
 
 func TestCompareHints_SecurityTypeUnknownSkipped(t *testing.T) {
 	// UNKNOWN hint should not produce a diff.
-	diffs := CompareHints(identifier.Hints{SecurityTypeHint: "UNKNOWN"}, nil, &identifier.Instrument{AssetClass: "STOCK"}, nil)
+	diffs := CompareHints(context.Background(), identifier.Hints{SecurityTypeHint: "UNKNOWN"}, nil, &identifier.Instrument{AssetClass: "STOCK"}, nil, nil)
 	if len(diffs) != 0 {
 		t.Errorf("expected no diffs when hint is UNKNOWN, got %v", diffs)
 	}
 	// UNKNOWN resolved should not produce a diff.
-	diffs = CompareHints(identifier.Hints{SecurityTypeHint: "STOCK"}, nil, &identifier.Instrument{AssetClass: "UNKNOWN"}, nil)
+	diffs = CompareHints(context.Background(), identifier.Hints{SecurityTypeHint: "STOCK"}, nil, &identifier.Instrument{AssetClass: "UNKNOWN"}, nil, nil)
 	if len(diffs) != 0 {
 		t.Errorf("expected no diffs when resolved is UNKNOWN, got %v", diffs)
 	}
@@ -774,7 +782,7 @@ func TestCompareHints_ExchangeViaMICTickerDomain(t *testing.T) {
 	idnHints := []identifier.Identifier{{Type: "MIC_TICKER", Domain: "XNAS", Value: "AAPL"}}
 	inst := &identifier.Instrument{Exchange: "XNYS"}
 
-	diffs := CompareHints(hints, idnHints, inst, nil)
+	diffs := CompareHints(context.Background(), hints, idnHints, inst, nil, nil)
 	if len(diffs) != 1 {
 		t.Fatalf("expected 1 diff, got %d", len(diffs))
 	}
@@ -787,7 +795,7 @@ func TestCompareHints_ExchangeViaMICTickerMatch(t *testing.T) {
 	idnHints := []identifier.Identifier{{Type: "MIC_TICKER", Domain: "XNAS", Value: "AAPL"}}
 	inst := &identifier.Instrument{Exchange: "XNAS"}
 
-	diffs := CompareHints(identifier.Hints{}, idnHints, inst, nil)
+	diffs := CompareHints(context.Background(), identifier.Hints{}, idnHints, inst, nil, nil)
 	if len(diffs) != 0 {
 		t.Errorf("expected no diffs, got %v", diffs)
 	}
@@ -797,7 +805,7 @@ func TestCompareHints_ExchangeEmptyDomainSkipped(t *testing.T) {
 	idnHints := []identifier.Identifier{{Type: "MIC_TICKER", Domain: "", Value: "AAPL"}}
 	inst := &identifier.Instrument{Exchange: "XNAS"}
 
-	diffs := CompareHints(identifier.Hints{}, idnHints, inst, nil)
+	diffs := CompareHints(context.Background(), identifier.Hints{}, idnHints, inst, nil, nil)
 	if len(diffs) != 0 {
 		t.Errorf("expected no diffs when MIC_TICKER domain empty, got %v", diffs)
 	}
@@ -807,7 +815,7 @@ func TestCompareHints_IdentifierValueMismatch(t *testing.T) {
 	idnHints := []identifier.Identifier{{Type: "ISIN", Value: "US0378331005"}}
 	resolvedIDs := []identifier.Identifier{{Type: "ISIN", Value: "GB0002634946"}}
 
-	diffs := CompareHints(identifier.Hints{}, idnHints, &identifier.Instrument{}, resolvedIDs)
+	diffs := CompareHints(context.Background(), identifier.Hints{}, idnHints, &identifier.Instrument{}, resolvedIDs, nil)
 	if len(diffs) != 1 {
 		t.Fatalf("expected 1 diff, got %d", len(diffs))
 	}
@@ -820,7 +828,7 @@ func TestCompareHints_IdentifierTypeNotInResolved(t *testing.T) {
 	idnHints := []identifier.Identifier{{Type: "CUSIP", Value: "037833100"}}
 	resolvedIDs := []identifier.Identifier{{Type: "ISIN", Value: "US0378331005"}}
 
-	diffs := CompareHints(identifier.Hints{}, idnHints, &identifier.Instrument{}, resolvedIDs)
+	diffs := CompareHints(context.Background(), identifier.Hints{}, idnHints, &identifier.Instrument{}, resolvedIDs, nil)
 	if len(diffs) != 0 {
 		t.Errorf("expected no diffs when hint type not in resolved, got %v", diffs)
 	}
@@ -835,7 +843,7 @@ func TestCompareHints_MultipleDiffs(t *testing.T) {
 	inst := &identifier.Instrument{Currency: "EUR", AssetClass: "ETF", Exchange: "XNYS"}
 	resolvedIDs := []identifier.Identifier{{Type: "ISIN", Value: "GB0002634946"}}
 
-	diffs := CompareHints(hints, idnHints, inst, resolvedIDs)
+	diffs := CompareHints(context.Background(), hints, idnHints, inst, resolvedIDs, nil)
 	if len(diffs) != 4 {
 		t.Fatalf("expected 4 diffs, got %d: %v", len(diffs), diffs)
 	}
@@ -851,7 +859,7 @@ func TestCompareHints_MultipleDiffs(t *testing.T) {
 }
 
 func TestCompareHints_NilInstrument(t *testing.T) {
-	diffs := CompareHints(identifier.Hints{Currency: "USD"}, nil, nil, nil)
+	diffs := CompareHints(context.Background(), identifier.Hints{Currency: "USD"}, nil, nil, nil, nil)
 	if diffs != nil {
 		t.Errorf("expected nil diffs for nil instrument, got %v", diffs)
 	}
@@ -865,6 +873,7 @@ func TestResolveWithPlugins_ConsistentPluginsMerged(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 
 	// Plugin A (higher precedence): XNAS/USD with ISIN
@@ -911,5 +920,56 @@ func TestResolveWithPlugins_ConsistentPluginsMerged(t *testing.T) {
 		false, nil, nil, nil, 0, nil)
 	if err != nil {
 		t.Fatalf("ResolveWithPlugins: %v", err)
+	}
+}
+
+// --- MIC normalization tests ---
+
+func testMICNormalizer() MICNormalizer {
+	mapping := map[string]string{
+		"XNGS": "XNAS", "XNMS": "XNAS", "XNAS": "XNAS",
+		"ARCX": "XNYS", "XNYS": "XNYS",
+	}
+	return func(_ context.Context, mic string) string {
+		if op, ok := mapping[mic]; ok {
+			return op
+		}
+		return mic
+	}
+}
+
+func TestConsistentWith_SegmentVsOperatingMIC(t *testing.T) {
+	w := &pluginResult{
+		inst: &identifier.Instrument{Exchange: "XNAS", Currency: "USD"},
+		ids:  []identifier.Identifier{{Type: "ISIN", Value: "US0378331005"}},
+	}
+	o := &pluginResult{
+		inst: &identifier.Instrument{Exchange: "XNGS", Currency: "USD"},
+		ids:  []identifier.Identifier{{Type: "OPENFIGI_SHARE_CLASS", Value: "BBG001S5N8V8"}},
+	}
+	// Without normalizer: different exchanges are inconsistent.
+	if consistentWith(context.Background(), nil, "a", "b", w, o, nil) {
+		t.Error("expected inconsistent without normalizer")
+	}
+	// With normalizer: XNGS and XNAS map to the same operating MIC.
+	if !consistentWith(context.Background(), nil, "a", "b", w, o, testMICNormalizer()) {
+		t.Error("expected consistent with normalizer (XNGS -> XNAS)")
+	}
+}
+
+func TestCompareHints_SegmentMICNormalized(t *testing.T) {
+	idnHints := []identifier.Identifier{{Type: "MIC_TICKER", Domain: "XNGS", Value: "AAPL"}}
+	inst := &identifier.Instrument{Exchange: "XNAS"}
+
+	// Without normalizer: segment vs operating produces a diff.
+	diffs := CompareHints(context.Background(), identifier.Hints{}, idnHints, inst, nil, nil)
+	if len(diffs) != 1 || diffs[0].Field != "Exchange" {
+		t.Fatalf("expected Exchange diff without normalizer, got %v", diffs)
+	}
+
+	// With normalizer: both normalize to XNAS, no diff.
+	diffs = CompareHints(context.Background(), identifier.Hints{}, idnHints, inst, nil, testMICNormalizer())
+	if len(diffs) != 0 {
+		t.Errorf("expected no diffs with normalizer, got %v", diffs)
 	}
 }

--- a/server/service/ingestion/corporate_event_worker_test.go
+++ b/server/service/ingestion/corporate_event_worker_test.go
@@ -22,6 +22,7 @@ func TestProcessCorporateEventImport_HappyPath(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 
 	req := &apiv1.ImportCorporateEventsRequest{
@@ -130,6 +131,7 @@ func TestProcessCorporateEventImport_RejectsBadSplitRatio(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 
 	req := &apiv1.ImportCorporateEventsRequest{
@@ -182,6 +184,7 @@ func TestProcessCorporateEventImport_DividendOnlyDoesNotRecompute(t *testing.T) 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 
 	req := &apiv1.ImportCorporateEventsRequest{
@@ -223,6 +226,7 @@ func TestProcessCorporateEventImport_RejectsBadCoverageDate(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 
 	req := &apiv1.ImportCorporateEventsRequest{
@@ -274,6 +278,7 @@ func TestProcessCorporateEventImport_AcceptsHighPrecisionDecimal(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 
 	req := &apiv1.ImportCorporateEventsRequest{
@@ -317,6 +322,7 @@ func TestProcessCorporateEventImport_RejectsInvalidDecimal(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 
 	req := &apiv1.ImportCorporateEventsRequest{
@@ -364,6 +370,7 @@ func TestProcessCorporateEventImport_RejectsHintDiff(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 
 	req := &apiv1.ImportCorporateEventsRequest{

--- a/server/service/ingestion/price_worker.go
+++ b/server/service/ingestion/price_worker.go
@@ -270,7 +270,8 @@ func resolveOrIdentifyInstrument(ctx context.Context, database db.DB, pluginRegi
 			Exchange:   resolved[0].Exchange,
 			Currency:   resolved[0].Currency,
 		}
-		diffs := identification.CompareHints(hints, []identifier.Identifier{hint}, inst, nil)
+		normMIC := identification.NewDBMICNormalizer(database)
+		diffs := identification.CompareHints(ctx, hints, []identifier.Identifier{hint}, inst, nil, normMIC)
 		return identification.ResolveResult{InstrumentID: resolved[0].ID, Identified: true, HintDiffs: diffs}, nil
 	}
 	id, err := ensureWithSuppliedIdentifier(ctx, database, idType, domain, value)

--- a/server/service/ingestion/price_worker_test.go
+++ b/server/service/ingestion/price_worker_test.go
@@ -16,6 +16,7 @@ func TestProcessPriceImport_RejectsUnknownIdentifierType(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 
 	ctx := context.Background()
@@ -71,6 +72,7 @@ func TestProcessPriceImport_AcceptsValidIdentifierType(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 
 	ctx := context.Background()
@@ -118,6 +120,7 @@ func TestProcessPriceImport_WithCoverage_UsesUpsertWithFill(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 
 	ctx := context.Background()
@@ -172,6 +175,7 @@ func TestProcessPriceImport_WithCoverage_NoCoverageForInstrument_UsesPlanUpsert(
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 
 	ctx := context.Background()
@@ -229,6 +233,7 @@ func TestProcessPriceImport_RejectsHintDiff(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 
 	ctx := context.Background()
@@ -293,6 +298,7 @@ func TestProcessPriceImport_RejectsCurrencyHintDiff(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 
 	ctx := context.Background()

--- a/server/service/ingestion/resolve_test.go
+++ b/server/service/ingestion/resolve_test.go
@@ -46,6 +46,7 @@ func TestResolve_CacheHit_FromPrePass(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 
 	ctx := context.Background()
@@ -72,6 +73,7 @@ func TestResolve_TickerOnlyFallback_ResolvesByTypeAndValue(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 
 	ctx := context.Background()
@@ -101,6 +103,7 @@ func TestResolve_CacheHit_NoPluginCall(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 
 	ctx := context.Background()
@@ -123,6 +126,7 @@ func TestResolve_NoExtractedHints_ExtractionFailed(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 	// nil extractedHintsCache → no hints → extraction failed path
 	ctx := context.Background()
@@ -150,6 +154,7 @@ func TestResolve_AllPluginsErrNotIdentified_BrokerDescriptionOnly(t *testing.T) 
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 	registry.Register("p1", &fakePlugin{err: identifier.ErrNotIdentified})
 
@@ -181,6 +186,7 @@ func TestResolve_OnePluginSuccess_EnsureInstrumentWithResult(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 	source := "IBKR:test:statement"
 	registry.Register("local", &fakePlugin{
@@ -227,6 +233,7 @@ func TestResolve_BrokerDescriptionAlwaysStored(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 	source := "IBKR:test:statement"
 	desc := "APPLE INC COM"
@@ -279,6 +286,7 @@ func TestResolve_PluginReturnsUnderlying_ResolvesUnderlyingThenDerivative(t *tes
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 	source := "IBKR:test:statement"
 	desc := "AAPL  20250117C200"
@@ -334,6 +342,7 @@ func TestResolve_TwoPlugins_HigherPrecedenceWins(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 	source := "IBKR:test:statement"
 	registry.Register("low", &fakePlugin{
@@ -380,6 +389,7 @@ func TestResolve_TwoPlugins_MergedIdentifiersByPrecedence(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 	source := "IBKR:test:statement"
 	registry.Register("low", &fakePlugin{
@@ -434,6 +444,7 @@ func TestResolve_TwoPlugins_SameType_HighPrecedenceWins(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 	source := "IBKR:test:statement"
 	registry.Register("low", &fakePlugin{
@@ -485,6 +496,7 @@ func TestResolve_PluginTimeout_FallbackAndMessage(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 	source := "IBKR:test:statement"
 	// Plugin that returns context.DeadlineExceeded (simulate timeout)
@@ -521,6 +533,7 @@ func TestResolve_PluginUnavailable_FallbackAndMessage(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 	source := "IBKR:test:statement"
 	registry.Register("bad", &fakePlugin{err: errors.New("connection refused")})
@@ -748,6 +761,7 @@ func TestResolve_SameDescription_DifferentHints_NoCacheConflict(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 
 	ctx := context.Background()
@@ -834,6 +848,7 @@ func TestResolve_PluginFailsThenRetrySucceeds(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 	source := "IBKR:test:statement"
 	registry.Register("retry", &retryPlugin{

--- a/server/service/ingestion/worker_test.go
+++ b/server/service/ingestion/worker_test.go
@@ -38,6 +38,7 @@ func TestProcessBulk_AppendsIdentificationErrorsWhenBrokerDescriptionOnly(t *tes
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry() // no plugins
 
 	ctx := context.Background()
@@ -110,6 +111,7 @@ func TestProcessBulk_BatchCache_ResolvesSameDescriptionOnce(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 
 	ctx := context.Background()
@@ -170,6 +172,7 @@ func TestProcessBulk_DropsTxTypeSplitTransactions(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 
 	ctx := context.Background()
@@ -243,6 +246,7 @@ func TestProcessBulk_BuystockIncomeSameDescriptionFails(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 
 	ctx := context.Background()
@@ -310,6 +314,7 @@ func TestProcessBulk_StockEtfEquivalence(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 
 	ctx := context.Background()
@@ -369,6 +374,7 @@ func TestProcessBulk_StockMutualFundNotEquivalent(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 
 	ctx := context.Background()
@@ -426,6 +432,7 @@ func TestProcessBulk_TransferToCashRejected(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 
 	ctx := context.Background()
@@ -478,6 +485,7 @@ func TestProcessBulk_TransferToStockAllowed(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 
 	ctx := context.Background()
@@ -534,6 +542,7 @@ func TestProcessSingle_DropsTxTypeSplitTransaction(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
 	registry := identifier.NewRegistry()
 
 	ctx := context.Background()


### PR DESCRIPTION
## Summary
- Normalizes MIC_TICKER identifier domains from segment MICs to operating MICs in `EnsureInstrument` and `InsertInstrumentIdentifier` via the exchanges table
- Adds `MICNormalizer` type and threads it through `consistentWith` and `CompareHints` so exchange comparisons use operating MICs
- Segment-vs-operating exchange differences between plugins no longer cause consistency failures

**Depends on:** #218

## Test plan
- [x] `make server-test` passes
- [x] `make db-test` passes
- [x] New `TestEnsureInstrument_NormalizesSegmentMIC` -- verifies XNGS (segment) is stored as XNAS (operating) in both exchangeMIC and MIC_TICKER domain
- [x] New `TestInsertInstrumentIdentifier_NormalizesSegmentMIC` -- verifies post-creation identifier insert also normalizes
- [x] Existing consistency and CompareHints tests continue to pass with nil normalizer

🤖 Generated with [Claude Code](https://claude.com/claude-code)