### PR TITLE
Use provider-specific identifiers in price and corporate event fetchers

### DIFF
--- a/server/corporateevents/worker.go
+++ b/server/corporateevents/worker.go
@@ -177,6 +177,13 @@ func processInstrument(ctx context.Context, database db.DB, plugins []pluginEntr
 				continue
 			}
 			ids := pluginutil.FilterIdentifiers(pe.plugin.SupportedIdentifierTypes(), inst.Identifiers)
+			// Merge provider-specific identifiers for this plugin.
+			for _, pi := range inst.ProviderIdentifiers {
+				if pi.Provider == pe.id {
+					ids = append(ids, db.IdentifierInput{Type: pi.Type, Domain: pi.Domain, Value: pi.Value})
+				}
+			}
+			ids = pluginutil.FilterIdentifiers(pe.plugin.SupportedIdentifierTypes(), ids)
 			if len(ids) == 0 {
 				continue
 			}

--- a/server/plugins/eodhd/corporateevents/plugin.go
+++ b/server/plugins/eodhd/corporateevents/plugin.go
@@ -65,7 +65,7 @@ func (p *Plugin) DefaultConfig() []byte {
 }
 
 func (p *Plugin) SupportedIdentifierTypes() []string {
-	return []string{"MIC_TICKER", "OPENFIGI_TICKER"}
+	return []string{"EODHD_EXCH_CODE", "MIC_TICKER", "OPENFIGI_TICKER"}
 }
 
 func (p *Plugin) AcceptableAssetClasses() map[string]bool {
@@ -153,6 +153,22 @@ func (p *Plugin) translateError(err error, symbol string) error {
 // symbolFromIdentifiers picks the EODHD API symbol from identifiers.
 // Format: {ticker}.{eodhd_exchange_code}.
 func (p *Plugin) symbolFromIdentifiers(ids []corporateevents.Identifier) string {
+	// Prefer provider-specific EODHD exchange code over MIC lookup.
+	var ticker string
+	for _, id := range ids {
+		if (id.Type == "MIC_TICKER" || id.Type == "OPENFIGI_TICKER") && id.Value != "" {
+			ticker = id.Value
+			break
+		}
+	}
+	if ticker != "" {
+		for _, id := range ids {
+			if id.Type == "EODHD_EXCH_CODE" && id.Value != "" {
+				return ticker + "." + id.Value
+			}
+		}
+	}
+	// Fallback: resolve MIC domain to EODHD code via exchange map.
 	for _, id := range ids {
 		if id.Type == "MIC_TICKER" && id.Value != "" {
 			if code := p.micToEODHDCode(id.Domain); code != "" {

--- a/server/plugins/eodhd/price/plugin.go
+++ b/server/plugins/eodhd/price/plugin.go
@@ -54,7 +54,7 @@ func (p *Plugin) DefaultConfig() []byte {
 }
 
 func (p *Plugin) SupportedIdentifierTypes() []string {
-	return []string{"MIC_TICKER", "OPENFIGI_TICKER", "FX_PAIR"}
+	return []string{"EODHD_EXCH_CODE", "MIC_TICKER", "OPENFIGI_TICKER", "FX_PAIR"}
 }
 
 func (p *Plugin) AcceptableAssetClasses() map[string]bool {
@@ -155,6 +155,22 @@ func (p *Plugin) symbolForAssetClass(ids []pricefetcher.Identifier, assetClass s
 		return "", 1
 	}
 	// Stock/ETF: need {ticker}.{exchange_code}
+	// Prefer provider-specific EODHD exchange code over MIC lookup.
+	var ticker string
+	for _, id := range ids {
+		if (id.Type == "MIC_TICKER" || id.Type == "OPENFIGI_TICKER") && id.Value != "" {
+			ticker = id.Value
+			break
+		}
+	}
+	if ticker != "" {
+		for _, id := range ids {
+			if id.Type == "EODHD_EXCH_CODE" && id.Value != "" {
+				return ticker + "." + id.Value, 1
+			}
+		}
+	}
+	// Fallback: resolve MIC domain to EODHD code via exchange map.
 	for _, id := range ids {
 		if id.Type == "MIC_TICKER" && id.Value != "" {
 			if code := p.micToEODHDCode(id.Domain); code != "" {

--- a/server/plugins/eodhd/price/plugin_test.go
+++ b/server/plugins/eodhd/price/plugin_test.go
@@ -330,7 +330,7 @@ func TestPluginInterface(t *testing.T) {
 		t.Errorf("AcceptableExchanges should be nil, got %v", ex)
 	}
 	types := p.SupportedIdentifierTypes()
-	if len(types) != 3 || types[0] != "MIC_TICKER" || types[1] != "OPENFIGI_TICKER" || types[2] != "FX_PAIR" {
+	if len(types) != 4 || types[0] != "EODHD_EXCH_CODE" || types[1] != "MIC_TICKER" || types[2] != "OPENFIGI_TICKER" || types[3] != "FX_PAIR" {
 		t.Errorf("SupportedIdentifierTypes = %v", types)
 	}
 }

--- a/server/plugins/massive/corporateevents/plugin.go
+++ b/server/plugins/massive/corporateevents/plugin.go
@@ -61,7 +61,7 @@ func (p *Plugin) DefaultConfig() []byte {
 }
 
 func (p *Plugin) SupportedIdentifierTypes() []string {
-	return []string{"MIC_TICKER", "OPENFIGI_TICKER"}
+	return []string{"SEGMENT_MIC_TICKER", "MIC_TICKER", "OPENFIGI_TICKER"}
 }
 
 func (p *Plugin) AcceptableAssetClasses() map[string]bool {
@@ -151,6 +151,11 @@ func (p *Plugin) translateError(err error, ticker string) error {
 // tickerFromIdentifiers picks a Massive ticker symbol from identifiers.
 // Massive uses bare tickers (no exchange suffix) for US securities.
 func tickerFromIdentifiers(ids []corporateevents.Identifier) string {
+	for _, id := range ids {
+		if id.Type == "SEGMENT_MIC_TICKER" && id.Value != "" {
+			return id.Value
+		}
+	}
 	for _, id := range ids {
 		if id.Type == "MIC_TICKER" && id.Value != "" {
 			return id.Value

--- a/server/plugins/massive/price/plugin.go
+++ b/server/plugins/massive/price/plugin.go
@@ -49,7 +49,7 @@ func (p *Plugin) DefaultConfig() []byte {
 }
 
 func (p *Plugin) SupportedIdentifierTypes() []string {
-	return []string{"MIC_TICKER", "OPENFIGI_TICKER", "OCC", "FX_PAIR"}
+	return []string{"SEGMENT_MIC_TICKER", "MIC_TICKER", "OPENFIGI_TICKER", "OCC", "FX_PAIR"}
 }
 
 func (p *Plugin) AcceptableAssetClasses() map[string]bool {
@@ -181,6 +181,12 @@ func tickerForAssetClass(ids []pricefetcher.Identifier, assetClass string) (stri
 			}
 		}
 		return "", 1
+	}
+	// Prefer provider-specific SEGMENT_MIC_TICKER over canonical MIC_TICKER.
+	for _, id := range ids {
+		if id.Type == "SEGMENT_MIC_TICKER" && id.Value != "" {
+			return id.Value, 1
+		}
 	}
 	for _, id := range ids {
 		if id.Type == "MIC_TICKER" && id.Value != "" {

--- a/server/plugins/massive/price/plugin_test.go
+++ b/server/plugins/massive/price/plugin_test.go
@@ -229,7 +229,7 @@ func TestPluginInterface(t *testing.T) {
 		t.Errorf("AcceptableExchanges should be nil, got %v", ex)
 	}
 	types := p.SupportedIdentifierTypes()
-	if len(types) != 4 || types[0] != "MIC_TICKER" || types[1] != "OPENFIGI_TICKER" || types[2] != "OCC" || types[3] != "FX_PAIR" {
+	if len(types) != 5 || types[0] != "SEGMENT_MIC_TICKER" || types[1] != "MIC_TICKER" || types[2] != "OPENFIGI_TICKER" || types[3] != "OCC" || types[4] != "FX_PAIR" {
 		t.Errorf("SupportedIdentifierTypes = %v", types)
 	}
 }

--- a/server/pricefetcher/worker.go
+++ b/server/pricefetcher/worker.go
@@ -161,6 +161,13 @@ func processGaps(ctx context.Context, database db.DB, plugins []pluginEntry, gap
 				continue
 			}
 			ids := pluginutil.FilterIdentifiers(pe.plugin.SupportedIdentifierTypes(), inst.Identifiers)
+			// Merge provider-specific identifiers for this plugin.
+			for _, pi := range inst.ProviderIdentifiers {
+				if pi.Provider == pe.id {
+					ids = append(ids, db.IdentifierInput{Type: pi.Type, Domain: pi.Domain, Value: pi.Value})
+				}
+			}
+			ids = pluginutil.FilterIdentifiers(pe.plugin.SupportedIdentifierTypes(), ids)
 			if len(ids) == 0 {
 				continue
 			}


### PR DESCRIPTION
## Summary
- Price fetcher and corporate event orchestrators merge provider-specific identifiers into the list passed to plugins
- Massive price/corporate event plugins prefer `SEGMENT_MIC_TICKER` (segment MIC from Polygon.io) over `MIC_TICKER`
- EODHD price/corporate event plugins prefer `EODHD_EXCH_CODE` to build `ticker.code` symbols directly, bypassing MIC-to-EODHD exchange map lookup
- Falls back to existing behavior when provider-specific identifiers are not available

**Depends on:** #220

## Test plan
- [x] `make server-test` passes
- [x] Updated plugin interface tests verify new supported identifier types
- [x] Existing price and corporate event tests pass unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)