### PR TITLE
Convert GBX to Bloomberg GBp for OpenFIGI currency filter

### DIFF
--- a/server/plugins/openfigi/identifier/map.go
+++ b/server/plugins/openfigi/identifier/map.go
@@ -8,6 +8,23 @@ import (
 	"github.com/leedenison/portfoliodb/server/plugins/openfigi/exchangemap"
 )
 
+// openFIGICurrencyOverrides maps ISO minor-unit currency codes to the
+// Bloomberg-style codes that the OpenFIGI Mapping API expects.
+// For example, GBX (ISO pence sterling) must be sent as "GBp".
+var openFIGICurrencyOverrides = map[string]string{
+	"GBX": "GBp",
+}
+
+// toOpenFIGICurrency converts a currency code to the form expected by the
+// OpenFIGI API. Most codes pass through unchanged; known minor-unit codes
+// (e.g. GBX) are replaced with their Bloomberg equivalents.
+func toOpenFIGICurrency(code string) string {
+	if v, ok := openFIGICurrencyOverrides[code]; ok {
+		return v
+	}
+	return code
+}
+
 // classificationRule maps OpenFIGI response fields to a PortfolioDB asset class.
 // Non-nil set fields are ANDed: all must match. Nil means "don't care".
 // Rules are evaluated in slice order; first match wins.
@@ -187,7 +204,7 @@ func openFIGIResultToInstrument(r *OpenFIGIResult, exchMap *exchangemap.Exchange
 	inst := &identifier.Instrument{
 		AssetClass: assetClass,
 		Exchange:   resolveExchange(r.ExchCode, exchMap),
-		Currency:   "", // OpenFIGI often omits; leave empty
+		Currency:   "", // OpenFIGI does not return currency; caller sets from hints
 		Name:       name,
 	}
 	if r.FIGI != "" {

--- a/server/plugins/openfigi/identifier/plugin.go
+++ b/server/plugins/openfigi/identifier/plugin.go
@@ -96,6 +96,9 @@ func (p *Plugin) Identify(ctx context.Context, config []byte, broker, source, in
 		return nil, nil, err
 	}
 	if inst, ids, ok := p.resolveResults(results, hints, true); ok {
+		if hints.Currency != "" {
+			inst.Currency = hints.Currency
+		}
 		// When the matched hint was a MIC_TICKER, include it in the returned
 		// identifiers. A successful Mapping API response for that ticker proves
 		// the association. Other hint types (ISIN, CUSIP, etc.) are not appended
@@ -215,7 +218,7 @@ func (p *Plugin) tryOpenFIGIFromHints(ctx context.Context, identifierHints []ide
 			job.ExchCode = h.Domain
 		}
 		if hints.Currency != "" {
-			job.Currency = hints.Currency
+			job.Currency = toOpenFIGICurrency(hints.Currency)
 		}
 		results, err := p.openfigi.Mapping(ctx, job)
 		if err != nil {


### PR DESCRIPTION
## Summary
- OpenFIGI uses Bloomberg-style minor currency codes (`GBp`) rather than ISO codes (`GBX`). Passing `GBX` directly caused mapping queries to return no results for LSE-listed equities like AZN and HSBA.
- Added a currency override map that converts `GBX` → `GBp` before querying the OpenFIGI Mapping API.
- When identification succeeds with a currency hint, the original hint currency (e.g. `GBX`) is now propagated onto the returned instrument.

## Test plan
- [x] Existing unit tests pass
- [ ] Manual verification: identify an LSE-listed equity (e.g. AZN) with a GBX currency hint and confirm OpenFIGI returns results
- [ ] Manual verification: confirm the returned instrument has currency set to `GBX` (not `GBp`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)