### PR TITLE
Pass asset class and currency hints through price import fallback

### DIFF
--- a/server/service/ingestion/price_worker.go
+++ b/server/service/ingestion/price_worker.go
@@ -245,7 +245,7 @@ func resolveOrIdentifyInstrument(ctx context.Context, database db.DB, pluginRegi
 
 	if assetClass != "" && pluginRegistry != nil {
 		fallback := func(ctx context.Context, database db.DB) (string, error) {
-			return ensureWithSuppliedIdentifier(ctx, database, idType, domain, value)
+			return ensureWithSuppliedIdentifier(ctx, database, assetClass, currency, idType, domain, value)
 		}
 		result, err := identification.ResolveWithPlugins(ctx, database, pluginRegistry,
 			"", "", "", hints,
@@ -274,17 +274,18 @@ func resolveOrIdentifyInstrument(ctx context.Context, database db.DB, pluginRegi
 		diffs := identification.CompareHints(ctx, hints, []identifier.Identifier{hint}, inst, nil, normMIC)
 		return identification.ResolveResult{InstrumentID: resolved[0].ID, Identified: true, HintDiffs: diffs}, nil
 	}
-	id, err := ensureWithSuppliedIdentifier(ctx, database, idType, domain, value)
+	id, err := ensureWithSuppliedIdentifier(ctx, database, assetClass, currency, idType, domain, value)
 	if err != nil {
 		return identification.ResolveResult{}, err
 	}
 	return identification.ResolveResult{InstrumentID: id}, nil
 }
 
-func ensureWithSuppliedIdentifier(ctx context.Context, database db.DB, idType, domain, value string) (string, error) {
+func ensureWithSuppliedIdentifier(ctx context.Context, database db.DB, assetClass, currency, idType, domain, value string) (string, error) {
 	slog.Debug("creating instrument from price import with supplied identifier only",
-		"identifier_type", idType, "identifier_domain", domain, "identifier_value", value)
-	return database.EnsureInstrument(ctx, "", "", "", "", "", "",
+		"identifier_type", idType, "identifier_domain", domain, "identifier_value", value,
+		"asset_class", assetClass, "currency", currency)
+	return database.EnsureInstrument(ctx, assetClass, "", currency, "", "", "",
 		[]db.IdentifierInput{{Type: idType, Domain: domain, Value: value, Canonical: true}},
 		"", nil, nil, nil)
 }

--- a/server/service/ingestion/price_worker_test.go
+++ b/server/service/ingestion/price_worker_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	"github.com/leedenison/portfoliodb/server/db"
 	"github.com/leedenison/portfoliodb/server/db/mock"
 	"github.com/leedenison/portfoliodb/server/identifier"
 	"go.uber.org/mock/gomock"
@@ -356,5 +357,73 @@ func TestProcessPriceImport_RejectsCurrencyHintDiff(t *testing.T) {
 	}
 	if !strings.Contains(capturedErrs[0].Message, "Currency") {
 		t.Errorf("expected message to mention Currency, got %s", capturedErrs[0].Message)
+	}
+}
+
+// TestProcessPriceImport_FallbackPassesAssetClassAndCurrency verifies that
+// when no identifier plugin can handle the identifier type (e.g. FX_PAIR),
+// the fallback creates the instrument with the asset class and currency from
+// the import row rather than empty strings.
+func TestProcessPriceImport_FallbackPassesAssetClassAndCurrency(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
+	database.EXPECT().SaveProviderIdentifiers(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	registry := identifier.NewRegistry()
+
+	ctx := context.Background()
+	req := &apiv1.ImportPricesRequest{
+		Prices: []*apiv1.ImportPriceRow{
+			{
+				IdentifierType:  "FX_PAIR",
+				IdentifierValue: "EURGBP",
+				PriceDate:       "2021-12-31",
+				Close:           0.84,
+				AssetClass:      apiv1.AssetClass_ASSET_CLASS_FX,
+				Currency:        "EUR",
+			},
+		},
+	}
+	payload, err := proto.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	j := &JobRequest{JobID: "job-price-fx", JobType: "price"}
+
+	database.EXPECT().LoadJobPayload(gomock.Any(), "job-price-fx").Return(payload, nil)
+	database.EXPECT().ClearJobPayload(gomock.Any(), "job-price-fx").Return(nil)
+	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-price-fx", int32(1)).Return(nil)
+
+	// asset_class is non-empty so the plugin path is taken. With no plugins
+	// registered, ListEnabledPluginConfigs returns empty and the DB-only
+	// lookup inside ResolveWithPlugins finds nothing, triggering the fallback.
+	database.EXPECT().
+		ListEnabledPluginConfigs(gomock.Any(), "identifier").
+		Return(nil, nil)
+	database.EXPECT().
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "FX_PAIR", "", "EURGBP").
+		Return("", "", "", "", nil) // not found
+	database.EXPECT().
+		FindInstrumentByTypeAndValue(gomock.Any(), "FX_PAIR", "EURGBP").
+		Return("", nil) // not found
+
+	// The key assertion: EnsureInstrument must receive "FX" and "EUR".
+	database.EXPECT().
+		EnsureInstrument(gomock.Any(), "FX", "", "EUR", "", "", "",
+			[]db.IdentifierInput{{Type: "FX_PAIR", Domain: "", Value: "EURGBP", Canonical: true}},
+			"", nil, nil, nil).
+		Return("inst-eurgbp", nil)
+	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-price-fx").Return(nil)
+	database.EXPECT().
+		UpsertPrices(gomock.Any(), gomock.Any()).
+		Return(nil)
+	database.EXPECT().
+		SetJobStatus(gomock.Any(), "job-price-fx", apiv1.JobStatus_SUCCESS).
+		Return(nil)
+
+	if !processPriceImport(ctx, database, registry, j) {
+		t.Error("expected persisted=true after a successful upsert")
 	}
 }


### PR DESCRIPTION
## Summary
- When no identifier plugin handles a price import row (e.g. FX_PAIR identifier type), `ensureWithSuppliedIdentifier` was called with empty strings for asset class and currency, causing instruments like EURGBP to be created with no asset class (displayed as OTHER in the UI)
- Updated `ensureWithSuppliedIdentifier` to accept and pass through `assetClass` and `currency` from the import row to `EnsureInstrument`
- Both call sites (plugin fallback and DB-only fallback) now propagate the hints

## Test plan
- [x] Added `TestProcessPriceImport_FallbackPassesAssetClassAndCurrency` — imports an FX_PAIR/EURGBP row with `asset_class=FX` and `currency=EUR`, asserts `EnsureInstrument` receives `"FX"` and `"EUR"` (not empty strings)
- [ ] Manual QA: upload prices CSV with FX_PAIR rows and verify instrument appears with FX asset class in admin UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)