### PR TITLE
Add FX instruments to admin UI and filter exports by type

### DIFF
--- a/client/app/admin/instruments/page.tsx
+++ b/client/app/admin/instruments/page.tsx
@@ -28,6 +28,7 @@ const IDENTIFIER_LABELS: Record<number, string> = {
   [IdentifierType.OPENFIGI_TICKER]: "Ticker",
   [IdentifierType.BROKER_DESCRIPTION]: "Broker Desc",
   [IdentifierType.CURRENCY]: "Currency",
+  [IdentifierType.FX_PAIR]: "FX Pair",
 };
 
 function idLabel(id: InstrumentIdentifier): string {
@@ -75,8 +76,11 @@ export default function AdminInstrumentsPage() {
     setExportLoading(true);
     setExportError(null);
     try {
+      const classes = [...activeClasses] as AssetClass[];
       const instruments: Instrument[] = [];
-      for await (const inst of exportInstruments()) {
+      for await (const inst of exportInstruments({
+        assetClasses: classes.length < ALL_ASSET_CLASSES.length ? classes : [],
+      })) {
         instruments.push(inst);
       }
       const json = instrumentsToJson(instruments);

--- a/client/lib/asset-class.ts
+++ b/client/lib/asset-class.ts
@@ -6,6 +6,7 @@ export const ALL_ASSET_CLASSES = [
   AssetClass.ETF,
   AssetClass.OPTION,
   AssetClass.FUTURE,
+  AssetClass.FX,
   AssetClass.CASH,
   AssetClass.MUTUAL_FUND,
   AssetClass.FIXED_INCOME,

--- a/client/lib/portfolio-api.ts
+++ b/client/lib/portfolio-api.ts
@@ -603,9 +603,12 @@ export async function listJobs(pageToken?: string | null): Promise<ListJobsResul
 }
 
 /** Stream all exported instruments (admin only). */
-export async function* exportInstruments(params?: { exchange?: string }): AsyncGenerator<Instrument> {
+export async function* exportInstruments(params?: { exchange?: string; assetClasses?: AssetClass[] }): AsyncGenerator<Instrument> {
   const base = getBaseUrl();
-  const req = create(ExportInstrumentsRequestSchema, { exchange: params?.exchange ?? "" });
+  const req = create(ExportInstrumentsRequestSchema, {
+    exchange: params?.exchange ?? "",
+    assetClasses: params?.assetClasses ?? [],
+  });
   for await (const bytes of streamingFetch(base, ApiServicePrefix + "ExportInstruments", toBinary(ExportInstrumentsRequestSchema, req), { credentials: "include" })) {
     yield fromBinary(InstrumentSchema, bytes);
   }

--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -475,7 +475,8 @@ message ListInstrumentsResponse {
 
 // ExportInstruments streams all instruments that have at least one canonical identifier. Optional exchange filter.
 message ExportInstrumentsRequest {
-  string exchange = 1;  // optional; empty = all exchanges
+  string exchange = 1;              // optional; empty = all exchanges
+  repeated AssetClass asset_classes = 2;  // optional; empty = server default (excludes CASH/FX)
 }
 
 // ImportInstruments ensures the given instruments exist (find-or-create by identifiers, merge on conflict). No overwrite of canonical fields for existing.

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -582,8 +582,8 @@ type InstrumentDB interface {
 	GetInstrument(ctx context.Context, instrumentID string) (*InstrumentRow, error)
 	// ListInstrumentsByIDs returns instruments by ID slice (for batch underlying lookup). Missing IDs are omitted; order not guaranteed.
 	ListInstrumentsByIDs(ctx context.Context, ids []string) ([]*InstrumentRow, error)
-	// ListInstrumentsForExport returns all instruments that have at least one identifier with canonical = true. Excludes CASH and FX asset classes (reference data). If exchangeFilter != "", filter by instruments.exchange_mic. Order by instruments.id.
-	ListInstrumentsForExport(ctx context.Context, exchangeFilter string) ([]*InstrumentRow, error)
+	// ListInstrumentsForExport returns all instruments that have at least one identifier with canonical = true. If assetClasses is non-empty, filter to those classes; otherwise exclude CASH and FX (reference data). If exchangeFilter != "", filter by instruments.exchange_mic. Order by instruments.id.
+	ListInstrumentsForExport(ctx context.Context, exchangeFilter string, assetClasses []string) ([]*InstrumentRow, error)
 	// ValidateMIC checks whether the given MIC code exists in the exchanges reference table.
 	ValidateMIC(ctx context.Context, mic string) (bool, error)
 	// ListInstruments returns instruments sorted alphabetically by display name (ticker, then name, then broker description). If search is non-empty, only instruments with at least one identifier value matching (case-insensitive substring) are returned. If assetClasses is non-empty, only instruments with matching asset_class are returned. Returns (rows, totalCount, nextPageToken, error).

--- a/server/db/postgres/instruments.go
+++ b/server/db/postgres/instruments.go
@@ -251,31 +251,34 @@ func (p *Postgres) GetInstrument(ctx context.Context, instrumentID string) (*db.
 }
 
 // ListInstrumentsForExport implements db.InstrumentDB.
-func (p *Postgres) ListInstrumentsForExport(ctx context.Context, exchangeFilter string) ([]*db.InstrumentRow, error) {
+func (p *Postgres) ListInstrumentsForExport(ctx context.Context, exchangeFilter string, assetClasses []string) ([]*db.InstrumentRow, error) {
 	var irows []instrumentRow
 	var err error
-	if exchangeFilter != "" {
-		err = p.q.SelectContext(ctx, &irows, `
-			SELECT i.id, i.asset_class, i.exchange_mic, i.currency, i.name, i.exchange, i.underlying_id, i.valid_from, i.valid_to,
-			       e.name AS exchange_name, e.acronym AS exchange_acronym, e.country_code AS exchange_country_code
-			FROM instruments i
-			LEFT JOIN exchanges e ON e.mic = i.exchange_mic
-			WHERE EXISTS (SELECT 1 FROM instrument_identifiers ii WHERE ii.instrument_id = i.id AND ii.canonical = true)
-			AND i.asset_class NOT IN ('CASH', 'FX')
-			AND i.exchange_mic = $1
-			ORDER BY i.id
-		`, exchangeFilter)
+
+	base := `
+		SELECT i.id, i.asset_class, i.exchange_mic, i.currency, i.name, i.exchange, i.underlying_id, i.valid_from, i.valid_to,
+		       e.name AS exchange_name, e.acronym AS exchange_acronym, e.country_code AS exchange_country_code
+		FROM instruments i
+		LEFT JOIN exchanges e ON e.mic = i.exchange_mic
+		WHERE EXISTS (SELECT 1 FROM instrument_identifiers ii WHERE ii.instrument_id = i.id AND ii.canonical = true)`
+
+	args := []interface{}{}
+	argN := 1
+
+	if len(assetClasses) > 0 {
+		base += fmt.Sprintf("\n\t\t\tAND i.asset_class = ANY($%d)", argN)
+		args = append(args, pq.Array(assetClasses))
+		argN++
 	} else {
-		err = p.q.SelectContext(ctx, &irows, `
-			SELECT i.id, i.asset_class, i.exchange_mic, i.currency, i.name, i.exchange, i.underlying_id, i.valid_from, i.valid_to,
-			       e.name AS exchange_name, e.acronym AS exchange_acronym, e.country_code AS exchange_country_code
-			FROM instruments i
-			LEFT JOIN exchanges e ON e.mic = i.exchange_mic
-			WHERE EXISTS (SELECT 1 FROM instrument_identifiers ii WHERE ii.instrument_id = i.id AND ii.canonical = true)
-			AND i.asset_class NOT IN ('CASH', 'FX')
-			ORDER BY i.id
-		`)
+		base += "\n\t\t\tAND i.asset_class NOT IN ('CASH', 'FX')"
 	}
+	if exchangeFilter != "" {
+		base += fmt.Sprintf("\n\t\t\tAND i.exchange_mic = $%d", argN)
+		args = append(args, exchangeFilter)
+	}
+	base += "\n\t\t\tORDER BY i.id"
+
+	err = p.q.SelectContext(ctx, &irows, base, args...)
 	if err != nil {
 		return nil, fmt.Errorf("list instruments for export: %w", err)
 	}

--- a/server/db/postgres/instruments_test.go
+++ b/server/db/postgres/instruments_test.go
@@ -127,7 +127,7 @@ func TestListInstrumentsForExport_ExcludesBrokerDescriptionOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ensure with canonical: %v", err)
 	}
-	list, err := p.ListInstrumentsForExport(ctx, "")
+	list, err := p.ListInstrumentsForExport(ctx, "", nil)
 	if err != nil {
 		t.Fatalf("ListInstrumentsForExport: %v", err)
 	}
@@ -160,7 +160,7 @@ func TestListInstrumentsForExport_ExchangeFilter(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ensure XNYS: %v", err)
 	}
-	list, err := p.ListInstrumentsForExport(ctx, "XNAS")
+	list, err := p.ListInstrumentsForExport(ctx, "XNAS", nil)
 	if err != nil {
 		t.Fatalf("ListInstrumentsForExport: %v", err)
 	}
@@ -172,7 +172,7 @@ func TestListInstrumentsForExport_ExchangeFilter(t *testing.T) {
 		}
 		t.Fatalf("expected 1 instrument with exchange XNAS, got %d (first exchange %q)", len(list), ex)
 	}
-	listAll, err := p.ListInstrumentsForExport(ctx, "")
+	listAll, err := p.ListInstrumentsForExport(ctx, "", nil)
 	if err != nil {
 		t.Fatalf("ListInstrumentsForExport all: %v", err)
 	}

--- a/server/service/api/instruments.go
+++ b/server/service/api/instruments.go
@@ -47,7 +47,11 @@ func (s *Server) ExportInstruments(req *apiv1.ExportInstrumentsRequest, stream a
 	if _, authErr := auth.RequireAdmin(ctx); authErr != nil {
 		return authErr
 	}
-	rows, err := s.db.ListInstrumentsForExport(ctx, req.GetExchange())
+	var acStrsExport []string
+	for _, ac := range req.GetAssetClasses() {
+		acStrsExport = append(acStrsExport, db.AssetClassToStr(ac))
+	}
+	rows, err := s.db.ListInstrumentsForExport(ctx, req.GetExchange(), acStrsExport)
 	if err != nil {
 		return status.Error(codes.Internal, err.Error())
 	}

--- a/server/service/api/instruments_test.go
+++ b/server/service/api/instruments_test.go
@@ -115,7 +115,7 @@ func TestExportInstruments_Success(t *testing.T) {
 		{ID: "id-1", Name: strPtr("Apple"), Identifiers: []dbpkg.IdentifierInput{{Type: "ISIN", Value: "US0378331005", Canonical: true}}},
 	}
 	db.EXPECT().
-		ListInstrumentsForExport(gomock.Any(), "").
+		ListInstrumentsForExport(gomock.Any(), "", []string(nil)).
 		Return(rows, nil)
 	stream := &exportStreamMock{ctx: adminCtx("user-1", "sub|1")}
 	err := srv.ExportInstruments(&apiv1.ExportInstrumentsRequest{}, stream)
@@ -136,7 +136,7 @@ func TestExportInstruments_Success(t *testing.T) {
 func TestExportInstruments_WithExchangeFilter(t *testing.T) {
 	srv, db := newAPIServerWithMock(t)
 	db.EXPECT().
-		ListInstrumentsForExport(gomock.Any(), "XNAS").
+		ListInstrumentsForExport(gomock.Any(), "XNAS", []string(nil)).
 		Return(nil, nil)
 	stream := &exportStreamMock{ctx: adminCtx("user-1", "sub|1")}
 	err := srv.ExportInstruments(&apiv1.ExportInstrumentsRequest{Exchange: "XNAS"}, stream)


### PR DESCRIPTION
## Summary
- Add FX as a filterable asset class on the admin instruments page (alongside Stock, ETF, Option, Future, etc.)
- Add `FX_PAIR` to the identifier labels so FX pair identifiers render correctly in the expanded detail view
- Add `asset_classes` field to `ExportInstrumentsRequest` proto so the export API supports filtering by asset class
- Wire the active UI filter selection through to the export call, so "Export JSON" only exports instruments matching the selected types
- When all types are selected (or none specified), the server falls back to the existing default behavior (excludes CASH and FX reference data)

## Test plan
- [x] Unit tests updated and passing (`server/service/api`, `server/db/postgres`)
- [ ] Verify FX filter button appears in admin instruments UI
- [ ] Toggle FX filter on and confirm FX instruments appear in the list
- [ ] Export with FX selected and verify FX instruments are in the exported JSON
- [ ] Export with only Stock selected and verify only stocks are exported
- [ ] Export with all types selected and verify default behavior (CASH/FX excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)