### PR TITLE
Fix option fallback to resolve underlying from OCC symbol

### DIFF
--- a/server/service/ingestion/price_worker.go
+++ b/server/service/ingestion/price_worker.go
@@ -9,6 +9,7 @@ import (
 
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
 	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/derivative"
 	"github.com/leedenison/portfoliodb/server/identifier"
 	"github.com/leedenison/portfoliodb/server/service/identification"
 	"google.golang.org/protobuf/proto"
@@ -285,7 +286,28 @@ func ensureWithSuppliedIdentifier(ctx context.Context, database db.DB, assetClas
 	slog.Debug("creating instrument from price import with supplied identifier only",
 		"identifier_type", idType, "identifier_domain", domain, "identifier_value", value,
 		"asset_class", assetClass, "currency", currency)
+
+	var underlyingID string
+	var optFields *db.OptionFields
+	if assetClass == db.AssetClassOption {
+		parsed, ok := derivative.ParseOptionTicker(value)
+		if ok && parsed.Symbol != "" {
+			uHint := identifier.Identifier{Type: "MIC_TICKER", Value: parsed.Symbol}
+			resolved, err := identification.ResolveByHintsDBOnly(ctx, database, []identifier.Identifier{uHint})
+			if err == nil && len(resolved) == 1 {
+				underlyingID = resolved[0].ID
+			}
+			if parsed.Strike > 0 && !parsed.Expiry.IsZero() && parsed.PutCall != "" {
+				optFields = &db.OptionFields{
+					Strike:  parsed.Strike,
+					Expiry:  parsed.Expiry,
+					PutCall: parsed.PutCall,
+				}
+			}
+		}
+	}
+
 	return database.EnsureInstrument(ctx, assetClass, "", currency, "", "", "",
 		[]db.IdentifierInput{{Type: idType, Domain: domain, Value: value, Canonical: true}},
-		"", nil, nil, nil)
+		underlyingID, nil, nil, optFields)
 }

--- a/server/service/ingestion/price_worker_test.go
+++ b/server/service/ingestion/price_worker_test.go
@@ -427,3 +427,74 @@ func TestProcessPriceImport_FallbackPassesAssetClassAndCurrency(t *testing.T) {
 		t.Error("expected persisted=true after a successful upsert")
 	}
 }
+
+// TestProcessPriceImport_OptionFallbackResolvesUnderlying verifies that when
+// identifier plugins fail for an option OCC symbol, the fallback parses the
+// underlying ticker from the OCC and resolves it via DB lookup.
+func TestProcessPriceImport_OptionFallbackResolvesUnderlying(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
+	database.EXPECT().SaveProviderIdentifiers(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	registry := identifier.NewRegistry()
+
+	ctx := context.Background()
+	req := &apiv1.ImportPricesRequest{
+		Prices: []*apiv1.ImportPriceRow{
+			{
+				IdentifierType:  "OCC",
+				IdentifierValue: "NVDA240315P00510000",
+				PriceDate:       "2024-03-01",
+				Close:           12.50,
+				AssetClass:      apiv1.AssetClass_ASSET_CLASS_OPTION,
+				Currency:        "USD",
+			},
+		},
+	}
+	payload, err := proto.Marshal(req)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	j := &JobRequest{JobID: "job-price-opt", JobType: "price"}
+
+	database.EXPECT().LoadJobPayload(gomock.Any(), "job-price-opt").Return(payload, nil)
+	database.EXPECT().ClearJobPayload(gomock.Any(), "job-price-opt").Return(nil)
+	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-price-opt", int32(1)).Return(nil)
+
+	// No plugins registered: plugin path triggers fallback.
+	database.EXPECT().
+		ListEnabledPluginConfigs(gomock.Any(), "identifier").
+		Return(nil, nil)
+	// OCC DB lookup finds nothing.
+	database.EXPECT().
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "OCC", "", "NVDA240315P00510000").
+		Return("", "", "", "", nil)
+	database.EXPECT().
+		FindInstrumentByTypeAndValue(gomock.Any(), "OCC", "NVDA240315P00510000").
+		Return("", nil)
+
+	// Fallback parses underlying "NVDA" from OCC and resolves via DB.
+	database.EXPECT().
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "NVDA").
+		Return("inst-nvda", "STOCK", "XNAS", "USD", nil)
+
+	// EnsureInstrument must receive the underlying ID and option fields.
+	database.EXPECT().
+		EnsureInstrument(gomock.Any(), "OPTION", "", "USD", "", "", "",
+			[]db.IdentifierInput{{Type: "OCC", Domain: "", Value: "NVDA240315P00510000", Canonical: true}},
+			"inst-nvda", nil, nil, gomock.Not(gomock.Nil())).
+		Return("inst-opt", nil)
+	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-price-opt").Return(nil)
+	database.EXPECT().
+		UpsertPrices(gomock.Any(), gomock.Any()).
+		Return(nil)
+	database.EXPECT().
+		SetJobStatus(gomock.Any(), "job-price-opt", apiv1.JobStatus_SUCCESS).
+		Return(nil)
+
+	if !processPriceImport(ctx, database, registry, j) {
+		t.Error("expected persisted=true after a successful upsert")
+	}
+}


### PR DESCRIPTION
## Summary
- When identifier plugins (OpenFIGI, Massive) fail for an option OCC symbol (e.g. expired options), the price import fallback now parses the underlying ticker from the OCC symbol and resolves it via DB lookup
- Also extracts option fields (strike, expiry, put/call) from the OCC symbol for the fallback-created instrument
- Fixes "underlying_id required when asset_class is OPTION" errors during price CSV uploads for options not found by external APIs

## Test plan
- [x] Unit test `TestProcessPriceImport_OptionFallbackResolvesUnderlying` verifies the fallback resolves the underlying and passes it to `EnsureInstrument`
- [ ] Upload `local/standard-format/prices-unadjusted.csv` and verify NVDA240315P options no longer produce identification errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)