### PR TITLE
Add OCC_AT_EXPIRY identifier hint for OpenFIGI lookups

### DIFF
--- a/server/identifier/hints.go
+++ b/server/identifier/hints.go
@@ -65,6 +65,12 @@ type HintDiff struct {
 	ResolvedValue string
 }
 
+// InternalHintTypeOCCAtExpiry is an internally-computed hint type representing
+// the OCC symbol with splits applied only up to the option's expiry date
+// (rather than up to today). Used by OpenFIGI; never persisted or
+// client-supplied.
+const InternalHintTypeOCCAtExpiry = "OCC_AT_EXPIRY"
+
 // AllowedIdentifierTypes is the controlled vocabulary for identifier hint types (proto IdentifierType names).
 // Description plugins must return hints whose Type is in this set; invalid types are discarded at debug log.
 var AllowedIdentifierTypes = map[string]bool{

--- a/server/plugins/openfigi/identifier/plugin.go
+++ b/server/plugins/openfigi/identifier/plugin.go
@@ -177,7 +177,7 @@ func (p *Plugin) resolveResults(results []OpenFIGIResult, hints identifier.Hints
 // Returns empty string if the hint type is not supported by OpenFIGI Mapping.
 var openFIGIIDTypeFromHint = map[string]string{
 	"MIC_TICKER": "TICKER", "OPENFIGI_TICKER": "TICKER", "ISIN": "ID_ISIN", "CUSIP": "ID_CUSIP", "SEDOL": "ID_SEDOL", "CINS": "ID_CINS", "WERTPAPIER": "ID_WERTPAPIER",
-	"OCC": "OCC_SYMBOL", "OPRA": "OPRA_SYMBOL", "FUT_OPT": "UNIQUE_ID_FUT_OPT",
+	"OCC": "OCC_SYMBOL", "OCC_AT_EXPIRY": "OCC_SYMBOL", "OPRA": "OPRA_SYMBOL", "FUT_OPT": "UNIQUE_ID_FUT_OPT",
 	"OPENFIGI_SHARE_CLASS": "ID_BB_GLOBAL_SHARE_CLASS_LEVEL", "OPENFIGI_COMPOSITE": "COMPOSITE_ID_BB_GLOBAL",
 }
 

--- a/server/service/identification/resolve.go
+++ b/server/service/identification/resolve.go
@@ -66,6 +66,9 @@ func ResolveByHintsDBOnly(ctx context.Context, database db.InstrumentDB, hints [
 		if h.Type == "" || h.Value == "" {
 			continue
 		}
+		if h.Type == identifier.InternalHintTypeOCCAtExpiry {
+			continue
+		}
 		// Normalize OCC to compact form (DB stores compact).
 		value := h.Value
 		if h.Type == "OCC" {
@@ -105,6 +108,9 @@ func ResolveIDsByHintsDBOnly(ctx context.Context, database db.InstrumentDB, hint
 	var ids []string
 	for _, h := range hints {
 		if h.Type == "" || h.Value == "" {
+			continue
+		}
+		if h.Type == identifier.InternalHintTypeOCCAtExpiry {
 			continue
 		}
 		value := h.Value

--- a/server/service/identification/split_adjust.go
+++ b/server/service/identification/split_adjust.go
@@ -22,39 +22,53 @@ func AdjustOCCForKnownSplits(ctx context.Context, database db.CorporateEventDB, 
 	if hintsValidAt == nil {
 		return hints
 	}
-	adjusted := make([]identifier.Identifier, len(hints))
-	copy(adjusted, hints)
+	now := timer.Now().Truncate(24 * time.Hour)
+	var adjusted []identifier.Identifier
 
-	for i, h := range adjusted {
+	for _, h := range hints {
 		if h.Type != "OCC" {
+			adjusted = append(adjusted, h)
 			continue
 		}
 		compact, ok := derivative.OCCCompact(h.Value)
 		if !ok {
+			adjusted = append(adjusted, h)
 			continue
 		}
 		parsed, ok := derivative.ParseOptionTicker(compact)
 		if !ok || parsed.Symbol == "" || parsed.Strike <= 0 {
+			adjusted = append(adjusted, h)
 			continue
 		}
 
 		splits, err := database.SplitsByUnderlyingTicker(ctx, parsed.Symbol)
 		if err != nil || len(splits) == 0 {
+			adjusted = append(adjusted, h)
 			continue
 		}
 
+		// Compute OCC_AT_EXPIRY for expired options: apply splits only
+		// up to the expiry date so OpenFIGI receives the OCC as it was
+		// when the option expired.
+		expiry := parsed.Expiry.Truncate(24 * time.Hour)
+		if !expiry.After(now) {
+			factorAtExpiry := splitFactorBetween(splits, *hintsValidAt, expiry)
+			expiryStrike := parsed.Strike / factorAtExpiry
+			if expiryOCC, ok := derivative.BuildOCCCompact(parsed.Symbol, parsed.Expiry, parsed.PutCall, expiryStrike); ok {
+				adjusted = append(adjusted, identifier.Identifier{Type: identifier.InternalHintTypeOCCAtExpiry, Domain: h.Domain, Value: expiryOCC})
+			}
+		}
+
+		// Adjust the OCC hint for DB lookups (splits up to now).
 		factor := splitFactorSince(splits, *hintsValidAt, timer)
-		if factor == 1.0 {
-			continue
+		if factor != 1.0 {
+			newStrike := parsed.Strike / factor
+			if newOCC, ok := derivative.BuildOCCCompact(parsed.Symbol, parsed.Expiry, parsed.PutCall, newStrike); ok {
+				adjusted = append(adjusted, identifier.Identifier{Type: h.Type, Domain: h.Domain, Value: newOCC})
+				continue
+			}
 		}
-
-		newStrike := parsed.Strike / factor
-		newOCC, ok := derivative.BuildOCCCompact(parsed.Symbol, parsed.Expiry, parsed.PutCall, newStrike)
-		if !ok {
-			continue
-		}
-
-		adjusted[i] = identifier.Identifier{Type: h.Type, Domain: h.Domain, Value: newOCC}
+		adjusted = append(adjusted, h)
 	}
 	return adjusted
 }
@@ -64,11 +78,17 @@ func AdjustOCCForKnownSplits(ctx context.Context, database db.CorporateEventDB, 
 // ex_date <= now. Returns 1.0 when no applicable splits. timer may be
 // nil (uses time.Now).
 func splitFactorSince(splits []db.StockSplit, since time.Time, timer *clock.Timer) float64 {
+	return splitFactorBetween(splits, since, timer.Now().Truncate(24*time.Hour))
+}
+
+// splitFactorBetween computes the cumulative split factor for splits where
+// ex_date > since AND ex_date <= until. Returns 1.0 when no applicable splits.
+func splitFactorBetween(splits []db.StockSplit, since, until time.Time) float64 {
 	factor := 1.0
-	now := timer.Now().Truncate(24 * time.Hour)
 	sinceDate := since.Truncate(24 * time.Hour)
+	untilDate := until.Truncate(24 * time.Hour)
 	for _, s := range splits {
-		if s.ExDate.After(now) || !s.ExDate.After(sinceDate) {
+		if s.ExDate.After(untilDate) || !s.ExDate.After(sinceDate) {
 			continue
 		}
 		from, okF := new(big.Rat).SetString(s.SplitFrom)

--- a/server/service/identification/split_adjust_test.go
+++ b/server/service/identification/split_adjust_test.go
@@ -146,8 +146,23 @@ func TestAdjustOCCForKnownSplits_SplitAfterHintsValidAt(t *testing.T) {
 
 	adjusted := AdjustOCCForKnownSplits(ctx, mockDB, hints, &validAt, timer)
 
-	if adjusted[0].Value != "AAPL250117C00100000" {
-		t.Errorf("adjusted OCC = %q, want AAPL250117C00100000", adjusted[0].Value)
+	// Option expires 2025-01-17, split is 2025-06-01 (after expiry).
+	// OCC_AT_EXPIRY should have original strike (no post-hintsValidAt
+	// splits before expiry), OCC should be adjusted.
+	if len(adjusted) != 2 {
+		t.Fatalf("want 2 hints (OCC_AT_EXPIRY + OCC), got %d", len(adjusted))
+	}
+	if adjusted[0].Type != identifier.InternalHintTypeOCCAtExpiry {
+		t.Errorf("adjusted[0].Type = %q, want OCC_AT_EXPIRY", adjusted[0].Type)
+	}
+	if adjusted[0].Value != "AAPL250117C00200000" {
+		t.Errorf("OCC_AT_EXPIRY = %q, want AAPL250117C00200000 (original strike)", adjusted[0].Value)
+	}
+	if adjusted[1].Type != "OCC" {
+		t.Errorf("adjusted[1].Type = %q, want OCC", adjusted[1].Type)
+	}
+	if adjusted[1].Value != "AAPL250117C00100000" {
+		t.Errorf("adjusted OCC = %q, want AAPL250117C00100000", adjusted[1].Value)
 	}
 }
 
@@ -171,8 +186,16 @@ func TestAdjustOCCForKnownSplits_SplitBeforeHintsValidAt(t *testing.T) {
 
 	adjusted := AdjustOCCForKnownSplits(ctx, mockDB, hints, &validAt, timer)
 
-	if adjusted[0].Value != "AAPL250117C00200000" {
-		t.Errorf("OCC should not change, got %q", adjusted[0].Value)
+	// No split adjustment (split before hintsValidAt), but OCC_AT_EXPIRY
+	// is still emitted for the expired option.
+	if len(adjusted) != 2 {
+		t.Fatalf("want 2 hints, got %d", len(adjusted))
+	}
+	if adjusted[0].Type != identifier.InternalHintTypeOCCAtExpiry {
+		t.Errorf("adjusted[0].Type = %q, want OCC_AT_EXPIRY", adjusted[0].Type)
+	}
+	if adjusted[1].Value != "AAPL250117C00200000" {
+		t.Errorf("OCC should not change, got %q", adjusted[1].Value)
 	}
 }
 
@@ -196,8 +219,16 @@ func TestAdjustOCCForKnownSplits_FutureSplit(t *testing.T) {
 
 	adjusted := AdjustOCCForKnownSplits(ctx, mockDB, hints, &validAt, timer)
 
-	if adjusted[0].Value != "AAPL250117C00400000" {
-		t.Errorf("OCC should not change for future split, got %q", adjusted[0].Value)
+	// Option expired (Jan 17 < Jun 1), so OCC_AT_EXPIRY is emitted.
+	// Split is after now, so neither OCC nor OCC_AT_EXPIRY is adjusted.
+	if len(adjusted) != 2 {
+		t.Fatalf("want 2 hints, got %d", len(adjusted))
+	}
+	if adjusted[0].Type != identifier.InternalHintTypeOCCAtExpiry {
+		t.Errorf("adjusted[0].Type = %q, want OCC_AT_EXPIRY", adjusted[0].Type)
+	}
+	if adjusted[1].Value != "AAPL250117C00400000" {
+		t.Errorf("OCC should not change for future split, got %q", adjusted[1].Value)
 	}
 }
 
@@ -260,5 +291,177 @@ func TestSplitFactorSince_WithTimer(t *testing.T) {
 	got = splitFactorSince(splits, d(2024, 1, 1), timer)
 	if got != 4.0 {
 		t.Errorf("with timer after ex_date: got %f, want 4.0", got)
+	}
+}
+
+func TestSplitFactorBetween(t *testing.T) {
+	splits := []db.StockSplit{
+		{ExDate: d(2024, 3, 1), SplitFrom: "1", SplitTo: "2"},
+		{ExDate: d(2025, 6, 1), SplitFrom: "1", SplitTo: "5"},
+	}
+	tests := []struct {
+		name         string
+		since, until time.Time
+		want         float64
+	}{
+		{"both included", d(2024, 1, 1), d(2026, 1, 1), 10.0},
+		{"only first", d(2024, 1, 1), d(2025, 1, 1), 2.0},
+		{"only second", d(2024, 6, 1), d(2026, 1, 1), 5.0},
+		{"none (too early)", d(2023, 1, 1), d(2024, 1, 1), 1.0},
+		{"none (too late)", d(2026, 1, 1), d(2027, 1, 1), 1.0},
+		{"until equals ex_date (inclusive)", d(2024, 1, 1), d(2024, 3, 1), 2.0},
+		{"since equals ex_date (exclusive)", d(2024, 3, 1), d(2025, 1, 1), 1.0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := splitFactorBetween(splits, tt.since, tt.until)
+			if got != tt.want {
+				t.Errorf("got %f, want %f", got, tt.want)
+			}
+		})
+	}
+}
+
+// TestAdjustOCC_OCCAtExpiry_PostExpirySplit verifies that when a split
+// occurs after the option's expiry, OCC_AT_EXPIRY has the original
+// strike while the OCC hint is adjusted.
+func TestAdjustOCC_OCCAtExpiry_PostExpirySplit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockDB := mock.NewMockDB(ctrl)
+	ctx := context.Background()
+
+	// Option expires 2025-01-17, split on 2025-06-01 (after expiry).
+	splits := []db.StockSplit{
+		{ExDate: d(2025, 6, 1), SplitFrom: "1", SplitTo: "2"},
+	}
+	mockDB.EXPECT().SplitsByUnderlyingTicker(gomock.Any(), "AAPL").Return(splits, nil)
+
+	hints := []identifier.Identifier{
+		{Type: "OCC", Value: "AAPL250117C00200000"}, // $200 strike
+	}
+	validAt := d(2024, 6, 1) // before split
+	timer := fixedTimer(d(2025, 7, 1)) // after split
+
+	adjusted := AdjustOCCForKnownSplits(ctx, mockDB, hints, &validAt, timer)
+
+	if len(adjusted) != 2 {
+		t.Fatalf("want 2 hints, got %d: %+v", len(adjusted), adjusted)
+	}
+	// OCC_AT_EXPIRY: no splits between validAt and expiry, original strike.
+	if adjusted[0].Type != identifier.InternalHintTypeOCCAtExpiry {
+		t.Errorf("[0].Type = %q, want OCC_AT_EXPIRY", adjusted[0].Type)
+	}
+	if adjusted[0].Value != "AAPL250117C00200000" {
+		t.Errorf("OCC_AT_EXPIRY = %q, want AAPL250117C00200000", adjusted[0].Value)
+	}
+	// OCC: split applied, $100 strike.
+	if adjusted[1].Value != "AAPL250117C00100000" {
+		t.Errorf("OCC = %q, want AAPL250117C00100000", adjusted[1].Value)
+	}
+}
+
+// TestAdjustOCC_OCCAtExpiry_PreExpirySplit verifies that when a split
+// occurs before the option's expiry, both OCC and OCC_AT_EXPIRY have
+// the adjusted strike.
+func TestAdjustOCC_OCCAtExpiry_PreExpirySplit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockDB := mock.NewMockDB(ctrl)
+	ctx := context.Background()
+
+	// Option expires 2026-01-17, split on 2025-06-01 (before expiry).
+	splits := []db.StockSplit{
+		{ExDate: d(2025, 6, 1), SplitFrom: "1", SplitTo: "2"},
+	}
+	mockDB.EXPECT().SplitsByUnderlyingTicker(gomock.Any(), "AAPL").Return(splits, nil)
+
+	hints := []identifier.Identifier{
+		{Type: "OCC", Value: "AAPL260117C00200000"}, // $200 strike, expires 2026-01-17
+	}
+	validAt := d(2024, 6, 1)
+	timer := fixedTimer(d(2025, 7, 1))
+
+	adjusted := AdjustOCCForKnownSplits(ctx, mockDB, hints, &validAt, timer)
+
+	// Option hasn't expired (2026-01-17 > 2025-07-01), so no OCC_AT_EXPIRY.
+	if len(adjusted) != 1 {
+		t.Fatalf("want 1 hint (no OCC_AT_EXPIRY for non-expired), got %d: %+v", len(adjusted), adjusted)
+	}
+	if adjusted[0].Type != "OCC" {
+		t.Errorf("[0].Type = %q, want OCC", adjusted[0].Type)
+	}
+	if adjusted[0].Value != "AAPL260117C00100000" {
+		t.Errorf("OCC = %q, want AAPL260117C00100000", adjusted[0].Value)
+	}
+}
+
+// TestAdjustOCC_OCCAtExpiry_MultipleSplits verifies correct handling
+// when one split is before expiry and another is after.
+func TestAdjustOCC_OCCAtExpiry_MultipleSplits(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockDB := mock.NewMockDB(ctrl)
+	ctx := context.Background()
+
+	// Option expires 2025-06-17.
+	// Split 1: 2025-03-01 (before expiry) 2:1
+	// Split 2: 2025-09-01 (after expiry) 5:1
+	splits := []db.StockSplit{
+		{ExDate: d(2025, 3, 1), SplitFrom: "1", SplitTo: "2"},
+		{ExDate: d(2025, 9, 1), SplitFrom: "1", SplitTo: "5"},
+	}
+	mockDB.EXPECT().SplitsByUnderlyingTicker(gomock.Any(), "AAPL").Return(splits, nil)
+
+	hints := []identifier.Identifier{
+		{Type: "OCC", Value: "AAPL250617C01000000"}, // $1000 strike, expires 2025-06-17
+	}
+	validAt := d(2024, 6, 1)
+	timer := fixedTimer(d(2025, 12, 1))
+
+	adjusted := AdjustOCCForKnownSplits(ctx, mockDB, hints, &validAt, timer)
+
+	if len(adjusted) != 2 {
+		t.Fatalf("want 2 hints, got %d: %+v", len(adjusted), adjusted)
+	}
+	// OCC_AT_EXPIRY: only pre-expiry split (2:1) applied. $1000/2 = $500.
+	if adjusted[0].Type != identifier.InternalHintTypeOCCAtExpiry {
+		t.Errorf("[0].Type = %q, want OCC_AT_EXPIRY", adjusted[0].Type)
+	}
+	if adjusted[0].Value != "AAPL250617C00500000" {
+		t.Errorf("OCC_AT_EXPIRY = %q, want AAPL250617C00500000", adjusted[0].Value)
+	}
+	// OCC: both splits applied. $1000/10 = $100.
+	if adjusted[1].Value != "AAPL250617C00100000" {
+		t.Errorf("OCC = %q, want AAPL250617C00100000", adjusted[1].Value)
+	}
+}
+
+// TestAdjustOCC_OCCAtExpiry_NotExpired verifies that OCC_AT_EXPIRY is
+// not emitted for options that have not yet expired.
+func TestAdjustOCC_OCCAtExpiry_NotExpired(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockDB := mock.NewMockDB(ctrl)
+	ctx := context.Background()
+
+	splits := []db.StockSplit{
+		{ExDate: d(2025, 6, 1), SplitFrom: "1", SplitTo: "2"},
+	}
+	mockDB.EXPECT().SplitsByUnderlyingTicker(gomock.Any(), "AAPL").Return(splits, nil)
+
+	hints := []identifier.Identifier{
+		{Type: "OCC", Value: "AAPL261219C00200000"}, // expires 2026-12-19
+	}
+	validAt := d(2024, 6, 1)
+	timer := fixedTimer(d(2025, 7, 1)) // option not expired yet
+
+	adjusted := AdjustOCCForKnownSplits(ctx, mockDB, hints, &validAt, timer)
+
+	// No OCC_AT_EXPIRY for non-expired options.
+	if len(adjusted) != 1 {
+		t.Fatalf("want 1 hint, got %d: %+v", len(adjusted), adjusted)
+	}
+	if adjusted[0].Type != "OCC" {
+		t.Errorf("[0].Type = %q, want OCC", adjusted[0].Type)
+	}
+	if adjusted[0].Value != "AAPL261219C00100000" {
+		t.Errorf("OCC = %q, want AAPL261219C00100000 (split applied)", adjusted[0].Value)
 	}
 }


### PR DESCRIPTION
## Summary
- Adds an internal `OCC_AT_EXPIRY` identifier hint type, computed during split adjustment by applying splits only up to the option's expiry date (not up to today)
- OpenFIGI plugin maps `OCC_AT_EXPIRY` to `OCC_SYMBOL` and tries it before regular `OCC`, so expired options are looked up with the correct historical strike
- For non-expired options, `OCC_AT_EXPIRY` is not emitted and OpenFIGI falls back to the regular `OCC` hint via normal hint iteration order
- Extracts `splitFactorBetween(since, until)` from `splitFactorSince` to support custom upper bounds
- DB lookups skip `OCC_AT_EXPIRY` hints (never persisted)

## Test plan
- [x] All existing split adjustment tests updated and passing
- [x] New `TestSplitFactorBetween` unit tests for the extracted function
- [x] New `TestAdjustOCC_OCCAtExpiry_PostExpirySplit` -- post-expiry split: OCC_AT_EXPIRY has original strike, OCC is adjusted
- [x] New `TestAdjustOCC_OCCAtExpiry_PreExpirySplit` -- non-expired option: no OCC_AT_EXPIRY emitted
- [x] New `TestAdjustOCC_OCCAtExpiry_MultipleSplits` -- splits straddling expiry: OCC_AT_EXPIRY gets only pre-expiry split
- [x] New `TestAdjustOCC_OCCAtExpiry_NotExpired` -- non-expired option: only OCC hint, no OCC_AT_EXPIRY
- [x] Full `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)