### PR TITLE
Fix instrument export writing display name instead of MIC code for exchange

### DIFF
--- a/server/service/api/server.go
+++ b/server/service/api/server.go
@@ -95,7 +95,7 @@ func instrumentRowToProto(row *db.InstrumentRow) *apiv1.Instrument {
 	if row.AssetClass != nil {
 		out.AssetClass = db.StrToAssetClass(*row.AssetClass)
 	}
-	out.Exchange = row.Exchange
+	out.Exchange = derefStr(row.ExchangeMIC)
 	if row.ExchangeName != nil || row.ExchangeAcronym != nil || row.ExchangeCountryCode != nil {
 		out.ExchangeInfo = &apiv1.Exchange{
 			Mic:         derefStr(row.ExchangeMIC),


### PR DESCRIPTION
## Summary
- `instrumentRowToProto` was populating `Instrument.exchange` with `row.Exchange` (the trigger-computed display name, e.g. "NASDAQ") instead of `row.ExchangeMIC` (the actual MIC code, e.g. "XNAS")
- When exported instruments were re-imported via `ImportInstruments`, the display name was passed to `EnsureInstrument` as `exchangeMIC`, violating the FK constraint `instruments_exchange_mic_fkey` against the `exchanges` table
- Fixed by using `derefStr(row.ExchangeMIC)` so the proto field contains the MIC code that round-trips correctly

## Test plan
- [x] All existing unit tests pass
- [ ] Export instruments from a populated database and verify the JSON contains MIC codes (e.g. "XNAS") not display names (e.g. "NASDAQ")
- [ ] Re-import the exported JSON into a clean database and confirm no FK violation errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)