### PR TITLE
Fix OpenFIGI returning at-expiry OCC instead of split-adjusted OCC

### DIFF
--- a/server/plugins/openfigi/identifier/plugin.go
+++ b/server/plugins/openfigi/identifier/plugin.go
@@ -103,6 +103,27 @@ func (p *Plugin) Identify(ctx context.Context, config []byte, broker, source, in
 		// identifiers. A successful Mapping API response for that ticker proves
 		// the association. Other hint types (ISIN, CUSIP, etc.) are not appended
 		// because OpenFIGI may return corrected values for those.
+		// When matched via OCC_AT_EXPIRY, the API response reflects the
+		// at-expiry strike. Replace the returned OCC with the
+		// split-adjusted OCC from identifierHints so downstream
+		// storage and comparison use the current strike.
+		if matchedHint != nil && matchedHint.Type == identifier.InternalHintTypeOCCAtExpiry {
+			for _, h := range identifierHints {
+				if h.Type == "OCC" {
+					occVal := h.Value
+					if c, ok := derivative.OCCCompact(occVal); ok {
+						occVal = c
+					}
+					for i := range ids {
+						if ids[i].Type == "OCC" {
+							ids[i].Value = occVal
+							break
+						}
+					}
+					break
+				}
+			}
+		}
 		if matchedHint != nil && matchedHint.Type == "MIC_TICKER" {
 			hasMICTicker := false
 			for _, id := range ids {

--- a/server/plugins/openfigi/identifier/plugin_test.go
+++ b/server/plugins/openfigi/identifier/plugin_test.go
@@ -785,6 +785,73 @@ func TestPlugin_Identify_NonTickerHintNotAppended(t *testing.T) {
 	}
 }
 
+func TestPlugin_Identify_OCCAtExpiry_ReplacesReturnedOCC(t *testing.T) {
+	// When OpenFIGI is matched via OCC_AT_EXPIRY, the API response reflects
+	// the at-expiry strike ($510). The plugin should replace the returned OCC
+	// with the split-adjusted OCC ($51) from the regular OCC hint.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if r.URL.Path != "/v3/mapping" {
+			http.Error(w, "not found", http.StatusNotFound)
+			return
+		}
+		var jobs []MappingJob
+		if err := json.NewDecoder(r.Body).Decode(&jobs); err != nil || len(jobs) != 1 {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		// Expect the OCC_AT_EXPIRY value (padded to 21 chars).
+		if jobs[0].IDValue == "NVDA  240315P00510000" {
+			json.NewEncoder(w).Encode([]MappingResponseItem{
+				{Data: []OpenFIGIResult{{
+					FIGI:          "BBG00OPTION2",
+					Ticker:        "NVDA  240315P00510000",
+					Name:          "NVDA Mar 2024 510 Put",
+					ExchCode:      "US",
+					SecurityType:  "Option",
+					SecurityType2: "Equity Option",
+					MarketSector:  "Equity",
+				}}},
+			})
+		} else {
+			json.NewEncoder(w).Encode([]MappingResponseItem{{Data: nil}})
+		}
+	}))
+	defer server.Close()
+
+	config := mustJSON(map[string]string{
+		"openfigi_api_key":  "test-key",
+		"openfigi_base_url": server.URL,
+	})
+	ctx := context.Background()
+	p := NewPlugin(nil, nil, http.DefaultClient, nil)
+
+	// OCC_AT_EXPIRY first (at-expiry strike $510), then OCC (split-adjusted $51).
+	hints := []identifier.Identifier{
+		{Type: identifier.InternalHintTypeOCCAtExpiry, Value: "NVDA240315P00510000"},
+		{Type: "OCC", Value: "NVDA240315P00051000"},
+	}
+	inst, ids, err := p.Identify(ctx, config, "IBKR", "IBKR:test:statement", "NVDA Mar 2024 510 Put",
+		identifier.Hints{SecurityTypeHint: identifier.SecurityTypeHintOption}, hints)
+	if err != nil {
+		t.Fatalf("Identify: %v", err)
+	}
+	if inst == nil {
+		t.Fatal("expected instrument")
+	}
+
+	// The returned OCC should be the split-adjusted value, not the at-expiry value.
+	for _, id := range ids {
+		if id.Type == "OCC" {
+			if id.Value != "NVDA240315P00051000" {
+				t.Errorf("OCC = %q, want NVDA240315P00051000 (split-adjusted)", id.Value)
+			}
+			return
+		}
+	}
+	t.Errorf("expected OCC identifier in %+v", ids)
+}
+
 func mustJSON(v interface{}) []byte {
 	b, err := json.Marshal(v)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Fixes price import failures caused by #228: when the OpenFIGI plugin matched on `OCC_AT_EXPIRY`, it returned the at-expiry strike in its OCC identifier, causing `CompareHints` to flag a mismatch against the split-adjusted OCC
- The plugin now replaces the API-response-derived OCC with the split-adjusted OCC from the regular `OCC` hint when matched via `OCC_AT_EXPIRY`

## Test plan
- [x] New `TestPlugin_Identify_OCCAtExpiry_ReplacesReturnedOCC` verifies the returned OCC uses the split-adjusted value ($51) not the at-expiry value ($510)
- [x] All existing tests pass
- [x] Full `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)