### PR TITLE
Add dividend type and route special cash dividends to unhandled events

### DIFF
--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -1053,7 +1053,7 @@ message UnhandledCorporateEvent {
   string id = 1;
   string instrument_id = 2;
   string instrument_name = 3;
-  string event_type = 4;   // REVERSE_SPLIT, NON_WHOLE_SPLIT, MERGER, EXTRAORDINARY_DIVIDEND, FUTURES_SPLIT
+  string event_type = 4;   // REVERSE_SPLIT, NON_WHOLE_SPLIT, MERGER, EXTRAORDINARY_DIVIDEND, SPECIAL_CASH_DIVIDEND, FUTURES_SPLIT
   string ex_date = 5;      // YYYY-MM-DD, may be empty
   string detail = 6;
   string data = 7;         // JSON

--- a/server/corporateevents/plugin.go
+++ b/server/corporateevents/plugin.go
@@ -85,6 +85,8 @@ type Split struct {
 
 // CashDividend is a single cash dividend returned by a plugin. Optional
 // fields are zero (time.Time{}, "") when the provider does not supply them.
+// Type uses terse codes: "CD" (regular cash dividend), "SC" (special cash
+// dividend). Empty string is treated as "CD".
 type CashDividend struct {
 	ExDate          time.Time
 	PayDate         time.Time
@@ -93,4 +95,5 @@ type CashDividend struct {
 	Amount          string // decimal string per share
 	Currency        string
 	Frequency       string
+	Type            string // "CD", "SC"; empty = "CD"
 }

--- a/server/corporateevents/worker.go
+++ b/server/corporateevents/worker.go
@@ -2,6 +2,7 @@ package corporateevents
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -226,12 +227,22 @@ func processInstrument(ctx context.Context, database db.DB, plugins []pluginEntr
 					splitsLanded = true
 				}
 				if len(result.CashDividends) > 0 {
-					if err := database.UpsertCashDividends(ctx, dividendsToDB(inst.ID, pe.id, result.CashDividends)); err != nil {
-						if log != nil {
-							log.ErrorContext(ctx, "corporate event fetch: upsert dividends",
-								"plugin", pe.id, "instrument", inst.ID, "err", err)
+					var regular []CashDividend
+					for _, d := range result.CashDividends {
+						if d.Type == "SC" {
+							insertSpecialDividend(ctx, database, inst.ID, pe.id, d, log)
+						} else {
+							regular = append(regular, d)
 						}
-						continue
+					}
+					if len(regular) > 0 {
+						if err := database.UpsertCashDividends(ctx, dividendsToDB(inst.ID, pe.id, regular)); err != nil {
+							if log != nil {
+								log.ErrorContext(ctx, "corporate event fetch: upsert dividends",
+									"plugin", pe.id, "instrument", inst.ID, "err", err)
+							}
+							continue
+						}
 					}
 				}
 			}
@@ -332,12 +343,17 @@ func splitsToDB(instrumentID, provider string, splits []Split) []db.StockSplit {
 func dividendsToDB(instrumentID, provider string, dividends []CashDividend) []db.CashDividend {
 	out := make([]db.CashDividend, len(dividends))
 	for i, d := range dividends {
+		typ := d.Type
+		if typ == "" {
+			typ = "CD"
+		}
 		row := db.CashDividend{
 			InstrumentID: instrumentID,
 			ExDate:       d.ExDate,
 			Amount:       d.Amount,
 			Currency:     d.Currency,
 			Frequency:    d.Frequency,
+			Type:         typ,
 			DataProvider: provider,
 		}
 		if !d.PayDate.IsZero() {
@@ -355,5 +371,58 @@ func dividendsToDB(instrumentID, provider string, dividends []CashDividend) []db
 		out[i] = row
 	}
 	return out
+}
+
+// insertSpecialDividend stores a special cash dividend as an unhandled
+// corporate event with the dividend details in the JSONB data field.
+func insertSpecialDividend(ctx context.Context, database db.CorporateEventDB, instrumentID, provider string, d CashDividend, log *slog.Logger) {
+	type specialDivData struct {
+		Amount          string `json:"amount"`
+		Currency        string `json:"currency"`
+		PayDate         string `json:"pay_date,omitempty"`
+		RecordDate      string `json:"record_date,omitempty"`
+		DeclarationDate string `json:"declaration_date,omitempty"`
+		Frequency       string `json:"frequency,omitempty"`
+		DividendType    string `json:"dividend_type"`
+		DataProvider    string `json:"data_provider"`
+	}
+	sd := specialDivData{
+		Amount:       d.Amount,
+		Currency:     d.Currency,
+		DividendType: d.Type,
+		DataProvider: provider,
+		Frequency:    d.Frequency,
+	}
+	if !d.PayDate.IsZero() {
+		sd.PayDate = d.PayDate.Format("2006-01-02")
+	}
+	if !d.RecordDate.IsZero() {
+		sd.RecordDate = d.RecordDate.Format("2006-01-02")
+	}
+	if !d.DeclarationDate.IsZero() {
+		sd.DeclarationDate = d.DeclarationDate.Format("2006-01-02")
+	}
+	data, err := json.Marshal(sd)
+	if err != nil {
+		if log != nil {
+			log.ErrorContext(ctx, "corporate event fetch: marshal special dividend",
+				"instrument", instrumentID, "err", err)
+		}
+		return
+	}
+	exDate := d.ExDate
+	event := db.UnhandledCorporateEvent{
+		InstrumentID: instrumentID,
+		EventType:    "SPECIAL_CASH_DIVIDEND",
+		ExDate:       &exDate,
+		Detail:       fmt.Sprintf("Special cash dividend %s %s (provider: %s)", d.Amount, d.Currency, provider),
+		Data:         data,
+	}
+	if err := database.InsertUnhandledCorporateEvent(ctx, event); err != nil {
+		if log != nil {
+			log.ErrorContext(ctx, "corporate event fetch: insert special dividend",
+				"instrument", instrumentID, "err", err)
+		}
+	}
 }
 

--- a/server/corporateevents/worker_test.go
+++ b/server/corporateevents/worker_test.go
@@ -353,6 +353,70 @@ func TestRunCycle_PermanentErrorCreatesBlock(t *testing.T) {
 	}
 }
 
+// TestRunCycle_SpecialDividendRoutedToUnhandled verifies that dividends with
+// Type="SC" are inserted as unhandled corporate events, while regular
+// dividends are upserted into the cash_dividends table.
+func TestRunCycle_SpecialDividendRoutedToUnhandled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockDB := mock.NewMockDB(ctrl)
+	ctx := context.Background()
+
+	instID := "55555555-5555-5555-5555-555555555555"
+
+	plugin := &stubPlugin{
+		name:         "massive",
+		idTypes:      []string{"MIC_TICKER"},
+		assetClasses: map[string]bool{"STOCK": true, "ETF": true},
+		result: &Events{
+			CashDividends: []CashDividend{
+				{ExDate: d(2024, 2, 9), Amount: "0.24", Currency: "USD", Type: "CD"},
+				{ExDate: d(2024, 6, 1), Amount: "1.50", Currency: "USD", Type: "SC"},
+			},
+		},
+	}
+	reg := NewRegistry()
+	reg.Register("massive", plugin)
+
+	mockDB.EXPECT().HeldEventBearingInstruments(gomock.Any()).Return([]db.HeldInstrument{
+		{InstrumentID: instID, EarliestTxDate: d(2024, 1, 1)},
+	}, nil)
+	mockDB.EXPECT().ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryCorporateEvent).Return([]db.PluginConfigRow{
+		{PluginID: "massive", Precedence: 10, Config: []byte("{}")},
+	}, nil)
+	mockDB.EXPECT().BlockedCorporateEventPluginsForInstruments(gomock.Any(), []string{instID}).Return(nil, nil)
+	mockDB.EXPECT().ListInstrumentsByIDs(gomock.Any(), []string{instID}).Return([]*db.InstrumentRow{
+		{
+			ID:         instID,
+			AssetClass: strPtr("STOCK"),
+			Identifiers: []db.IdentifierInput{{Type: "MIC_TICKER", Value: "AAPL"}},
+		},
+	}, nil)
+	mockDB.EXPECT().ListCorporateEventCoverage(gomock.Any(), []string{instID}).Return(nil, nil)
+
+	// Regular dividend goes to UpsertCashDividends.
+	mockDB.EXPECT().UpsertCashDividends(gomock.Any(), gomock.Len(1)).Return(nil)
+	// Special dividend goes to InsertUnhandledCorporateEvent.
+	mockDB.EXPECT().InsertUnhandledCorporateEvent(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, e db.UnhandledCorporateEvent) error {
+			if e.EventType != "SPECIAL_CASH_DIVIDEND" {
+				t.Errorf("event type: got %q, want SPECIAL_CASH_DIVIDEND", e.EventType)
+			}
+			if e.InstrumentID != instID {
+				t.Errorf("instrument: got %q, want %q", e.InstrumentID, instID)
+			}
+			if e.ExDate == nil || !e.ExDate.Equal(d(2024, 6, 1)) {
+				t.Errorf("ex_date: got %v", e.ExDate)
+			}
+			if len(e.Data) == 0 {
+				t.Error("expected non-empty JSONB data")
+			}
+			return nil
+		})
+	mockDB.EXPECT().UpsertCorporateEventCoverage(gomock.Any(), instID, "massive", gomock.Any(), gomock.Any()).Return(nil)
+
+	runCycle(ctx, mockDB, reg, nil, nil, nil)
+}
+
 // TestRunCycle_BlockedPluginSkipped verifies that fetch blocks are honored.
 func TestRunCycle_BlockedPluginSkipped(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -673,7 +673,8 @@ type StockSplit struct {
 
 // CashDividend is a single cash dividend row. Amount is per share in Currency.
 // PayDate, RecordDate, DeclarationDate, and Frequency are optional and may be
-// nil/empty when the provider does not supply them.
+// nil/empty when the provider does not supply them. Type is "CD" (regular) or
+// "SC" (special cash); defaults to "CD" when empty.
 type CashDividend struct {
 	InstrumentID    string
 	ExDate          time.Time
@@ -683,6 +684,7 @@ type CashDividend struct {
 	Amount          string // numeric, e.g. "0.24"
 	Currency        string
 	Frequency       string // empty when unknown
+	Type            string // "CD" or "SC"; empty = "CD"
 	DataProvider    string
 	FetchedAt       time.Time
 }
@@ -863,4 +865,5 @@ type ExportCashDividend struct {
 	Amount           string
 	Currency         string
 	Frequency        string
+	Type             string
 }

--- a/server/db/postgres/corporate_events.go
+++ b/server/db/postgres/corporate_events.go
@@ -99,6 +99,7 @@ func (p *Postgres) UpsertCashDividends(ctx context.Context, dividends []db.CashD
 	amounts := make([]string, len(dividends))
 	currencies := make([]string, len(dividends))
 	frequencies := make([]sql.NullString, len(dividends))
+	types := make([]string, len(dividends))
 	providers := make([]string, len(dividends))
 	for i, d := range dividends {
 		instIDs[i] = d.InstrumentID
@@ -111,17 +112,21 @@ func (p *Postgres) UpsertCashDividends(ctx context.Context, dividends []db.CashD
 		if d.Frequency != "" {
 			frequencies[i] = sql.NullString{String: d.Frequency, Valid: true}
 		}
+		types[i] = d.Type
+		if types[i] == "" {
+			types[i] = "CD"
+		}
 		providers[i] = d.DataProvider
 	}
 	_, err := p.q.ExecContext(ctx, `
 		INSERT INTO cash_dividends (
 			instrument_id, ex_date, pay_date, record_date, declaration_date,
-			amount, currency, frequency, data_provider, fetched_at
+			amount, currency, frequency, type, data_provider, fetched_at
 		)
 		SELECT unnest($1::uuid[]), unnest($2::date[]),
 			unnest($3::date[]), unnest($4::date[]), unnest($5::date[]),
 			unnest($6::numeric[]), unnest($7::text[]), unnest($8::text[]),
-			unnest($9::text[]), now()
+			unnest($9::text[]), unnest($10::text[]), now()
 		ON CONFLICT (instrument_id, ex_date) DO UPDATE SET
 			pay_date         = EXCLUDED.pay_date,
 			record_date      = EXCLUDED.record_date,
@@ -129,12 +134,13 @@ func (p *Postgres) UpsertCashDividends(ctx context.Context, dividends []db.CashD
 			amount           = EXCLUDED.amount,
 			currency         = EXCLUDED.currency,
 			frequency        = EXCLUDED.frequency,
+			type             = EXCLUDED.type,
 			data_provider    = EXCLUDED.data_provider,
 			fetched_at       = EXCLUDED.fetched_at
 	`, pq.Array(instIDs), pq.Array(exDates),
 		pq.Array(payDates), pq.Array(recordDates), pq.Array(declDates),
 		pq.Array(amounts), pq.Array(currencies), pq.Array(frequencies),
-		pq.Array(providers))
+		pq.Array(types), pq.Array(providers))
 	if err != nil {
 		return fmt.Errorf("upsert cash dividends: %w", err)
 	}
@@ -149,7 +155,7 @@ func (p *Postgres) ListCashDividends(ctx context.Context, instrumentID string) (
 	}
 	rows, err := p.q.QueryContext(ctx, `
 		SELECT instrument_id, ex_date, pay_date, record_date, declaration_date,
-			amount::text, currency, frequency, data_provider, fetched_at
+			amount::text, currency, frequency, type, data_provider, fetched_at
 		FROM cash_dividends
 		WHERE instrument_id = $1
 		ORDER BY ex_date
@@ -165,7 +171,7 @@ func (p *Postgres) ListCashDividends(ctx context.Context, instrumentID string) (
 		var pay, record, decl sql.NullTime
 		var freq sql.NullString
 		if err := rows.Scan(&instUUID, &d.ExDate, &pay, &record, &decl,
-			&d.Amount, &d.Currency, &freq, &d.DataProvider, &d.FetchedAt); err != nil {
+			&d.Amount, &d.Currency, &freq, &d.Type, &d.DataProvider, &d.FetchedAt); err != nil {
 			return nil, fmt.Errorf("list cash dividends scan: %w", err)
 		}
 		d.InstrumentID = instUUID.String()
@@ -379,7 +385,7 @@ func (p *Postgres) ListCashDividendsForExport(ctx context.Context) ([]db.ExportC
 		SELECT best_id.identifier_type, best_id.value, COALESCE(best_id.domain, '') AS domain,
 			COALESCE(i.asset_class, '') AS asset_class,
 			d.data_provider, d.ex_date, d.pay_date, d.record_date, d.declaration_date,
-			d.amount::text, d.currency, d.frequency
+			d.amount::text, d.currency, d.frequency, d.type
 		FROM cash_dividends d
 		JOIN instruments i ON i.id = d.instrument_id
 		` + bestIdentifierJoin + `
@@ -397,7 +403,7 @@ func (p *Postgres) ListCashDividendsForExport(ctx context.Context) ([]db.ExportC
 		var freq sql.NullString
 		if err := rows.Scan(&r.IdentifierType, &r.IdentifierValue, &r.IdentifierDomain,
 			&r.AssetClass, &r.DataProvider, &r.ExDate, &pay, &rec, &decl,
-			&r.Amount, &r.Currency, &freq); err != nil {
+			&r.Amount, &r.Currency, &freq, &r.Type); err != nil {
 			return nil, fmt.Errorf("list cash dividends for export scan: %w", err)
 		}
 		if pay.Valid {

--- a/server/db/postgres/corporate_events_test.go
+++ b/server/db/postgres/corporate_events_test.go
@@ -113,6 +113,9 @@ func TestUpsertCashDividends_RoundTrip(t *testing.T) {
 	if d0.Amount != "0.24" || d0.Currency != "USD" || d0.Frequency != "quarterly" {
 		t.Errorf("dividend: %+v", d0)
 	}
+	if d0.Type != "CD" {
+		t.Errorf("type: got %q, want %q", d0.Type, "CD")
+	}
 	if d0.PayDate == nil || !d0.PayDate.Equal(pay) {
 		t.Errorf("pay_date: %+v", d0.PayDate)
 	}
@@ -121,6 +124,36 @@ func TestUpsertCashDividends_RoundTrip(t *testing.T) {
 	}
 	if d0.DeclarationDate == nil || !d0.DeclarationDate.Equal(decl) {
 		t.Errorf("declaration_date: %+v", d0.DeclarationDate)
+	}
+}
+
+func TestUpsertCashDividends_TypeDefaultsToCD(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	instID := setupInstrument(t, p, "AAPL")
+
+	// Insert without setting Type (empty string) — should default to "CD".
+	if err := p.UpsertCashDividends(ctx, []db.CashDividend{
+		{
+			InstrumentID: instID,
+			ExDate:       d(2024, 3, 1),
+			Amount:       "0.50",
+			Currency:     "USD",
+			DataProvider: "test",
+		},
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	got, err := p.ListCashDividends(ctx, instID)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 dividend, got %d", len(got))
+	}
+	if got[0].Type != "CD" {
+		t.Errorf("type: got %q, want %q", got[0].Type, "CD")
 	}
 }
 

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -381,6 +381,7 @@ CREATE TABLE cash_dividends (
   amount           NUMERIC     NOT NULL CHECK (amount >= 0),
   currency         TEXT        NOT NULL,
   frequency        TEXT,
+  type             TEXT        NOT NULL DEFAULT 'CD',
   data_provider    TEXT        NOT NULL,
   fetched_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
   PRIMARY KEY (instrument_id, ex_date)

--- a/server/plugins/massive/corporateevents/plugin.go
+++ b/server/plugins/massive/corporateevents/plugin.go
@@ -191,6 +191,7 @@ func parseDividend(r client.DividendResult) (corporateevents.CashDividend, bool)
 		Amount:    formatFloat(r.CashAmount),
 		Currency:  r.Currency,
 		Frequency: frequencyFromInt(r.Frequency),
+		Type:      dividendType(r.DividendType),
 	}
 	if t, err := time.Parse("2006-01-02", r.PayDate); err == nil {
 		d.PayDate = t
@@ -202,6 +203,17 @@ func parseDividend(r client.DividendResult) (corporateevents.CashDividend, bool)
 		d.DeclarationDate = t
 	}
 	return d, true
+}
+
+// dividendType maps Massive's dividend_type code to the canonical type.
+// "CD" (or empty) is a regular cash dividend. "LT" and "ST" are capital
+// gains distributions which behave like regular dividends for portfolio
+// tracking. "SC" is a special cash dividend routed to unhandled events.
+func dividendType(dt string) string {
+	if dt == "SC" {
+		return "SC"
+	}
+	return "CD"
 }
 
 // frequencyFromInt translates Massive's payments-per-year integer into a

--- a/server/plugins/massive/corporateevents/plugin_test.go
+++ b/server/plugins/massive/corporateevents/plugin_test.go
@@ -86,6 +86,9 @@ func TestFetchEvents_StockSplitsAndDividends(t *testing.T) {
 	if d0.Amount != "0.24" || d0.Currency != "USD" || d0.Frequency != "quarterly" {
 		t.Errorf("dividend: %+v", d0)
 	}
+	if d0.Type != "CD" {
+		t.Errorf("type: got %q, want %q", d0.Type, "CD")
+	}
 	if d0.PayDate != time.Date(2024, 2, 15, 0, 0, 0, 0, time.UTC) {
 		t.Errorf("pay date: %v", d0.PayDate)
 	}
@@ -187,6 +190,63 @@ func TestFetchEvents_NoSupportedIdentifier(t *testing.T) {
 		time.Date(2024, 1, 31, 0, 0, 0, 0, time.UTC))
 	if !errors.Is(err, corporateevents.ErrNoData) {
 		t.Errorf("expected ErrNoData, got %v", err)
+	}
+}
+
+func TestDividendType(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"", "CD"},
+		{"CD", "CD"},
+		{"SC", "SC"},
+		{"LT", "CD"},
+		{"ST", "CD"},
+	}
+	for _, c := range cases {
+		if got := dividendType(c.in); got != c.want {
+			t.Errorf("dividendType(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestFetchEvents_SpecialDividendType(t *testing.T) {
+	dividends := []client.DividendResult{
+		{
+			Ticker:         "AAPL",
+			ExDividendDate: "2024-06-01",
+			CashAmount:     1.50,
+			Currency:       "USD",
+			DividendType:   "SC",
+		},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/v3/reference/splits":
+			_ = json.NewEncoder(w).Encode(envelope{Status: "OK", Results: []client.SplitResult{}})
+		case "/v3/reference/dividends":
+			_ = json.NewEncoder(w).Encode(envelope{Status: "OK", Results: dividends})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer srv.Close()
+
+	p := NewPlugin(nil, nil, srv.Client())
+	ids := []corporateevents.Identifier{{Type: "MIC_TICKER", Value: "AAPL"}}
+	got, err := p.FetchEvents(context.Background(), configWithURL(srv.URL), ids, db.AssetClassStock,
+		time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2024, 12, 31, 0, 0, 0, 0, time.UTC))
+	if err != nil {
+		t.Fatalf("FetchEvents: %v", err)
+	}
+	if len(got.CashDividends) != 1 {
+		t.Fatalf("expected 1 dividend, got %d", len(got.CashDividends))
+	}
+	if got.CashDividends[0].Type != "SC" {
+		t.Errorf("type: got %q, want %q", got.CashDividends[0].Type, "SC")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds a `type` column (`CD`/`SC`) to the `cash_dividends` table to distinguish regular from special cash dividends
- Routes special cash dividends (`SC`) to `unhandled_corporate_events` with full dividend metadata in the JSONB `data` field, since we don't yet perform price adjustments for them
- Massive plugin now maps its `DividendType` field: `SC` -> special, everything else (`CD`, `LT`, `ST`, empty) -> regular. Capital gains distributions (`LT`/`ST`) don't require price adjustments so are treated as regular dividends
- EODHD doesn't provide dividend type data; all its dividends default to `CD`

## Test plan
- [x] `TestUpsertCashDividends_RoundTrip` updated to verify type column
- [x] `TestUpsertCashDividends_TypeDefaultsToCD` — empty type defaults to CD
- [x] `TestDividendType` — mapping of Massive codes (CD, SC, LT, ST, empty)
- [x] `TestFetchEvents_SpecialDividendType` — SC flows through Massive plugin
- [x] `TestRunCycle_SpecialDividendRoutedToUnhandled` — worker routes SC to unhandled events and CD to cash_dividends
- [ ] Rebuild dev containers and verify migration applies cleanly
- [ ] Verify SC dividends appear in unhandled events admin UI with Massive data

🤖 Generated with [Claude Code](https://claude.com/claude-code)