### PR TITLE
Simplify Makefile .env handling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,9 @@
 .DEFAULT_GOAL := help
 
-# Load .env so DB_INITIALISE_SCRIPT etc. are available to run/init-db
--include .env
+include .env
 export
 
 # === Stack Isolation ===
-# Each stack uses an explicit -p project name and non-overlapping host ports.
-# All stacks can run simultaneously without collision.
-#   Dev  (portfoliodb-dev):  postgres 5432, redis 6379, grpc 50051, envoy 8080
-#   Test (portfoliodb-test): postgres 5433, redis 6380
-#   E2E  (portfoliodb-e2e):  postgres 5434, redis 6381, grpc 50052, envoy 8081
-
 COMPOSE_RUN  = docker compose -p portfoliodb      -f docker/docker-compose.yml --env-file .env
 COMPOSE_DEV  = docker compose -p portfoliodb-dev   -f docker/docker-compose.yml -f docker/docker-compose.dev.yml --env-file .env
 COMPOSE_E2E  = docker compose -p portfoliodb-e2e   -f docker/docker-compose.yml -f docker/docker-compose.e2e.yml --env-file .env
@@ -29,6 +22,10 @@ STAMP_DIR := .stamps
 
 $(STAMP_DIR):
 	@mkdir -p $(STAMP_DIR)
+
+# --- .env bootstrap ---
+.env:
+	@touch $@
 
 # --- tools stamp ---
 # Re-run when Go module deps or JS package manifests change.


### PR DESCRIPTION
## Summary
- Switch from `-include .env` to unconditional `include .env` with a `.env:` bootstrap rule that touches the file when missing
- Drop the redundant `env` alias target and its `.PHONY` entry (no callers; `include` already triggers the bootstrap on every invocation)
- Remove now-obsolete comments above the include and stack-isolation blocks

## Test plan
- [ ] `rm .env && make help` — confirm `.env` is auto-created and help renders
- [ ] `make run` — confirm `DB_INITIALISE_SCRIPT` and other env vars are still exported to compose

🤖 Generated with [Claude Code](https://claude.com/claude-code)