### PR TITLE
Replace host grpcurl readiness probe with in-container gRPC health check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ run: $(STAMP_DIR)/tools $(STAMP_DIR)/generate
 	@echo "Waiting for Postgres..."
 	@scripts/postgres-ready.sh "$(COMPOSE_DEV)"
 	@echo "Waiting for portfoliodb (gRPC)..."
-	@scripts/server-ready.sh
+	@scripts/server-ready.sh "$(COMPOSE_DEV)"
 	@$(MAKE) init-db
 
 # Run the DB initialise script when DB_INITIALISE_SCRIPT is set and the file exists. Used by 'make run'.
@@ -116,7 +116,7 @@ e2e-test: $(STAMP_DIR)/generate
 		echo "Waiting for Postgres..."; \
 		scripts/postgres-ready.sh "$(COMPOSE_E2E)"; \
 		echo "Waiting for portfoliodb (gRPC)..."; \
-		scripts/server-ready.sh localhost:50052; \
+		scripts/server-ready.sh "$(COMPOSE_E2E)"; \
 		HOST_UID=$$(id -u) HOST_GID=$$(id -g) $(COMPOSE_E2E) --profile test run --rm playwright npx playwright test; \
 		rc=$$?; $(COMPOSE_E2E) --profile test down; exit $$rc
 
@@ -135,7 +135,7 @@ e2e-test-record: $(STAMP_DIR)/generate
 		echo "Waiting for Postgres..."; \
 		scripts/postgres-ready.sh "$(COMPOSE_E2E)"; \
 		echo "Waiting for portfoliodb (gRPC)..."; \
-		scripts/server-ready.sh localhost:50052; \
+		scripts/server-ready.sh "$(COMPOSE_E2E)"; \
 		logdir="/tmp/e2e-record-$$(date +%Y%m%d-%H%M%S)"; mkdir -p "$$logdir"; \
 		HOST_UID=$$(id -u) HOST_GID=$$(id -g) VCR_MODE=$(VCR_SUITES) $(COMPOSE_E2E) --profile test run --rm playwright \
 			sh -c 'npx playwright test 2>&1; echo $$? > /e2e/.e2e-rc' | tee "$$logdir/playwright.log"; \

--- a/docker/server/Dockerfile.dev
+++ b/docker/server/Dockerfile.dev
@@ -4,6 +4,7 @@ RUN apk add --no-cache git
 RUN go install github.com/bufbuild/buf/cmd/buf@latest
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+RUN go install github.com/grpc-ecosystem/grpc-health-probe@latest
 RUN go install github.com/air-verse/air@latest
 WORKDIR /app
 CMD ["air"]

--- a/scripts/server-ready.sh
+++ b/scripts/server-ready.sh
@@ -1,16 +1,13 @@
 #!/usr/bin/env bash
-# Wait for portfoliodb gRPC server to be ready (grpcurl list). Exits 0 when ready, 1 after max tries.
-# Usage: scripts/server-ready.sh [target] [max_tries]
-#   target defaults to localhost:50051
+# Wait for portfoliodb gRPC server to report SERVING via grpc_health_probe. Exits 0 when ready, 1 after max tries.
+# Probes from inside the portfoliodb container so no host-side grpc tooling is required.
+# Usage: scripts/server-ready.sh <compose-cmd> [max_tries]
+#   e.g. scripts/server-ready.sh "docker compose -p portfoliodb-dev -f docker/docker-compose.yml -f docker/docker-compose.dev.yml --env-file .env"
 set -e
-TARGET="${1:-localhost:50051}"
+COMPOSE_CMD="$1"
 MAX_TRIES="${2:-20}"
-if ! command -v grpcurl >/dev/null 2>&1; then
-	echo "grpcurl not found (install from https://github.com/fullstorydev/grpcurl)" >&2
-	exit 1
-fi
 for i in $(seq 1 "$MAX_TRIES"); do
-	if grpcurl -plaintext -connect-timeout 2 "$TARGET" list >/dev/null 2>&1; then
+	if $COMPOSE_CMD exec -T portfoliodb grpc-health-probe -addr=localhost:50051 -connect-timeout=2s >/dev/null 2>&1; then
 		exit 0
 	fi
 	sleep 1

--- a/server/cmd/portfoliodb/main.go
+++ b/server/cmd/portfoliodb/main.go
@@ -56,6 +56,8 @@ import (
 	_ "github.com/lib/pq"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
@@ -171,7 +173,7 @@ func main() {
 	)
 
 	interceptorConfig := auth.InterceptorConfig{
-		SkipAuthPrefixes: append([]string{"/grpc.reflection."}, e2eSkipPrefixes()...),
+		SkipAuthPrefixes: append([]string{"/grpc.reflection.", "/grpc.health.v1."}, e2eSkipPrefixes()...),
 		NoSessionMethods: []string{
 			"/portfoliodb.auth.v1.AuthService/AuthUser",
 			"/portfoliodb.auth.v1.AuthService/AuthMachine",
@@ -325,6 +327,9 @@ func main() {
 	}))
 	ingestionv1.RegisterIngestionServiceServer(svc, ingestion.NewServer(database, queue))
 	reflection.Register(svc)
+	healthSrv := health.NewServer()
+	healthpb.RegisterHealthServer(svc, healthSrv)
+	healthSrv.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
 	registerE2EService(svc)
 	lis, err := net.Listen("tcp", *grpcAddr)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Register the standard gRPC health service (`google.golang.org/grpc/health`) in `server/cmd/portfoliodb/main.go` and mark the overall server as `SERVING` at startup.
- Bake `grpc-health-probe` into `docker/server/Dockerfile.dev`.
- Rewrite `scripts/server-ready.sh` to match the `postgres-ready.sh` contract: takes a compose-cmd argument and execs `grpc-health-probe` inside the `portfoliodb` container. No more host-side `grpcurl`.
- Add `/grpc.health.v1.` to `SkipAuthPrefixes` alongside the existing `/grpc.reflection.` entry so the probe isn't rejected by the session auth interceptor.
- Update the three Makefile callers (`make run`, `make e2e-test`, `make e2e-test-record`) to pass the appropriate compose command.

This is prep work for subsequent PRs that move the remaining host-side `go`/`buf` invocations into containers. The `grpcurl` install is still in `make tools` for now; it gets removed in PR 2.

## Test plan
- [x] `make run` cycles the dev stack and the new readiness check reports `SERVING`.
- [x] `grpc-health-probe` reports `status: SERVING` when run directly inside the container.
- [x] `go test ./server/...` still green.
- [ ] `make e2e-test` passes end-to-end with the new readiness check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)