### PR TITLE
Move build, generate, and test into containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,14 @@ COMPOSE_DEV  = docker compose -p portfoliodb-dev   -f docker/docker-compose.yml 
 COMPOSE_E2E  = docker compose -p portfoliodb-e2e   -f docker/docker-compose.yml -f docker/docker-compose.e2e.yml --env-file .env
 COMPOSE_TEST = docker compose -p portfoliodb-test  -f docker/docker-compose.test.yml
 
+# One-shot invocations of the dev server image for buf/go/go-generate/go-test/go-build.
+# --no-deps skips postgres/redis/envoy/client; bind mount + GOCACHE + GOMODCACHE come from the compose service definition.
+COMPOSE_TOOLS        = HOST_UID=$$(id -u) HOST_GID=$$(id -g) $(COMPOSE_DEV)  run --rm --no-deps -T portfoliodb
+# One-shot invocations of the client image for TS codegen (needs node + buf). -w /app overrides the /app/client working_dir.
+COMPOSE_TOOLS_CLIENT = HOST_UID=$$(id -u) HOST_GID=$$(id -g) $(COMPOSE_DEV)  run --rm --no-deps -T -w /app client
+# DB-backed tests run in the test stack so they share a network with postgres.
+COMPOSE_TEST_TESTER  = HOST_UID=$$(id -u) HOST_GID=$$(id -g) $(COMPOSE_TEST) run --rm -T tester
+
 # Git revision for Docker build args (works in both regular repos and worktrees).
 BUILD_REV ?= $(shell git rev-parse HEAD 2>/dev/null || echo unknown)
 export BUILD_REV
@@ -28,15 +36,11 @@ $(STAMP_DIR):
 	@touch $@
 
 # --- tools stamp ---
-# Re-run when Go module deps or JS package manifests change.
-TOOLS_DEPS := go.mod go.sum client/package.json client/package-lock.json e2e/package.json e2e/package-lock.json
+# Re-run when JS package manifests change. Go tooling (buf, protoc plugins, grpc-health-probe)
+# is baked into docker/server/Dockerfile.dev; go modules resolve at `go test`/`go build` time.
+TOOLS_DEPS := client/package.json client/package-lock.json e2e/package.json e2e/package-lock.json
 
 $(STAMP_DIR)/tools: $(TOOLS_DEPS) | $(STAMP_DIR)
-	@command -v go >/dev/null 2>&1 || { echo "go is required; install from https://go.dev/dl"; exit 1; }
-	go install github.com/bufbuild/buf/cmd/buf@latest
-	go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-	go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
-	go install github.com/fullstorydev/grpcurl/cmd/grpcurl@latest
 	HOST_UID=$$(id -u) HOST_GID=$$(id -g) $(COMPOSE_DEV) run --rm client npm ci
 	HOST_UID=$$(id -u) HOST_GID=$$(id -g) $(COMPOSE_E2E) --profile test run --rm playwright npm ci
 	@touch $@
@@ -46,9 +50,9 @@ $(STAMP_DIR)/tools: $(TOOLS_DEPS) | $(STAMP_DIR)
 PROTO_FILES := $(shell find proto -name '*.proto' 2>/dev/null)
 GENERATE_DEPS := $(PROTO_FILES) buf.gen.go.yaml buf.gen.ts.yaml buf.gen.e2e.yaml server/db/db.go
 
-$(STAMP_DIR)/generate: $(GENERATE_DEPS) | $(STAMP_DIR)
-	buf generate --template buf.gen.go.yaml && buf generate --template buf.gen.ts.yaml --include-imports && buf generate --template buf.gen.e2e.yaml --include-imports --path proto/e2e --path proto/api
-	go generate ./server/db
+$(STAMP_DIR)/generate: $(GENERATE_DEPS) $(STAMP_DIR)/tools | $(STAMP_DIR)
+	$(COMPOSE_TOOLS) sh -c 'buf generate --template buf.gen.go.yaml && go generate ./server/db'
+	$(COMPOSE_TOOLS_CLIENT) sh -c 'buf generate --template buf.gen.ts.yaml --include-imports && buf generate --template buf.gen.e2e.yaml --include-imports --path proto/e2e --path proto/api'
 	@touch $@
 
 # PHONY aliases so 'make tools' and 'make generate' still work directly.
@@ -56,10 +60,10 @@ tools: $(STAMP_DIR)/tools
 generate: $(STAMP_DIR)/generate
 
 build: $(STAMP_DIR)/generate
-	go build -o portfoliodb ./server/cmd/portfoliodb
+	$(COMPOSE_TOOLS) sh -c 'CGO_ENABLED=0 go build -o portfoliodb ./server/cmd/portfoliodb'
 
 google-finance-cli: $(STAMP_DIR)/generate
-	go build -o bin/google-finance-cli ./cli/google
+	$(COMPOSE_TOOLS) sh -c 'CGO_ENABLED=0 go build -o bin/google-finance-cli ./cli/google'
 
 # Full stack (Postgres 5432, Redis 6379, portfoliodb, Envoy, client SPA) for local dev. SPA at localhost:8080.
 # Uses dev override: source mounts, host UID/GID, Air + next dev for live-reload.
@@ -84,27 +88,24 @@ stop:
 	$(COMPOSE_DEV) down
 
 server-test: $(STAMP_DIR)/generate
-	go test ./server/...
+	$(COMPOSE_TOOLS) go test ./server/...
 
 client-test: $(STAMP_DIR)/tools
 	HOST_UID=$$(id -u) HOST_GID=$$(id -g) $(COMPOSE_DEV) run --rm client npm run test:run
 
 db-test: $(STAMP_DIR)/generate
-	$(COMPOSE_TEST) up -d
-	@echo "Waiting for Postgres..."
-	@scripts/postgres-ready.sh "$(COMPOSE_TEST)"
-	TEST_DATABASE_URL="postgres://portfoliodb:portfoliodb@localhost:5433/portfoliodb_test?sslmode=disable" go test -v ./server/db/postgres/...
+	$(COMPOSE_TEST_TESTER) go test -v ./server/db/postgres/...
 	@$(COMPOSE_TEST) down
 
 integration-test: $(STAMP_DIR)/generate
-	go test -tags integration -v ./server/plugins/...
+	$(COMPOSE_TOOLS) go test -tags integration -v ./server/plugins/...
 
 integration-test-list:
 	@find server/plugins -name 'integration_test.go' | xargs -I{} dirname {} | sed 's|^server/plugins/||' | sort
 
 integration-test-record: $(STAMP_DIR)/generate
 	@if [ -z "$(VCR_SUITES)" ]; then echo "usage: make integration-test-record VCR_SUITES=eodhd/identifier,massive/price"; exit 1; fi
-	VCR_MODE=$(VCR_SUITES) go test -tags integration -v -count=1 ./server/plugins/...
+	$(COMPOSE_TOOLS) env VCR_MODE=$(VCR_SUITES) go test -tags integration -v -count=1 ./server/plugins/...
 
 # E2E tests: replay mode (VCR cassettes, dummy API keys, no rate limits).
 # Full stack at isolated ports: Postgres 5434, Redis 6381, Envoy 8081.
@@ -171,7 +172,7 @@ help:
 	@echo "portfoliodb Makefile"
 	@echo ""
 	@echo "Setup:"
-	@echo "  make tools              Install Go tools and npm deps (auto-skipped if up-to-date)"
+	@echo "  make tools              Install npm deps into containers (auto-skipped if up-to-date)"
 	@echo "  make generate           Run protobuf + mock codegen (auto-skipped if up-to-date)"
 	@echo ""
 	@echo "Development:"

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ run: $(STAMP_DIR)/tools $(STAMP_DIR)/generate
 	@echo "Waiting for Postgres..."
 	@scripts/postgres-ready.sh "$(COMPOSE_DEV)"
 	@echo "Waiting for portfoliodb (gRPC)..."
-	@scripts/server-ready.sh
+	@scripts/server-ready.sh "$(COMPOSE_DEV)"
 	@$(MAKE) init-db
 
 # Run the DB initialise script when DB_INITIALISE_SCRIPT is set and the file exists. Used by 'make run'.
@@ -116,7 +116,7 @@ e2e-test: $(STAMP_DIR)/generate
 		echo "Waiting for Postgres..."; \
 		scripts/postgres-ready.sh "$(COMPOSE_E2E)"; \
 		echo "Waiting for portfoliodb (gRPC)..."; \
-		scripts/server-ready.sh localhost:50052; \
+		scripts/server-ready.sh "$(COMPOSE_E2E)"; \
 		HOST_UID=$$(id -u) HOST_GID=$$(id -g) $(COMPOSE_E2E) --profile test run --rm playwright npx playwright test; \
 		rc=$$?; $(COMPOSE_E2E) --profile test down; exit $$rc
 
@@ -135,7 +135,7 @@ e2e-test-record: $(STAMP_DIR)/generate
 		echo "Waiting for Postgres..."; \
 		scripts/postgres-ready.sh "$(COMPOSE_E2E)"; \
 		echo "Waiting for portfoliodb (gRPC)..."; \
-		scripts/server-ready.sh localhost:50052; \
+		scripts/server-ready.sh "$(COMPOSE_E2E)"; \
 		logdir="/tmp/e2e-record-$$(date +%Y%m%d-%H%M%S)"; mkdir -p "$$logdir"; \
 		HOST_UID=$$(id -u) HOST_GID=$$(id -g) VCR_MODE=$(VCR_SUITES) $(COMPOSE_E2E) --profile test run --rm playwright \
 			sh -c 'npx playwright test 2>&1; echo $$? > /e2e/.e2e-rc' | tee "$$logdir/playwright.log"; \

--- a/Makefile
+++ b/Makefile
@@ -94,8 +94,7 @@ client-test: $(STAMP_DIR)/tools
 	HOST_UID=$$(id -u) HOST_GID=$$(id -g) $(COMPOSE_DEV) run --rm client npm run test:run
 
 db-test: $(STAMP_DIR)/generate
-	$(COMPOSE_TEST_TESTER) go test -v ./server/db/postgres/...
-	@$(COMPOSE_TEST) down
+	@rc=0; $(COMPOSE_TEST_TESTER) go test -v ./server/db/postgres/... || rc=$$?; $(COMPOSE_TEST) down; exit $$rc
 
 integration-test: $(STAMP_DIR)/generate
 	$(COMPOSE_TOOLS) go test -tags integration -v ./server/plugins/...

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -23,3 +23,23 @@ services:
       interval: 2s
       timeout: 2s
       retries: 10
+
+  # Go test runner for db-test. Reuses the server dev image (go + cached module deps)
+  # and connects to the postgres service over the compose network.
+  tester:
+    build:
+      context: ..
+      dockerfile: docker/server/Dockerfile.dev
+    user: "${HOST_UID:-1000}:${HOST_GID:-1000}"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      GOCACHE: /app/.cache/go-build
+      GOMODCACHE: /app/.gomodcache
+      TEST_DATABASE_URL: postgres://portfoliodb:portfoliodb@postgres:5432/portfoliodb_test?sslmode=disable
+    volumes:
+      - ..:/app
+    working_dir: /app
+    entrypoint: []
+    command: ["true"]

--- a/docker/server/Dockerfile.dev
+++ b/docker/server/Dockerfile.dev
@@ -4,6 +4,7 @@ RUN apk add --no-cache git
 RUN go install github.com/bufbuild/buf/cmd/buf@latest
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+RUN go install github.com/grpc-ecosystem/grpc-health-probe@latest
 RUN go install github.com/air-verse/air@latest
 WORKDIR /app
 CMD ["air"]

--- a/scripts/server-ready.sh
+++ b/scripts/server-ready.sh
@@ -1,16 +1,13 @@
 #!/usr/bin/env bash
-# Wait for portfoliodb gRPC server to be ready (grpcurl list). Exits 0 when ready, 1 after max tries.
-# Usage: scripts/server-ready.sh [target] [max_tries]
-#   target defaults to localhost:50051
+# Wait for portfoliodb gRPC server to report SERVING via grpc_health_probe. Exits 0 when ready, 1 after max tries.
+# Probes from inside the portfoliodb container so no host-side grpc tooling is required.
+# Usage: scripts/server-ready.sh <compose-cmd> [max_tries]
+#   e.g. scripts/server-ready.sh "docker compose -p portfoliodb-dev -f docker/docker-compose.yml -f docker/docker-compose.dev.yml --env-file .env"
 set -e
-TARGET="${1:-localhost:50051}"
+COMPOSE_CMD="$1"
 MAX_TRIES="${2:-20}"
-if ! command -v grpcurl >/dev/null 2>&1; then
-	echo "grpcurl not found (install from https://github.com/fullstorydev/grpcurl)" >&2
-	exit 1
-fi
 for i in $(seq 1 "$MAX_TRIES"); do
-	if grpcurl -plaintext -connect-timeout 2 "$TARGET" list >/dev/null 2>&1; then
+	if $COMPOSE_CMD exec -T portfoliodb grpc-health-probe -addr=localhost:50051 -connect-timeout=2s >/dev/null 2>&1; then
 		exit 0
 	fi
 	sleep 1

--- a/server/cmd/portfoliodb/main.go
+++ b/server/cmd/portfoliodb/main.go
@@ -56,6 +56,8 @@ import (
 	_ "github.com/lib/pq"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/health"
+	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
@@ -171,7 +173,7 @@ func main() {
 	)
 
 	interceptorConfig := auth.InterceptorConfig{
-		SkipAuthPrefixes: append([]string{"/grpc.reflection."}, e2eSkipPrefixes()...),
+		SkipAuthPrefixes: append([]string{"/grpc.reflection.", "/grpc.health.v1."}, e2eSkipPrefixes()...),
 		NoSessionMethods: []string{
 			"/portfoliodb.auth.v1.AuthService/AuthUser",
 			"/portfoliodb.auth.v1.AuthService/AuthMachine",
@@ -325,6 +327,9 @@ func main() {
 	}))
 	ingestionv1.RegisterIngestionServiceServer(svc, ingestion.NewServer(database, queue))
 	reflection.Register(svc)
+	healthSrv := health.NewServer()
+	healthpb.RegisterHealthServer(svc, healthSrv)
+	healthSrv.SetServingStatus("", healthpb.HealthCheckResponse_SERVING)
 	registerE2EService(svc)
 	lis, err := net.Listen("tcp", *grpcAddr)
 	if err != nil {


### PR DESCRIPTION
## Summary

Host now needs only Docker. Drops the last host-side `go`/`buf` invocations in the Makefile.

- **`$(STAMP_DIR)/tools`** slims to two `npm ci` steps; `go install buf`/`protoc-gen-*`/`grpcurl` are gone (already baked into `docker/server/Dockerfile.dev`).
- **`$(STAMP_DIR)/generate`** splits into two steps: Go codegen (`buf generate --template buf.gen.go.yaml && go generate ./server/db`) in the server image, TS codegen (`buf generate --template buf.gen.ts.yaml` and the e2e template) in the client image.
- **`make build`** and **`make google-finance-cli`** run `go build` in the server image with `CGO_ENABLED=0` so the alpine-musl container produces static binaries runnable on any Linux host (project has no CGO).
- **`make server-test`**, **`make integration-test`**, **`make integration-test-record`** run in the server image via a new `COMPOSE_TOOLS` variable (`docker compose run --rm --no-deps -T portfoliodb ...`).
- **`make db-test`** now uses a new `tester` service in `docker/docker-compose.test.yml` so the test runner shares the compose network with postgres. `TEST_DATABASE_URL` points at `postgres:5432` (internal) instead of `localhost:5433` (host-mapped). `depends_on: service_healthy` replaces the previous `postgres-ready.sh` wait.

## Dependency

Based on #233 (gRPC health probe). The two PRs together close out the host-tool removal: #233 drops `grpcurl` from `scripts/server-ready.sh`; this PR drops the `go install grpcurl` from `make tools` along with the other Go installs. Merge #233 first, then rebase this onto `main`.

## Test plan
- [x] `rm -rf .stamps && make tools generate` — both stamps populate via containers (npm ci + buf + go generate).
- [x] `make server-test` — green, warm cache completes in ~1.6 s.
- [x] `make build` — produces `./portfoliodb` reported by `file` as `statically linked`.
- [x] `make db-test` — green, connects to postgres via compose network.
- [x] `make integration-test` — green.
- [ ] `make test` end-to-end after this lands on `main`.
- [ ] `make run` + `make e2e-test` on a host with `/home/lee/go/bin` removed from PATH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)