### PR TITLE
Collapse CI workflow to make-target matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,96 +8,13 @@ permissions:
   contents: read
 
 jobs:
-  server-test:
-    name: Server Unit Tests
+  test:
+    name: ${{ matrix.target }}
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target: [server-test, client-test, db-test]
     steps:
       - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
-      - name: Install protobuf tools
-        run: |
-          go install github.com/bufbuild/buf/cmd/buf@latest
-          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
-
-      - name: Generate protobuf and mocks
-        run: |
-          buf generate --template buf.gen.go.yaml
-          go generate ./server/db
-
-      - name: Run server tests
-        run: go test ./server/...
-
-  client-test:
-    name: Client Tests
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: npm
-          cache-dependency-path: client/package-lock.json
-
-      - name: Install client dependencies
-        working-directory: client
-        run: npm ci
-
-      - name: Install buf
-        run: go install github.com/bufbuild/buf/cmd/buf@latest
-
-      - name: Generate TypeScript protobuf
-        run: buf generate --template buf.gen.ts.yaml --include-imports
-
-      - name: Run client tests
-        working-directory: client
-        run: npm run test:run
-
-  db-test:
-    name: DB Integration Tests
-    runs-on: ubuntu-latest
-    services:
-      postgres:
-        image: timescale/timescaledb:latest-pg16
-        env:
-          POSTGRES_USER: portfoliodb
-          POSTGRES_PASSWORD: portfoliodb
-          POSTGRES_DB: portfoliodb_test
-        ports:
-          - 5433:5432
-        options: >-
-          --health-cmd "pg_isready -U portfoliodb"
-          --health-interval 2s
-          --health-timeout 2s
-          --health-retries 10
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
-
-      - name: Install protobuf tools
-        run: |
-          go install github.com/bufbuild/buf/cmd/buf@latest
-          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
-          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
-
-      - name: Generate protobuf and mocks
-        run: |
-          buf generate --template buf.gen.go.yaml
-          go generate ./server/db
-
-      - name: Run DB integration tests
-        env:
-          TEST_DATABASE_URL: postgres://portfoliodb:portfoliodb@localhost:5433/portfoliodb_test?sslmode=disable
-        run: go test -v ./server/db/postgres/...
+      - run: make ${{ matrix.target }}

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ stop:
 server-test: $(STAMP_DIR)/generate
 	$(COMPOSE_TOOLS) go test ./server/...
 
-client-test: $(STAMP_DIR)/tools
+client-test: $(STAMP_DIR)/generate
 	HOST_UID=$$(id -u) HOST_GID=$$(id -g) $(COMPOSE_DEV) run --rm client npm run test:run
 
 db-test: $(STAMP_DIR)/generate

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -42,6 +42,8 @@ services:
       NEXT_PUBLIC_GOOGLE_CLIENT_ID: ${GOOGLE_OAUTH_CLIENT_ID:-}
       # Poll for file changes so bind-mounted source updates are picked up (inotify often doesn't propagate into the container).
       CHOKIDAR_USEPOLLING: "true"
+      # Give npm a writable HOME when HOST_UID has no /etc/passwd entry (e.g. CI runner uid 1001).
+      HOME: /tmp
     volumes:
       - ..:/app
     working_dir: /app/client

--- a/docker/docker-compose.e2e.yml
+++ b/docker/docker-compose.e2e.yml
@@ -47,6 +47,8 @@ services:
     working_dir: /e2e
     user: "${HOST_UID:-1000}:${HOST_GID:-1000}"
     environment:
+      # Give npm a writable HOME when HOST_UID has no /etc/passwd entry (e.g. CI runner uid 1001).
+      HOME: /tmp
       E2E_BASE_URL: http://envoy:8080
       E2E_REDIS_URL: redis://redis:6379/0
       E2E_DATABASE_URL: postgres://portfoliodb:portfoliodb@postgres:5432/portfoliodb


### PR DESCRIPTION
## Summary

CI now just runs `make <target>` for each of server-test, client-test, db-test. The runner only needs Docker, which ubuntu-latest ships with.

- Drops `setup-go`, `setup-node`, and all the manual `go install` of buf/protoc plugins.
- Drops the external `services: postgres` block — `make db-test` manages its own compose test stack via the `tester` service added in #234.
- Three separate jobs collapse into a single matrixed job.

CI and local dev now share the same entrypoint and the same tool versions (pinned by the Dockerfiles). No more host-toolchain drift between the two.

## Dependency chain

- #233 — gRPC health probe (replaces host grpcurl)
- #234 — Containerize generate/build/test (introduces the make targets CI now calls)
- This PR — CI refactor

Each must land in that order. This PR is based on #234; rebase onto `main` once #233 and #234 are merged.

## Test plan
- [ ] CI matrix runs green on this PR (all three targets pass).
- [ ] Compare CI runtime against a recent green run on `main` — expect first-run image build to add ~1-2 min per matrix job; warm-cache runs should be comparable or faster.

## Follow-ups (out of scope)

Image layer caching via `docker/build-push-action` + `type=gha` could be added later if CI runtime becomes painful. Deferred for a simpler initial landing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)