### PR TITLE
Update README prerequisites to reflect Docker-only setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,21 +4,9 @@ gRPC-backed service for portfolio and transaction data. Backend is Go with Postg
 
 ## Prerequisites
 
-To develop and run this project you need:
-
 | Tool | Purpose |
 |------|---------|
-| **Go 1.25+** | Build and run the server; run tests; install buf and protoc plugins via `make tools`. |
-| **Node.js & npm** | Client app and `protoc-gen-es` for TypeScript codegen; install client deps via `make tools`. |
-| **Docker & Docker Compose** | Run PostgreSQL for local development and for the DB integration tests. |
-
-Install project tooling and dependencies (buf, protoc-gen-go, protoc-gen-go-grpc, and client npm packages) with:
-
-```bash
-make tools
-```
-
-Ensure `$(go env GOPATH)/bin` is on your `PATH` so `buf` and the protoc plugins are found.
+| **Docker & Docker Compose** | Required for local development, building, testing, and code generation. |
 
 ## Quick start
 


### PR DESCRIPTION
## Summary

The prerequisites section listed Go 1.25+ and Node.js, walked through `make tools` as a host-side install of buf/protoc-gen-go/protoc-gen-go-grpc/grpcurl, and told contributors to add `\$(go env GOPATH)/bin` to their PATH. None of that matches how the project is actually set up — development is done via Docker. This trims the section to a single-row prerequisites table naming Docker as the host requirement.

The Quick Start below already covers `make tools` in step 1, so the separate install block wasn't adding anything anyway.

## Test plan
- [x] \`git diff README.md\` shows a single hunk: trimmed Prerequisites section.
- [x] All commands referenced in the Quick Start still work with only Docker on the host (verified via recent CI and local testing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)