### PR TITLE
Drop make tools target; bootstrap npm deps from container entrypoint

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,8 +73,7 @@ If the changes cannot be cleanly separated into independent PRs (e.g., extensive
 Whenever you begin work in a new worktree you should:
 1. Copy the .env file from the root of the repo
 2. Copy the local directory from the root of the repo
-3. run `make tools` to install tool depdendencies
-4. run `make generate` to generate protobuf bindings and go mocks.
+3. run `make generate` to generate protobuf bindings and go mocks.
 
 ## User Interface
 

--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,10 @@ BUILD_REV ?= $(shell git rev-parse HEAD 2>/dev/null || echo unknown)
 export BUILD_REV
 
 # --- Stamp infrastructure ---
-# Stamp files track when expensive operations (tools, generate) last ran.
-# Make compares stamp mtimes against source file mtimes -- if any source is
-# newer, the stamp is stale and the recipe re-runs. Downstream targets depend
-# on stamps, so staleness propagates automatically.
+# Stamp files track when expensive operations (generate) last ran. Make compares
+# stamp mtimes against source file mtimes -- if any source is newer, the stamp
+# is stale and the recipe re-runs. Downstream targets depend on stamps, so
+# staleness propagates automatically.
 STAMP_DIR := .stamps
 
 $(STAMP_DIR):
@@ -35,28 +35,18 @@ $(STAMP_DIR):
 .env:
 	@touch $@
 
-# --- tools stamp ---
-# Re-run when JS package manifests change. Go tooling (buf, protoc plugins, grpc-health-probe)
-# is baked into docker/server/Dockerfile.dev; go modules resolve at `go test`/`go build` time.
-TOOLS_DEPS := client/package.json client/package-lock.json e2e/package.json e2e/package-lock.json
-
-$(STAMP_DIR)/tools: $(TOOLS_DEPS) | $(STAMP_DIR)
-	HOST_UID=$$(id -u) HOST_GID=$$(id -g) $(COMPOSE_DEV) run --rm client npm ci
-	HOST_UID=$$(id -u) HOST_GID=$$(id -g) $(COMPOSE_E2E) --profile test run --rm playwright npm ci
-	@touch $@
-
 # --- generate stamp ---
 # Re-run when proto files, buf configs, or go:generate source changes.
+# npm deps for the client container are bootstrapped by its compose entrypoint before buf runs.
 PROTO_FILES := $(shell find proto -name '*.proto' 2>/dev/null)
 GENERATE_DEPS := $(PROTO_FILES) buf.gen.go.yaml buf.gen.ts.yaml buf.gen.e2e.yaml server/db/db.go
 
-$(STAMP_DIR)/generate: $(GENERATE_DEPS) $(STAMP_DIR)/tools | $(STAMP_DIR)
+$(STAMP_DIR)/generate: $(GENERATE_DEPS) | $(STAMP_DIR)
 	$(COMPOSE_TOOLS) sh -c 'buf generate --template buf.gen.go.yaml && go generate ./server/db'
 	$(COMPOSE_TOOLS_CLIENT) sh -c 'buf generate --template buf.gen.ts.yaml --include-imports && buf generate --template buf.gen.e2e.yaml --include-imports --path proto/e2e --path proto/api'
 	@touch $@
 
-# PHONY aliases so 'make tools' and 'make generate' still work directly.
-tools: $(STAMP_DIR)/tools
+# PHONY alias so 'make generate' still works directly.
 generate: $(STAMP_DIR)/generate
 
 build: $(STAMP_DIR)/generate
@@ -67,7 +57,7 @@ google-finance-cli: $(STAMP_DIR)/generate
 
 # Full stack (Postgres 5432, Redis 6379, portfoliodb, Envoy, client SPA) for local dev. SPA at localhost:8080.
 # Uses dev override: source mounts, host UID/GID, Air + next dev for live-reload.
-run: $(STAMP_DIR)/tools $(STAMP_DIR)/generate
+run: $(STAMP_DIR)/generate
 	HOST_UID=$$(id -u) HOST_GID=$$(id -g) $(COMPOSE_DEV) up -d --build
 	@echo "Waiting for Postgres..."
 	@scripts/postgres-ready.sh "$(COMPOSE_DEV)"
@@ -159,10 +149,10 @@ clean-docker:
 	$(COMPOSE_TEST) down --rmi local --volumes
 	$(COMPOSE_E2E) --profile test down --rmi local --volumes --remove-orphans
 
-# Remove client node_modules and .next (e.g. after switching Node versions). Re-run 'make tools' to reinstall.
+# Remove client node_modules and .next (e.g. after switching Node versions). The client container
+# will re-run npm ci on next start.
 clean-next:
 	rm -rf client/node_modules client/.next
-	rm -f $(STAMP_DIR)/tools
 
 clean-stamps:
 	rm -rf $(STAMP_DIR)
@@ -171,7 +161,6 @@ help:
 	@echo "portfoliodb Makefile"
 	@echo ""
 	@echo "Setup:"
-	@echo "  make tools              Install npm deps into containers (auto-skipped if up-to-date)"
 	@echo "  make generate           Run protobuf + mock codegen (auto-skipped if up-to-date)"
 	@echo ""
 	@echo "Development:"
@@ -199,7 +188,6 @@ help:
 	@echo "  make clean-docker       Remove all Docker containers, images, and volumes"
 	@echo "  make clean-next         Remove client node_modules and .next"
 	@echo ""
-	@echo "After 'git pull', run 'make tools generate' if deps or protos changed."
 	@echo "Dependencies are tracked automatically -- stale steps re-run as needed."
 
-.PHONY: tools generate build google-finance-cli server-test db-test client-test integration-test integration-test-list integration-test-record e2e-test e2e-test-list e2e-test-record run init-db logs stop clean clean-generated clean-docker clean-next clean-stamps test help
+.PHONY: generate build google-finance-cli server-test db-test client-test integration-test integration-test-list integration-test-record e2e-test e2e-test-list e2e-test-record run init-db logs stop clean clean-generated clean-docker clean-next clean-stamps test help

--- a/README.md
+++ b/README.md
@@ -4,21 +4,9 @@ gRPC-backed service for portfolio and transaction data. Backend is Go with Postg
 
 ## Prerequisites
 
-To develop and run this project you need:
-
 | Tool | Purpose |
 |------|---------|
-| **Go 1.25+** | Build and run the server; run tests; install buf and protoc plugins via `make tools`. |
-| **Node.js & npm** | Client app and `protoc-gen-es` for TypeScript codegen; install client deps via `make tools`. |
-| **Docker & Docker Compose** | Run PostgreSQL for local development and for the DB integration tests. |
-
-Install project tooling and dependencies (buf, protoc-gen-go, protoc-gen-go-grpc, and client npm packages) with:
-
-```bash
-make tools
-```
-
-Ensure `$(go env GOPATH)/bin` is on your `PATH` so `buf` and the protoc plugins are found.
+| **Docker & Docker Compose** | Required for local development, building, testing, and code generation. |
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -12,39 +12,23 @@ gRPC-backed service for portfolio and transaction data. Backend is Go with Postg
 
 These steps verify the system builds and the core test suites pass.
 
-### 1. Install tools and generate code
+### 1. Generate code and build
 
 ```bash
-make tools
-make generate
 make build
 ```
 
-### 2. Run server tests
+This runs protobuf and mock code generation as a dependency, then builds the server binary.
 
-`make server-test` runs all server tests.
-
-```bash
-make server-test
-```
-
-### 3. Run client tests
-
-`make client-test` runs the Next.js/Vitest front-end tests under `client/`.
+### 2. Run the tests
 
 ```bash
-make client-test
+make test
 ```
 
-### 4. Run database tests
+Runs the server, client, database, and plugin integration test suites. Individual suites are available as `make server-test`, `make client-test`, `make db-test`, and `make integration-test`.
 
-`make db-test` brings up Postgres in Docker, applies migrations, runs the DB integration tests, and then tears everything down.
-
-```bash
-make db-test
-```
-
-### 5. Run the server locally
+### 3. Run the server locally
 
 From the repo root, configure the environment and then use `make run`:
 

--- a/buf.gen.e2e.yaml
+++ b/buf.gen.e2e.yaml
@@ -5,6 +5,6 @@
 # Use: buf generate --template buf.gen.e2e.yaml --path proto/e2e
 version: v2
 plugins:
-  - local: e2e/node_modules/.bin/protoc-gen-es
+  - local: client/node_modules/.bin/protoc-gen-es
     out: e2e/gen
     opt: target=ts

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -47,6 +47,16 @@ services:
     volumes:
       - ..:/app
     working_dir: /app/client
+    # Bootstrap node_modules on first start (or after package-lock.json changes), then exec the command.
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        if [ ! -f /app/client/node_modules/.package-lock.json ] || [ /app/client/package-lock.json -nt /app/client/node_modules/.package-lock.json ]; then
+          (cd /app/client && npm ci)
+        fi
+        exec "$$@"
+      - --
     command: [ "sh", "/app/client/scripts/dev-with-codegen.sh" ]
 
 volumes:

--- a/docker/docker-compose.e2e.yml
+++ b/docker/docker-compose.e2e.yml
@@ -59,6 +59,16 @@ services:
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
     volumes:
       - ../e2e:/e2e
+    # Bootstrap node_modules on first start (or after package-lock.json changes), then exec the command.
+    entrypoint:
+      - /bin/sh
+      - -c
+      - |
+        if [ ! -f /e2e/node_modules/.package-lock.json ] || [ /e2e/package-lock.json -nt /e2e/node_modules/.package-lock.json ]; then
+          (cd /e2e && npm ci)
+        fi
+        exec "$$@"
+      - --
     depends_on:
       - envoy
     profiles:


### PR DESCRIPTION
## Summary

Replaces the explicit \`make tools\` step with a lazy-bootstrap entrypoint on the client and playwright services. On first start (or when \`package-lock.json\` is newer than the recorded marker in \`node_modules/.package-lock.json\`), the container runs \`npm ci\` in its working directory, then execs the requested command. Subsequent invocations short-circuit the check in under a second.

### Changes

- **\`docker/docker-compose.dev.yml\`** / **\`docker/docker-compose.e2e.yml\`** — add an \`entrypoint\` wrapper to the \`client\` and \`playwright\` services that bootstraps \`node_modules\` if missing or stale, then execs \`\$@\`.
- **\`Makefile\`** — remove the \`\$(STAMP_DIR)/tools\` recipe, the \`tools\` alias, the \`TOOLS_DEPS\` variable, and all references to \`\$(STAMP_DIR)/tools\` in downstream targets (\`run\`, \`generate\`, \`clean-next\`) and in help text.
- **\`buf.gen.e2e.yaml\`** — point \`protoc-gen-es\` at \`client/node_modules/.bin/\` instead of \`e2e/node_modules/.bin/\`. Same package/version in both \`package.json\` files, and this keeps \`make generate\` within the client container without needing e2e deps populated too.
- **\`README.md\`** — collapse the three separate \`make xxx-test\` blocks into a single \`make test\` block; drop \`make tools\` from step 1.
- **\`CLAUDE.md\`** — drop \`make tools\` from the worktree setup checklist.

## Dependency

Stacked on #237 (README prerequisites cleanup). Rebase onto \`main\` once #237 lands.

## Test plan
- [x] \`rm -rf client/node_modules e2e/node_modules .stamps && make generate\` — client container bootstraps on first \`docker compose run\`, buf codegen succeeds; second invocation is instant.
- [x] \`make server-test\` — green.
- [x] \`make client-test\` — green (121 tests).
- [x] \`make db-test\` — green.
- [ ] \`make e2e-test\` — playwright bootstraps \`e2e/node_modules\` on first use.
- [ ] CI matrix stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)