### PR TITLE
Add milestone M12 with issues for double-entry postings and cost basis

### DIFF
--- a/docs/issues/0036-tx-groups-postings.md
+++ b/docs/issues/0036-tx-groups-postings.md
@@ -1,6 +1,7 @@
 ---
 status: open
 title: Group transaction legs with tx_groups
+milestone: M12
 ---
 
 Add a `tx_groups` table and a nullable `txs.group_id` so that the legs of one

--- a/docs/issues/0036-tx-groups-postings.md
+++ b/docs/issues/0036-tx-groups-postings.md
@@ -1,0 +1,48 @@
+---
+status: open
+title: Group transaction legs with tx_groups
+---
+
+Add a `tx_groups` table and a nullable `txs.group_id` so that the legs of one
+economic event can be grouped. No balance constraint in this change.
+
+## Motivation
+
+`txs` is already a posting table in all but name: `instrument_id` is the
+commodity (currencies are instruments), `quantity` is a signed amount,
+`broker` + `account` is the account, and `timestamp` is the date. Holdings are
+`SUM(quantity)` grouped by instrument with no type-based sign flip
+(server/db/postgres/holdings.go). What is missing is the parent record that
+groups the legs of a single event and the invariant that they sum to zero.
+
+The concrete driver is money-weighted return. MWR requires knowing which cash
+flows crossed the portfolio boundary (deposits, withdrawals) versus which were
+internal (a buy converts cash into shares inside the boundary); TWR needs the
+same boundary to sub-period correctly. With single-legged txs that is a
+classification problem over the ~22 OFX tx types, per broker, with no
+structural guarantee and nothing that fails loudly when a mapping is wrong.
+With grouped postings and a small non-asset account vocabulary it is
+structural: a flow is external iff it crosses out of the asset accounts.
+
+## Inspiration
+
+Double-entry as implemented by beancount and ledger: a transaction is a set of
+postings that must sum to zero.
+
+## Design
+
+- `tx_groups (id, user_id, timestamp, narration, source)`.
+- `txs.group_id` nullable FK to `tx_groups`.
+- Backfill: each existing tx becomes its own single-posting group.
+- No balance constraint here (see 0041) and no ingestion change (see 0038).
+
+The read path is untouched. holdings.go, valuation.go, price_cache.go and
+declarations.go all aggregate `SUM(quantity)` grouped by instrument; adding a
+grouping key does not change any of them. Cash balance remains `SUM(quantity)`
+over currency instruments.
+
+## Note
+
+The decision to adopt double-entry is architectural and should be recorded as
+an ADR before this lands. It relates to ADR 0011 (synthetic INITIALIZE
+transactions), whose pad has no counterparty today -- see 0037.

--- a/docs/issues/0037-reserved-account-vocabulary.md
+++ b/docs/issues/0037-reserved-account-vocabulary.md
@@ -1,0 +1,48 @@
+---
+status: open
+title: Reserved non-asset account vocabulary
+---
+
+Introduce a small set of reserved account names that are not broker accounts:
+`Equity.Opening_Balances`, `Imbalance.<currency>`, `Transfers.InFlight`.
+
+## Motivation
+
+Double-entry needs somewhere to post the other side of events that are
+one-sided in the source data. Three cases exist today:
+
+- **INITIALIZE synthetic transactions** (docs/spec/fixed-point.md, ADR 0011)
+  are one-sided by construction. A pad has no counterparty.
+- **Derived cash legs** will not always balance, because the standard CSV
+  carries no fees and `unit_price` is optional (see 0038, 0040).
+- **Transfers** (JRNLFUND, JRNLSEC, TRANSFER) are inherently two-account and
+  brokers report each side in a separate statement, often in different imports.
+
+## Inspiration
+
+Beancount's five account roots (Assets, Liabilities, Income, Expenses, Equity)
+and its use of `Equity:Opening-Balances` as the counterparty for `pad`.
+Ledger's automatic `Imbalance:<CUR>` account, which absorbs the residual of an
+unbalanced transaction rather than rejecting it.
+
+## Design
+
+- A reserved-prefix convention on `txs.account` rather than a full account
+  tree. Accounts are per-user.
+- Reserved accounts must be excluded by default from holdings, portfolio
+  views, and valuation, so they do not appear as spurious positions.
+
+**Naming is dot-separated and restricted to alphanumerics and underscore** --
+`Equity.Opening_Balances`, not beancount's `Equity:Opening-Balances`. This is
+deliberate: these are valid `ltree` paths, so if the account model later moves
+to a real hierarchy (0046) the stored strings migrate with a column type change
+and no rewrite. Colons are not valid `ltree` labels, and hyphen support varies
+by PostgreSQL version, so both are avoided.
+
+## Sufficient for the cash flow boundary
+
+A reserved *root* is all that money-weighted return needs: a flow is external
+iff it crosses between a broker account and one of `Equity`, `Income`,
+`Expenses` or `Imbalance`. That classification does not require broker accounts
+themselves to be hierarchical, so this issue -- not 0046 -- is what unblocks
+MWR.

--- a/docs/issues/0037-reserved-account-vocabulary.md
+++ b/docs/issues/0037-reserved-account-vocabulary.md
@@ -1,6 +1,7 @@
 ---
 status: open
 title: Reserved non-asset account vocabulary
+milestone: M12
 ---
 
 Introduce a small set of reserved account names that are not broker accounts:

--- a/docs/issues/0038-derive-cash-legs-imbalance.md
+++ b/docs/issues/0038-derive-cash-legs-imbalance.md
@@ -1,0 +1,55 @@
+---
+status: open
+title: Derive cash legs at ingestion and route residuals to Imbalance
+dependencies: [0036, 0037]
+---
+
+Ingestion produces a group of postings per source row rather than a single tx.
+Derive the cash leg from the security leg and route any residual to
+`Imbalance:<currency>`. Still no balance constraint.
+
+## Motivation
+
+Today a BUYSTOCK row records the shares but not the corresponding cash
+decrease, so cash balances are only as good as whatever separate cash rows the
+broker happened to supply. That blocks MWR and makes reconciliation
+unreliable.
+
+## The problem
+
+The standard CSV (docs/spec/csv-format.md) cannot express a balanced
+transaction:
+
+- there is no `fees` or `commission` column, so `quantity * unit_price` is the
+  gross consideration, not the cash movement -- the derived leg is wrong by the
+  fee;
+- `unit_price` is optional, so sometimes the cash leg cannot be derived at all.
+
+Requiring every broker converter to be correct before double-entry can be
+turned on would make this change unshippable.
+
+## The solution
+
+Never reject. Derive what can be derived and post the residual to an explicit
+`Imbalance:<currency>` account. This is ledger's behaviour, and it is what
+makes double-entry adoptable before the source data is perfect:
+
+- the invariant holds structurally, by construction, from day one;
+- the residual becomes visible and measurable instead of being silently
+  absorbed into a cash balance;
+- coverage tightens per broker over time rather than in a single cut-over.
+
+## Design
+
+- Cash leg: `-(quantity * unit_price)` denominated in `settlement_currency`,
+  falling back to `trading_currency` when settlement is absent.
+- Where `unit_price` is absent, emit only the security leg and let the whole
+  consideration fall to `Imbalance`.
+- Amount elision follows beancount: state one side, infer the other.
+- **Transfers** (JRNLFUND, JRNLSEC, TRANSFER): do not attempt to pair the two
+  sides at ingest. Brokers report them in separate statements and matching is
+  unreliable. Post each side against `Transfers:InFlight`; a later matching
+  job nets them to zero. A non-zero balance there means an unmatched transfer,
+  surfaced for review (see 0039).
+- INITIALIZE synthetic transactions gain `Equity:Opening-Balances` as their
+  counterparty.

--- a/docs/issues/0038-derive-cash-legs-imbalance.md
+++ b/docs/issues/0038-derive-cash-legs-imbalance.md
@@ -1,6 +1,7 @@
 ---
 status: open
 title: Derive cash legs at ingestion and route residuals to Imbalance
+milestone: M12
 dependencies: [0036, 0037]
 ---
 

--- a/docs/issues/0039-imbalance-report.md
+++ b/docs/issues/0039-imbalance-report.md
@@ -1,6 +1,7 @@
 ---
 status: open
 title: Imbalance and unmatched-transfer reporting
+milestone: M12
 dependencies: [0038]
 ---
 

--- a/docs/issues/0039-imbalance-report.md
+++ b/docs/issues/0039-imbalance-report.md
@@ -1,0 +1,36 @@
+---
+status: open
+title: Imbalance and unmatched-transfer reporting
+dependencies: [0038]
+---
+
+Report the balance of `Imbalance:*` and `Transfers:InFlight` accounts, grouped
+by broker, account and currency.
+
+## Motivation
+
+Once residuals are routed to an explicit account (0038), the size of that
+account is a direct measure of how lossy each broker converter is. This turns
+data quality from something inferred into something observed, so the CSV format
+work in 0040 can be prioritised by evidence rather than guesswork. A large
+`Imbalance:USD` under one broker says exactly where the missing fee data is.
+
+Unmatched transfers surface the same way: a non-zero `Transfers:InFlight`
+balance means one side of a journal was imported and the other was not.
+
+## Design
+
+- Admin-visible, following the existing patterns for surfacing data problems
+  (`validation_errors`, `identification_errors`,
+  `unhandled_corporate_events`).
+- Group by broker, account and currency; a per-broker total is the useful
+  headline number.
+- Consider a time dimension so that a converter fix can be seen to work.
+
+## Note
+
+This is the natural stopping point if the full sequence is not pursued. Groups
+plus imbalance routing plus a report gives most of the practical value of
+double-entry -- reliable cash, a measurable data-quality signal, and a
+structural boundary for MWR -- without touching the CSV format or enabling the
+constraint.

--- a/docs/issues/0040-csv-fees-net-amount.md
+++ b/docs/issues/0040-csv-fees-net-amount.md
@@ -1,6 +1,7 @@
 ---
 status: open
 title: Extend standard CSV with fees and net amount
+milestone: M12
 dependencies: [0039]
 ---
 

--- a/docs/issues/0040-csv-fees-net-amount.md
+++ b/docs/issues/0040-csv-fees-net-amount.md
@@ -1,0 +1,42 @@
+---
+status: open
+title: Extend standard CSV with fees and net amount
+dependencies: [0039]
+---
+
+Add `fees` and `net_amount` columns to the standard CSV format and update the
+broker converters to populate them.
+
+## Motivation
+
+The standard CSV cannot currently express a balanced transaction. It carries
+`quantity`, an optional `unit_price`, `trading_currency` and
+`settlement_currency`, but no fee and no cash total. `quantity * unit_price` is
+the gross consideration; the actual cash movement is gross plus commissions and
+charges. Without those, every derived cash leg is wrong by the fee and the
+difference lands in `Imbalance` (0038).
+
+This is a breaking change to the format, which is acceptable: the project is
+pre-release and CLAUDE.md states that data models and APIs are not stable and
+should not carry migrations or back-compat.
+
+## Design
+
+- `net_amount` -- signed cash movement in `settlement_currency`. Authoritative
+  when present: use it directly for the cash leg rather than deriving.
+- `fees` -- total commissions and charges for the row, in
+  `settlement_currency`.
+- Precedence: `net_amount` when supplied; otherwise
+  `-(quantity * unit_price) - fees`; otherwise security leg only with the
+  balance falling to `Imbalance`.
+- Post `fees` to an expense account rather than folding it into the cash leg,
+  so that cost basis and expenses stay separable. This matters for the lot and
+  cost-basis work if that is taken up later.
+- Both columns optional, so existing hand-written CSVs keep working and only
+  contribute imbalance.
+
+## Sequencing
+
+Prioritise converter updates using the imbalance report from 0039 -- fix the
+broker with the largest residual first. The Fidelity converter (0013) is the
+existing worked example.

--- a/docs/issues/0041-enable-balance-constraint.md
+++ b/docs/issues/0041-enable-balance-constraint.md
@@ -1,6 +1,7 @@
 ---
 status: open
 title: Enforce posting balance with a deferred constraint trigger
+milestone: M12
 dependencies: [0038, 0042]
 ---
 

--- a/docs/issues/0041-enable-balance-constraint.md
+++ b/docs/issues/0041-enable-balance-constraint.md
@@ -1,0 +1,54 @@
+---
+status: open
+title: Enforce posting balance with a deferred constraint trigger
+dependencies: [0038, 0042]
+---
+
+Add a `DEFERRABLE INITIALLY DEFERRED` constraint trigger that checks, at
+COMMIT, that the postings of each `tx_group` sum to zero.
+
+## Motivation
+
+Enforcing the invariant in the database rather than the application makes it
+unbypassable: no code path, no bad import, and no manual psql session can leave
+an unbalanced group behind. This is stronger than beancount, which validates
+only at load time -- a database constraint has no equivalent of an unchecked
+writer.
+
+It is also cheap. Once 0038 routes residuals to `Imbalance`, balance is always
+satisfiable by construction, so turning the constraint on cannot reject
+otherwise-valid data.
+
+## Design
+
+```sql
+CREATE CONSTRAINT TRIGGER tx_postings_balance
+  AFTER INSERT OR UPDATE OR DELETE ON txs
+  DEFERRABLE INITIALLY DEFERRED
+  FOR EACH ROW EXECUTE FUNCTION check_tx_group_balances();
+```
+
+Deferral to COMMIT is required so that the legs of a group can be inserted in
+any order within one database transaction. There is precedent in the schema:
+`exchanges.operating_mic` and the `plugin_config` precedence uniqueness both
+use `DEFERRABLE`.
+
+Balance is checked on weight -- quantity for same-commodity postings, and
+quantity times price for postings carrying a cost or conversion.
+
+## Blocker: quantity is DOUBLE PRECISION
+
+An exact `SUM(...) = 0` check cannot be written against
+`txs.quantity`/`unit_price`, which are `DOUBLE PRECISION`. Summing float buys
+and sells does not land on exactly zero -- this is already why
+`qty_is_zero(q) := ABS(q) < 1e-9` exists in 001_initial.sql. Applying the same
+epsilon to a balance check would defeat its purpose, since a genuine imbalance
+smaller than the tolerance would pass silently and a legitimate group could
+still fail as the number of legs grows.
+
+Tracked as 0042.
+
+## Sequencing
+
+Requires 0038 and 0042. Best landed after 0040, when residuals are small and
+the `Imbalance` postings being written are few and explainable.

--- a/docs/issues/0042-exact-decimal-quantities-prices.md
+++ b/docs/issues/0042-exact-decimal-quantities-prices.md
@@ -1,6 +1,7 @@
 ---
 status: open
 title: Use exact decimals for quantities and prices
+milestone: M12
 ---
 
 Move the `txs` quantity and price columns from `DOUBLE PRECISION` to `NUMERIC`

--- a/docs/issues/0042-exact-decimal-quantities-prices.md
+++ b/docs/issues/0042-exact-decimal-quantities-prices.md
@@ -1,0 +1,87 @@
+---
+status: open
+title: Use exact decimals for quantities and prices
+---
+
+Move the `txs` quantity and price columns from `DOUBLE PRECISION` to `NUMERIC`
+and carry exact decimals through the Go layer and the protobuf API.
+
+## Motivation
+
+Money and share quantities are decimal, not binary floating point. Four
+columns on `txs` are currently `DOUBLE PRECISION`:
+
+- `quantity`
+- `split_adjusted_quantity`
+- `unit_price`
+- `split_adjusted_unit_price`
+
+They are the only exception in the schema. `eod_prices` OHLC,
+`instruments.strike`, `instruments.contract_multiplier`, `stock_splits`,
+`cash_dividends`, `inflation_indices` and `holding_declarations.declared_qty`
+are all `NUMERIC` already.
+
+The symptom is visible in 001_initial.sql. `qty_is_zero` exists because summing
+float buys and sells does not land on zero:
+
+```sql
+CREATE FUNCTION qty_is_zero(q double precision) RETURNS boolean ...
+    SELECT q IS NULL OR ABS(q) < 1e-9
+```
+
+That epsilon answers "is this position closed" in holdings.go, but the same
+residual flows into valuation as `quantity * price`, where there is no guard.
+And `holding_declarations.declared_qty` is `NUMERIC` while the computed holding
+it is compared against is not, so reconciliation already crosses a
+float/exact boundary -- which matters if declarations become checked assertions
+rather than only pads.
+
+## Blocks
+
+0041. A balance constraint needs an exact `SUM(...) = 0`. With floats it would
+need an epsilon, which defeats the purpose: a genuine imbalance below the
+tolerance passes silently, while a legitimate group can still fail as the
+number of legs grows.
+
+## Scope: three layers, not one
+
+1. **Postgres** -- column types, `qty_is_zero`, `split_factor_at`.
+2. **Go** -- there is no decimal dependency today; `go.mod` has `lib/pq` and
+   nothing else relevant.
+3. **Wire and clients** -- proto and TypeScript.
+
+The API is already lossy for prices independently of `txs`: `eod_prices` stores
+`NUMERIC` but api.proto exposes `double open/high/low/close`, and `double
+quantity`, `double unit_price`, `double strike`, `double contract_multiplier`.
+TypeScript `number` is float64, so the browser is lossy too. This is not only a
+`txs` problem.
+
+## Design
+
+**Postgres.** `NUMERIC` for the four columns. `qty_is_zero` becomes `q = 0`, or
+is dropped entirely.
+
+**Go.** `shopspring/decimal` implements `sql.Scanner` and `driver.Valuer`, so
+it works with `lib/pq` without changing drivers.
+
+**Wire.** A protobuf `double` cannot carry an exact decimal. Use canonical
+decimal strings: `google.type.Decimal` is already in the buf module cache, and
+a plain `string` field is equivalent and simpler. Client-side arithmetic needs
+a decimal library (decimal.js, big.js); display-only paths can parse the string
+directly.
+
+## Sub-problem: split_factor_at
+
+`split_factor_at()` returns `DOUBLE PRECISION` and computes the cumulative
+factor as `exp(sum(ln(...)))`. Multiplying a `NUMERIC` quantity by a double
+factor returns to floating point, so this needs deciding as part of the work.
+Options: compute the product in Go; use a numeric custom aggregate or a
+recursive CTE in Postgres; or store the cumulative factor per instrument. The
+existing comment on the function documents why exp/ln was acceptable for
+realistic split chains -- that reasoning holds for the factor itself, but not
+once the result feeds an exact balance check.
+
+## Note
+
+Pre-release, so there is no migration or back-compat burden (CLAUDE.md). The
+change is wide but mechanical, and it will never be cheaper than now.

--- a/docs/issues/0043-holding-declarations-pad-assert.md
+++ b/docs/issues/0043-holding-declarations-pad-assert.md
@@ -1,0 +1,62 @@
+---
+status: open
+title: Split holding declarations into pads and checked assertions
+---
+
+Allow more than one declaration per holding and distinguish declarations that
+seed an opening balance from declarations that are verified against computed
+holdings.
+
+## Motivation
+
+`holding_declarations` plus the INITIALIZE synthetic transaction is beancount's
+`pad` directive: a user states a quantity at a date and the system generates a
+plug transaction to make it true. That is the right design and it is well
+specified in docs/spec/fixed-point.md and ADR 0011.
+
+But in beancount `pad` and `balance` are a pair, and the safety comes from
+`balance`. A pad is true by construction -- it can never catch an error. A
+balance assertion is checked, and fails when the computed position disagrees
+with what the user says they hold.
+
+The schema currently forecloses assertions:
+
+```sql
+UNIQUE (user_id, broker, account, instrument_id)   -- one declaration, ever
+```
+
+A user can state "I held 500 shares on 2021-01-01" but cannot state "and 500 on
+2022-12-31, and 650 on 2023-12-31". Those later statements are precisely the
+ones that catch a misparsed broker CSV, a missed transfer, or a converter that
+silently drops a row.
+
+## Inspiration
+
+Beancount's `pad` and `balance` directives. `pad` establishes an opening
+position against `Equity:Opening-Balances`; `balance` verifies a position at a
+date and fails the run when it does not reconcile.
+
+## Design
+
+- Widen the unique key to `(user_id, broker, account, instrument_id,
+  as_of_date)`.
+- Add a `kind` discriminator: `PAD` or `ASSERT`.
+- The earliest declaration for a holding is the pad and generates the
+  INITIALIZE transaction, as today. Later declarations are assertions and
+  generate nothing.
+- A verification pass compares the computed holding at `as_of_date` to
+  `declared_qty` and surfaces mismatches, following the existing patterns for
+  data problems (`validation_errors`, `identification_errors`,
+  `unhandled_corporate_events`).
+- Re-verify after any ingestion or recompute that could change historical
+  quantities, including split recompute.
+
+The API, recalc and UI plumbing already exist in
+server/service/api/declarations.go and server/service/api/recalc.go.
+
+## Note on exactness
+
+`declared_qty` is `NUMERIC` but computed holdings sum `DOUBLE PRECISION`
+columns, so the comparison crosses a float boundary. 0042 removes that. This
+issue does not have to wait: an interim tolerance comparable to `qty_is_zero`
+is acceptable, and tightens to an exact comparison once 0042 lands.

--- a/docs/issues/0044-lot-identity-disposal-matching.md
+++ b/docs/issues/0044-lot-identity-disposal-matching.md
@@ -1,0 +1,49 @@
+---
+status: open
+title: Lot identity and disposal matching
+---
+
+Give acquisitions a lot identity and make disposals reference the lots they
+reduce.
+
+## Motivation
+
+`unit_price` is recorded on each tx, so cost basis is derivable by replay, but
+there is no lot identity and no disposal matching -- a sale does not reference
+what it sold. Holdings are `SUM(quantity)` grouped by instrument, which
+collapses every acquisition into a scalar.
+
+What that scalar costs:
+
+- **No realised gain.** Current value is computable; return is not.
+- **No unrealised/realised split**, and no way to attribute a change in value
+  to market movement versus contributions and withdrawals.
+- **No capital gains reporting**, which needs acquisition history per
+  disposal.
+
+The information is present in the transaction data. It is discarded by the
+aggregation.
+
+## Inspiration
+
+Beancount's inventory model, where a posting carries a cost
+(`10 SYM0 {£4.50}`) and a disposal nominates the lot it reduces, so that the
+gain falls out of the requirement that the transaction balances rather than
+being computed separately.
+
+## Design
+
+- Acquisitions get a lot identity; disposals reference the lot or lots they
+  reduce, with a quantity per reference where a disposal spans lots.
+- Beancount derives inventory by replaying the journal rather than storing it.
+  Deriving on every query is expensive here and storing risks drift, so the
+  likely shape is stored lots plus a periodic re-derivation that asserts
+  equality -- the same reconciliation pattern as 0043.
+- Corporate actions must adjust lots, not just totals: `split_factor_at` and
+  the `split_adjusted_*` recompute need a lot-aware equivalent.
+- Composes with 0036: with grouped postings, the disposal and the resulting
+  gain are legs of one balanced group and the gain is implied by the zero-sum
+  rule.
+
+This issue covers the data model only. The choice of matching method and the
+gains computation are 0045.

--- a/docs/issues/0045-realised-gains-cost-basis-methods.md
+++ b/docs/issues/0045-realised-gains-cost-basis-methods.md
@@ -1,0 +1,41 @@
+---
+status: open
+title: Realised gains and cost basis methods
+dependencies: [0044]
+---
+
+Compute realised gains from matched disposals, with a configurable cost basis
+method.
+
+## Motivation
+
+Once disposals reference lots (0044), realised gain per disposal and per period
+becomes computable, along with the realised/unrealised split that performance
+attribution needs.
+
+The method is not universal, and this is the part that cannot be borrowed.
+Beancount's `{cost}` model is **specific identification**, which reflects US
+practice. UK capital gains tax uses **Section 104 pooling**: acquisitions of the
+same security are pooled at a weighted average cost, with same-day matching and
+the 30-day bed-and-breakfast rule taking precedence over the pool. Beancount
+handles this awkwardly, through plugins, because it cuts against its lot model.
+
+So pooling has to be implemented here regardless of what is adopted elsewhere.
+Only the data model requirement is shared, which is why 0044 is separable and
+comes first.
+
+## Design
+
+- Method configurable rather than hard-coded, since it follows the user's
+  jurisdiction: specific identification, FIFO, and Section 104 at minimum.
+- Section 104 needs same-day matching first, then the 30-day rule, then the
+  pool -- ordering matters and is the usual source of error.
+- Report realised gains per disposal and aggregated per tax year, with the
+  matching decisions visible so a user can check them.
+- Unrealised gain is the complement: current value less remaining basis.
+
+## Note
+
+This unlocks the performance work in the unscheduled milestone list (TWR and
+MWR). MWR additionally needs the external/internal cash flow boundary, which
+comes from double-entry (0036 onward), not from this issue.

--- a/docs/issues/0046-account-hierarchy-ltree.md
+++ b/docs/issues/0046-account-hierarchy-ltree.md
@@ -1,0 +1,65 @@
+---
+status: open
+title: Account hierarchy with ltree
+dependencies: [0037]
+---
+
+Model accounts as a hierarchy using the Postgres `ltree` type rather than flat
+opaque `broker` and `account` text.
+
+## Motivation
+
+`txs.broker` and `txs.account` are independent opaque strings, and portfolio
+membership is expressed through `portfolio_filters` with AND between categories
+and OR within, implemented in the `portfolio_matched_txs` view. That works, but
+every aggregation level has to be enumerated as filter rows.
+
+A tree makes aggregation at any level free: all accounts at one broker, all
+ISAs across brokers, one account, or everything, are the same query with a
+different prefix.
+
+0037 introduces a reserved-prefix convention for non-asset accounts
+(`Equity.`, `Imbalance.`, `Transfers.`) as the deliberate minimum needed for
+double-entry, using dot-separated `ltree`-valid names so that those strings
+migrate here unchanged. This issue is the general case: broker accounts
+themselves become paths.
+
+## Scope of the benefit
+
+This is portfolio-definition ergonomics, not correctness. The cash flow
+boundary that MWR needs is satisfied by the reserved roots in 0037, since
+classification depends only on the root, not on broker accounts being
+hierarchical. What a full tree adds is aggregation over account subtrees --
+"everything at IBKR", "all ISAs across brokers" -- without enumerating a filter
+row per account.
+
+## Inspiration
+
+Beancount's account tree, where `Assets:Broker:IBKR:Stocks` aggregates at any
+depth.
+
+## Design
+
+- `ltree` path per account, GiST indexed, with `<@` and `@>` for
+  ancestor/descendant queries. This is the idiomatic Postgres answer and avoids
+  recursive CTEs or a closure table.
+- Migrate existing `broker` + `account` pairs into paths.
+- Replace the category matching in `portfolio_matched_txs` with prefix
+  matching; `portfolio_filters` rows become path prefixes.
+- Reserved accounts from 0037 become real roots rather than a naming
+  convention.
+
+## Note: decide whether this is wanted at all
+
+Not urgent, and possibly not correct. The existing `portfolio_matched_txs` view
+works, and nothing else here depends on this issue.
+
+There is also a modelling question to settle first. The unscheduled milestone
+list already contains "portfolio definition based on tagged instruments" and
+"portfolio sharing between users and aggregates that combine portfolios". Tags
+and aggregates are orthogonal to hierarchy -- an account belongs to exactly one
+place in a tree but can carry many tags -- so migrating to `ltree` and then
+discovering that portfolios are really tag-driven would be wasted work.
+
+Resolve the tags-versus-hierarchy question before starting this. Closing it as
+not-planned is a reasonable outcome; 0037 stands on its own either way.

--- a/docs/issues/milestones.md
+++ b/docs/issues/milestones.md
@@ -11,6 +11,7 @@
 - **M09** - Portfolio filtering UI.
 - **M10** - Allow per-user fixed points to define initial holdings.
 - **M11** - Allow users to set a display currency.
+- **M12** - Move transactions to grouped double-entry postings with exact decimal amounts and an enforced balance constraint.
 
 ## Unscheduled
 


### PR DESCRIPTION
Adds milestone **M12** and issues 0036-0046 to `docs/issues/`. Documentation only -- no code changes.

The set records a route from the current single-sided `txs` table to grouped double-entry postings, plus the lot-level accounting that money-weighted return and realised gains depend on.

## M12 -- move to double-entry postings

> **M12** - Move transactions to grouped double-entry postings with exact decimal amounts and an enforced balance constraint.

| # | Title | Depends on |
|---|---|---|
| 0036 | Group transaction legs with `tx_groups` | -- |
| 0037 | Reserved non-asset account vocabulary | -- |
| 0038 | Derive cash legs at ingestion and route residuals to Imbalance | 0036, 0037 |
| 0039 | Imbalance and unmatched-transfer reporting | 0038 |
| 0040 | Extend standard CSV with fees and net amount | 0039 |
| 0041 | Enforce posting balance with a deferred constraint trigger | 0038, 0042 |
| 0042 | Use exact decimals for quantities and prices | -- |

The ordering is deliberate: grouping and the reserved accounts land first with no balance constraint, residuals are made visible (0039) before the CSV format is changed to fix them (0040), and the database constraint is turned on last, once balance is satisfiable by construction.

0042 is in the milestone because it blocks 0041 -- an exact `SUM(...) = 0` is not possible over `DOUBLE PRECISION` columns, and an epsilon-tolerance balance check defeats the point of the constraint.

## Unscheduled

Left without a milestone, on each issue's own reasoning:

| # | Title | Depends on | Why unscheduled |
|---|---|---|---|
| 0043 | Split holding declarations into pads and checked assertions | -- | States it does not have to wait on 0042; an interim tolerance is acceptable |
| 0044 | Lot identity and disposal matching | -- | Cost basis, independent of double entry |
| 0045 | Realised gains and cost basis methods | 0044 | As above |
| 0046 | Account hierarchy with ltree | 0037 | Records an unresolved tags-versus-hierarchy question; closing as not-planned is a stated outcome |

0045 notes that the method is jurisdiction-specific -- UK Section 104 pooling is not the same as specific identification -- so it is configurable rather than assumed.

## Notes

All issues are `status: open`. Frontmatter follows the `issue-tracker` skill. The existing `## Unscheduled` entry for TWR/MWR in `milestones.md` is left as-is: M12 is a prerequisite for those metrics but does not deliver them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)