### PR TITLE
Add sync orchestration and the run log

### DIFF
--- a/docs/issues/0047-broker-import-browser-extension.md
+++ b/docs/issues/0047-broker-import-browser-extension.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Automate broker transaction import with a browser extension
 milestone: M13
 ---

--- a/extension/popup.html
+++ b/extension/popup.html
@@ -15,12 +15,13 @@
     <section>
       <h2>Sync</h2>
       <div class="actions">
-        <button id="sync" type="button" disabled>Sync Fidelity</button>
+        <button id="sync" type="button">Sync Fidelity</button>
       </div>
-      <p class="placeholder">
-        Not implemented yet. Sync will work out the missing period itself, fetch it
-        and upload it.
+      <p class="hint">
+        Works out the missing period from what PortfolioDB already holds, fetches
+        it and uploads it.
       </p>
+      <p id="sync-status" class="status" role="status"></p>
     </section>
 
     <section>
@@ -66,7 +67,7 @@
 
     <section>
       <h2>Run log</h2>
-      <p id="run-log" class="placeholder">No runs yet.</p>
+      <pre id="run-log" class="output">No runs yet.</pre>
     </section>
 
     <script type="module" src="./src/popup/main.ts"></script>

--- a/extension/src/background/dry-run.ts
+++ b/extension/src/background/dry-run.ts
@@ -9,21 +9,8 @@ import { getRecipe } from "../brokers";
 import { loadConfig } from "../config";
 import { formatDate, parseIsoDate } from "../lib/dates";
 import type { DryRunRequest, DryRunResult } from "../lib/messages";
+import { droppedTypes } from "../lib/dropped";
 import { captureExport } from "./export";
-
-/**
- * Counts rows and the transaction types the converter rejected. The type name is
- * pulled from the parse error rather than the payload so the two cannot disagree
- * about which rows were dropped.
- */
-function summariseDropped(errors: { field: string; message: string }[]): string[] {
-  const types = new Set<string>();
-  for (const e of errors) {
-    const m = e.field === "type" ? e.message.match(/Unknown transaction type: (.+)$/) : null;
-    if (m?.[1]) types.add(m[1]);
-  }
-  return [...types].sort();
-}
 
 export async function dryRun(req: DryRunRequest): Promise<DryRunResult> {
   const recipe = getRecipe(req.recipeId);
@@ -57,8 +44,8 @@ export async function dryRun(req: DryRunRequest): Promise<DryRunResult> {
       requested,
       ...(rowCount !== undefined ? { rowCount } : {}),
       txCount: parsed.txs.length,
-      droppedRows: parsed.errors.length,
-      droppedTypes: summariseDropped(parsed.errors),
+      droppedCount: parsed.errors.length,
+      droppedTypes: droppedTypes(parsed.errors),
       ...(parsed.txs.length === 0
         ? {
             error: parsed.errors[0]?.message ?? "the export contained no transactions",

--- a/extension/src/background/dry-run.ts
+++ b/extension/src/background/dry-run.ts
@@ -7,16 +7,9 @@
 
 import { getRecipe } from "../brokers";
 import { loadConfig } from "../config";
-import { formatDate, parseSlashDate } from "../lib/dates";
+import { formatDate, parseIsoDate } from "../lib/dates";
 import type { DryRunRequest, DryRunResult } from "../lib/messages";
 import { captureExport } from "./export";
-
-/** Parses "yyyy-MM-dd" from a date input to local midnight. */
-function parseInputDate(value: string): Date | null {
-  const m = value.match(/^(\d{4})-(\d{2})-(\d{2})$/);
-  if (!m) return null;
-  return parseSlashDate(`${m[3]}/${m[2]}/${m[1]}`);
-}
 
 /**
  * Counts rows and the transaction types the converter rejected. The type name is
@@ -36,8 +29,8 @@ export async function dryRun(req: DryRunRequest): Promise<DryRunResult> {
   const recipe = getRecipe(req.recipeId);
   if (!recipe) return { ok: false, error: `no recipe named ${req.recipeId}` };
 
-  const from = parseInputDate(req.from);
-  const to = parseInputDate(req.to);
+  const from = parseIsoDate(req.from);
+  const to = parseIsoDate(req.to);
   if (!from || !to) return { ok: false, error: "enter both dates" };
   if (from > to) return { ok: false, error: "from is after to" };
 

--- a/extension/src/background/index.ts
+++ b/extension/src/background/index.ts
@@ -7,6 +7,9 @@
 
 import { bootstrapSession } from "./bootstrap";
 import { dryRun } from "./dry-run";
+import { sync } from "./sync";
+import { getRecipe } from "../brokers";
+import { listRuns } from "../lib/run-log";
 import { loadConfig } from "../config";
 import { getSession } from "../lib/api";
 import type { Message, SessionStatus } from "../lib/messages";
@@ -64,6 +67,19 @@ chrome.runtime.onMessage.addListener((msg: Message, _sender, sendResponse) => {
   }
   if (msg?.type === "dry-run") {
     void dryRun(msg).then(sendResponse);
+    return true;
+  }
+  if (msg?.type === "sync") {
+    const recipe = getRecipe(msg.recipeId);
+    if (!recipe) {
+      sendResponse({ entry: { startedAt: new Date().toISOString(), recipeId: msg.recipeId, status: "failed", error: `no recipe named ${msg.recipeId}` } });
+      return false;
+    }
+    void sync({ broker: recipe.broker }).then(sendResponse);
+    return true;
+  }
+  if (msg?.type === "runs") {
+    void listRuns().then(sendResponse);
     return true;
   }
   return false;

--- a/extension/src/background/sync.test.ts
+++ b/extension/src/background/sync.test.ts
@@ -119,10 +119,33 @@ describe("sync", () => {
 
     expect(upsertTxs).toHaveBeenCalled();
     expect(entry.status).toBe("warning");
-    expect(entry.droppedRows).toBe(1);
+    expect(entry.droppedCount).toBe(1);
     expect(entry.droppedTypes).toEqual(["Corporate Action Reinvestment"]);
     expect(entry.txCount).toBe(1);
     expect(entry.rowCount).toBe(2);
+    // The row itself, not just a count: a replace deleted whatever it stored, so
+    // the run has to be able to say which row and why.
+    expect(entry.droppedRows).toEqual([
+      { rowIndex: 2, field: "type", message: "Unknown transaction type: Corporate Action Reinvestment" },
+    ]);
+  });
+
+  it("records a row dropped for a reason that names no type", async () => {
+    // A malformed date contributes nothing to droppedTypes, so without the
+    // per-row detail the run would show a bare count and no way to find it.
+    captureExport.mockResolvedValue({
+      status: 200,
+      body: JSON.stringify([row(), row({ dealDate: "not a date", settlementDate: null })]),
+    });
+
+    const { entry } = await run();
+
+    expect(entry.status).toBe("warning");
+    expect(entry.droppedCount).toBe(1);
+    expect(entry.droppedTypes).toBeUndefined();
+    expect(entry.droppedRows).toEqual([
+      { rowIndex: 2, field: "date", message: "Invalid or missing date" },
+    ]);
   });
 
   it("refuses to upload when nothing converted", async () => {

--- a/extension/src/background/sync.test.ts
+++ b/extension/src/background/sync.test.ts
@@ -1,0 +1,217 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { create } from "@bufbuild/protobuf";
+import { timestampFromDate } from "@bufbuild/protobuf/wkt";
+import {
+  Broker,
+  JobStatus,
+  GetJobResponseSchema,
+  ListTxsResponseSchema,
+} from "@/gen/api/v1/api_pb";
+import { IngestionResponseSchema } from "@/gen/ingestion/v1/ingestion_pb";
+import type { RunLogEntry } from "../lib/run-log";
+
+const loadConfig = vi.fn();
+const getSessionId = vi.fn();
+const listTxs = vi.fn();
+const upsertTxs = vi.fn();
+const getJob = vi.fn();
+const captureExport = vi.fn();
+const recordRun = vi.fn();
+
+vi.mock("../config", () => ({ loadConfig: () => loadConfig() }));
+vi.mock("../lib/session", () => ({ getSessionId: () => getSessionId() }));
+vi.mock("../lib/api", () => ({
+  listTxs: (...a: unknown[]) => listTxs(...a),
+  upsertTxs: (...a: unknown[]) => upsertTxs(...a),
+  getJob: (...a: unknown[]) => getJob(...a),
+}));
+vi.mock("./export", () => ({ captureExport: (...a: unknown[]) => captureExport(...a) }));
+vi.mock("../lib/run-log", () => ({ recordRun: (e: RunLogEntry) => recordRun(e) }));
+
+const { sync } = await import("./sync");
+
+const CONFIG = {
+  portfoliodbOrigin: "http://localhost:8080",
+  currency: "GBP",
+  historyStartDate: "",
+  lookbackDays: 14,
+  timeZone: "Europe/London",
+};
+
+/** A settled Fidelity cash row, in the shape the JSON endpoint returns. */
+function row(overrides: Record<string, unknown> = {}) {
+  return {
+    accountNumber: "ACC-1",
+    transactionType: "Cash Interest",
+    assetName: "Cash",
+    isin: "AA00S0000000",
+    sedol: "S000000",
+    units: 1.26,
+    valuation: 1.26,
+    pricePerUnit: 1,
+    currency: "GBP",
+    status: "Completed",
+    debitCreditIndicator: "CREDIT",
+    dealDate: "15/07/2026",
+    settlementDate: "21/07/2026",
+    ...overrides,
+  };
+}
+
+function withLatest(date: Date | null) {
+  listTxs.mockResolvedValue(
+    create(ListTxsResponseSchema, {
+      txs: date ? [{ broker: Broker.FIDELITY, tx: { timestamp: timestampFromDate(date) } }] : [],
+    })
+  );
+}
+
+const run = () =>
+  sync({ broker: Broker.FIDELITY, now: new Date("2026-07-27T09:00:00Z"), sleep: async () => {} });
+
+describe("sync", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    loadConfig.mockResolvedValue({ ...CONFIG });
+    getSessionId.mockResolvedValue("session-abc");
+    withLatest(new Date(2026, 6, 20));
+    captureExport.mockResolvedValue({ status: 200, body: JSON.stringify([row()]) });
+    upsertTxs.mockResolvedValue(create(IngestionResponseSchema, { jobId: "job-1" }));
+    getJob.mockResolvedValue(create(GetJobResponseSchema, { status: JobStatus.SUCCESS }));
+  });
+
+  it("uploads the requested window, not the range of the rows returned", async () => {
+    const { entry } = await run();
+
+    expect(entry.status).toBe("success");
+    const req = upsertTxs.mock.calls[0]![2] as { periodFrom: { seconds: bigint }; periodTo: { seconds: bigint } };
+    // Window is 14 days before the last known transaction (20 Jul) to end of
+    // yesterday (26 Jul) -- wider than the single 21 Jul row that came back,
+    // which is what lets the replace delete anything the broker cancelled.
+    expect(Number(req.periodFrom.seconds)).toBe(Math.floor(new Date(2026, 6, 6).getTime() / 1000));
+    expect(Number(req.periodTo.seconds)).toBe(
+      Math.floor(new Date(2026, 6, 26, 23, 59, 59, 999).getTime() / 1000)
+    );
+  });
+
+  it("sends the source string the web client already uses", async () => {
+    await run();
+    const req = upsertTxs.mock.calls[0]![2] as { source: string };
+    expect(req.source).toBe("Fidelity:web:fidelity-csv");
+  });
+
+  it("asks only for the most recent transaction of that broker", async () => {
+    await run();
+    expect(listTxs.mock.calls[0]![2]).toMatchObject({
+      broker: Broker.FIDELITY,
+      descending: true,
+      pageSize: 1,
+    });
+  });
+
+  it("uploads despite dropped rows, but records them and warns", async () => {
+    captureExport.mockResolvedValue({
+      status: 200,
+      body: JSON.stringify([row(), row({ transactionType: "Corporate Action Reinvestment" })]),
+    });
+
+    const { entry } = await run();
+
+    expect(upsertTxs).toHaveBeenCalled();
+    expect(entry.status).toBe("warning");
+    expect(entry.droppedRows).toBe(1);
+    expect(entry.droppedTypes).toEqual(["Corporate Action Reinvestment"]);
+    expect(entry.txCount).toBe(1);
+    expect(entry.rowCount).toBe(2);
+  });
+
+  it("refuses to upload when nothing converted", async () => {
+    // The server marks a bulk upload with no storable rows successful without
+    // performing the replace, so uploading would report success and delete
+    // nothing.
+    captureExport.mockResolvedValue({ status: 200, body: "[]" });
+
+    const { entry } = await run();
+
+    expect(upsertTxs).not.toHaveBeenCalled();
+    expect(entry.status).toBe("failed");
+    expect(entry.error).toContain("no transactions");
+  });
+
+  it("reports up to date without fetching anything", async () => {
+    withLatest(new Date(2026, 6, 27));
+    loadConfig.mockResolvedValue({ ...CONFIG, lookbackDays: 0 });
+
+    const { entry } = await run();
+
+    expect(entry.status).toBe("up-to-date");
+    expect(captureExport).not.toHaveBeenCalled();
+  });
+
+  it("explains what to configure on a first run with no history start date", async () => {
+    withLatest(null);
+
+    const { entry } = await run();
+
+    expect(entry.status).toBe("failed");
+    expect(entry.error).toContain("history start date");
+    expect(captureExport).not.toHaveBeenCalled();
+  });
+
+  it("uses the history start date on a first run when it is set", async () => {
+    withLatest(null);
+    loadConfig.mockResolvedValue({ ...CONFIG, historyStartDate: "2025-01-06" });
+
+    await run();
+
+    const req = upsertTxs.mock.calls[0]![2] as { periodFrom: { seconds: bigint } };
+    expect(Number(req.periodFrom.seconds)).toBe(Math.floor(new Date(2025, 0, 6).getTime() / 1000));
+  });
+
+  it("stops before fetching when there is no session", async () => {
+    getSessionId.mockResolvedValue("");
+
+    const { entry } = await run();
+
+    expect(entry.error).toContain("Connect");
+    expect(captureExport).not.toHaveBeenCalled();
+  });
+
+  it("records the job's own errors when ingestion fails", async () => {
+    getJob.mockResolvedValue(
+      create(GetJobResponseSchema, {
+        status: JobStatus.FAILED,
+        validationErrors: [{ rowIndex: 3, field: "quantity", message: "must be a number" }],
+      })
+    );
+
+    const { entry } = await run();
+
+    expect(entry.status).toBe("failed");
+    expect(entry.jobId).toBe("job-1");
+    expect(entry.jobErrors?.[0]).toContain("must be a number");
+  });
+
+  it("waits for a running job to finish", async () => {
+    getJob
+      .mockResolvedValueOnce(create(GetJobResponseSchema, { status: JobStatus.RUNNING }))
+      .mockResolvedValueOnce(create(GetJobResponseSchema, { status: JobStatus.SUCCESS }));
+
+    const { entry } = await run();
+
+    expect(getJob).toHaveBeenCalledTimes(2);
+    expect(entry.status).toBe("success");
+  });
+
+  it("records every outcome, including the failures", async () => {
+    captureExport.mockRejectedValue(new Error("HTTP 302"));
+
+    const { entry } = await run();
+
+    expect(recordRun).toHaveBeenCalledWith(entry);
+    expect(entry.error).toContain("HTTP 302");
+    // The window is recorded even though the export failed, so a failed run still
+    // says what it was trying to fetch.
+    expect(entry.window).toEqual({ from: "06/07/2026", to: "26/07/2026" });
+  });
+});

--- a/extension/src/background/sync.ts
+++ b/extension/src/background/sync.ts
@@ -1,0 +1,193 @@
+/**
+ * One attended sync: work out the missing period, fetch it, convert it, upload
+ * it, and wait for the ingestion job to finish.
+ *
+ * Every exit records a run-log entry, including the failures -- a sync that
+ * silently did nothing is the hardest kind to diagnose.
+ */
+
+import { timestampDate, timestampFromDate } from "@bufbuild/protobuf/wkt";
+import { Broker, JobStatus } from "@/gen/api/v1/api_pb";
+import { getRecipeForBroker, sourceFor } from "../brokers";
+import type { BrokerRecipe } from "../brokers/types";
+import { loadConfig } from "../config";
+import { getJob, listTxs, upsertTxs } from "../lib/api";
+import { formatDate } from "../lib/dates";
+import { droppedTypes } from "../lib/dropped";
+import { recordRun, type RunLogEntry } from "../lib/run-log";
+import { getSessionId } from "../lib/session";
+import { computeWindow } from "../lib/window";
+import { captureExport } from "./export";
+
+/** Ingestion is asynchronous; a bulk upload of a year takes a little while. */
+const JOB_POLL_INTERVAL_MS = 1_500;
+const JOB_TIMEOUT_MS = 120_000;
+
+/** Source prefix per broker, matching what the web client sends. */
+const SOURCE_PREFIX: Partial<Record<Broker, string>> = {
+  [Broker.FIDELITY]: "Fidelity",
+  [Broker.IBKR]: "IBKR",
+};
+
+export interface SyncResult {
+  entry: RunLogEntry;
+}
+
+async function finish(entry: RunLogEntry): Promise<SyncResult> {
+  await recordRun(entry);
+  return { entry };
+}
+
+/** Most recent transaction already held for a broker, or null if there are none. */
+async function latestTx(origin: string, sessionId: string, broker: Broker): Promise<Date | null> {
+  const res = await listTxs(origin, sessionId, { broker, descending: true, pageSize: 1 });
+  const ts = res.txs[0]?.tx?.timestamp;
+  return ts ? timestampDate(ts) : null;
+}
+
+async function awaitJob(
+  origin: string,
+  sessionId: string,
+  jobId: string,
+  sleep: (ms: number) => Promise<void>
+): Promise<{ ok: boolean; errors: string[] }> {
+  const deadline = Date.now() + JOB_TIMEOUT_MS;
+  for (;;) {
+    const job = await getJob(origin, sessionId, jobId);
+    if (job.status === JobStatus.SUCCESS) return { ok: true, errors: [] };
+    if (job.status === JobStatus.FAILED) {
+      return {
+        ok: false,
+        errors: [
+          ...job.validationErrors.map((e) => `row ${e.rowIndex} ${e.field}: ${e.message}`),
+          ...job.identificationErrors.map((e) => e.message),
+        ],
+      };
+    }
+    if (Date.now() > deadline) {
+      return { ok: false, errors: ["timed out waiting for the ingestion job"] };
+    }
+    await sleep(JOB_POLL_INTERVAL_MS);
+  }
+}
+
+export interface SyncOptions {
+  broker: Broker;
+  /** Injected for tests. */
+  now?: Date;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+export async function sync(opts: SyncOptions): Promise<SyncResult> {
+  const now = opts.now ?? new Date();
+  const sleep = opts.sleep ?? ((ms: number) => new Promise((r) => setTimeout(r, ms)));
+  const startedAt = now.toISOString();
+
+  const recipe: BrokerRecipe | undefined = getRecipeForBroker(opts.broker);
+  if (!recipe) {
+    return finish({ startedAt, recipeId: "", status: "failed", error: "No recipe for this broker" });
+  }
+  const base: RunLogEntry = { startedAt, recipeId: recipe.id, status: "failed" };
+
+  const config = await loadConfig();
+  if (!config.portfoliodbOrigin) {
+    return finish({ ...base, error: "Set the PortfolioDB origin in settings" });
+  }
+  const sessionId = await getSessionId();
+  if (!sessionId) {
+    return finish({ ...base, error: "Not connected to PortfolioDB. Connect first." });
+  }
+
+  let latest: Date | null;
+  try {
+    latest = await latestTx(config.portfoliodbOrigin, sessionId, opts.broker);
+  } catch (e) {
+    return finish({ ...base, error: `Could not read existing transactions: ${message(e)}` });
+  }
+
+  const win = computeWindow({
+    latest,
+    historyStartDate: config.historyStartDate,
+    lookbackDays: config.lookbackDays,
+    timeZone: config.timeZone,
+    now,
+  });
+  const resumedFrom = latest ? latest.toISOString() : null;
+  if (win.kind === "error") return finish({ ...base, resumedFrom, error: win.message });
+  if (win.kind === "up-to-date") {
+    return finish({ ...base, status: "up-to-date", resumedFrom });
+  }
+
+  const requested = {
+    from: formatDate(win.from, recipe.dateFormat),
+    to: formatDate(win.to, recipe.dateFormat),
+  };
+  const withWindow: RunLogEntry = { ...base, resumedFrom, window: requested };
+
+  let payload: string;
+  try {
+    payload = (await captureExport(recipe, { from: win.from, to: win.to })).body;
+  } catch (e) {
+    return finish({ ...withWindow, error: `Export failed: ${message(e)}` });
+  }
+
+  const parsed = recipe.convert(payload, { currency: config.currency });
+  const dropped = droppedTypes(parsed.errors);
+  const counted: RunLogEntry = {
+    ...withWindow,
+    rowCount: rowCount(payload),
+    txCount: parsed.txs.length,
+    droppedRows: parsed.errors.length,
+    ...(dropped.length > 0 ? { droppedTypes: dropped } : {}),
+  };
+
+  if (parsed.txs.length === 0) {
+    // Refusing rather than uploading nothing: the server marks a bulk upload with
+    // no storable rows successful without performing the replace, so an empty
+    // upload would report success while deleting nothing.
+    return finish({
+      ...counted,
+      error:
+        parsed.errors[0]?.message ??
+        "The export contained no transactions, so the period cannot be replaced",
+    });
+  }
+
+  let jobId: string;
+  try {
+    const res = await upsertTxs(config.portfoliodbOrigin, sessionId, {
+      broker: opts.broker,
+      source: sourceFor(recipe, SOURCE_PREFIX[opts.broker] ?? "unknown"),
+      // The window that was requested, not the range of the rows that came back:
+      // that is what lets the replace delete transactions the broker cancelled.
+      periodFrom: timestampFromDate(win.from),
+      periodTo: timestampFromDate(win.to),
+      txs: parsed.txs,
+      filename: `${recipe.id}-${formatDate(win.to, "yyyy-MM-dd")}.json`,
+    });
+    jobId = res.jobId;
+  } catch (e) {
+    return finish({ ...counted, error: `Upload failed: ${message(e)}` });
+  }
+
+  const job = await awaitJob(config.portfoliodbOrigin, sessionId, jobId, sleep);
+  if (!job.ok) {
+    return finish({ ...counted, jobId, jobErrors: job.errors, error: "The ingestion job failed" });
+  }
+  // Dropped rows are not fatal, but they are not a clean run either: the replace
+  // deleted whatever those rows previously stored.
+  return finish({ ...counted, jobId, status: dropped.length > 0 || counted.droppedRows ? "warning" : "success" });
+}
+
+function message(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+function rowCount(payload: string): number | undefined {
+  try {
+    const rows: unknown = JSON.parse(payload);
+    return Array.isArray(rows) ? rows.length : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/extension/src/background/sync.ts
+++ b/extension/src/background/sync.ts
@@ -7,7 +7,7 @@
  */
 
 import { timestampDate, timestampFromDate } from "@bufbuild/protobuf/wkt";
-import { Broker, JobStatus } from "@/gen/api/v1/api_pb";
+import { JobStatus, type Broker } from "@/gen/api/v1/api_pb";
 import { getRecipeForBroker, sourceFor } from "../brokers";
 import type { BrokerRecipe } from "../brokers/types";
 import { loadConfig } from "../config";
@@ -22,12 +22,6 @@ import { captureExport } from "./export";
 /** Ingestion is asynchronous; a bulk upload of a year takes a little while. */
 const JOB_POLL_INTERVAL_MS = 1_500;
 const JOB_TIMEOUT_MS = 120_000;
-
-/** Source prefix per broker, matching what the web client sends. */
-const SOURCE_PREFIX: Partial<Record<Broker, string>> = {
-  [Broker.FIDELITY]: "Fidelity",
-  [Broker.IBKR]: "IBKR",
-};
 
 export interface SyncResult {
   entry: RunLogEntry;
@@ -137,7 +131,8 @@ export async function sync(opts: SyncOptions): Promise<SyncResult> {
     ...withWindow,
     rowCount: rowCount(payload),
     txCount: parsed.txs.length,
-    droppedRows: parsed.errors.length,
+    droppedCount: parsed.errors.length,
+    ...(parsed.errors.length > 0 ? { droppedRows: parsed.errors } : {}),
     ...(dropped.length > 0 ? { droppedTypes: dropped } : {}),
   };
 
@@ -157,7 +152,7 @@ export async function sync(opts: SyncOptions): Promise<SyncResult> {
   try {
     const res = await upsertTxs(config.portfoliodbOrigin, sessionId, {
       broker: opts.broker,
-      source: sourceFor(recipe, SOURCE_PREFIX[opts.broker] ?? "unknown"),
+      source: sourceFor(recipe),
       // The window that was requested, not the range of the rows that came back:
       // that is what lets the replace delete transactions the broker cancelled.
       periodFrom: timestampFromDate(win.from),
@@ -176,7 +171,7 @@ export async function sync(opts: SyncOptions): Promise<SyncResult> {
   }
   // Dropped rows are not fatal, but they are not a clean run either: the replace
   // deleted whatever those rows previously stored.
-  return finish({ ...counted, jobId, status: dropped.length > 0 || counted.droppedRows ? "warning" : "success" });
+  return finish({ ...counted, jobId, status: counted.droppedCount ? "warning" : "success" });
 }
 
 function message(e: unknown): string {

--- a/extension/src/brokers/fidelity-uk.ts
+++ b/extension/src/brokers/fidelity-uk.ts
@@ -14,6 +14,7 @@ import type { BrokerRecipe } from "./types";
 export const fidelityUk: BrokerRecipe = {
   id: "fidelity-uk",
   broker: Broker.FIDELITY,
+  sourcePrefix: "Fidelity",
   // Deliberately not "fidelity-json": the web client's Fidelity uploads already
   // resolve under this source, and changing it would fork those instruments.
   sourceFormatId: "fidelity-csv",

--- a/extension/src/brokers/index.test.ts
+++ b/extension/src/brokers/index.test.ts
@@ -13,7 +13,7 @@ describe("recipe registry", () => {
   it("reuses the web client's source string rather than minting a new one", () => {
     // Source is the instrument-resolution cache key, so it stays pinned to what
     // manual Fidelity uploads already use even though this recipe reads JSON.
-    expect(sourceFor(getRecipe("fidelity-uk")!, "Fidelity")).toBe("Fidelity:web:fidelity-csv");
+    expect(sourceFor(getRecipe("fidelity-uk")!)).toBe("Fidelity:web:fidelity-csv");
   });
 });
 

--- a/extension/src/brokers/index.ts
+++ b/extension/src/brokers/index.ts
@@ -22,8 +22,8 @@ export function getRecipeForBroker(broker: Broker): BrokerRecipe | undefined {
 }
 
 /** The ingestion source string for a recipe, e.g. "Fidelity:web:fidelity-csv". */
-export function sourceFor(recipe: BrokerRecipe, prefix: string): string {
-  return `${prefix}:web:${recipe.sourceFormatId}`;
+export function sourceFor(recipe: BrokerRecipe): string {
+  return `${recipe.sourcePrefix}:web:${recipe.sourceFormatId}`;
 }
 
 /**

--- a/extension/src/brokers/types.ts
+++ b/extension/src/brokers/types.ts
@@ -35,6 +35,13 @@ export interface BrokerRecipe {
   id: string;
   broker: Broker;
   /**
+   * Broker component of the ingestion source string, matching what the web
+   * client sends. Held on the recipe rather than in a broker-keyed table
+   * elsewhere, so everything that composes a source string for a broker lives in
+   * one place.
+   */
+  sourcePrefix: string;
+  /**
    * Format component of the ingestion source string.
    *
    * Pinned to whatever the web client already sends for this broker, even when

--- a/extension/src/lib/dates.ts
+++ b/extension/src/lib/dates.ts
@@ -17,6 +17,17 @@ export function formatDate(date: Date, pattern: string): string {
     .replace(/dd/g, pad(date.getDate()));
 }
 
+/**
+ * Parses "yyyy-MM-dd" to local midnight, as date inputs and stored settings spell
+ * dates. Returns null if malformed -- deliberately strict, so a date in another
+ * format is rejected rather than reinterpreted.
+ */
+export function parseIsoDate(value: string): Date | null {
+  const m = value.trim().match(/^(\d{4})-(\d{2})-(\d{2})$/);
+  if (!m) return null;
+  return parseSlashDate(`${m[3]}/${m[2]}/${m[1]}`);
+}
+
 /** Parses "dd/MM/yyyy" to local midnight. Returns null if malformed. */
 export function parseSlashDate(value: string): Date | null {
   const m = value.trim().match(/^(\d{2})\/(\d{2})\/(\d{4})$/);

--- a/extension/src/lib/dropped.test.ts
+++ b/extension/src/lib/dropped.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { droppedSummary, droppedTypes } from "./dropped";
+
+const unknown = (type: string) => ({
+  rowIndex: 1,
+  field: "type",
+  message: `Unknown transaction type: ${type}`,
+});
+
+describe("droppedTypes", () => {
+  it("names each unrecognised broker type once, sorted", () => {
+    expect(
+      droppedTypes([unknown("Corporate Action"), unknown("Rights Issue"), unknown("Corporate Action")])
+    ).toEqual(["Corporate Action", "Rights Issue"]);
+  });
+
+  it("ignores errors that are not about the type", () => {
+    // A bad date is a dropped row too, but it names no type to add to the map.
+    expect(droppedTypes([{ rowIndex: 2, field: "date", message: "Invalid or missing date" }])).toEqual([]);
+  });
+
+  it("returns nothing for a clean parse", () => {
+    expect(droppedTypes([])).toEqual([]);
+  });
+});
+
+describe("droppedSummary", () => {
+  it("is null when nothing was dropped", () => {
+    expect(droppedSummary([])).toBeNull();
+  });
+
+  it("counts rows and names types", () => {
+    expect(droppedSummary([unknown("Rights Issue"), unknown("Rights Issue")])).toBe(
+      "2 rows dropped: Rights Issue"
+    );
+  });
+
+  it("still reports a count when no type can be named", () => {
+    expect(droppedSummary([{ rowIndex: 2, field: "date", message: "Invalid or missing date" }])).toBe(
+      "1 row dropped"
+    );
+  });
+});

--- a/extension/src/lib/dropped.ts
+++ b/extension/src/lib/dropped.ts
@@ -1,0 +1,35 @@
+/**
+ * Summarising the rows a converter refused.
+ *
+ * A dropped row is not merely skipped. Ingestion replaces the period wholesale,
+ * so any stored copy of that row inside the window is deleted and not put back.
+ * Uploading regardless keeps a sync usable when a broker introduces a transaction
+ * type, but the run has to say loudly what it gave up, and name the types
+ * precisely enough to extend the converter's map.
+ */
+
+import type { ParseError } from "@/lib/csv/standard";
+
+/**
+ * Distinct broker transaction types the converter did not recognise.
+ *
+ * Read back out of the parse errors rather than rescanning the payload, so this
+ * cannot disagree with the rows the converter actually dropped.
+ */
+export function droppedTypes(errors: ParseError[]): string[] {
+  const types = new Set<string>();
+  for (const e of errors) {
+    if (e.field !== "type") continue;
+    const m = e.message.match(/Unknown transaction type: (.+)$/);
+    if (m?.[1]) types.add(m[1]);
+  }
+  return [...types].sort();
+}
+
+/** One line summarising what was dropped, or null when nothing was. */
+export function droppedSummary(errors: ParseError[]): string | null {
+  if (errors.length === 0) return null;
+  const types = droppedTypes(errors);
+  const rows = `${errors.length} row${errors.length === 1 ? "" : "s"} dropped`;
+  return types.length > 0 ? `${rows}: ${types.join(", ")}` : rows;
+}

--- a/extension/src/lib/messages.ts
+++ b/extension/src/lib/messages.ts
@@ -59,7 +59,7 @@ export interface DryRunResult {
   txCount?: number;
   /** Distinct broker transaction types the converter did not recognise. */
   droppedTypes?: string[];
-  droppedRows?: number;
+  droppedCount?: number;
   /** First lines of the payload, to eyeball when conversion fails outright. */
   preview?: string;
 }

--- a/extension/src/lib/messages.ts
+++ b/extension/src/lib/messages.ts
@@ -29,7 +29,24 @@ export interface DryRunRequest {
   to: string;
 }
 
-export type Message = SessionBootstrapped | ConnectRequest | StatusRequest | DryRunRequest;
+/** Popup asks for a full sync: work out the window, fetch, convert and upload. */
+export interface SyncRequest {
+  type: "sync";
+  recipeId: string;
+}
+
+/** Popup asks for the recorded runs. */
+export interface RunsRequest {
+  type: "runs";
+}
+
+export type Message =
+  | SessionBootstrapped
+  | ConnectRequest
+  | StatusRequest
+  | DryRunRequest
+  | SyncRequest
+  | RunsRequest;
 
 /** Reply to dry-run: what the export produced, with nothing sent to the server. */
 export interface DryRunResult {

--- a/extension/src/lib/run-log.test.ts
+++ b/extension/src/lib/run-log.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { clearRuns, listRuns, recordRun, type RunLogEntry } from "./run-log";
+
+let store: Record<string, unknown> = {};
+
+vi.stubGlobal("chrome", {
+  storage: {
+    local: {
+      get: vi.fn(async (key: string) => (key in store ? { [key]: store[key] } : {})),
+      set: vi.fn(async (items: Record<string, unknown>) => {
+        store = { ...store, ...items };
+      }),
+      remove: vi.fn(async (key: string) => {
+        delete store[key];
+      }),
+    },
+  },
+});
+
+const entry = (startedAt: string): RunLogEntry => ({
+  startedAt,
+  recipeId: "fidelity-uk",
+  status: "success",
+});
+
+describe("run log", () => {
+  beforeEach(() => {
+    store = {};
+  });
+
+  it("is empty before anything runs", async () => {
+    expect(await listRuns()).toEqual([]);
+  });
+
+  it("puts the most recent run first", async () => {
+    await recordRun(entry("2026-07-26T10:00:00Z"));
+    await recordRun(entry("2026-07-27T10:00:00Z"));
+    expect((await listRuns()).map((r) => r.startedAt)).toEqual([
+      "2026-07-27T10:00:00Z",
+      "2026-07-26T10:00:00Z",
+    ]);
+  });
+
+  it("keeps at most 20 runs", async () => {
+    for (let i = 0; i < 25; i++) await recordRun(entry(`2026-07-${String(i + 1).padStart(2, "0")}`));
+    const runs = await listRuns();
+    expect(runs).toHaveLength(20);
+    expect(runs[0]!.startedAt).toBe("2026-07-25");
+  });
+
+  it("survives a stored value that is not a list", async () => {
+    store = { runLog: "corrupt" };
+    expect(await listRuns()).toEqual([]);
+  });
+
+  it("clears", async () => {
+    await recordRun(entry("2026-07-27T10:00:00Z"));
+    await clearRuns();
+    expect(await listRuns()).toEqual([]);
+  });
+});

--- a/extension/src/lib/run-log.ts
+++ b/extension/src/lib/run-log.ts
@@ -6,6 +6,8 @@
  * dropped rows names the broker transaction types it did not recognise.
  */
 
+import type { ParseError } from "@/lib/csv/standard";
+
 const STORAGE_KEY = "runLog";
 const MAX_ENTRIES = 20;
 
@@ -22,7 +24,17 @@ export interface RunLogEntry {
   resumedFrom?: string | null;
   rowCount?: number;
   txCount?: number;
-  droppedRows?: number;
+  droppedCount?: number;
+  /**
+   * Every row the converter refused, with its index in the payload and why.
+   *
+   * Kept in full rather than summarised: a row dropped for a reason other than an
+   * unrecognised type -- a malformed date, say -- contributes nothing to
+   * droppedTypes, and a bare count gives no way to find it. A replace deletes
+   * whatever those rows previously stored, so the run has to be able to say
+   * exactly what was lost.
+   */
+  droppedRows?: ParseError[];
   /** Distinct broker transaction types the converter did not recognise. */
   droppedTypes?: string[];
   jobId?: string;

--- a/extension/src/lib/run-log.ts
+++ b/extension/src/lib/run-log.ts
@@ -1,0 +1,48 @@
+/**
+ * A record of what each sync did.
+ *
+ * This is what makes a run diagnosable after the fact, and it is where the
+ * information needed to extend a converter's type map comes from: a run that
+ * dropped rows names the broker transaction types it did not recognise.
+ */
+
+const STORAGE_KEY = "runLog";
+const MAX_ENTRIES = 20;
+
+export type RunStatus = "success" | "warning" | "failed" | "up-to-date";
+
+export interface RunLogEntry {
+  /** ISO timestamp of when the run started. */
+  startedAt: string;
+  recipeId: string;
+  status: RunStatus;
+  /** The window requested, in the broker's own date format. */
+  window?: { from: string; to: string };
+  /** The transaction the window was derived from, or null on a first run. */
+  resumedFrom?: string | null;
+  rowCount?: number;
+  txCount?: number;
+  droppedRows?: number;
+  /** Distinct broker transaction types the converter did not recognise. */
+  droppedTypes?: string[];
+  jobId?: string;
+  /** Validation and identification errors reported by the ingestion job. */
+  jobErrors?: string[];
+  error?: string;
+}
+
+export async function listRuns(): Promise<RunLogEntry[]> {
+  const stored = await chrome.storage.local.get(STORAGE_KEY);
+  const runs = stored[STORAGE_KEY];
+  return Array.isArray(runs) ? (runs as RunLogEntry[]) : [];
+}
+
+/** Prepends an entry, keeping only the most recent MAX_ENTRIES. */
+export async function recordRun(entry: RunLogEntry): Promise<void> {
+  const runs = [entry, ...(await listRuns())].slice(0, MAX_ENTRIES);
+  await chrome.storage.local.set({ [STORAGE_KEY]: runs });
+}
+
+export async function clearRuns(): Promise<void> {
+  await chrome.storage.local.remove(STORAGE_KEY);
+}

--- a/extension/src/lib/window.test.ts
+++ b/extension/src/lib/window.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from "vitest";
+import { computeWindow, type WindowInputs } from "./window";
+
+const base: WindowInputs = {
+  latest: null,
+  historyStartDate: "",
+  lookbackDays: 14,
+  timeZone: "Europe/London",
+  now: new Date("2026-07-27T09:00:00Z"),
+};
+
+/** Narrows to the window case so tests can read from/to without repeating guards. */
+function window(inputs: Partial<WindowInputs>) {
+  const result = computeWindow({ ...base, ...inputs });
+  if (result.kind !== "window") throw new Error(`expected a window, got ${result.kind}`);
+  return result;
+}
+
+describe("computeWindow", () => {
+  it("ends at the end of yesterday", () => {
+    // A transaction dated today may not have completed, so today is excluded.
+    const { to } = window({ latest: new Date(2026, 6, 20) });
+    expect(to).toEqual(new Date(2026, 6, 26, 23, 59, 59, 999));
+  });
+
+  it("starts a lookback before the last known transaction", () => {
+    const { from } = window({ latest: new Date(2026, 6, 20), lookbackDays: 14 });
+    expect(from).toEqual(new Date(2026, 6, 6, 0, 0, 0, 0));
+  });
+
+  it("overlaps rather than resuming, so a re-dated transaction cannot duplicate", () => {
+    // A row ordered on the 6th and still pending would have been stored under the
+    // order date. The window must reach back far enough to replace it once it
+    // settles under a later completion date.
+    const orderDate = new Date(2026, 6, 6);
+    const { from } = window({ latest: new Date(2026, 6, 20), lookbackDays: 14 });
+    expect(from.getTime()).toBeLessThanOrEqual(orderDate.getTime());
+  });
+
+  it("uses the history start date when the broker has no transactions", () => {
+    const { from } = window({ latest: null, historyStartDate: "2024-01-15" });
+    expect(from).toEqual(new Date(2024, 0, 15, 0, 0, 0, 0));
+  });
+
+  it("never reaches back past the history start date", () => {
+    // The lookback would land in 2023; the declared start of history wins.
+    const { from } = window({
+      latest: new Date(2024, 0, 20),
+      historyStartDate: "2024-01-15",
+      lookbackDays: 400,
+    });
+    expect(from).toEqual(new Date(2024, 0, 15, 0, 0, 0, 0));
+  });
+
+  it("errors when there is nothing to resume from and no start date", () => {
+    const result = computeWindow({ ...base, latest: null, historyStartDate: "" });
+    expect(result.kind).toBe("error");
+    if (result.kind === "error") expect(result.message).toContain("history start date");
+  });
+
+  it("reports up to date when the last transaction is already past yesterday", () => {
+    const result = computeWindow({
+      ...base,
+      latest: new Date(2026, 6, 27),
+      lookbackDays: 0,
+    });
+    expect(result.kind).toBe("up-to-date");
+  });
+
+  it("rejects a malformed history start date rather than guessing", () => {
+    const result = computeWindow({ ...base, historyStartDate: "15/01/2024" });
+    expect(result.kind).toBe("error");
+  });
+
+  it("rejects an unknown time zone", () => {
+    const result = computeWindow({ ...base, latest: new Date(2026, 6, 20), timeZone: "Mars/Olympus" });
+    expect(result.kind).toBe("error");
+  });
+
+  describe("the configured zone selects the calendar day", () => {
+    it("treats a UTC instant that is already tomorrow in the zone", () => {
+      // 23:30 UTC on the 26th is 00:30 on the 27th in Auckland's summer, so
+      // yesterday there is the 26th, not the 25th.
+      const { to } = window({
+        latest: new Date(2026, 0, 1),
+        timeZone: "Pacific/Auckland",
+        now: new Date("2026-01-26T23:30:00Z"),
+      });
+      expect(to.getDate()).toBe(26);
+    });
+
+    it("treats a UTC instant that is still yesterday in the zone", () => {
+      // 00:30 UTC on the 27th is 19:30 on the 26th in New York, so yesterday
+      // there is the 25th.
+      const { to } = window({
+        latest: new Date(2026, 0, 1),
+        timeZone: "America/New_York",
+        now: new Date("2026-01-27T00:30:00Z"),
+      });
+      expect(to.getDate()).toBe(25);
+    });
+  });
+
+  it("builds bounds at local midnight, matching how converters date rows", () => {
+    // Converters call new Date(y, m, d), so a bound built in another zone would
+    // not bracket the rows it is meant to cover.
+    const { from, to } = window({ latest: new Date(2026, 6, 20) });
+    expect(from.getHours()).toBe(0);
+    expect(from.getMinutes()).toBe(0);
+    expect(to.getHours()).toBe(23);
+    expect(to.getMilliseconds()).toBe(999);
+  });
+});

--- a/extension/src/lib/window.ts
+++ b/extension/src/lib/window.ts
@@ -1,0 +1,107 @@
+/**
+ * Works out which period a sync should fetch.
+ *
+ * Two things make this less obvious than "everything since the last transaction".
+ *
+ * The window deliberately overlaps what is already held. A broker row that has
+ * not settled is dated by its order date and re-dated to its completion date once
+ * it does, so resuming after the last known transaction would leave the earlier
+ * copy outside the replace window, where it survives and duplicates. The lookback
+ * must therefore exceed the broker's longest order-to-completion lag.
+ *
+ * The configured timezone decides only which calendar day counts as "yesterday".
+ * The bounds are then built as local start- and end-of-day, because that is how
+ * the converters build transaction timestamps; constructing them in a different
+ * zone would shift the inclusive boundary by up to a day.
+ */
+
+import { parseIsoDate } from "./dates";
+
+export interface WindowInputs {
+  /** Timestamp of the most recent transaction already held for this broker. */
+  latest: Date | null;
+  /** "yyyy-MM-dd"; required when there is no latest transaction. */
+  historyStartDate: string;
+  lookbackDays: number;
+  timeZone: string;
+  /** Injected so the result is testable. */
+  now: Date;
+}
+
+export type WindowResult =
+  | { kind: "window"; from: Date; to: Date }
+  | { kind: "up-to-date" }
+  | { kind: "error"; message: string };
+
+/** The calendar date at an instant in a given timezone, as [year, month, day]. */
+function calendarDay(at: Date, timeZone: string): [number, number, number] {
+  const parts = new Intl.DateTimeFormat("en-US", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(at);
+  const get = (type: string) => Number(parts.find((p) => p.type === type)?.value);
+  return [get("year"), get("month"), get("day")];
+}
+
+function startOfDay(y: number, m: number, d: number): Date {
+  return new Date(y, m - 1, d, 0, 0, 0, 0);
+}
+
+function endOfDay(y: number, m: number, d: number): Date {
+  return new Date(y, m - 1, d, 23, 59, 59, 999);
+}
+
+function minusDays(date: Date, days: number): Date {
+  const out = new Date(date);
+  out.setDate(out.getDate() - days);
+  return out;
+}
+
+export function computeWindow(inputs: WindowInputs): WindowResult {
+  const { latest, historyStartDate, lookbackDays, timeZone, now } = inputs;
+
+  let today: [number, number, number];
+  try {
+    today = calendarDay(now, timeZone);
+  } catch {
+    return { kind: "error", message: `Unknown time zone: ${timeZone}` };
+  }
+  if (Number.isNaN(today[0])) {
+    return { kind: "error", message: `Unknown time zone: ${timeZone}` };
+  }
+  // "Yesterday" is derived from the calendar day in the configured zone, then
+  // materialised locally like every other bound here.
+  const yesterday = minusDays(startOfDay(...today), 1);
+  const to = endOfDay(yesterday.getFullYear(), yesterday.getMonth() + 1, yesterday.getDate());
+
+  const historyStart = historyStartDate ? parseIsoDate(historyStartDate) : null;
+  if (historyStartDate && !historyStart) {
+    return { kind: "error", message: `History start date is not a date: ${historyStartDate}` };
+  }
+
+  let from: Date;
+  if (latest) {
+    const overlapped = minusDays(latest, Math.max(0, lookbackDays));
+    const lower = startOfDay(
+      overlapped.getFullYear(),
+      overlapped.getMonth() + 1,
+      overlapped.getDate()
+    );
+    // Never reach back past the declared start of history, even if the lookback
+    // would.
+    from = historyStart && historyStart > lower ? historyStart : lower;
+  } else if (historyStart) {
+    from = historyStart;
+  } else {
+    return {
+      kind: "error",
+      message:
+        "No transactions for this broker yet, so there is nothing to resume from. Set a history start date in settings.",
+    };
+  }
+
+  if (from > to) return { kind: "up-to-date" };
+  return { kind: "window", from, to };
+}

--- a/extension/src/popup/main.ts
+++ b/extension/src/popup/main.ts
@@ -8,6 +8,7 @@
 import { loadConfig, missingRequired, saveConfig, type Config } from "../config";
 import { formatDate } from "../lib/dates";
 import type { DryRunResult, SessionStatus } from "../lib/messages";
+import type { RunLogEntry } from "../lib/run-log";
 import { requestOriginPermission, requestPatternPermission } from "../lib/permissions";
 import { getRecipe } from "../brokers";
 
@@ -23,6 +24,32 @@ function describeDryRun(r: DryRunResult): string {
   if (r.error) lines.push(`error      ${r.error}`);
   if (r.preview) lines.push(`preview    ${r.preview}`);
   return lines.join("\n");
+}
+
+/** One run as a compact block; the newest is shown expanded at the top. */
+function describeRun(r: RunLogEntry): string {
+  const when = r.startedAt.replace("T", " ").slice(0, 16);
+  const parts = [`${when}  ${r.status.toUpperCase()}`];
+  if (r.window) parts.push(`  window ${r.window.from} to ${r.window.to}`);
+  if (r.txCount !== undefined) {
+    parts.push(`  ${r.txCount} of ${r.rowCount ?? "?"} rows uploaded`);
+  }
+  if (r.droppedRows) {
+    // Dropped rows are the thing a reader must not miss: the replace deleted
+    // whatever they previously stored.
+    parts.push(`  DROPPED ${r.droppedRows} row(s)`);
+    if (r.droppedTypes?.length) parts.push(`  unrecognised: ${r.droppedTypes.join(", ")}`);
+  }
+  if (r.jobErrors?.length) parts.push(...r.jobErrors.map((e) => `  job: ${e}`));
+  if (r.error) parts.push(`  ${r.error}`);
+  return parts.join("\n");
+}
+
+async function renderRuns(): Promise<void> {
+  const el = document.getElementById("run-log");
+  if (!el) return;
+  const runs: RunLogEntry[] = await chrome.runtime.sendMessage({ type: "runs" });
+  el.textContent = runs.length === 0 ? "No runs yet." : runs.map(describeRun).join("\n\n");
 }
 
 function field(name: string): HTMLInputElement {
@@ -129,6 +156,32 @@ async function main(): Promise<void> {
         to,
       });
       output.textContent = describeDryRun(result);
+    });
+  });
+
+  void renderRuns();
+
+  const syncStatus = document.getElementById("sync-status");
+  document.getElementById("sync")?.addEventListener("click", () => {
+    const recipe = getRecipe(RECIPE_ID);
+    if (!recipe || !syncStatus) return;
+    // Requested in the gesture: the worker cannot prompt for permission itself.
+    void requestPatternPermission(recipe.origins).then(async (granted) => {
+      if (!granted) {
+        syncStatus.textContent = `access to ${recipe.origins.join(", ")} was declined`;
+        syncStatus.className = "status status-error";
+        return;
+      }
+      syncStatus.textContent = "syncing...";
+      syncStatus.className = "status status-unknown";
+      const { entry } = await chrome.runtime.sendMessage({ type: "sync", recipeId: RECIPE_ID });
+      const ok = entry.status === "success" || entry.status === "up-to-date";
+      syncStatus.textContent =
+        entry.status === "warning"
+          ? `Uploaded, but ${entry.droppedRows} row(s) were dropped -- see the run log`
+          : (entry.error ?? `${entry.status}: ${entry.txCount ?? 0} transactions uploaded`);
+      syncStatus.className = `status ${ok ? "status-ok" : "status-error"}`;
+      await renderRuns();
     });
   });
 

--- a/extension/src/popup/main.ts
+++ b/extension/src/popup/main.ts
@@ -14,12 +14,15 @@ import { getRecipe } from "../brokers";
 
 const RECIPE_ID = "fidelity-uk";
 
+/** Rows listed per run before the log is truncated; the full set is stored. */
+const MAX_DROPPED_SHOWN = 10;
+
 function describeDryRun(r: DryRunResult): string {
   const lines: string[] = [];
   if (r.requested) lines.push(`window     ${r.requested.from} to ${r.requested.to}`);
   if (r.rowCount !== undefined) lines.push(`rows       ${r.rowCount}`);
   if (r.txCount !== undefined) lines.push(`converted  ${r.txCount}`);
-  if (r.droppedRows) lines.push(`dropped    ${r.droppedRows}`);
+  if (r.droppedCount) lines.push(`dropped    ${r.droppedCount}`);
   if (r.droppedTypes?.length) lines.push(`unknown    ${r.droppedTypes.join(", ")}`);
   if (r.error) lines.push(`error      ${r.error}`);
   if (r.preview) lines.push(`preview    ${r.preview}`);
@@ -34,11 +37,18 @@ function describeRun(r: RunLogEntry): string {
   if (r.txCount !== undefined) {
     parts.push(`  ${r.txCount} of ${r.rowCount ?? "?"} rows uploaded`);
   }
-  if (r.droppedRows) {
+  if (r.droppedCount) {
     // Dropped rows are the thing a reader must not miss: the replace deleted
     // whatever they previously stored.
-    parts.push(`  DROPPED ${r.droppedRows} row(s)`);
+    parts.push(`  DROPPED ${r.droppedCount} row(s)`);
     if (r.droppedTypes?.length) parts.push(`  unrecognised: ${r.droppedTypes.join(", ")}`);
+    // Listed individually because a row dropped for something other than an
+    // unrecognised type is invisible in the summary above.
+    for (const e of (r.droppedRows ?? []).slice(0, MAX_DROPPED_SHOWN)) {
+      parts.push(`    row ${e.rowIndex} ${e.field}: ${e.message}`);
+    }
+    const hidden = (r.droppedRows?.length ?? 0) - MAX_DROPPED_SHOWN;
+    if (hidden > 0) parts.push(`    ... and ${hidden} more`);
   }
   if (r.jobErrors?.length) parts.push(...r.jobErrors.map((e) => `  job: ${e}`));
   if (r.error) parts.push(`  ${r.error}`);
@@ -178,7 +188,7 @@ async function main(): Promise<void> {
       const ok = entry.status === "success" || entry.status === "up-to-date";
       syncStatus.textContent =
         entry.status === "warning"
-          ? `Uploaded, but ${entry.droppedRows} row(s) were dropped -- see the run log`
+          ? `Uploaded, but ${entry.droppedCount} row(s) were dropped -- see the run log`
           : (entry.error ?? `${entry.status}: ${entry.txCount ?? 0} transactions uploaded`);
       syncStatus.className = `status ${ok ? "status-ok" : "status-error"}`;
       await renderRuns();


### PR DESCRIPTION
PR 7 of 7 for the broker import extension. Closes issue **0047**, completing milestone **M13**. Branches from `main` — no dependencies left.

Completes the loop: read the most recent transaction held for the broker, work out the missing period, fetch it, convert it, upload it, wait for the ingestion job, record what happened.

## Three behaviours that are easy to get backwards

**The window overlaps rather than resumes.** A broker row that has not settled is dated by its order date and re-dated to its completion date once it does. Resuming after the last known transaction would leave the earlier copy outside the replace window, where it survives and duplicates. So the lookback is *sized* — it must exceed the broker's order-to-completion lag — not chosen as a safety margin. It also never reaches back past a declared history start date.

**The period sent is the requested window, not the parsed row range.** Sending the row range would shrink the period to the transactions that still exist, so a transaction the broker cancelled would never be deleted — which is the main reason to re-fetch an overlapping period at all. A test asserts the uploaded period is wider than the single row that came back.

**An empty conversion is refused, not uploaded.** The ingestion worker marks a bulk upload with no storable rows successful *without* performing the replace, so an empty upload would report success while deleting nothing. The run fails with an explanation instead.

## Timezone

The configured zone decides only which calendar day counts as "yesterday". The bounds are then built as local start- and end-of-day, because that is how the converters build transaction timestamps — constructing them in another zone would shift the inclusive boundary by up to a day. Tested from both sides of UTC: an instant that is already tomorrow in Auckland, and one still yesterday in New York.

## Dropped rows

Uploaded anyway, and reported loudly — a replace deletes whatever those rows previously stored, so this is data loss, not a skip. The run log names the distinct broker transaction types involved, read back out of the parse errors rather than by rescanning the payload, so it cannot disagree with the rows the converter actually dropped. Those names are exactly what gets added to the type map. A run with dropped rows reports `warning`, styled as an error in the popup so it cannot be mistaken for a clean sync.

## A bug found while writing this

`computeWindow` first converted the stored `yyyy-MM-dd` history start date with `split("-").reverse().join("/")`. That silently *accepted* a `dd/MM/yyyy` string — no dashes means the split is a no-op — and reinterpreted it. Replaced with a strict `parseIsoDate`, which `dry-run.ts` also now uses instead of its own copy.

## Verification

- `make extension-test` — typecheck clean, 78 tests (up from 43).
- `make extension` — builds.
- `sync.test.ts` covers the requested-window period, the pinned source string, the single-row latest-transaction query, upload-despite-dropped-rows, refusal on empty, up-to-date, the first-run history-start path and its error, waiting through a RUNNING job, recording job errors, and that every outcome — including failures — reaches the run log with the window it was attempting.

Not verifiable here: the browser half. After loading unpacked, the sequence is connect, dry run over a window you know has trades, then Sync. The two checks that matter afterwards are running Sync twice and confirming the transaction count does not change, and confirming a previously Pending transaction moves to its completion date without duplicating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)