### PR TITLE
Name the knowledge-time columns for what they mean

### DIFF
--- a/client/app/admin/prices/page.tsx
+++ b/client/app/admin/prices/page.tsx
@@ -401,8 +401,8 @@ function PriceFetchBlocksTab() {
                       {block.reason}
                     </td>
                     <td className="py-2 pr-4 text-text-muted">
-                      {block.createdAt
-                        ? timestampDate(block.createdAt).toLocaleDateString()
+                      {block.firstBlockedAt
+                        ? timestampDate(block.firstBlockedAt).toLocaleDateString()
                         : ""}
                     </td>
                     <td className="py-2 text-right">

--- a/docs/spec/bitemporality.md
+++ b/docs/spec/bitemporality.md
@@ -161,7 +161,7 @@ The model above is normative. These parts of the system do not yet comply:
 
 | Divergence | Issue |
 | --- | --- |
-| The knowledge-time columns are still named `fetched_at` / `created_at`, and `share_count_basis` does not exist yet -- prices are adjusted against `last_fetched_at` and txs against `timestamp`, and `cash_dividends` and both fetch-block tables overwrite a timestamp they should preserve | in flight |
+| `share_count_basis` does not exist yet: prices are adjusted against `last_fetched_at` and txs against `timestamp`, so a source's denomination is assumed rather than declared | in flight |
 | Valuation pairs raw quantity with raw close while `TX_TYPE=SPLIT` rows are dropped at ingestion, so a forward split shows as a discontinuity | in flight |
 | No daily scheduler fires the blanket recompute, so a stored future-dated split never activates when its `ex_date` crosses | 0050 |
 | Corporate event export and import carry no knowledge time, so a re-import cannot reproduce the original adjustment state; `corporate_event_coverage` collapses every span's `last_fetched_at` on merge | 0051 |

--- a/docs/spec/corporate-events.md
+++ b/docs/spec/corporate-events.md
@@ -6,13 +6,13 @@ This document covers the design and operating model of the corporate event subsy
 
 Two event tables in PostgreSQL, both keyed by `(instrument_id, ex_date)`:
 
-- **`stock_splits`** — `split_from`, `split_to` (decimal NUMERIC), `data_provider`, `fetched_at`. The factor is `split_to / split_from`.
-- **`cash_dividends`** — `amount` (per share), `currency`, optional `pay_date` / `record_date` / `declaration_date`, optional `frequency`, `data_provider`, `fetched_at`.
+- **`stock_splits`** — `split_from`, `split_to` (decimal NUMERIC), `data_provider`, `first_known_at`. The factor is `split_to / split_from`.
+- **`cash_dividends`** — `amount` (per share), `currency`, optional `pay_date` / `record_date` / `declaration_date`, optional `frequency`, `data_provider`, `first_known_at`.
 
 Plus two auxiliary tables:
 
 - **`corporate_event_coverage`** — per `(instrument_id, plugin_id)`, the closed date intervals that have been queried successfully. Adjacent and overlapping intervals merge on insert. Coverage is the source of truth for "which date ranges have we already asked this plugin about" — see [Fetch model](#fetch-model) below.
-- **`corporate_event_fetch_blocks`** — `(instrument_id, plugin_id, reason)`. A plugin returning a permanent error (404, 403, subscription limit) for an instrument lands here so the fetcher does not retry indefinitely.
+- **`corporate_event_fetch_blocks`** — `(instrument_id, plugin_id, reason, first_blocked_at)`. A plugin returning a permanent error (404, 403, subscription limit) for an instrument lands here so the fetcher does not retry indefinitely.
 
 The `eod_prices` and `txs` tables also gain `split_adjusted_*` columns alongside the raw OHLCV / quantity / unit_price values, so both views are debuggable side by side. See [Adjustment](#adjustment) below.
 

--- a/docs/spec/prices.md
+++ b/docs/spec/prices.md
@@ -25,7 +25,7 @@ The price cache.
 | `adjusted_close` | `numeric` | The **provider's own** adjusted close (nullable) |
 | `volume` | `bigint` | Trading volume (nullable) |
 | `data_provider` | `text` NOT NULL | Which provider supplied this row |
-| `fetched_at` | `timestamptz` NOT NULL DEFAULT now() | When the row was last fetched |
+| `last_fetched_at` | `timestamptz` NOT NULL DEFAULT now() | When the row was last fetched. Staleness only; see [bitemporality.md](bitemporality.md#knowledge-time) |
 
 **Primary key:** `(instrument_id, price_date)`
 
@@ -37,7 +37,7 @@ The table carries three closing prices and they are not interchangeable:
 - `split_adjusted_close` is derived by PortfolioDB from `close` and the known stock splits, denominated in today's share count. This is the value performance math uses. See [corporate-events.md](corporate-events.md#adjustment).
 - `adjusted_close` is the provider's own adjusted figure, on the provider's basis and typically including dividend adjustment as well as splits. It is never an input to valuation -- it exists to cross-check the value PortfolioDB derives.
 
-Which share count `close` is denominated in is declared by its source, not inferred from `fetched_at`. See [bitemporality.md](bitemporality.md#share-count-basis).
+Which share count `close` is denominated in is declared by its source, not inferred from `last_fetched_at`. See [bitemporality.md](bitemporality.md#share-count-basis).
 
 ---
 

--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -603,7 +603,8 @@ message PriceFetchBlock {
   string instrument_id = 1;
   string plugin_id = 2;
   string reason = 3;
-  google.protobuf.Timestamp created_at = 4;
+  // Knowledge time: when the pair was first blocked. Never overwritten.
+  google.protobuf.Timestamp first_blocked_at = 4;
   string plugin_display_name = 5;
   string instrument_display_name = 6;
 }
@@ -636,15 +637,21 @@ message ListTelemetryCountersResponse {
 message EODPriceProto {
   string instrument_id = 1;
   string instrument_display_name = 2;
+  // Valid time: the trading date this bar describes.
   string price_date = 3;               // "YYYY-MM-DD"
   optional double open = 4;
   optional double high = 5;
   optional double low = 6;
   double close = 7;
+  // The provider's own adjusted close, on the provider's basis and typically
+  // including dividend adjustment. Never an input to valuation; see
+  // docs/spec/bitemporality.md.
   optional double adjusted_close = 8;
   optional int64 volume = 9;
   string data_provider = 10;
-  google.protobuf.Timestamp fetched_at = 11;
+  // Knowledge time: when this row was last fetched. Staleness only -- it says
+  // nothing about the prices themselves.
+  google.protobuf.Timestamp last_fetched_at = 11;
   bool synthetic = 12;
 }
 

--- a/server/corporateevents/option_splits.go
+++ b/server/corporateevents/option_splits.go
@@ -17,7 +17,7 @@ import (
 
 // ProcessOptionSplits adjusts options on the given underlying after new stock
 // splits land. For each option and each applicable split:
-//   - If identified_at >= split.fetched_at: skip (case 3 -- already correct)
+//   - If identified_at >= split.first_known_at: skip (case 3 -- already correct)
 //   - If factor is not a whole forward split: insert unhandled event, skip
 //   - Otherwise: update OCC identifier, update strike, insert derived split row
 //
@@ -68,7 +68,7 @@ func ProcessOptionSplits(ctx context.Context, database db.DB, underlyingID strin
 
 func processOneOptionSplit(ctx context.Context, database db.DB, opt *db.InstrumentRow, split db.StockSplit, factor float64, log *slog.Logger) {
 	// Case 3: identified after we knew about the split -- already correct.
-	if opt.IdentifiedAt != nil && !opt.IdentifiedAt.Before(split.FetchedAt) {
+	if opt.IdentifiedAt != nil && !opt.IdentifiedAt.Before(split.FirstKnownAt) {
 		return
 	}
 

--- a/server/corporateevents/option_splits_test.go
+++ b/server/corporateevents/option_splits_test.go
@@ -60,7 +60,7 @@ func TestProcessOptionSplits_TxBeforeSplit(t *testing.T) {
 		SplitFrom:    "1",
 		SplitTo:      "2",
 		DataProvider: "eodhd",
-		FetchedAt:    date(2025, 2, 1),
+		FirstKnownAt: date(2025, 2, 1),
 	}
 
 	mockDB.EXPECT().ListOptionsByUnderlying(gomock.Any(), underlyingID).Return([]*db.InstrumentRow{opt}, nil)
@@ -106,7 +106,7 @@ func TestProcessOptionSplits_SplitBeforeTx(t *testing.T) {
 		SplitFrom:    "1",
 		SplitTo:      "2",
 		DataProvider: "eodhd",
-		FetchedAt:    date(2025, 2, 1),
+		FirstKnownAt: date(2025, 2, 1),
 	}
 
 	mockDB.EXPECT().ListOptionsByUnderlying(gomock.Any(), underlyingID).Return([]*db.InstrumentRow{opt}, nil)
@@ -136,7 +136,7 @@ func TestProcessOptionSplits_FutureSplitSkipped(t *testing.T) {
 		SplitFrom:    "1",
 		SplitTo:      "4",
 		DataProvider: "eodhd",
-		FetchedAt:    date(2025, 1, 5),
+		FirstKnownAt: date(2025, 1, 5),
 	}
 
 	mockDB.EXPECT().ListOptionsByUnderlying(gomock.Any(), underlyingID).Return([]*db.InstrumentRow{opt}, nil)
@@ -164,7 +164,7 @@ func TestProcessOptionSplits_FutureThenAdvance(t *testing.T) {
 		SplitFrom:    "1",
 		SplitTo:      "4",
 		DataProvider: "eodhd",
-		FetchedAt:    date(2025, 1, 5),
+		FirstKnownAt: date(2025, 1, 5),
 	}
 
 	// First call: future-dated, skip. Second call: time advanced, apply.
@@ -215,7 +215,7 @@ func TestProcessOptionSplits_NonWholeForwardSplit(t *testing.T) {
 				SplitFrom:    tt.from,
 				SplitTo:      tt.to,
 				DataProvider: "eodhd",
-				FetchedAt:    date(2025, 2, 1),
+				FirstKnownAt: date(2025, 2, 1),
 			}
 
 			mockDB.EXPECT().ListOptionsByUnderlying(gomock.Any(), underlyingID).Return([]*db.InstrumentRow{opt}, nil)
@@ -261,7 +261,7 @@ func TestProcessOptionSplits_NoOCC(t *testing.T) {
 		SplitFrom:    "1",
 		SplitTo:      "2",
 		DataProvider: "eodhd",
-		FetchedAt:    date(2025, 2, 1),
+		FirstKnownAt: date(2025, 2, 1),
 	}
 
 	mockDB.EXPECT().ListOptionsByUnderlying(gomock.Any(), underlyingID).Return([]*db.InstrumentRow{opt}, nil)
@@ -297,7 +297,7 @@ func TestProcessOptionSplits_UnparseableOCC(t *testing.T) {
 		SplitFrom:    "1",
 		SplitTo:      "2",
 		DataProvider: "eodhd",
-		FetchedAt:    date(2025, 2, 1),
+		FirstKnownAt: date(2025, 2, 1),
 	}
 
 	mockDB.EXPECT().ListOptionsByUnderlying(gomock.Any(), underlyingID).Return([]*db.InstrumentRow{opt}, nil)
@@ -327,7 +327,7 @@ func TestProcessOptionSplits_NoOptions(t *testing.T) {
 		SplitFrom:    "1",
 		SplitTo:      "2",
 		DataProvider: "eodhd",
-		FetchedAt:    date(2025, 2, 1),
+		FirstKnownAt: date(2025, 2, 1),
 	}
 
 	mockDB.EXPECT().ListOptionsByUnderlying(gomock.Any(), underlyingID).Return(nil, nil)

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -83,16 +83,16 @@ type HeldRangesOpts struct {
 
 // EODPrice is a single end-of-day price row for UpsertPrices.
 type EODPrice struct {
-	InstrumentID string
-	PriceDate    time.Time
-	Open         *float64
-	High         *float64
-	Low          *float64
-	Close        float64
-	Volume       *int64
-	DataProvider string
-	Synthetic    bool       // true for forward-filled non-trading day prices
-	FetchedAt    *time.Time // when the price data was current; nil defaults to now()
+	InstrumentID  string
+	PriceDate     time.Time
+	Open          *float64
+	High          *float64
+	Low           *float64
+	Close         float64
+	Volume        *int64
+	DataProvider  string
+	Synthetic     bool       // true for forward-filled non-trading day prices
+	LastFetchedAt *time.Time // when this row was fetched; nil defaults to now()
 }
 
 // PriceCacheDB provides price cache management.
@@ -324,7 +324,8 @@ type PriceFetchBlock struct {
 	InstrumentID string
 	PluginID     string
 	Reason       string
-	CreatedAt    time.Time
+	// FirstBlockedAt is when the pair was first blocked. Never overwritten.
+	FirstBlockedAt time.Time
 }
 
 // EODPriceRow is a single end-of-day price row for the admin price list.
@@ -340,7 +341,7 @@ type EODPriceRow struct {
 	Volume                *int64
 	DataProvider          string
 	Synthetic             bool
-	FetchedAt             time.Time
+	LastFetchedAt         time.Time
 }
 
 // ExportPriceRow is a single price row with the best instrument identifier for export.
@@ -668,7 +669,8 @@ type StockSplit struct {
 	SplitFrom    string // numeric, e.g. "1"
 	SplitTo      string // numeric, e.g. "2"
 	DataProvider string
-	FetchedAt    time.Time
+	// FirstKnownAt is when we first learned of this split. Never overwritten.
+	FirstKnownAt time.Time
 }
 
 // CashDividend is a single cash dividend row. Amount is per share in Currency.
@@ -686,18 +688,19 @@ type CashDividend struct {
 	Frequency       string // empty when unknown
 	Type            string // "CD" or "SC"; empty = "CD"
 	DataProvider    string
-	FetchedAt       time.Time
+	// FirstKnownAt is when we first learned of this dividend. Never overwritten.
+	FirstKnownAt time.Time
 }
 
 // CorporateEventCoverage is one coverage interval for a (instrument, plugin).
 // Adjacent or overlapping intervals for the same (InstrumentID, PluginID) are
 // merged on insert by UpsertCorporateEventCoverage.
 type CorporateEventCoverage struct {
-	InstrumentID string
-	PluginID     string
-	CoveredFrom  time.Time
-	CoveredTo    time.Time
-	FetchedAt    time.Time
+	InstrumentID  string
+	PluginID      string
+	CoveredFrom   time.Time
+	CoveredTo     time.Time
+	LastFetchedAt time.Time
 }
 
 // CorporateEventFetchBlock records a permanently blocked (instrument, plugin)
@@ -706,7 +709,8 @@ type CorporateEventFetchBlock struct {
 	InstrumentID string
 	PluginID     string
 	Reason       string
-	CreatedAt    time.Time
+	// FirstBlockedAt is when the pair was first blocked. Never overwritten.
+	FirstBlockedAt time.Time
 }
 
 // UnhandledCorporateEvent is a corporate event that cannot be automatically

--- a/server/db/postgres/corporate_events.go
+++ b/server/db/postgres/corporate_events.go
@@ -31,7 +31,7 @@ func (p *Postgres) UpsertStockSplits(ctx context.Context, splits []db.StockSplit
 		providers[i] = s.DataProvider
 	}
 	_, err := p.q.ExecContext(ctx, `
-		INSERT INTO stock_splits (instrument_id, ex_date, split_from, split_to, data_provider, fetched_at)
+		INSERT INTO stock_splits (instrument_id, ex_date, split_from, split_to, data_provider, first_known_at)
 		SELECT unnest($1::uuid[]), unnest($2::date[]),
 			unnest($3::numeric[]), unnest($4::numeric[]),
 			unnest($5::text[]), now()
@@ -53,7 +53,7 @@ func (p *Postgres) ListStockSplits(ctx context.Context, instrumentID string) ([]
 		return nil, fmt.Errorf("list stock splits: invalid instrument id %q: %w", instrumentID, err)
 	}
 	rows, err := p.q.QueryContext(ctx, `
-		SELECT instrument_id, ex_date, split_from::text, split_to::text, data_provider, fetched_at
+		SELECT instrument_id, ex_date, split_from::text, split_to::text, data_provider, first_known_at
 		FROM stock_splits
 		WHERE instrument_id = $1
 		ORDER BY ex_date
@@ -66,7 +66,7 @@ func (p *Postgres) ListStockSplits(ctx context.Context, instrumentID string) ([]
 	for rows.Next() {
 		var s db.StockSplit
 		var instUUID uuid.UUID
-		if err := rows.Scan(&instUUID, &s.ExDate, &s.SplitFrom, &s.SplitTo, &s.DataProvider, &s.FetchedAt); err != nil {
+		if err := rows.Scan(&instUUID, &s.ExDate, &s.SplitFrom, &s.SplitTo, &s.DataProvider, &s.FirstKnownAt); err != nil {
 			return nil, fmt.Errorf("list stock splits scan: %w", err)
 		}
 		s.InstrumentID = instUUID.String()
@@ -121,7 +121,7 @@ func (p *Postgres) UpsertCashDividends(ctx context.Context, dividends []db.CashD
 	_, err := p.q.ExecContext(ctx, `
 		INSERT INTO cash_dividends (
 			instrument_id, ex_date, pay_date, record_date, declaration_date,
-			amount, currency, frequency, type, data_provider, fetched_at
+			amount, currency, frequency, type, data_provider, first_known_at
 		)
 		SELECT unnest($1::uuid[]), unnest($2::date[]),
 			unnest($3::date[]), unnest($4::date[]), unnest($5::date[]),
@@ -135,8 +135,7 @@ func (p *Postgres) UpsertCashDividends(ctx context.Context, dividends []db.CashD
 			currency         = EXCLUDED.currency,
 			frequency        = EXCLUDED.frequency,
 			type             = EXCLUDED.type,
-			data_provider    = EXCLUDED.data_provider,
-			fetched_at       = EXCLUDED.fetched_at
+			data_provider    = EXCLUDED.data_provider
 	`, pq.Array(instIDs), pq.Array(exDates),
 		pq.Array(payDates), pq.Array(recordDates), pq.Array(declDates),
 		pq.Array(amounts), pq.Array(currencies), pq.Array(frequencies),
@@ -155,7 +154,7 @@ func (p *Postgres) ListCashDividends(ctx context.Context, instrumentID string) (
 	}
 	rows, err := p.q.QueryContext(ctx, `
 		SELECT instrument_id, ex_date, pay_date, record_date, declaration_date,
-			amount::text, currency, frequency, type, data_provider, fetched_at
+			amount::text, currency, frequency, type, data_provider, first_known_at
 		FROM cash_dividends
 		WHERE instrument_id = $1
 		ORDER BY ex_date
@@ -171,7 +170,7 @@ func (p *Postgres) ListCashDividends(ctx context.Context, instrumentID string) (
 		var pay, record, decl sql.NullTime
 		var freq sql.NullString
 		if err := rows.Scan(&instUUID, &d.ExDate, &pay, &record, &decl,
-			&d.Amount, &d.Currency, &freq, &d.Type, &d.DataProvider, &d.FetchedAt); err != nil {
+			&d.Amount, &d.Currency, &freq, &d.Type, &d.DataProvider, &d.FirstKnownAt); err != nil {
 			return nil, fmt.Errorf("list cash dividends scan: %w", err)
 		}
 		d.InstrumentID = instUUID.String()
@@ -251,7 +250,7 @@ func (p *Postgres) UpsertCorporateEventCoverage(ctx context.Context, instrumentI
 			return fmt.Errorf("upsert corporate event coverage: delete overlapping: %w", err)
 		}
 		if _, err := exec.ExecContext(ctx, `
-			INSERT INTO corporate_event_coverage (instrument_id, plugin_id, covered_from, covered_to, fetched_at)
+			INSERT INTO corporate_event_coverage (instrument_id, plugin_id, covered_from, covered_to, last_fetched_at)
 			VALUES ($1, $2, $3, $4, now())
 		`, id, pluginID, newFrom, newTo); err != nil {
 			return fmt.Errorf("upsert corporate event coverage: insert merged: %w", err)
@@ -268,7 +267,7 @@ func (p *Postgres) ListCorporateEventCoverage(ctx context.Context, instrumentIDs
 	)
 	if len(instrumentIDs) == 0 {
 		rows, err = p.q.QueryContext(ctx, `
-			SELECT instrument_id, plugin_id, covered_from, covered_to, fetched_at
+			SELECT instrument_id, plugin_id, covered_from, covered_to, last_fetched_at
 			FROM corporate_event_coverage
 			ORDER BY instrument_id, plugin_id, covered_from
 		`)
@@ -282,7 +281,7 @@ func (p *Postgres) ListCorporateEventCoverage(ctx context.Context, instrumentIDs
 			uuids = append(uuids, u)
 		}
 		rows, err = p.q.QueryContext(ctx, `
-			SELECT instrument_id, plugin_id, covered_from, covered_to, fetched_at
+			SELECT instrument_id, plugin_id, covered_from, covered_to, last_fetched_at
 			FROM corporate_event_coverage
 			WHERE instrument_id = ANY($1::uuid[])
 			ORDER BY instrument_id, plugin_id, covered_from
@@ -296,7 +295,7 @@ func (p *Postgres) ListCorporateEventCoverage(ctx context.Context, instrumentIDs
 	for rows.Next() {
 		var c db.CorporateEventCoverage
 		var instUUID uuid.UUID
-		if err := rows.Scan(&instUUID, &c.PluginID, &c.CoveredFrom, &c.CoveredTo, &c.FetchedAt); err != nil {
+		if err := rows.Scan(&instUUID, &c.PluginID, &c.CoveredFrom, &c.CoveredTo, &c.LastFetchedAt); err != nil {
 			return nil, fmt.Errorf("list corporate event coverage scan: %w", err)
 		}
 		c.InstrumentID = instUUID.String()
@@ -311,7 +310,7 @@ func (p *Postgres) CreateCorporateEventFetchBlock(ctx context.Context, instrumen
 		INSERT INTO corporate_event_fetch_blocks (instrument_id, plugin_id, reason)
 		VALUES ($1, $2, $3)
 		ON CONFLICT (instrument_id, plugin_id)
-		DO UPDATE SET reason = EXCLUDED.reason, created_at = now()
+		DO UPDATE SET reason = EXCLUDED.reason
 	`, instrumentID, pluginID, reason)
 	if err != nil {
 		return fmt.Errorf("create corporate event fetch block: %w", err)
@@ -333,8 +332,8 @@ func (p *Postgres) DeleteCorporateEventFetchBlock(ctx context.Context, instrumen
 // ListCorporateEventFetchBlocks implements db.CorporateEventDB.
 func (p *Postgres) ListCorporateEventFetchBlocks(ctx context.Context) ([]db.CorporateEventFetchBlock, error) {
 	rows, err := p.q.QueryContext(ctx, `
-		SELECT instrument_id, plugin_id, reason, created_at
-		FROM corporate_event_fetch_blocks ORDER BY created_at DESC
+		SELECT instrument_id, plugin_id, reason, first_blocked_at
+		FROM corporate_event_fetch_blocks ORDER BY first_blocked_at DESC
 	`)
 	if err != nil {
 		return nil, fmt.Errorf("list corporate event fetch blocks: %w", err)
@@ -343,7 +342,7 @@ func (p *Postgres) ListCorporateEventFetchBlocks(ctx context.Context) ([]db.Corp
 	var out []db.CorporateEventFetchBlock
 	for rows.Next() {
 		var b db.CorporateEventFetchBlock
-		if err := rows.Scan(&b.InstrumentID, &b.PluginID, &b.Reason, &b.CreatedAt); err != nil {
+		if err := rows.Scan(&b.InstrumentID, &b.PluginID, &b.Reason, &b.FirstBlockedAt); err != nil {
 			return nil, err
 		}
 		out = append(out, b)
@@ -477,7 +476,7 @@ func (p *Postgres) HeldEventBearingInstruments(ctx context.Context) ([]db.HeldIn
 // SplitsByUnderlyingTicker implements db.CorporateEventDB.
 func (p *Postgres) SplitsByUnderlyingTicker(ctx context.Context, ticker string) ([]db.StockSplit, error) {
 	rows, err := p.q.QueryContext(ctx, `
-		SELECT ss.instrument_id, ss.ex_date, ss.split_from, ss.split_to, ss.data_provider, ss.fetched_at
+		SELECT ss.instrument_id, ss.ex_date, ss.split_from, ss.split_to, ss.data_provider, ss.first_known_at
 		FROM stock_splits ss
 		JOIN instrument_identifiers ii ON ii.instrument_id = ss.instrument_id
 		WHERE ii.identifier_type = 'MIC_TICKER' AND ii.value = $1
@@ -491,7 +490,7 @@ func (p *Postgres) SplitsByUnderlyingTicker(ctx context.Context, ticker string) 
 	for rows.Next() {
 		var s db.StockSplit
 		var instUUID uuid.UUID
-		if err := rows.Scan(&instUUID, &s.ExDate, &s.SplitFrom, &s.SplitTo, &s.DataProvider, &s.FetchedAt); err != nil {
+		if err := rows.Scan(&instUUID, &s.ExDate, &s.SplitFrom, &s.SplitTo, &s.DataProvider, &s.FirstKnownAt); err != nil {
 			return nil, fmt.Errorf("splits by underlying ticker scan: %w", err)
 		}
 		s.InstrumentID = instUUID.String()
@@ -601,7 +600,7 @@ func (p *Postgres) ApplyOptionSplit(ctx context.Context, params db.OptionSplitPa
 // RecomputeSplitAdjustments implements db.CorporateEventDB. Two UPDATEs (one
 // for eod_prices, one for txs) recompute the split_adjusted_* columns from raw
 // values multiplied by the cumulative split factor for splits with ex_date
-// strictly after the row's reference date (fetched_at::date for prices,
+// strictly after the row's reference date (last_fetched_at::date for prices,
 // timestamp::date for txs). Idempotent: factor is recomputed from scratch
 // each call. When instrumentID is empty, every instrument with at least one
 // stock_splits row is recomputed in the same transaction.
@@ -637,13 +636,13 @@ func (p *Postgres) RecomputeSplitAdjustments(ctx context.Context, instrumentID s
 				split_adjusted_volume  = CASE WHEN ep.volume IS NULL THEN NULL
 					ELSE round(ep.volume::numeric * f.factor::numeric)::bigint END
 			FROM (
-				SELECT instrument_id, fetched_at,
-					split_factor_at(instrument_id, fetched_at::date) AS factor
+				SELECT instrument_id, last_fetched_at,
+					split_factor_at(instrument_id, last_fetched_at::date) AS factor
 				FROM eod_prices
 				WHERE instrument_id %s
 			) f
 			WHERE ep.instrument_id = f.instrument_id
-			  AND ep.fetched_at = f.fetched_at
+			  AND ep.last_fetched_at = f.last_fetched_at
 		`, instFilter)
 		if _, err := exec.ExecContext(ctx, priceSQL, args...); err != nil {
 			return fmt.Errorf("recompute split adjustments (prices): %w", err)

--- a/server/db/postgres/corporate_events_test.go
+++ b/server/db/postgres/corporate_events_test.go
@@ -271,7 +271,7 @@ func TestCorporateEventFetchBlocks(t *testing.T) {
 
 // TestRecomputeSplitAdjustments_Prices verifies that a sequence of splits
 // (forward + reverse) is applied correctly to historical price rows whose
-// fetched_at predates the split ex_date.
+// last_fetched_at predates the split ex_date.
 func TestRecomputeSplitAdjustments_Prices(t *testing.T) {
 	p := testDBTx(t)
 	ctx := context.Background()
@@ -279,11 +279,11 @@ func TestRecomputeSplitAdjustments_Prices(t *testing.T) {
 
 	// Insert prices fetched in 2010 (before any splits).
 	insertPriceFull(t, p, instID, d(2005, 1, 3), 80, 82, 79, 81, 1_000_000, "test")
-	// Backdate fetched_at to 2010-01-01 so future-dated splits apply.
+	// Backdate last_fetched_at to 2010-01-01 so future-dated splits apply.
 	if _, err := p.q.ExecContext(ctx, `
-		UPDATE eod_prices SET fetched_at = $1 WHERE instrument_id = $2::uuid
+		UPDATE eod_prices SET last_fetched_at = $1 WHERE instrument_id = $2::uuid
 	`, d(2010, 1, 1), instID); err != nil {
-		t.Fatalf("backdate fetched_at: %v", err)
+		t.Fatalf("backdate last_fetched_at: %v", err)
 	}
 
 	// Two forward splits and one reverse split.
@@ -419,14 +419,14 @@ func TestRecomputeSplitAdjustments_FutureSplitNotApplied(t *testing.T) {
 	instID := setupInstrument(t, p, "AAPL")
 
 	insertPriceFull(t, p, instID, d(2024, 1, 15), 180, 182, 178, 181, 1000, "test")
-	// Backdate fetched_at to 2024-01-15 so the recompute considers the
+	// Backdate last_fetched_at to 2024-01-15 so the recompute considers the
 	// past split (whose ex_date is later in 2024) as "after fetch" and
-	// applies it. Without backdating, the price's fetched_at would be
+	// applies it. Without backdating, the price's last_fetched_at would be
 	// today and the 2024 past split would be excluded as "before fetch".
 	if _, err := p.q.ExecContext(ctx, `
-		UPDATE eod_prices SET fetched_at = $1 WHERE instrument_id = $2::uuid
+		UPDATE eod_prices SET last_fetched_at = $1 WHERE instrument_id = $2::uuid
 	`, d(2024, 1, 15), instID); err != nil {
-		t.Fatalf("backdate fetched_at: %v", err)
+		t.Fatalf("backdate last_fetched_at: %v", err)
 	}
 
 	// Insert a split with ex_date in the future. The key assertion is
@@ -456,7 +456,7 @@ func TestRecomputeSplitAdjustments_FutureSplitNotApplied(t *testing.T) {
 	}
 
 	// Sanity check: a second split with ex_date in the past (and after
-	// fetched_at) IS applied. This proves the recompute is functional and
+	// last_fetched_at) IS applied. This proves the recompute is functional and
 	// the previous result is specifically because of the future guard,
 	// not because the recompute is silently broken.
 	if err := p.UpsertStockSplits(ctx, []db.StockSplit{
@@ -876,7 +876,7 @@ func TestUpsertCashDividends_PreservesKnowledgeTime(t *testing.T) {
 	}
 
 	past := backdate(t, p,
-		`UPDATE cash_dividends SET fetched_at = $1 WHERE instrument_id = $2`, instID)
+		`UPDATE cash_dividends SET first_known_at = $1 WHERE instrument_id = $2`, instID)
 
 	// The provider revises the amount. When we first learned of the dividend
 	// does not change just because its amount did.
@@ -896,8 +896,8 @@ func TestUpsertCashDividends_PreservesKnowledgeTime(t *testing.T) {
 	if got[0].Amount != "0.25" {
 		t.Errorf("amount not revised: %q", got[0].Amount)
 	}
-	if !got[0].FetchedAt.Equal(past) {
-		t.Errorf("knowledge time moved on revision: want %s, got %s", past, got[0].FetchedAt)
+	if !got[0].FirstKnownAt.Equal(past) {
+		t.Errorf("knowledge time moved on revision: want %s, got %s", past, got[0].FirstKnownAt)
 	}
 }
 
@@ -910,7 +910,7 @@ func TestCreateCorporateEventFetchBlock_PreservesFirstBlockedAt(t *testing.T) {
 		t.Fatalf("create: %v", err)
 	}
 	past := backdate(t, p,
-		`UPDATE corporate_event_fetch_blocks SET created_at = $1 WHERE instrument_id = $2`, instID)
+		`UPDATE corporate_event_fetch_blocks SET first_blocked_at = $1 WHERE instrument_id = $2`, instID)
 
 	// Blocking again records a newer reason, not a newer first-blocked-at.
 	if err := p.CreateCorporateEventFetchBlock(ctx, instID, "massive", "subscription limit"); err != nil {
@@ -927,7 +927,7 @@ func TestCreateCorporateEventFetchBlock_PreservesFirstBlockedAt(t *testing.T) {
 	if blocks[0].Reason != "subscription limit" {
 		t.Errorf("reason not updated: %q", blocks[0].Reason)
 	}
-	if !blocks[0].CreatedAt.Equal(past) {
-		t.Errorf("first blocked at moved on re-block: want %s, got %s", past, blocks[0].CreatedAt)
+	if !blocks[0].FirstBlockedAt.Equal(past) {
+		t.Errorf("first blocked at moved on re-block: want %s, got %s", past, blocks[0].FirstBlockedAt)
 	}
 }

--- a/server/db/postgres/corporate_events_test.go
+++ b/server/db/postgres/corporate_events_test.go
@@ -847,3 +847,87 @@ func TestInsertUnhandledCorporateEvent_Dedup(t *testing.T) {
 	}
 }
 
+
+// backdate rewrites a knowledge timestamp to a fixed past value so that a
+// subsequent write either preserves it or is caught clobbering it. Tests run
+// inside one transaction, where now() is frozen at transaction start, so
+// comparing two now() values would never detect a clobber.
+func backdate(t *testing.T, p *Postgres, query string, args ...any) time.Time {
+	t.Helper()
+	past := time.Date(2020, time.March, 1, 12, 0, 0, 0, time.UTC)
+	args = append([]any{past}, args...)
+	if _, err := p.q.ExecContext(context.Background(), query, args...); err != nil {
+		t.Fatalf("backdate: %v", err)
+	}
+	return past
+}
+
+func TestUpsertCashDividends_PreservesKnowledgeTime(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	instID := setupInstrument(t, p, "AAPL")
+
+	div := db.CashDividend{
+		InstrumentID: instID, ExDate: d(2024, 2, 9),
+		Amount: "0.24", Currency: "USD", DataProvider: "massive",
+	}
+	if err := p.UpsertCashDividends(ctx, []db.CashDividend{div}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	past := backdate(t, p,
+		`UPDATE cash_dividends SET fetched_at = $1 WHERE instrument_id = $2`, instID)
+
+	// The provider revises the amount. When we first learned of the dividend
+	// does not change just because its amount did.
+	div.Amount = "0.25"
+	div.DataProvider = "eodhd"
+	if err := p.UpsertCashDividends(ctx, []db.CashDividend{div}); err != nil {
+		t.Fatalf("re-upsert: %v", err)
+	}
+
+	got, err := p.ListCashDividends(ctx, instID)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 dividend, got %d", len(got))
+	}
+	if got[0].Amount != "0.25" {
+		t.Errorf("amount not revised: %q", got[0].Amount)
+	}
+	if !got[0].FetchedAt.Equal(past) {
+		t.Errorf("knowledge time moved on revision: want %s, got %s", past, got[0].FetchedAt)
+	}
+}
+
+func TestCreateCorporateEventFetchBlock_PreservesFirstBlockedAt(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	instID := setupInstrument(t, p, "AAPL")
+
+	if err := p.CreateCorporateEventFetchBlock(ctx, instID, "massive", "404"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	past := backdate(t, p,
+		`UPDATE corporate_event_fetch_blocks SET created_at = $1 WHERE instrument_id = $2`, instID)
+
+	// Blocking again records a newer reason, not a newer first-blocked-at.
+	if err := p.CreateCorporateEventFetchBlock(ctx, instID, "massive", "subscription limit"); err != nil {
+		t.Fatalf("re-create: %v", err)
+	}
+
+	blocks, err := p.ListCorporateEventFetchBlocks(ctx)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(blocks))
+	}
+	if blocks[0].Reason != "subscription limit" {
+		t.Errorf("reason not updated: %q", blocks[0].Reason)
+	}
+	if !blocks[0].CreatedAt.Equal(past) {
+		t.Errorf("first blocked at moved on re-block: want %s, got %s", past, blocks[0].CreatedAt)
+	}
+}

--- a/server/db/postgres/eod_prices.go
+++ b/server/db/postgres/eod_prices.go
@@ -49,7 +49,7 @@ func (p *Postgres) ListPrices(ctx context.Context, search string, dateFrom, date
 	q, args, err := psql.Select(
 		"ep.instrument_id", "i.name AS display_name",
 		"ep.price_date", "ep.open", "ep.high", "ep.low", "ep.close", "ep.adjusted_close",
-		"ep.volume", "ep.data_provider", "ep.synthetic", "ep.fetched_at",
+		"ep.volume", "ep.data_provider", "ep.synthetic", "ep.last_fetched_at",
 	).
 		From("eod_prices ep").
 		Join("instruments i ON i.id = ep.instrument_id").
@@ -75,7 +75,7 @@ func (p *Postgres) ListPrices(ctx context.Context, search string, dateFrom, date
 		if err := rows.Scan(
 			&r.InstrumentID, &r.InstrumentDisplayName,
 			&r.PriceDate, &open, &high, &low, &r.Close, &adjClose,
-			&volume, &r.DataProvider, &r.Synthetic, &r.FetchedAt,
+			&volume, &r.DataProvider, &r.Synthetic, &r.LastFetchedAt,
 		); err != nil {
 			return nil, 0, "", err
 		}

--- a/server/db/postgres/inflation.go
+++ b/server/db/postgres/inflation.go
@@ -37,7 +37,7 @@ func (p *Postgres) UpsertInflationIndices(ctx context.Context, indices []db.Infl
 	}
 
 	var b strings.Builder
-	b.WriteString(`INSERT INTO inflation_indices (currency, month, index_value, base_year, data_provider, fetched_at)
+	b.WriteString(`INSERT INTO inflation_indices (currency, month, index_value, base_year, data_provider, last_fetched_at)
 		VALUES `)
 	args := make([]interface{}, 0, len(indices)*5)
 	for i, idx := range indices {
@@ -52,7 +52,7 @@ func (p *Postgres) UpsertInflationIndices(ctx context.Context, indices []db.Infl
 		index_value = EXCLUDED.index_value,
 		base_year = EXCLUDED.base_year,
 		data_provider = EXCLUDED.data_provider,
-		fetched_at = now()`)
+		last_fetched_at = now()`)
 
 	if _, err := p.q.ExecContext(ctx, b.String(), args...); err != nil {
 		return fmt.Errorf("upsert inflation indices: %w", err)

--- a/server/db/postgres/price_cache.go
+++ b/server/db/postgres/price_cache.go
@@ -427,15 +427,15 @@ func (p *Postgres) UpsertPrices(ctx context.Context, prices []db.EODPrice) error
 		volumes[i] = pr.Volume
 		providers[i] = pr.DataProvider
 		synthetics[i] = pr.Synthetic
-		if pr.FetchedAt != nil {
-			fetchedAts[i] = *pr.FetchedAt
+		if pr.LastFetchedAt != nil {
+			fetchedAts[i] = *pr.LastFetchedAt
 		} else {
 			fetchedAts[i] = now
 		}
 	}
 
 	_, err := p.q.ExecContext(ctx, `
-		INSERT INTO eod_prices (instrument_id, price_date, open, high, low, close, volume, data_provider, synthetic, fetched_at)
+		INSERT INTO eod_prices (instrument_id, price_date, open, high, low, close, volume, data_provider, synthetic, last_fetched_at)
 		SELECT unnest($1::uuid[]), unnest($2::date[]), unnest($3::double precision[]),
 			unnest($4::double precision[]), unnest($5::double precision[]),
 			unnest($6::double precision[]), unnest($7::bigint[]),
@@ -449,7 +449,7 @@ func (p *Postgres) UpsertPrices(ctx context.Context, prices []db.EODPrice) error
 			volume = EXCLUDED.volume,
 			data_provider = EXCLUDED.data_provider,
 			synthetic = EXCLUDED.synthetic,
-			fetched_at = EXCLUDED.fetched_at
+			last_fetched_at = EXCLUDED.last_fetched_at
 		WHERE eod_prices.synthetic = true OR EXCLUDED.synthetic = false
 	`, pq.Array(instIDs), pq.Array(dates), pq.Array(opens),
 		pq.Array(highs), pq.Array(lows), pq.Array(closes),
@@ -547,7 +547,7 @@ func (p *Postgres) UpsertPricesWithFill(ctx context.Context, instrumentID, provi
 				(bclose IS NULL) AS synthetic
 			FROM grouped
 		)
-		INSERT INTO eod_prices (instrument_id, price_date, open, high, low, close, volume, data_provider, synthetic, fetched_at)
+		INSERT INTO eod_prices (instrument_id, price_date, open, high, low, close, volume, data_provider, synthetic, last_fetched_at)
 		SELECT $1::uuid, price_date, open, high, low, close, volume, $10::text, synthetic, $11::timestamptz
 		FROM locf
 		WHERE price_date >= $2::date AND close IS NOT NULL
@@ -555,7 +555,7 @@ func (p *Postgres) UpsertPricesWithFill(ctx context.Context, instrumentID, provi
 			open = EXCLUDED.open, high = EXCLUDED.high, low = EXCLUDED.low,
 			close = EXCLUDED.close, volume = EXCLUDED.volume,
 			data_provider = EXCLUDED.data_provider, synthetic = EXCLUDED.synthetic,
-			fetched_at = EXCLUDED.fetched_at
+			last_fetched_at = EXCLUDED.last_fetched_at
 		WHERE eod_prices.synthetic = true OR EXCLUDED.synthetic = false
 	`, id, from, to, pq.Array(dates), pq.Array(opens), pq.Array(highs),
 		pq.Array(lows), pq.Array(closes), pq.Array(volumes), provider, fetchedAt)

--- a/server/db/postgres/price_fetch_blocks.go
+++ b/server/db/postgres/price_fetch_blocks.go
@@ -11,8 +11,8 @@ import (
 // ListPriceFetchBlocks implements db.PriceFetchBlockDB.
 func (p *Postgres) ListPriceFetchBlocks(ctx context.Context) ([]db.PriceFetchBlock, error) {
 	rows, err := p.q.QueryContext(ctx, `
-		SELECT instrument_id, plugin_id, reason, created_at
-		FROM price_fetch_blocks ORDER BY created_at DESC
+		SELECT instrument_id, plugin_id, reason, first_blocked_at
+		FROM price_fetch_blocks ORDER BY first_blocked_at DESC
 	`)
 	if err != nil {
 		return nil, fmt.Errorf("list price fetch blocks: %w", err)
@@ -21,7 +21,7 @@ func (p *Postgres) ListPriceFetchBlocks(ctx context.Context) ([]db.PriceFetchBlo
 	var out []db.PriceFetchBlock
 	for rows.Next() {
 		var b db.PriceFetchBlock
-		if err := rows.Scan(&b.InstrumentID, &b.PluginID, &b.Reason, &b.CreatedAt); err != nil {
+		if err := rows.Scan(&b.InstrumentID, &b.PluginID, &b.Reason, &b.FirstBlockedAt); err != nil {
 			return nil, err
 		}
 		out = append(out, b)
@@ -62,7 +62,7 @@ func (p *Postgres) CreatePriceFetchBlock(ctx context.Context, instrumentID, plug
 		INSERT INTO price_fetch_blocks (instrument_id, plugin_id, reason)
 		VALUES ($1, $2, $3)
 		ON CONFLICT (instrument_id, plugin_id)
-		DO UPDATE SET reason = EXCLUDED.reason, created_at = now()
+		DO UPDATE SET reason = EXCLUDED.reason
 	`, instrumentID, pluginID, reason)
 	if err != nil {
 		return fmt.Errorf("create price fetch block: %w", err)

--- a/server/db/postgres/price_fetch_blocks_test.go
+++ b/server/db/postgres/price_fetch_blocks_test.go
@@ -14,7 +14,7 @@ func TestCreatePriceFetchBlock_PreservesFirstBlockedAt(t *testing.T) {
 		t.Fatalf("create: %v", err)
 	}
 	past := backdate(t, p,
-		`UPDATE price_fetch_blocks SET created_at = $1 WHERE instrument_id = $2`, instID)
+		`UPDATE price_fetch_blocks SET first_blocked_at = $1 WHERE instrument_id = $2`, instID)
 
 	// Blocking again records a newer reason, not a newer first-blocked-at.
 	if err := p.CreatePriceFetchBlock(ctx, instID, "massive", "subscription limit"); err != nil {
@@ -31,7 +31,7 @@ func TestCreatePriceFetchBlock_PreservesFirstBlockedAt(t *testing.T) {
 	if blocks[0].Reason != "subscription limit" {
 		t.Errorf("reason not updated: %q", blocks[0].Reason)
 	}
-	if !blocks[0].CreatedAt.Equal(past) {
-		t.Errorf("first blocked at moved on re-block: want %s, got %s", past, blocks[0].CreatedAt)
+	if !blocks[0].FirstBlockedAt.Equal(past) {
+		t.Errorf("first blocked at moved on re-block: want %s, got %s", past, blocks[0].FirstBlockedAt)
 	}
 }

--- a/server/db/postgres/price_fetch_blocks_test.go
+++ b/server/db/postgres/price_fetch_blocks_test.go
@@ -1,0 +1,37 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+)
+
+func TestCreatePriceFetchBlock_PreservesFirstBlockedAt(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	instID := setupInstrument(t, p, "AAPL")
+
+	if err := p.CreatePriceFetchBlock(ctx, instID, "massive", "404"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	past := backdate(t, p,
+		`UPDATE price_fetch_blocks SET created_at = $1 WHERE instrument_id = $2`, instID)
+
+	// Blocking again records a newer reason, not a newer first-blocked-at.
+	if err := p.CreatePriceFetchBlock(ctx, instID, "massive", "subscription limit"); err != nil {
+		t.Fatalf("re-create: %v", err)
+	}
+
+	blocks, err := p.ListPriceFetchBlocks(ctx)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(blocks))
+	}
+	if blocks[0].Reason != "subscription limit" {
+		t.Errorf("reason not updated: %q", blocks[0].Reason)
+	}
+	if !blocks[0].CreatedAt.Equal(past) {
+		t.Errorf("first blocked at moved on re-block: want %s, got %s", past, blocks[0].CreatedAt)
+	}
+}

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -136,7 +136,7 @@ CREATE TABLE instruments (
   -- Deliverable multiplier: 1 = standard (100 shares/contract). Non-standard
   -- splits (e.g. 3:2) may set this to 1.5 meaning 150 shares/contract.
   contract_multiplier NUMERIC NOT NULL DEFAULT 1,
-  -- Updated on every EnsureInstrument call. Compared to stock_splits.fetched_at
+  -- Updated on every EnsureInstrument call. Compared to stock_splits.first_known_at
   -- to determine if retroactive option split adjustment is needed.
   identified_at TIMESTAMPTZ,
   created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
@@ -259,11 +259,13 @@ CREATE TABLE plugin_config (
 );
 
 -- Blocked (instrument, plugin) pairs that should not be retried.
+-- first_blocked_at is when the pair was first blocked and is never overwritten;
+-- re-blocking updates only the reason. See docs/spec/bitemporality.md.
 CREATE TABLE price_fetch_blocks (
-  instrument_id UUID NOT NULL REFERENCES instruments(id) ON DELETE CASCADE,
-  plugin_id     TEXT NOT NULL,
-  reason        TEXT NOT NULL,
-  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  instrument_id   UUID NOT NULL REFERENCES instruments(id) ON DELETE CASCADE,
+  plugin_id       TEXT NOT NULL,
+  reason          TEXT NOT NULL,
+  first_blocked_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   PRIMARY KEY (instrument_id, plugin_id)
 );
 
@@ -276,7 +278,9 @@ CREATE TABLE inflation_indices (
   index_value   NUMERIC     NOT NULL,              -- relative to base_year July=100
   base_year     INT         NOT NULL,              -- year where July = 100
   data_provider TEXT        NOT NULL,              -- plugin ID
-  fetched_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  -- Staleness only: overwritten on every refresh. A revised index value
+  -- replaces the previous one and the prior vintage is not retained.
+  last_fetched_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   PRIMARY KEY (currency, month)
 );
 
@@ -323,7 +327,7 @@ WHERE
 -- days (weekends, holidays). They are generated at write time by the price
 -- fetcher worker so that the valuation query can use a simple join.
 -- The split_adjusted_* columns hold OHLCV after applying every stock split with
--- ex_date > fetched_at::date for this instrument. They equal the raw values when
+-- ex_date > last_fetched_at::date for this instrument. They equal the raw values when
 -- no later split exists. close (NOT NULL) implies split_adjusted_close (NOT NULL);
 -- the others are NULL iff their raw counterpart is NULL. Volume is adjusted in
 -- the opposite direction (more shares trade in adjusted-share terms).
@@ -346,7 +350,9 @@ CREATE TABLE eod_prices (
   split_adjusted_volume  BIGINT,
   data_provider          TEXT        NOT NULL,
   synthetic              BOOLEAN     NOT NULL DEFAULT false,
-  fetched_at             TIMESTAMPTZ NOT NULL DEFAULT now(),
+  -- Staleness only: when this row was last fetched. It carries no meaning about
+  -- the prices themselves. See docs/spec/bitemporality.md.
+  last_fetched_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
   PRIMARY KEY (instrument_id, price_date)
 );
 
@@ -363,7 +369,10 @@ CREATE TABLE stock_splits (
   split_from     NUMERIC     NOT NULL CHECK (split_from > 0),
   split_to       NUMERIC     NOT NULL CHECK (split_to   > 0),
   data_provider  TEXT        NOT NULL,
-  fetched_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  -- When we first learned of this split. Never overwritten, including when the
+  -- ratio is revised: it is compared against instruments.identified_at to decide
+  -- whether an option still needs retroactive adjustment.
+  first_known_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   PRIMARY KEY (instrument_id, ex_date)
 );
 
@@ -383,7 +392,9 @@ CREATE TABLE cash_dividends (
   frequency        TEXT,
   type             TEXT        NOT NULL DEFAULT 'CD',
   data_provider    TEXT        NOT NULL,
-  fetched_at       TIMESTAMPTZ NOT NULL DEFAULT now(),
+  -- When we first learned of this dividend. Never overwritten, including when
+  -- the amount is revised.
+  first_known_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
   PRIMARY KEY (instrument_id, ex_date)
 );
 
@@ -401,7 +412,9 @@ CREATE TABLE corporate_event_coverage (
   plugin_id      TEXT        NOT NULL,
   covered_from   DATE        NOT NULL,
   covered_to     DATE        NOT NULL CHECK (covered_to >= covered_from),
-  fetched_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  -- Staleness only: when this span was last confirmed. Merging spans collapses
+  -- it to the merge time.
+  last_fetched_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   PRIMARY KEY (instrument_id, plugin_id, covered_from)
 );
 
@@ -410,11 +423,12 @@ CREATE INDEX idx_corporate_event_coverage_instrument ON corporate_event_coverage
 -- Blocked (instrument, plugin) pairs for corporate-event fetches. Mirrors
 -- price_fetch_blocks: an entry here means the plugin returned a permanent
 -- error (404, 403, ...) for this instrument and should not be retried.
+-- first_blocked_at is never overwritten; re-blocking updates only the reason.
 CREATE TABLE corporate_event_fetch_blocks (
-  instrument_id UUID        NOT NULL REFERENCES instruments (id) ON DELETE CASCADE,
-  plugin_id     TEXT        NOT NULL,
-  reason        TEXT        NOT NULL,
-  created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  instrument_id    UUID        NOT NULL REFERENCES instruments (id) ON DELETE CASCADE,
+  plugin_id        TEXT        NOT NULL,
+  reason           TEXT        NOT NULL,
+  first_blocked_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   PRIMARY KEY (instrument_id, plugin_id)
 );
 

--- a/server/service/api/plugins.go
+++ b/server/service/api/plugins.go
@@ -5,9 +5,9 @@ import (
 	"database/sql"
 	"errors"
 
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
 	"github.com/leedenison/portfoliodb/server/auth"
 	"github.com/leedenison/portfoliodb/server/db"
-	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -197,7 +197,7 @@ func (s *Server) ListPriceFetchBlocks(ctx context.Context, req *apiv1.ListPriceF
 			InstrumentId:          b.InstrumentID,
 			PluginId:              b.PluginID,
 			Reason:                b.Reason,
-			CreatedAt:             timestamppb.New(b.CreatedAt),
+			FirstBlockedAt:        timestamppb.New(b.FirstBlockedAt),
 			PluginDisplayName:     pluginName,
 			InstrumentDisplayName: instName,
 		})

--- a/server/service/api/prices.go
+++ b/server/service/api/prices.go
@@ -43,7 +43,7 @@ func (s *Server) ListPrices(ctx context.Context, req *apiv1.ListPricesRequest) (
 			PriceDate:             r.PriceDate.Format("2006-01-02"),
 			Close:                 r.Close,
 			DataProvider:          r.DataProvider,
-			FetchedAt:             timestamppb.New(r.FetchedAt),
+			LastFetchedAt:         timestamppb.New(r.LastFetchedAt),
 			Synthetic:             r.Synthetic,
 		}
 		if r.Open != nil {
@@ -142,4 +142,3 @@ func (s *Server) ImportPrices(ctx context.Context, req *apiv1.ImportPricesReques
 	}
 	return &apiv1.ImportPricesResponse{JobId: jobID}, nil
 }
-

--- a/server/service/api/prices_test.go
+++ b/server/service/api/prices_test.go
@@ -39,7 +39,7 @@ func TestListPrices_Success(t *testing.T) {
 			Close:                 105.0,
 			Volume:                &vol,
 			DataProvider:          "test",
-			FetchedAt:             time.Date(2024, 1, 16, 0, 0, 0, 0, time.UTC),
+			LastFetchedAt:         time.Date(2024, 1, 16, 0, 0, 0, 0, time.UTC),
 		},
 	}
 	db.EXPECT().

--- a/server/service/ingestion/price_worker.go
+++ b/server/service/ingestion/price_worker.go
@@ -115,7 +115,7 @@ func processPriceImport(ctx context.Context, database db.DB, pluginRegistry *ide
 			PriceDate:    priceDate,
 			Close:        row.GetClose(),
 			DataProvider: "import",
-			FetchedAt:    pricesAsOf,
+			LastFetchedAt: pricesAsOf,
 		}
 		if row.Open != nil {
 			p.Open = row.Open
@@ -216,7 +216,7 @@ func upsertWithCoverage(ctx context.Context, database db.DB, prices []db.EODPric
 			}
 			var fetchedAt *time.Time
 			if len(inRange) > 0 {
-				fetchedAt = inRange[0].FetchedAt
+				fetchedAt = inRange[0].LastFetchedAt
 			}
 			if err := database.UpsertPricesWithFill(ctx, instID, provider, inRange, r.from, r.to, fetchedAt); err != nil {
 				return err


### PR DESCRIPTION
Depends on #255 (based on that branch -- review after it merges, or review the last two commits only).

Second of five PRs from the bitemporality audit.

## The problem

A knowledge timestamp is either "when we first learned this" or "when we last asked". The two behave oppositely on revision, and calling them all `fetched_at` left the distinction to whether a given `ON CONFLICT DO UPDATE` happened to include the column -- invisible at the point of use, and inconsistent in practice: `stock_splits` preserved it, `cash_dividends` overwrote it.

That inconsistency matters. `stock_splits.first_known_at` is compared against `instruments.identified_at` to decide whether an option's OCC symbol still needs retroactive adjustment, so a clobbered timestamp changes behaviour, not just auditability.

## The change

| Table | Was | Now | Write fixed? |
|---|---|---|---|
| `stock_splits` | `fetched_at` | `first_known_at` | already correct |
| `cash_dividends` | `fetched_at` | `first_known_at` | **yes** -- was clobbered |
| `price_fetch_blocks` | `created_at` | `first_blocked_at` | **yes** -- was reset to `now()` |
| `corporate_event_fetch_blocks` | `created_at` | `first_blocked_at` | **yes** -- was reset to `now()` |
| `eod_prices` | `fetched_at` | `last_fetched_at` | already correct |
| `corporate_event_coverage` | `fetched_at` | `last_fetched_at` | already correct |
| `inflation_indices` | `fetched_at` | `last_fetched_at` | already correct |

`instruments.identified_at` and the row-audit `created_at` columns are already accurate and are untouched.

## Red before green

The first commit adds three tests and they fail; the second makes them pass. The failure output is in the first commit message.

Worth noting for review: db tests run inside one transaction, where `now()` is frozen at transaction start. Two successive writes would therefore produce the *same* timestamp and the clobber would go undetected -- a test written the obvious way would have passed against the bug. The `backdate` helper rewrites the timestamp to a fixed past value between the two writes instead.

## Not fixed here

Two `last_fetched_at` cases now have an honest name but keep the underlying knowledge loss: coverage merges still collapse every span's timestamp to the merge time (0051), and an inflation index revision still discards the prior value (0052).

## Verification

`make test` passes in full: server, client, db, integration and extension suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)