### PR TITLE
Record the share count a price is denominated in

### DIFF
--- a/docs/spec/bitemporality.md
+++ b/docs/spec/bitemporality.md
@@ -161,7 +161,7 @@ The model above is normative. These parts of the system do not yet comply:
 
 | Divergence | Issue |
 | --- | --- |
-| `share_count_basis` does not exist yet: prices are adjusted against `last_fetched_at` and txs against `timestamp`, so a source's denomination is assumed rather than declared | in flight |
+| Transactions have no `share_count_basis`: they are adjusted against `timestamp`, so a broker that restates historical rows cannot say so | in flight |
 | Valuation pairs raw quantity with raw close while `TX_TYPE=SPLIT` rows are dropped at ingestion, so a forward split shows as a discontinuity | in flight |
 | No daily scheduler fires the blanket recompute, so a stored future-dated split never activates when its `ex_date` crosses | 0050 |
 | Corporate event export and import carry no knowledge time, so a re-import cannot reproduce the original adjustment state; `corporate_event_coverage` collapses every span's `last_fetched_at` on merge | 0051 |

--- a/docs/spec/prices.md
+++ b/docs/spec/prices.md
@@ -26,6 +26,7 @@ The price cache.
 | `volume` | `bigint` | Trading volume (nullable) |
 | `data_provider` | `text` NOT NULL | Which provider supplied this row |
 | `last_fetched_at` | `timestamptz` NOT NULL DEFAULT now() | When the row was last fetched. Staleness only; see [bitemporality.md](bitemporality.md#knowledge-time) |
+| `share_count_basis` | `date` NOT NULL | The share count the raw OHLCV is denominated in. Defaults to `price_date` |
 
 **Primary key:** `(instrument_id, price_date)`
 
@@ -37,7 +38,14 @@ The table carries three closing prices and they are not interchangeable:
 - `split_adjusted_close` is derived by PortfolioDB from `close` and the known stock splits, denominated in today's share count. This is the value performance math uses. See [corporate-events.md](corporate-events.md#adjustment).
 - `adjusted_close` is the provider's own adjusted figure, on the provider's basis and typically including dividend adjustment as well as splits. It is never an input to valuation -- it exists to cross-check the value PortfolioDB derives.
 
-Which share count `close` is denominated in is declared by its source, not inferred from `last_fetched_at`. See [bitemporality.md](bitemporality.md#share-count-basis).
+Which share count `close` is denominated in is recorded in `share_count_basis` and declared by its source, never inferred from `last_fetched_at`. See [bitemporality.md](bitemporality.md#share-count-basis).
+
+A price plugin declares the denomination of the bars it returns on its `FetchResult`:
+
+- `AsTraded` -- each bar is denominated in the share count current on its own date. Both current plugins return this: massive sends `?adjusted=false`, and EODHD's `/api/eod` OHLC is as-traded.
+- `AsOfFetch` -- the provider back-adjusted the whole series to the share count current when it answered.
+
+A forward-filled synthetic row carries the value of the bar it copied, so it inherits that bar's basis rather than taking its own date. Import rows default to `price_date`, matching PortfolioDB's own export, and may declare `share_count_basis` when the file holds a back-adjusted series.
 
 ---
 

--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -653,6 +653,8 @@ message EODPriceProto {
   // nothing about the prices themselves.
   google.protobuf.Timestamp last_fetched_at = 11;
   bool synthetic = 12;
+  // The share count the raw values are denominated in, as "YYYY-MM-DD".
+  string share_count_basis = 13;
 }
 
 message ListPricesRequest {
@@ -706,6 +708,11 @@ message ImportPriceRow {
   optional int64 volume = 10;
   AssetClass asset_class = 11;   // optional; security type hint for plugin routing on unknown instruments
   string currency = 12;          // optional; ISO 4217 currency code used as hint for validation
+  // The share count these raw values are denominated in, as "YYYY-MM-DD".
+  // Optional; defaults to price_date, meaning the row is as-traded. Set it only
+  // when the file holds a back-adjusted series, in which case it is the date the
+  // provider adjusted to. See docs/spec/bitemporality.md.
+  string share_count_basis = 13;
 }
 
 message ImportPricesRequest {
@@ -714,10 +721,10 @@ message ImportPricesRequest {
   // UpsertPricesWithFill to generate synthetic LOCF prices for non-trading
   // days within each range. When absent, prices are upserted as-is.
   repeated ImportCoverage coverage = 2;
-  // When set, used as pricesAsOf: prices and identifiers in the file are
-  // assumed current as of this time. OCC symbols are split-adjusted during
-  // instrument resolution, and imported price rows use this as fetched_at
-  // so that splits with ex_date after this timestamp are applied.
+  // Knowledge time: when the supplied data was current. OCC symbols are
+  // split-adjusted to this point during instrument resolution, and imported
+  // rows record it as last_fetched_at. It does not determine which share count
+  // the prices are denominated in -- that is ImportPriceRow.share_count_basis.
   google.protobuf.Timestamp exported_at = 3;
 }
 

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -83,16 +83,23 @@ type HeldRangesOpts struct {
 
 // EODPrice is a single end-of-day price row for UpsertPrices.
 type EODPrice struct {
-	InstrumentID  string
-	PriceDate     time.Time
-	Open          *float64
-	High          *float64
-	Low           *float64
-	Close         float64
-	Volume        *int64
-	DataProvider  string
+	InstrumentID string
+	PriceDate    time.Time
+	Open         *float64
+	High         *float64
+	Low          *float64
+	Close        float64
+	Volume       *int64
+	DataProvider string
+	// AdjustedClose is the provider's own adjusted close, on the provider's
+	// basis and typically including dividend adjustment. Stored for cross-checking
+	// only; never an input to valuation. nil when the provider does not supply it.
+	AdjustedClose *float64
 	Synthetic     bool       // true for forward-filled non-trading day prices
 	LastFetchedAt *time.Time // when this row was fetched; nil defaults to now()
+	// ShareCountBasis is the date at which the share count these raw values are
+	// denominated in was current. nil defaults to PriceDate (as-traded).
+	ShareCountBasis *time.Time
 }
 
 // PriceCacheDB provides price cache management.
@@ -342,6 +349,7 @@ type EODPriceRow struct {
 	DataProvider          string
 	Synthetic             bool
 	LastFetchedAt         time.Time
+	ShareCountBasis       time.Time
 }
 
 // ExportPriceRow is a single price row with the best instrument identifier for export.

--- a/server/db/postgres/corporate_events.go
+++ b/server/db/postgres/corporate_events.go
@@ -600,7 +600,7 @@ func (p *Postgres) ApplyOptionSplit(ctx context.Context, params db.OptionSplitPa
 // RecomputeSplitAdjustments implements db.CorporateEventDB. Two UPDATEs (one
 // for eod_prices, one for txs) recompute the split_adjusted_* columns from raw
 // values multiplied by the cumulative split factor for splits with ex_date
-// strictly after the row's reference date (last_fetched_at::date for prices,
+// strictly after the row's reference date (share_count_basis for prices,
 // timestamp::date for txs). Idempotent: factor is recomputed from scratch
 // each call. When instrumentID is empty, every instrument with at least one
 // stock_splits row is recomputed in the same transaction.
@@ -636,13 +636,13 @@ func (p *Postgres) RecomputeSplitAdjustments(ctx context.Context, instrumentID s
 				split_adjusted_volume  = CASE WHEN ep.volume IS NULL THEN NULL
 					ELSE round(ep.volume::numeric * f.factor::numeric)::bigint END
 			FROM (
-				SELECT instrument_id, last_fetched_at,
-					split_factor_at(instrument_id, last_fetched_at::date) AS factor
+				SELECT instrument_id, price_date,
+					split_factor_at(instrument_id, share_count_basis) AS factor
 				FROM eod_prices
 				WHERE instrument_id %s
 			) f
 			WHERE ep.instrument_id = f.instrument_id
-			  AND ep.last_fetched_at = f.last_fetched_at
+			  AND ep.price_date = f.price_date
 		`, instFilter)
 		if _, err := exec.ExecContext(ctx, priceSQL, args...); err != nil {
 			return fmt.Errorf("recompute split adjustments (prices): %w", err)

--- a/server/db/postgres/corporate_events_test.go
+++ b/server/db/postgres/corporate_events_test.go
@@ -978,3 +978,80 @@ func TestRecomputeSplitAdjustments_BackfilledPricesUseTheirOwnDate(t *testing.T)
 		t.Errorf("post-split bar should be unchanged: got %v want %v", got, want)
 	}
 }
+
+// TestRecomputeSplitAdjustments_BackAdjustedSourceDeclaresItsBasis is the
+// mirror of the as-traded case: a provider that restates its whole series to
+// the share count current when it answered has already applied the split, so
+// adjusting again would double-count it.
+func TestRecomputeSplitAdjustments_BackAdjustedSourceDeclaresItsBasis(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	instID := setupInstrument(t, p, "AAPL")
+
+	// Same bar as the as-traded case, but already expressed post-split by the
+	// provider, which declares that its series is current as of today.
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+	if err := p.UpsertPrices(ctx, []db.EODPrice{{
+		InstrumentID:    instID,
+		PriceDate:       d(2020, 8, 28),
+		Close:           124.75,
+		DataProvider:    "test",
+		ShareCountBasis: &today,
+	}}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if err := p.UpsertStockSplits(ctx, []db.StockSplit{
+		{InstrumentID: instID, ExDate: d(2020, 8, 31), SplitFrom: "1", SplitTo: "4", DataProvider: "test"},
+	}); err != nil {
+		t.Fatalf("upsert splits: %v", err)
+	}
+	if err := p.RecomputeSplitAdjustments(ctx, instID); err != nil {
+		t.Fatalf("recompute: %v", err)
+	}
+
+	if got := adjustedClose(t, p, instID, d(2020, 8, 28)); !approxEq(got, 124.75) {
+		t.Errorf("back-adjusted bar adjusted a second time: got %v want %v", got, 124.75)
+	}
+}
+
+// TestUpsertPrices_BasisTravelsWithTheRawValues covers a re-fetch replacing a
+// row: the basis must be restated together with the values it describes, or
+// the row is left claiming a denomination its numbers are not in.
+func TestUpsertPrices_BasisTravelsWithTheRawValues(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	instID := setupInstrument(t, p, "AAPL")
+
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+	row := db.EODPrice{
+		InstrumentID: instID, PriceDate: d(2020, 8, 28),
+		Close: 499, DataProvider: "test",
+	}
+	if err := p.UpsertPrices(ctx, []db.EODPrice{row}); err != nil {
+		t.Fatalf("upsert as-traded: %v", err)
+	}
+	assertBasis(t, p, instID, d(2020, 8, 28), d(2020, 8, 28))
+
+	// The same date re-fetched from a back-adjusting source.
+	row.Close = 124.75
+	row.ShareCountBasis = &today
+	if err := p.UpsertPrices(ctx, []db.EODPrice{row}); err != nil {
+		t.Fatalf("upsert back-adjusted: %v", err)
+	}
+	assertBasis(t, p, instID, d(2020, 8, 28), today)
+}
+
+func assertBasis(t *testing.T, p *Postgres, instID string, priceDate, want time.Time) {
+	t.Helper()
+	var got time.Time
+	if err := p.q.QueryRowContext(context.Background(), `
+		SELECT share_count_basis FROM eod_prices
+		WHERE instrument_id = $1::uuid AND price_date = $2
+	`, instID, priceDate).Scan(&got); err != nil {
+		t.Fatalf("read share_count_basis: %v", err)
+	}
+	if !got.Equal(want) {
+		t.Errorf("share_count_basis: got %s want %s",
+			got.Format("2006-01-02"), want.Format("2006-01-02"))
+	}
+}

--- a/server/db/postgres/corporate_events_test.go
+++ b/server/db/postgres/corporate_events_test.go
@@ -931,3 +931,50 @@ func TestCreateCorporateEventFetchBlock_PreservesFirstBlockedAt(t *testing.T) {
 		t.Errorf("first blocked at moved on re-block: want %s, got %s", past, blocks[0].FirstBlockedAt)
 	}
 }
+
+// adjustedClose reads the derived split-adjusted close for one price row.
+func adjustedClose(t *testing.T, p *Postgres, instID string, priceDate time.Time) float64 {
+	t.Helper()
+	var v float64
+	err := p.q.QueryRowContext(context.Background(), `
+		SELECT split_adjusted_close FROM eod_prices
+		WHERE instrument_id = $1::uuid AND price_date = $2
+	`, instID, priceDate).Scan(&v)
+	if err != nil {
+		t.Fatalf("read split_adjusted_close for %s: %v", priceDate.Format("2006-01-02"), err)
+	}
+	return v
+}
+
+// TestRecomputeSplitAdjustments_BackfilledPricesUseTheirOwnDate covers the
+// ordinary case: a user imports years of history today, so every bar is
+// fetched now. The plugins return as-traded bars, so a bar printed before a
+// split is denominated in the pre-split share count no matter when we fetched
+// it, and adjusting it must depend on its price_date rather than on the fetch.
+func TestRecomputeSplitAdjustments_BackfilledPricesUseTheirOwnDate(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	instID := setupInstrument(t, p, "AAPL")
+
+	// A 4:1 split with bars either side of it. No backdating: these rows are
+	// fetched now, exactly as a backfill leaves them.
+	insertPriceFull(t, p, instID, d(2020, 8, 28), 498, 500, 495, 499, 1_000_000, "test")
+	insertPriceFull(t, p, instID, d(2020, 9, 1), 124, 126, 123, 125, 4_000_000, "test")
+
+	if err := p.UpsertStockSplits(ctx, []db.StockSplit{
+		{InstrumentID: instID, ExDate: d(2020, 8, 31), SplitFrom: "1", SplitTo: "4", DataProvider: "test"},
+	}); err != nil {
+		t.Fatalf("upsert splits: %v", err)
+	}
+	if err := p.RecomputeSplitAdjustments(ctx, instID); err != nil {
+		t.Fatalf("recompute: %v", err)
+	}
+
+	if got, want := adjustedClose(t, p, instID, d(2020, 8, 28)), 499.0/4; !approxEq(got, want) {
+		t.Errorf("pre-split bar not adjusted: got %v want %v", got, want)
+	}
+	// Already in today's share count; adjusting it again would be wrong.
+	if got, want := adjustedClose(t, p, instID, d(2020, 9, 1)), 125.0; !approxEq(got, want) {
+		t.Errorf("post-split bar should be unchanged: got %v want %v", got, want)
+	}
+}

--- a/server/db/postgres/eod_prices.go
+++ b/server/db/postgres/eod_prices.go
@@ -50,6 +50,7 @@ func (p *Postgres) ListPrices(ctx context.Context, search string, dateFrom, date
 		"ep.instrument_id", "i.name AS display_name",
 		"ep.price_date", "ep.open", "ep.high", "ep.low", "ep.close", "ep.adjusted_close",
 		"ep.volume", "ep.data_provider", "ep.synthetic", "ep.last_fetched_at",
+		"ep.share_count_basis",
 	).
 		From("eod_prices ep").
 		Join("instruments i ON i.id = ep.instrument_id").
@@ -75,7 +76,7 @@ func (p *Postgres) ListPrices(ctx context.Context, search string, dateFrom, date
 		if err := rows.Scan(
 			&r.InstrumentID, &r.InstrumentDisplayName,
 			&r.PriceDate, &open, &high, &low, &r.Close, &adjClose,
-			&volume, &r.DataProvider, &r.Synthetic, &r.LastFetchedAt,
+			&volume, &r.DataProvider, &r.Synthetic, &r.LastFetchedAt, &r.ShareCountBasis,
 		); err != nil {
 			return nil, 0, "", err
 		}

--- a/server/db/postgres/price_cache.go
+++ b/server/db/postgres/price_cache.go
@@ -415,6 +415,8 @@ func (p *Postgres) UpsertPrices(ctx context.Context, prices []db.EODPrice) error
 	providers := make([]string, len(prices))
 	synthetics := make([]bool, len(prices))
 	fetchedAts := make([]time.Time, len(prices))
+	bases := make([]time.Time, len(prices))
+	adjCloses := make([]*float64, len(prices))
 	now := time.Now()
 
 	for i, pr := range prices {
@@ -427,20 +429,29 @@ func (p *Postgres) UpsertPrices(ctx context.Context, prices []db.EODPrice) error
 		volumes[i] = pr.Volume
 		providers[i] = pr.DataProvider
 		synthetics[i] = pr.Synthetic
+		adjCloses[i] = pr.AdjustedClose
 		if pr.LastFetchedAt != nil {
 			fetchedAts[i] = *pr.LastFetchedAt
 		} else {
 			fetchedAts[i] = now
 		}
+		// Undeclared basis means as-traded: denominated in the share count
+		// current on the bar's own date.
+		if pr.ShareCountBasis != nil {
+			bases[i] = *pr.ShareCountBasis
+		} else {
+			bases[i] = pr.PriceDate
+		}
 	}
 
 	_, err := p.q.ExecContext(ctx, `
-		INSERT INTO eod_prices (instrument_id, price_date, open, high, low, close, volume, data_provider, synthetic, last_fetched_at)
+		INSERT INTO eod_prices (instrument_id, price_date, open, high, low, close, volume, data_provider, synthetic, last_fetched_at, share_count_basis, adjusted_close)
 		SELECT unnest($1::uuid[]), unnest($2::date[]), unnest($3::double precision[]),
 			unnest($4::double precision[]), unnest($5::double precision[]),
 			unnest($6::double precision[]), unnest($7::bigint[]),
 			unnest($8::text[]), unnest($9::boolean[]),
-			unnest($10::timestamptz[])
+			unnest($10::timestamptz[]), unnest($11::date[]),
+			unnest($12::double precision[])
 		ON CONFLICT (instrument_id, price_date) DO UPDATE SET
 			open = EXCLUDED.open,
 			high = EXCLUDED.high,
@@ -449,12 +460,16 @@ func (p *Postgres) UpsertPrices(ctx context.Context, prices []db.EODPrice) error
 			volume = EXCLUDED.volume,
 			data_provider = EXCLUDED.data_provider,
 			synthetic = EXCLUDED.synthetic,
-			last_fetched_at = EXCLUDED.last_fetched_at
+			last_fetched_at = EXCLUDED.last_fetched_at,
+			-- Basis travels with the raw values it describes; restating one
+			-- without the other would leave the row self-inconsistent.
+			share_count_basis = EXCLUDED.share_count_basis,
+			adjusted_close = EXCLUDED.adjusted_close
 		WHERE eod_prices.synthetic = true OR EXCLUDED.synthetic = false
 	`, pq.Array(instIDs), pq.Array(dates), pq.Array(opens),
 		pq.Array(highs), pq.Array(lows), pq.Array(closes),
 		pq.Array(volumes), pq.Array(providers), pq.Array(synthetics),
-		pq.Array(fetchedAts))
+		pq.Array(fetchedAts), pq.Array(bases), pq.Array(adjCloses))
 	if err != nil {
 		return fmt.Errorf("upsert prices: %w", err)
 	}
@@ -497,6 +512,8 @@ func (p *Postgres) UpsertPricesWithFill(ctx context.Context, instrumentID, provi
 	lows := make([]*float64, len(bars))
 	closes := make([]float64, len(bars))
 	volumes := make([]*int64, len(bars))
+	bases := make([]time.Time, len(bars))
+	adjCloses := make([]*float64, len(bars))
 	for i, b := range bars {
 		dates[i] = b.PriceDate
 		opens[i] = b.Open
@@ -504,12 +521,19 @@ func (p *Postgres) UpsertPricesWithFill(ctx context.Context, instrumentID, provi
 		lows[i] = b.Low
 		closes[i] = b.Close
 		volumes[i] = b.Volume
+		adjCloses[i] = b.AdjustedClose
+		// Undeclared basis means as-traded.
+		if b.ShareCountBasis != nil {
+			bases[i] = *b.ShareCountBasis
+		} else {
+			bases[i] = b.PriceDate
+		}
 	}
 
 	_, err = p.q.ExecContext(ctx, `
 		WITH
 		seed AS (
-			SELECT close FROM eod_prices
+			SELECT close, share_count_basis FROM eod_prices
 			WHERE instrument_id = $1 AND price_date < $2::date AND NOT synthetic
 			ORDER BY price_date DESC LIMIT 1
 		),
@@ -519,18 +543,21 @@ func (p *Postgres) UpsertPricesWithFill(ctx context.Context, instrumentID, provi
 				unnest($6::double precision[]) AS bhigh,
 				unnest($7::double precision[]) AS blow,
 				unnest($8::double precision[]) AS bclose,
-				unnest($9::bigint[]) AS bvolume
+				unnest($9::bigint[]) AS bvolume,
+				unnest($12::date[]) AS bbasis,
+				unnest($13::double precision[]) AS badjclose
 		),
 		all_points AS (
 			-- Virtual seed point before range start for LOCF initialization.
 			SELECT ($2::date - 1) AS price_date,
 				NULL::double precision AS bopen, NULL::double precision AS bhigh,
 				NULL::double precision AS blow, s.close AS bclose,
-				NULL::bigint AS bvolume
+				NULL::bigint AS bvolume, s.share_count_basis AS bbasis,
+				NULL::double precision AS badjclose
 			FROM seed s
 			UNION ALL
 			-- Every date in [from, to) with real bar if available.
-			SELECT d::date, nb.bopen, nb.bhigh, nb.blow, nb.bclose, nb.bvolume
+			SELECT d::date, nb.bopen, nb.bhigh, nb.blow, nb.bclose, nb.bvolume, nb.bbasis, nb.badjclose
 			FROM generate_series($2::date, $3::date - interval '1 day', '1 day') d
 			LEFT JOIN new_bars nb ON nb.price_date = d::date
 		),
@@ -544,21 +571,31 @@ func (p *Postgres) UpsertPricesWithFill(ctx context.Context, instrumentID, provi
 				bopen AS open, bhigh AS high, blow AS low,
 				FIRST_VALUE(bclose) OVER (PARTITION BY grp ORDER BY price_date) AS close,
 				bvolume AS volume,
-				(bclose IS NULL) AS synthetic
+				badjclose AS adjusted_close,
+				(bclose IS NULL) AS synthetic,
+				-- A forward-filled row carries the value of the bar it copied, so
+				-- it is denominated in that bar's share count, not its own date's.
+				FIRST_VALUE(bbasis) OVER (PARTITION BY grp ORDER BY price_date) AS share_count_basis
 			FROM grouped
 		)
-		INSERT INTO eod_prices (instrument_id, price_date, open, high, low, close, volume, data_provider, synthetic, last_fetched_at)
-		SELECT $1::uuid, price_date, open, high, low, close, volume, $10::text, synthetic, $11::timestamptz
+		INSERT INTO eod_prices (instrument_id, price_date, open, high, low, close, volume, data_provider, synthetic, last_fetched_at, share_count_basis, adjusted_close)
+		SELECT $1::uuid, price_date, open, high, low, close, volume, $10::text, synthetic, $11::timestamptz,
+			COALESCE(share_count_basis, price_date), adjusted_close
 		FROM locf
 		WHERE price_date >= $2::date AND close IS NOT NULL
 		ON CONFLICT (instrument_id, price_date) DO UPDATE SET
 			open = EXCLUDED.open, high = EXCLUDED.high, low = EXCLUDED.low,
 			close = EXCLUDED.close, volume = EXCLUDED.volume,
 			data_provider = EXCLUDED.data_provider, synthetic = EXCLUDED.synthetic,
-			last_fetched_at = EXCLUDED.last_fetched_at
+			last_fetched_at = EXCLUDED.last_fetched_at,
+			-- Basis travels with the raw values it describes; restating one
+			-- without the other would leave the row self-inconsistent.
+			share_count_basis = EXCLUDED.share_count_basis,
+			adjusted_close = EXCLUDED.adjusted_close
 		WHERE eod_prices.synthetic = true OR EXCLUDED.synthetic = false
 	`, id, from, to, pq.Array(dates), pq.Array(opens), pq.Array(highs),
-		pq.Array(lows), pq.Array(closes), pq.Array(volumes), provider, fetchedAt)
+		pq.Array(lows), pq.Array(closes), pq.Array(volumes), provider, fetchedAt,
+		pq.Array(bases), pq.Array(adjCloses))
 	if err != nil {
 		return fmt.Errorf("upsert prices with fill: %w", err)
 	}

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -326,14 +326,20 @@ WHERE
 -- Rows with synthetic = true are forward-filled (LOCF) prices for non-trading
 -- days (weekends, holidays). They are generated at write time by the price
 -- fetcher worker so that the valuation query can use a simple join.
+-- share_count_basis is the date at which the share count the raw OHLCV is
+-- denominated in was current. It is declared by whoever supplied the row -- as
+-- price_date for an as-traded series, or the fetch date for a provider that
+-- back-adjusts -- and is never inferred from last_fetched_at. It defaults to
+-- price_date, the as-traded assumption. See docs/spec/bitemporality.md.
 -- The split_adjusted_* columns hold OHLCV after applying every stock split with
--- ex_date > last_fetched_at::date for this instrument. They equal the raw values when
+-- ex_date > share_count_basis for this instrument. They equal the raw values when
 -- no later split exists. close (NOT NULL) implies split_adjusted_close (NOT NULL);
 -- the others are NULL iff their raw counterpart is NULL. Volume is adjusted in
 -- the opposite direction (more shares trade in adjusted-share terms).
--- adjusted_close is preserved as-supplied by the data provider (typically
--- includes both split and dividend adjustments) and is not used in performance
--- math; split_adjusted_close is the value PortfolioDB derives itself.
+-- adjusted_close is preserved as-supplied by the data provider on the provider's
+-- own basis (typically including dividend adjustment as well as splits). It is
+-- never an input to valuation and exists to cross-check split_adjusted_close,
+-- which is the value PortfolioDB derives itself.
 CREATE TABLE eod_prices (
   instrument_id          UUID        NOT NULL REFERENCES instruments (id) ON DELETE CASCADE,
   price_date             DATE        NOT NULL,
@@ -350,6 +356,7 @@ CREATE TABLE eod_prices (
   split_adjusted_volume  BIGINT,
   data_provider          TEXT        NOT NULL,
   synthetic              BOOLEAN     NOT NULL DEFAULT false,
+  share_count_basis      DATE        NOT NULL,
   -- Staleness only: when this row was last fetched. It carries no meaning about
   -- the prices themselves. See docs/spec/bitemporality.md.
   last_fetched_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
@@ -498,6 +505,11 @@ CREATE TRIGGER trg_default_split_adjusted_tx
 CREATE OR REPLACE FUNCTION default_split_adjusted_eod_price() RETURNS TRIGGER AS $$
 BEGIN
   IF TG_OP = 'INSERT' THEN
+    -- As-traded is the default denomination: a bar with no declared basis is
+    -- assumed to be expressed in the share count current on its own date.
+    IF NEW.share_count_basis IS NULL THEN
+      NEW.share_count_basis := NEW.price_date;
+    END IF;
     IF NEW.split_adjusted_open IS NULL THEN
       NEW.split_adjusted_open := NEW.open;
     END IF;

--- a/server/plugins/eodhd/price/plugin.go
+++ b/server/plugins/eodhd/price/plugin.go
@@ -127,6 +127,7 @@ func (p *Plugin) FetchPrices(ctx context.Context, config []byte, identifiers []p
 		h := b.High
 		l := b.Low
 		v := b.Volume
+		ac := b.AdjClose
 		result[i] = pricefetcher.DailyBar{
 			Date:   d,
 			Open:   &o,
@@ -134,6 +135,9 @@ func (p *Plugin) FetchPrices(ctx context.Context, config []byte, identifiers []p
 			Low:    &l,
 			Close:  b.Close,
 			Volume: &v,
+			// EODHD's /api/eod OHLC is as-traded; adjusted_close is its own
+			// separate, provider-adjusted series.
+			AdjustedClose: &ac,
 		}
 	}
 	if fxDivisor != 1 {

--- a/server/pricefetcher/plugin.go
+++ b/server/pricefetcher/plugin.go
@@ -47,11 +47,34 @@ type DailyBar struct {
 	Low    *float64
 	Close  float64
 	Volume *int64
+	// AdjustedClose is the provider's own adjusted close when it supplies one.
+	// Stored for cross-checking; never an input to valuation.
+	AdjustedClose *float64
 }
+
+// ShareCountBasis states which share count a plugin's bars are denominated in.
+// It cannot be inferred from the fetch: an as-traded series is expressed in the
+// share count current on each bar's own date, while a back-adjusted series is
+// expressed in the share count current when the provider answered. Plugins
+// declare it so the storage layer never has to assume.
+// See docs/spec/bitemporality.md.
+type ShareCountBasis int
+
+const (
+	// AsTraded means each bar is denominated in the share count current on its
+	// own date. This is what a provider returns when asked for unadjusted data.
+	AsTraded ShareCountBasis = iota
+	// AsOfFetch means the provider back-adjusted the whole series to the share
+	// count current when it answered.
+	AsOfFetch
+)
 
 // FetchResult holds the bars returned by a plugin for a single request.
 type FetchResult struct {
 	Bars []DailyBar
+	// ShareCountBasis defaults to AsTraded, which is correct for every plugin
+	// that requests unadjusted data.
+	ShareCountBasis ShareCountBasis
 }
 
 // Identifier is a minimal (type, domain, value) tuple passed to plugins.

--- a/server/pricefetcher/worker.go
+++ b/server/pricefetcher/worker.go
@@ -140,6 +140,9 @@ func runCycle(ctx context.Context, database db.DB, registry *Registry, counter t
 
 // processGaps iterates instrument gaps and fetches prices from matching plugins.
 func processGaps(ctx context.Context, database db.DB, plugins []pluginEntry, gaps []db.InstrumentDateRanges, instByID map[string]*db.InstrumentRow, blocked map[string]map[string]bool, log *slog.Logger) {
+	// One fetch time for the whole cycle, so every row a back-adjusting plugin
+	// returns shares the same share count basis.
+	now := time.Now()
 	for _, ig := range gaps {
 		if ctx.Err() != nil {
 			return
@@ -214,7 +217,7 @@ func processGaps(ctx context.Context, database db.DB, plugins []pluginEntry, gap
 					break
 				}
 
-				prices := barsToEODPrices(ig.InstrumentID, pe.id, result.Bars)
+				prices := barsToEODPrices(ig.InstrumentID, pe.id, result.Bars, result.ShareCountBasis, now)
 				if err := database.UpsertPricesWithFill(ctx, ig.InstrumentID, pe.id, prices, gap.From, gap.To, nil); err != nil {
 					if log != nil {
 						log.ErrorContext(ctx, "price fetch: upsert", "instrument", ig.InstrumentID, "err", err)
@@ -251,18 +254,28 @@ func toPricefetcherIDs(ids []db.IdentifierInput) []Identifier {
 	return out
 }
 
-func barsToEODPrices(instrumentID, provider string, bars []DailyBar) []db.EODPrice {
+// barsToEODPrices converts plugin bars to price rows, resolving the plugin's
+// declared denomination to a per-row share count basis. An as-traded bar is
+// denominated in the share count current on its own date; a back-adjusted
+// series is denominated in the share count current when we fetched it.
+func barsToEODPrices(instrumentID, provider string, bars []DailyBar, basis ShareCountBasis, fetchedAt time.Time) []db.EODPrice {
 	out := make([]db.EODPrice, len(bars))
 	for i, b := range bars {
+		scb := b.Date
+		if basis == AsOfFetch {
+			scb = fetchedAt
+		}
 		out[i] = db.EODPrice{
-			InstrumentID: instrumentID,
-			PriceDate:    b.Date,
-			Open:         b.Open,
-			High:         b.High,
-			Low:          b.Low,
-			Close:        b.Close,
-			Volume:       b.Volume,
-			DataProvider: provider,
+			InstrumentID:    instrumentID,
+			PriceDate:       b.Date,
+			Open:            b.Open,
+			High:            b.High,
+			Low:             b.Low,
+			Close:           b.Close,
+			Volume:          b.Volume,
+			AdjustedClose:   b.AdjustedClose,
+			DataProvider:    provider,
+			ShareCountBasis: &scb,
 		}
 	}
 	return out

--- a/server/service/api/prices.go
+++ b/server/service/api/prices.go
@@ -44,6 +44,7 @@ func (s *Server) ListPrices(ctx context.Context, req *apiv1.ListPricesRequest) (
 			Close:                 r.Close,
 			DataProvider:          r.DataProvider,
 			LastFetchedAt:         timestamppb.New(r.LastFetchedAt),
+			ShareCountBasis:       r.ShareCountBasis.Format("2006-01-02"),
 			Synthetic:             r.Synthetic,
 		}
 		if r.Open != nil {

--- a/server/service/ingestion/price_worker.go
+++ b/server/service/ingestion/price_worker.go
@@ -111,11 +111,27 @@ func processPriceImport(ctx context.Context, database db.DB, pluginRegistry *ide
 		}
 
 		p := db.EODPrice{
-			InstrumentID: entry.result.InstrumentID,
-			PriceDate:    priceDate,
-			Close:        row.GetClose(),
-			DataProvider: "import",
+			InstrumentID:  entry.result.InstrumentID,
+			PriceDate:     priceDate,
+			Close:         row.GetClose(),
+			DataProvider:  "import",
 			LastFetchedAt: pricesAsOf,
+		}
+		// An undeclared basis means as-traded, which is what PortfolioDB's own
+		// export emits. exported_at is knowledge time and does not imply the
+		// file was back-adjusted.
+		if b := row.GetShareCountBasis(); b != "" {
+			basis, err := time.Parse("2006-01-02", b)
+			if err != nil {
+				valErrs = append(valErrs, &apiv1.ValidationError{
+					RowIndex: int32(i),
+					Field:    "share_count_basis",
+					Message:  fmt.Sprintf("invalid date %q: want YYYY-MM-DD", b),
+				})
+				_ = database.IncrJobProcessedCount(ctx, j.JobID)
+				continue
+			}
+			p.ShareCountBasis = &basis
 		}
 		if row.Open != nil {
 			p.Open = row.Open
@@ -128,6 +144,9 @@ func processPriceImport(ctx context.Context, database db.DB, pluginRegistry *ide
 		}
 		if row.Volume != nil {
 			p.Volume = row.Volume
+		}
+		if row.AdjustedClose != nil {
+			p.AdjustedClose = row.AdjustedClose
 		}
 		prices = append(prices, p)
 		_ = database.IncrJobProcessedCount(ctx, j.JobID)


### PR DESCRIPTION
Depends on #256, which depends on #255. Review the last two commits only, or wait for the stack to merge down.

Third of five PRs from the bitemporality audit. **This one fixes a defect that produces wrong numbers today.**

## The defect

`eod_prices.split_adjusted_*` was computed with reference date `last_fetched_at::date`. That is only correct if the provider back-adjusted its series to the moment it answered. Neither plugin does:

- massive sends `?adjusted=false` ([bars.go:17](server/plugins/massive/client/bars.go#L17))
- eodhd's `/api/eod` OHLC is as-traded; its `adjusted_close` is a separate field the plugin discarded

So an ordinary backfill produced **no adjustment at all**: every row lands with `last_fetched_at = now`, no split has an `ex_date` after today, and the factor is 1 — leaving `split_adjusted_close` equal to the raw pre-split price.

The existing recompute tests missed this because they backdate `last_fetched_at` first. That backdating is the workaround, not the behaviour.

## Why not just use `price_date`

That would swap one inferred date for another. The denomination belongs to the *source*, so the source declares it:

- **`eod_prices.share_count_basis`**, defaulting to `price_date` via the existing BEFORE INSERT trigger.
- **`pricefetcher.FetchResult.ShareCountBasis`** — `AsTraded` or `AsOfFetch`. Both plugins declare `AsTraded`, which is what they actually request. Flipping massive to `adjusted=true` later becomes a one-line change instead of a silent corruption.
- **`ImportPriceRow.share_count_basis`**, optional, defaulting to `price_date` to match PortfolioDB's own export. `exported_at` goes back to being pure knowledge time.
- Upserts carry basis through `ON CONFLICT` **alongside** the raw values, so a re-fetch can never leave a row claiming a denomination its numbers are not in.

## Two details worth a look

**Synthetic LOCF rows** inherit the basis of the bar they copied rather than taking their own date. A weekend fill spanning a Monday ex_date would otherwise be treated as already post-split. Implemented as a second `FIRST_VALUE` over the same partition as the close.

**The recompute now joins on the primary key** instead of `last_fetched_at`. A bulk fetch stamps every row in the batch with the same timestamp, so the old join was an accidental N-squared self-join. Same result, one row per row.

## Also included

`adjusted_close` — the schema has always had it, the admin list has always read it, and nothing has ever written it, so it was always NULL. EODHD returns it and the plugin discarded it. Now populated, documented as the provider's own series on the provider's basis, and explicitly never an input to valuation: it exists to cross-check what we derive.

## Red before green

    corporate_events_test.go:974: pre-split bar not adjusted: got 499 want 124.75
    --- FAIL: TestRecomputeSplitAdjustments_BackfilledPricesUseTheirOwnDate

Plus three tests written alongside the implementation (no prior behaviour to be wrong): a back-adjusted source is not adjusted twice; basis and raw values stay consistent across a re-upsert; import rows honour a declared basis.

## Verification

`make test` passes in full — exit 0, zero failures across server, client, db, integration and extension suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)