### PR TITLE
Value holdings on a single share count

### DIFF
--- a/docs/spec/bitemporality.md
+++ b/docs/spec/bitemporality.md
@@ -161,7 +161,6 @@ The model above is normative. These parts of the system do not yet comply:
 
 | Divergence | Issue |
 | --- | --- |
-| Valuation pairs raw quantity with raw close while `TX_TYPE=SPLIT` rows are dropped at ingestion, so a forward split shows as a discontinuity | in flight |
 | No daily scheduler fires the blanket recompute, so a stored future-dated split never activates when its `ex_date` crosses | 0050 |
 | Corporate event export and import carry no knowledge time, so a re-import cannot reproduce the original adjustment state; `corporate_event_coverage` collapses every span's `last_fetched_at` on merge | 0051 |
 | A revised inflation index overwrites the prior value, so a previously published real-return figure cannot be reproduced | 0052 |

--- a/docs/spec/performance.md
+++ b/docs/spec/performance.md
@@ -9,7 +9,7 @@ Daily portfolio values are computed server-side in a single SQL query using five
 CTEs:
 
 1. **portfolio_txs** -- portfolio-matched transactions grouped by
-   (instrument, date) with net daily quantity.
+   (instrument, date) with net daily split-adjusted quantity.
 2. **cumulative** -- window function producing running position per instrument.
 3. **date_series** -- `generate_series` for every calendar date in the range.
 4. **daily_holdings** -- LATERAL subquery forward-filling the last known
@@ -18,7 +18,8 @@ CTEs:
    to forward-fill closing prices across weekends and holidays.
 
 The final SELECT joins holdings with prices and aggregates
-`SUM(qty * close)` per date.
+`SUM(qty * close)` per date, where both sides are split-adjusted (see
+[Share count](#share-count) below).
 
 ## TimescaleDB usage
 
@@ -96,8 +97,16 @@ adr/0007-calendar-day-valuation.md).
 
 ## Share count
 
-Quantities and prices are paired on the same share count: the valuation
-multiplies split-adjusted quantity by split-adjusted close, never one of each.
+Quantities and prices are paired on the same share count: the valuation reads
+`split_adjusted_quantity` and `split_adjusted_close`, never one of each. Raw
+quantity would not work, because `TX_TYPE=SPLIT` rows are dropped at ingestion
+(see adr/0005-corporate-events-design.md) so the raw position never steps up at
+a split, while the as-traded price does step down. Pairing them puts a cliff in
+the chart at every forward split.
+
+FX rates are the exception and are read raw: an exchange rate is not
+denominated in a share count, so it has no basis to adjust.
+
 Because split adjustment is bounded by today's date, the whole series is as-of
 now -- the same request on a later day may return different values if a split
 has become effective in between. See [bitemporality.md](bitemporality.md).

--- a/server/db/postgres/valuation.go
+++ b/server/db/postgres/valuation.go
@@ -36,7 +36,7 @@ WITH portfolio_txs AS (
         t.instrument_id,
         t.instrument_description,
         t.timestamp::date AS tx_date,
-        SUM(t.quantity) AS daily_qty` + txSource + `
+        SUM(t.split_adjusted_quantity) AS daily_qty` + txSource + `
     GROUP BY t.instrument_id, t.instrument_description, t.timestamp::date
 ),
 -- Merge transactions by instrument_id for identified instruments so that
@@ -91,7 +91,11 @@ daily_holdings AS (
     CROSS JOIN inst_list i
 ),
 prices AS (
-    SELECT instrument_id, price_date AS val_date, close
+    -- Adjusted quantity above pairs with adjusted close here: both are
+    -- denominated in today's share count. Mixing one of each would scale the
+    -- value by the split factor either side of an ex-date. See
+    -- docs/spec/bitemporality.md.
+    SELECT instrument_id, price_date AS val_date, split_adjusted_close AS close
     FROM eod_prices
     WHERE instrument_id = ANY(SELECT DISTINCT instrument_id FROM cumulative WHERE instrument_id IS NOT NULL)
       AND price_date >= $2::date
@@ -111,6 +115,8 @@ fx_instruments AS (
       AND inst.currency != 'USD'
 ),
 -- FX rates for each base currency (BASE/USD close values).
+-- Raw close, not split_adjusted_close: an exchange rate is not denominated in
+-- a share count, so it has no basis to adjust and never carries splits.
 fx_rates AS (
     SELECT fi.base_currency, ep.price_date AS val_date, ep.close AS rate
     FROM fx_instruments fi

--- a/server/db/postgres/valuation_test.go
+++ b/server/db/postgres/valuation_test.go
@@ -920,3 +920,56 @@ func valueOn(t *testing.T, points []db.ValuationPoint, want time.Time) float64 {
 	t.Fatalf("no valuation point for %s", want.Format("2006-01-02"))
 	return 0
 }
+
+// TestGetUserValuation_FXUnaffectedByASplit guards the FX leg against the
+// share-count change. An exchange rate is not denominated in a share count, so
+// the split must reach the holding and the price and leave the rate alone.
+func TestGetUserValuation_FXUnaffectedByASplit(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+
+	userID, _ := p.GetOrCreateUser(ctx, "sub|fxsplit", "U", "u@fxsplit.com")
+	instID, _ := p.EnsureInstrument(ctx, "STOCK", "", "EUR", "SAP", "", "", []db.IdentifierInput{
+		{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "SAP FXSplit", Canonical: false},
+	}, "", nil, nil, nil)
+
+	buyDate := time.Date(2020, 8, 3, 12, 0, 0, 0, time.UTC)
+	txs := []*apiv1.Tx{
+		{Timestamp: timestamppb.New(buyDate), InstrumentDescription: "SAP FXSplit", Type: apiv1.TxType_BUYSTOCK, Quantity: 100, Account: "main"},
+	}
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR",
+		timestamppb.New(buyDate.Add(-time.Hour)), timestamppb.New(buyDate.Add(time.Hour)),
+		txs, []string{instID}, nil); err != nil {
+		t.Fatalf("replace txs: %v", err)
+	}
+
+	eurFX := lookupFXInstrumentVal(t, p, "EUR")
+	if err := p.UpsertPrices(ctx, []db.EODPrice{
+		{InstrumentID: instID, PriceDate: d(2020, 8, 28), Close: 500, DataProvider: "test"},
+		{InstrumentID: instID, PriceDate: d(2020, 8, 31), Close: 125, DataProvider: "test"},
+		// A flat rate across both days: any movement in the result is the split.
+		{InstrumentID: eurFX, PriceDate: d(2020, 8, 28), Close: 1.2, DataProvider: "test"},
+		{InstrumentID: eurFX, PriceDate: d(2020, 8, 31), Close: 1.2, DataProvider: "test"},
+	}); err != nil {
+		t.Fatalf("upsert prices: %v", err)
+	}
+	if err := p.UpsertStockSplits(ctx, []db.StockSplit{
+		{InstrumentID: instID, ExDate: d(2020, 8, 31), SplitFrom: "1", SplitTo: "4", DataProvider: "test"},
+	}); err != nil {
+		t.Fatalf("upsert splits: %v", err)
+	}
+	if err := p.RecomputeSplitAdjustments(ctx, instID); err != nil {
+		t.Fatalf("recompute: %v", err)
+	}
+
+	points, err := p.GetUserValuation(ctx, userID, d(2020, 8, 28), d(2020, 8, 31), "USD")
+	if err != nil {
+		t.Fatalf("valuation: %v", err)
+	}
+	// 100 shares * 500 EUR * 1.2 USD/EUR = 60000 USD, on both days.
+	for _, day := range []time.Time{d(2020, 8, 28), d(2020, 8, 31)} {
+		if got := valueOn(t, points, day); !approxEq(got, 60_000) {
+			t.Errorf("value on %s: got %v want %v", day.Format("2006-01-02"), got, 60_000.0)
+		}
+	}
+}

--- a/server/db/postgres/valuation_test.go
+++ b/server/db/postgres/valuation_test.go
@@ -847,3 +847,76 @@ func TestGetUserValuation_CashForeignCurrency_NonUSDDisplay(t *testing.T) {
 		t.Errorf("expected no unpriced instruments, got %v", points[0].UnpricedInstruments)
 	}
 }
+
+// TestGetUserValuation_ContinuousAcrossSplit is the invariant that quantity and
+// price must be paired on the same share count. A holding untouched across a
+// 4:1 split is worth the same on both sides of the ex-date: the share count
+// quadruples and the per-share price quarters.
+//
+// Both series must be adjusted or neither. Raw quantity never steps up, because
+// TX_TYPE=SPLIT rows are dropped at ingestion and corporate events are shared
+// reference data (see adr/0005-corporate-events-design.md), while the as-traded
+// price does step down. Pairing them shows a cliff at the ex-date.
+func TestGetUserValuation_ContinuousAcrossSplit(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+
+	userID, _ := p.GetOrCreateUser(ctx, "sub|split1", "U", "u@split.com")
+	instID, err := p.EnsureInstrument(ctx, "STOCK", "", "USD", "AAPL", "", "", []db.IdentifierInput{
+		{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "AAPL Split", Canonical: false},
+	}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+
+	// Buy 100 shares well before the split, then leave the position alone.
+	buyDate := time.Date(2020, 8, 3, 12, 0, 0, 0, time.UTC)
+	txs := []*apiv1.Tx{
+		{Timestamp: timestamppb.New(buyDate), InstrumentDescription: "AAPL Split", Type: apiv1.TxType_BUYSTOCK, Quantity: 100, Account: "main"},
+	}
+	if err := p.ReplaceTxsInPeriod(ctx, userID,
+		"IBKR", timestamppb.New(buyDate.Add(-time.Hour)), timestamppb.New(buyDate.Add(time.Hour)),
+		txs, []string{instID}, nil); err != nil {
+		t.Fatalf("replace txs: %v", err)
+	}
+
+	// As-traded closes either side of a 4:1 split: ~500 before, ~125 after.
+	if err := p.UpsertPrices(ctx, []db.EODPrice{
+		{InstrumentID: instID, PriceDate: d(2020, 8, 28), Close: 500, DataProvider: "test"},
+		{InstrumentID: instID, PriceDate: d(2020, 8, 31), Close: 125, DataProvider: "test"},
+	}); err != nil {
+		t.Fatalf("upsert prices: %v", err)
+	}
+	if err := p.UpsertStockSplits(ctx, []db.StockSplit{
+		{InstrumentID: instID, ExDate: d(2020, 8, 31), SplitFrom: "1", SplitTo: "4", DataProvider: "test"},
+	}); err != nil {
+		t.Fatalf("upsert splits: %v", err)
+	}
+	if err := p.RecomputeSplitAdjustments(ctx, instID); err != nil {
+		t.Fatalf("recompute: %v", err)
+	}
+
+	points, err := p.GetUserValuation(ctx, userID, d(2020, 8, 28), d(2020, 8, 31), "USD")
+	if err != nil {
+		t.Fatalf("valuation: %v", err)
+	}
+	before, after := valueOn(t, points, d(2020, 8, 28)), valueOn(t, points, d(2020, 8, 31))
+	if !approxEq(before, 50_000) {
+		t.Errorf("value before the split: got %v want %v", before, 50_000.0)
+	}
+	if !approxEq(after, 50_000) {
+		t.Errorf("value after the split: got %v want %v (a %.0f%% cliff at the ex-date)",
+			after, 50_000.0, (1-after/before)*100)
+	}
+}
+
+func valueOn(t *testing.T, points []db.ValuationPoint, want time.Time) float64 {
+	t.Helper()
+	for _, pt := range points {
+		if pt.Date.Equal(want) {
+			return pt.TotalValue
+		}
+	}
+	t.Fatalf("no valuation point for %s", want.Format("2006-01-02"))
+	return 0
+}


### PR DESCRIPTION
Depends on #258 -> #257 -> #256 -> #255. Review the last two commits only, or wait for the stack to merge down.

Last of five PRs from the bitemporality audit. **Fixes the second defect that produces wrong numbers today.**

## The defect

Valuation summed raw `quantity` and multiplied by raw `close`. Those are two different share counts either side of a split:

- Raw position **never steps up**, because `TX_TYPE=SPLIT` rows are dropped at ingestion — corporate events are shared reference data, never derived from user transactions (adr/0005).
- The as-traded price **does step down** on the ex-date.

So a holding untouched across a 4:1 split lost three quarters of its value overnight on the performance chart. Meanwhile `GetHoldings` has always returned the split-adjusted quantity, so the two read paths disagreed.

## The fix

Read `split_adjusted_quantity` and `split_adjusted_close`. Both are denominated in today's share count, so the product is continuous through an ex-date, and valuation now agrees with holdings.

`split_adjusted_close` was, until this PR, written by the recompute and read by nothing at all.

## FX

FX rates stay on raw `close`, with a comment saying why: an exchange rate is not denominated in a share count, so it has no basis to adjust and adjusting it would be a category error. The plan said to assert this rather than assume it, so there is a test valuing a EUR holding across a split at a deliberately flat rate — any movement in the result would be the split leaking into the FX leg.

## Red before green

    valuation_test.go:908: value after the split: got 12500 want 50000
        (a 75% cliff at the ex-date)
    --- FAIL: TestGetUserValuation_ContinuousAcrossSplit

Worth noting: this branch sits on top of #257, so the failure isolates the *pairing* defect. On `main` the same test fails for both reasons at once, which is why the plan sequenced them this way.

## Verification

`make test` — exit 0, zero failures across server, client, db, integration and extension suites.

With this merged, `docs/spec/bitemporality.md` has no remaining "in flight" divergences; what is left is issues 0050-0056.

🤖 Generated with [Claude Code](https://claude.com/claude-code)