### PR TITLE
Let a converter declare its broker's share count convention

### DIFF
--- a/client/app/components/upload-modal.tsx
+++ b/client/app/components/upload-modal.tsx
@@ -89,6 +89,7 @@ export function UploadModal() {
         periodTo: timestampFromDate(parseResult.periodTo),
         txs: parseResult.txs,
         filename: file?.name,
+        shareCountBasis: parseResult.shareCountBasis,
       });
       setJobId(res.jobId);
     } catch (e) {

--- a/client/lib/csv/standard.test.ts
+++ b/client/lib/csv/standard.test.ts
@@ -321,4 +321,38 @@ not-a-date,FOO,BUYSTOCK,5
     expect(result.txs).toHaveLength(1);
     expect(result.txs[0].identifierHints).toHaveLength(0);
   });
+
+describe("share count basis", () => {
+  const rows = `date,instrument_description,type,quantity
+2024-01-01,AAPL,BUYSTOCK,10`;
+
+  it("is undeclared for an ordinary as-traded file", () => {
+    const result = parseStandardCSV(rows);
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.shareCountBasis).toBeUndefined();
+  });
+
+  it("reads the basis from a comment line", () => {
+    const result = parseStandardCSV(`# share_count_basis=2026-07-29\n${rows}`);
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.txs).toHaveLength(1);
+    expect(result.shareCountBasis).toBe("2026-07-29");
+  });
+
+  it("rejects a basis that is not a plain date", () => {
+    const result = parseStandardCSV(`# share_count_basis=29/07/2026\n${rows}`);
+
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].field).toBe("share_count_basis");
+  });
+
+  it("ignores other comment lines rather than parsing them as rows", () => {
+    const result = parseStandardCSV(`# exported from somewhere\n${rows}`);
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.txs).toHaveLength(1);
+  });
+});
 });

--- a/client/lib/csv/standard.ts
+++ b/client/lib/csv/standard.ts
@@ -20,11 +20,31 @@ export interface ParseError {
   message: string;
 }
 
+/** Comment line carrying the share count basis, e.g. "# share_count_basis=2026-07-29". */
+const SHARE_COUNT_BASIS_PREFIX = "# share_count_basis=";
+
 export interface StandardParseResult {
   txs: Tx[];
   periodFrom: Date;
   periodTo: Date;
   errors: ParseError[];
+  /**
+   * The share count the quantities and unit prices are denominated in, as
+   * "YYYY-MM-DD".
+   *
+   * Omit for an as-traded source: each row reflects the splits that happened
+   * before its own transaction date and nothing after it, which is what
+   * brokers normally supply and what the server assumes. Set it only when the
+   * source has post-adjusted historical rows for splits that happened *after*
+   * the transaction -- then this is the date those quantities are current as
+   * of, and the server will not apply those splits a second time.
+   *
+   * The converter declares the convention rather than undoing the arithmetic:
+   * reversing it here would need the split table, which lives server-side, and
+   * would store numbers the broker never printed. See
+   * docs/spec/bitemporality.md.
+   */
+  shareCountBasis?: string;
 }
 
 const TX_TYPE_BY_NAME = new Map<string, TxType>(
@@ -72,7 +92,24 @@ export function parseCSVLine(line: string): string[] {
  */
 export function parseStandardCSV(csvText: string): StandardParseResult {
   const errors: ParseError[] = [];
-  const lines = csvText.split(/\r?\n/).map((l) => l.trim()).filter((l) => l.length > 0);
+  // Metadata rides on comment lines, matching the price CSV's exported_at.
+  let shareCountBasis: string | undefined;
+  const lines: string[] = [];
+  for (const raw of csvText.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (line.length === 0) continue;
+    if (line.startsWith(SHARE_COUNT_BASIS_PREFIX)) {
+      const value = line.slice(SHARE_COUNT_BASIS_PREFIX.length).trim();
+      if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+        shareCountBasis = value;
+      } else {
+        errors.push({ rowIndex: 0, field: "share_count_basis", message: `Invalid date "${value}": expected YYYY-MM-DD` });
+      }
+      continue;
+    }
+    if (line.startsWith("#")) continue;
+    lines.push(line);
+  }
   if (lines.length === 0) {
     return { txs: [], periodFrom: new Date(0), periodTo: new Date(0), errors: [{ rowIndex: 0, field: "file", message: "File is empty or has no header" }] };
   }
@@ -215,5 +252,5 @@ export function parseStandardCSV(csvText: string): StandardParseResult {
   const periodFrom = minTime === Infinity ? new Date(0) : new Date(minTime);
   const periodTo = maxTime === -Infinity ? new Date(0) : new Date(maxTime);
 
-  return { txs, periodFrom, periodTo, errors };
+  return { txs, periodFrom, periodTo, errors, shareCountBasis };
 }

--- a/docs/issues/0043-holding-declarations-pad-assert.md
+++ b/docs/issues/0043-holding-declarations-pad-assert.md
@@ -51,6 +51,26 @@ date and fails the run when it does not reconcile.
 - Re-verify after any ingestion or recompute that could change historical
   quantities, including split recompute.
 
+## Which share count a declaration is in
+
+`declared_qty` has no stated denomination. The spec says only "the number of
+units the user held at `as_of_date`", while the computed side of the comparison
+is `SUM(t.split_adjusted_quantity)` -- today's share count. For any instrument
+that has split since `as_of_date` the two are in different units, so a correct
+portfolio fails the assertion by the split factor.
+
+That has to be settled before the verification pass is worth building, or it
+fires on every split and buries the errors it exists to find. A user reading
+"500 shares on 2021-01-01" off an old statement means the share count current
+then; a user reading today's holdings screen means today's. Both are
+reasonable, so the declaration needs to say which -- a `share_count_basis`
+alongside `as_of_date`, defaulting to `as_of_date`, the same question answered
+for txs and prices in docs/spec/bitemporality.md.
+
+Once denominated consistently, the assertion is the only thing in the system
+that detects a transaction stored on the wrong share count basis: a
+double-adjusted holding is wrong by exactly the split factor.
+
 The API, recalc and UI plumbing already exist in
 server/service/api/declarations.go and server/service/api/recalc.go.
 

--- a/docs/spec/broker-import-extension.md
+++ b/docs/spec/broker-import-extension.md
@@ -68,7 +68,7 @@ The window bounds are then materialised as local start-of-day and local end-of-d
 | `period_from`, `period_to` | The **requested** window from step 3 -- not the minimum and maximum of the parsed rows. |
 | `txs` | The converted transactions. |
 | `filename` | A synthetic name identifying the run, e.g. `fidelity-ext-2026-07-27.csv`. |
-| `share_count_basis` | Empty for an as-traded broker; the run date when the recipe sets `restatesHistoricalQuantities` (see Share count below). |
+| `share_count_basis` | Whatever the converter declared; empty for an as-traded broker (see Share count below). |
 
 Two of these need care.
 
@@ -80,7 +80,7 @@ Two of these need care.
 
 The extension reads the broker's live web UI, which is the one import path where a broker could present historical rows restated into post-split terms.
 
-The default is as-traded: quantities and unit prices are denominated in the share count current on the row's own transaction date, and no recipe found so far violates that. A recipe for a broker that does restate sets `restatesHistoricalQuantities`, which makes the upload declare `share_count_basis` as the run date so the server does not apply splits the broker has already applied. The flag belongs to the recipe rather than the run because it is a property of the broker. Getting it wrong in either direction scales historical quantities by the split factor; see [bitemporality.md](bitemporality.md#share-count-basis).
+The default is as-traded: quantities and unit prices are denominated in the share count current on the row's own transaction date, and no broker found so far violates that. A converter for a broker that does restate sets `shareCountBasis` on its parse result, and the extension forwards it. The declaration sits on the converter rather than the recipe or the run because it is a property of how the broker reports, and because the converter is shared with the web upload path -- so both routes get it from one place. See [bitemporality.md](bitemporality.md#share-count-basis).
 
 ### Account scope
 

--- a/docs/spec/csv-format.md
+++ b/docs/spec/csv-format.md
@@ -57,6 +57,14 @@ date,instrument_description,type,quantity,trading_currency,unit_price,account,sy
 
 Any extra columns are ignored. Empty optional fields can be omitted or left blank.
 
+## Comment lines
+
+Lines beginning with `#` are metadata or commentary and are not parsed as rows. One key is recognised:
+
+    # share_count_basis=2026-07-29
+
+It declares the share count the file's quantities and unit prices are denominated in. Omit it for an ordinary export, where each row reflects the splits that happened before its own transaction date and nothing after -- the as-traded convention the server assumes. Set it only when the source has post-adjusted historical rows for splits that happened *after* the transaction, in which case it is the date those quantities are current as of. See [bitemporality.md](bitemporality.md#share-count-basis).
+
 # Corporate event CSV format
 
 A separate CSV is used to import stock splits and cash dividends via the `ImportCorporateEvents` API. Splits and dividends share one file; the `event` column distinguishes them.

--- a/extension/src/background/sync.test.ts
+++ b/extension/src/background/sync.test.ts
@@ -100,7 +100,7 @@ describe("sync", () => {
     expect(req.source).toBe("Fidelity:web:fidelity-csv");
   });
 
-  it("leaves the share count undeclared for an as-traded broker", async () => {
+  it("leaves the share count undeclared when the converter does not declare one", async () => {
     await run();
     const req = upsertTxs.mock.calls[0]![2] as { shareCountBasis: string };
     // Declaring a basis on an as-traded export would tell the server the

--- a/extension/src/background/sync.ts
+++ b/extension/src/background/sync.ts
@@ -159,11 +159,10 @@ export async function sync(opts: SyncOptions): Promise<SyncResult> {
       periodTo: timestampFromDate(win.to),
       txs: parsed.txs,
       filename: `${recipe.id}-${formatDate(win.to, "yyyy-MM-dd")}.json`,
-      // Only declared when the broker restates: an as-traded export is
-      // denominated per row, which is what the server assumes by default.
-      shareCountBasis: recipe.restatesHistoricalQuantities
-        ? formatDate(new Date(startedAt), "yyyy-MM-dd")
-        : "",
+      // Declared by the converter, which knows its broker's convention. Empty
+      // for an as-traded export, which is denominated per row and is what the
+      // server assumes by default.
+      shareCountBasis: parsed.shareCountBasis ?? "",
     });
     jobId = res.jobId;
   } catch (e) {

--- a/extension/src/brokers/types.ts
+++ b/extension/src/brokers/types.ts
@@ -60,19 +60,6 @@ export interface BrokerRecipe {
   /** Token pattern for {{from}} and {{to}}; see formatDate. */
   dateFormat: string;
   export: ExportRequest;
-  /**
-   * True when the broker restates historical rows into current share terms --
-   * showing post-split quantities on pre-split trades. The extension reads the
-   * broker's live web UI, so this is the one import path where it can happen.
-   *
-   * Defaults to false, the as-traded assumption: a broker log line accounts
-   * only for events prior to the trade. Setting it makes the upload declare
-   * that its quantities are denominated as of the run, so the server does not
-   * apply splits that the broker has already applied. Getting it wrong in
-   * either direction scales historical quantities by the split factor.
-   * See docs/spec/bitemporality.md.
-   */
-  restatesHistoricalQuantities?: boolean;
   /** Turns the captured payload into standard transactions. */
   convert: (payload: string, options?: Record<string, unknown>) => StandardParseResult;
 }

--- a/proto/ingestion/v1/ingestion.proto
+++ b/proto/ingestion/v1/ingestion.proto
@@ -54,6 +54,10 @@ message CreateTxRequest {
   string source = 2 [(buf.validate.field).string.min_len = 1];
   // The transaction (must include account).
   portfoliodb.api.v1.Tx tx = 3 [(buf.validate.field).required = true];
+  // The share count the quantity and unit price are denominated in, as
+  // "YYYY-MM-DD". Optional; when empty the row falls back to its own
+  // transaction date, the as-traded assumption. See UpsertTxsRequest.
+  string share_count_basis = 4;
 }
 
 // IngestionResponse returned by UpsertTxs and CreateTx. Job status and

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -209,7 +209,7 @@ type TxDB interface {
 	// shareCountBasis is the date the uploaded quantities and unit prices are
 	// denominated in. nil means as-traded: each row uses its own timestamp.
 	ReplaceTxsInPeriod(ctx context.Context, userID, broker string, periodFrom, periodTo *timestamppb.Timestamp, txs []*apiv1.Tx, instrumentIDs []string, shareCountBasis *time.Time) error
-	CreateTx(ctx context.Context, userID, broker, account string, tx *apiv1.Tx, instrumentID string) error
+	CreateTx(ctx context.Context, userID, broker, account string, tx *apiv1.Tx, instrumentID string, shareCountBasis *time.Time) error
 	ListTxs(ctx context.Context, userID string, broker *apiv1.Broker, account string, periodFrom, periodTo *timestamppb.Timestamp, descending bool, pageSize int32, pageToken string) ([]*apiv1.PortfolioTx, string, error)
 	ListTxsByPortfolio(ctx context.Context, portfolioID string, broker *apiv1.Broker, periodFrom, periodTo *timestamppb.Timestamp, descending bool, pageSize int32, pageToken string) ([]*apiv1.PortfolioTx, string, error)
 }

--- a/server/db/postgres/declarations_test.go
+++ b/server/db/postgres/declarations_test.go
@@ -135,7 +135,7 @@ func TestGetPortfolioStartDate(t *testing.T) {
 	instID, _ := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "SD1", Canonical: false}}, "", nil, nil, nil)
 	ts := time.Date(2025, 3, 15, 10, 0, 0, 0, time.UTC)
 	tx := &apiv1.Tx{Timestamp: timestamppb.New(ts), InstrumentDescription: "SD1", Type: apiv1.TxType_BUYSTOCK, Quantity: 10, Account: "acct1"}
-	p.CreateTx(ctx, userID, "IBKR", "acct1", tx, instID)
+	p.CreateTx(ctx, userID, "IBKR", "acct1", tx, instID, nil)
 
 	startDate, err = p.GetPortfolioStartDate(ctx, userID)
 	if err != nil {
@@ -157,8 +157,8 @@ func TestComputeRunningBalance(t *testing.T) {
 
 	ts1 := time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC)
 	ts2 := time.Date(2025, 3, 15, 10, 0, 0, 0, time.UTC)
-	p.CreateTx(ctx, userID, "IBKR", "acct1", &apiv1.Tx{Timestamp: timestamppb.New(ts1), InstrumentDescription: "RB1", Type: apiv1.TxType_BUYSTOCK, Quantity: 100, Account: "acct1"}, instID)
-	p.CreateTx(ctx, userID, "IBKR", "acct1", &apiv1.Tx{Timestamp: timestamppb.New(ts2), InstrumentDescription: "RB1", Type: apiv1.TxType_SELLSTOCK, Quantity: -30, Account: "acct1"}, instID)
+	p.CreateTx(ctx, userID, "IBKR", "acct1", &apiv1.Tx{Timestamp: timestamppb.New(ts1), InstrumentDescription: "RB1", Type: apiv1.TxType_BUYSTOCK, Quantity: 100, Account: "acct1"}, instID, nil)
+	p.CreateTx(ctx, userID, "IBKR", "acct1", &apiv1.Tx{Timestamp: timestamppb.New(ts2), InstrumentDescription: "RB1", Type: apiv1.TxType_SELLSTOCK, Quantity: -30, Account: "acct1"}, instID, nil)
 
 	from := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2025, 12, 31, 23, 59, 59, 0, time.UTC)

--- a/server/db/postgres/price_cache_test.go
+++ b/server/db/postgres/price_cache_test.go
@@ -239,12 +239,12 @@ func TestHeldRanges_MultipleInstruments(t *testing.T) {
 	// Insert txs for inst2 using CreateTx to avoid ReplaceTxsInPeriod conflict with same broker/period.
 	if err := p.CreateTx(ctx, userID, "TEST2", "A", &apiv1.Tx{
 		Timestamp: ts(2024, 3, 1), InstrumentDescription: "INST2", Type: apiv1.TxType_BUYSTOCK, Quantity: 20, Account: "A",
-	}, inst2); err != nil {
+	}, inst2, nil); err != nil {
 		t.Fatalf("create tx: %v", err)
 	}
 	if err := p.CreateTx(ctx, userID, "TEST2", "A", &apiv1.Tx{
 		Timestamp: ts(2024, 4, 1), InstrumentDescription: "INST2", Type: apiv1.TxType_SELLSTOCK, Quantity: -20, Account: "A",
-	}, inst2); err != nil {
+	}, inst2, nil); err != nil {
 		t.Fatalf("create tx: %v", err)
 	}
 
@@ -279,12 +279,12 @@ func TestHeldRanges_MultipleUsers(t *testing.T) {
 	// User 2 holds Mar-Apr (separate broker to avoid replace conflict).
 	if err := p.CreateTx(ctx, user2, "TEST2", "B", &apiv1.Tx{
 		Timestamp: ts(2024, 3, 1), InstrumentDescription: "SHARED", Type: apiv1.TxType_BUYSTOCK, Quantity: 5, Account: "B",
-	}, instID); err != nil {
+	}, instID, nil); err != nil {
 		t.Fatalf("create tx: %v", err)
 	}
 	if err := p.CreateTx(ctx, user2, "TEST2", "B", &apiv1.Tx{
 		Timestamp: ts(2024, 4, 1), InstrumentDescription: "SHARED", Type: apiv1.TxType_SELLSTOCK, Quantity: -5, Account: "B",
-	}, instID); err != nil {
+	}, instID, nil); err != nil {
 		t.Fatalf("create tx: %v", err)
 	}
 
@@ -925,22 +925,22 @@ func TestFXGaps_MixedCurrencies(t *testing.T) {
 	})
 	if err := p.CreateTx(ctx, userID, "TEST2", "A", &apiv1.Tx{
 		Timestamp: ts(2024, 1, 10), InstrumentDescription: "HSBC", Type: apiv1.TxType_BUYSTOCK, Quantity: 5, Account: "A",
-	}, gbpInst); err != nil {
+	}, gbpInst, nil); err != nil {
 		t.Fatalf("create tx: %v", err)
 	}
 	if err := p.CreateTx(ctx, userID, "TEST2", "A", &apiv1.Tx{
 		Timestamp: ts(2024, 2, 10), InstrumentDescription: "HSBC", Type: apiv1.TxType_SELLSTOCK, Quantity: -5, Account: "A",
-	}, gbpInst); err != nil {
+	}, gbpInst, nil); err != nil {
 		t.Fatalf("create tx: %v", err)
 	}
 	if err := p.CreateTx(ctx, userID, "TEST3", "A", &apiv1.Tx{
 		Timestamp: ts(2024, 1, 10), InstrumentDescription: "AAPL-FX", Type: apiv1.TxType_BUYSTOCK, Quantity: 20, Account: "A",
-	}, usdInst); err != nil {
+	}, usdInst, nil); err != nil {
 		t.Fatalf("create tx: %v", err)
 	}
 	if err := p.CreateTx(ctx, userID, "TEST3", "A", &apiv1.Tx{
 		Timestamp: ts(2024, 2, 10), InstrumentDescription: "AAPL-FX", Type: apiv1.TxType_SELLSTOCK, Quantity: -20, Account: "A",
-	}, usdInst); err != nil {
+	}, usdInst, nil); err != nil {
 		t.Fatalf("create tx: %v", err)
 	}
 
@@ -1028,12 +1028,12 @@ func TestFXGaps_MultipleInstrumentsSameCurrency(t *testing.T) {
 	})
 	if err := p.CreateTx(ctx, userID, "TEST2", "A", &apiv1.Tx{
 		Timestamp: ts(2024, 1, 15), InstrumentDescription: "BMW-M1", Type: apiv1.TxType_BUYSTOCK, Quantity: 5, Account: "A",
-	}, eurInst2); err != nil {
+	}, eurInst2, nil); err != nil {
 		t.Fatalf("create tx: %v", err)
 	}
 	if err := p.CreateTx(ctx, userID, "TEST2", "A", &apiv1.Tx{
 		Timestamp: ts(2024, 1, 30), InstrumentDescription: "BMW-M1", Type: apiv1.TxType_SELLSTOCK, Quantity: -5, Account: "A",
-	}, eurInst2); err != nil {
+	}, eurInst2, nil); err != nil {
 		t.Fatalf("create tx: %v", err)
 	}
 
@@ -1130,12 +1130,12 @@ func TestFXGaps_DisplayCurrency_MixedHoldings(t *testing.T) {
 	})
 	if err := p.CreateTx(ctx, userID, "TEST2", "A", &apiv1.Tx{
 		Timestamp: ts(2024, 2, 1), InstrumentDescription: "AAPL-DC2", Type: apiv1.TxType_BUYSTOCK, Quantity: 10, Account: "A",
-	}, usdInst); err != nil {
+	}, usdInst, nil); err != nil {
 		t.Fatalf("create tx: %v", err)
 	}
 	if err := p.CreateTx(ctx, userID, "TEST2", "A", &apiv1.Tx{
 		Timestamp: ts(2024, 2, 10), InstrumentDescription: "AAPL-DC2", Type: apiv1.TxType_SELLSTOCK, Quantity: -10, Account: "A",
-	}, usdInst); err != nil {
+	}, usdInst, nil); err != nil {
 		t.Fatalf("create tx: %v", err)
 	}
 

--- a/server/db/postgres/txs.go
+++ b/server/db/postgres/txs.go
@@ -71,7 +71,7 @@ func (p *Postgres) ReplaceTxsInPeriod(ctx context.Context, userID, broker string
 }
 
 // CreateTx implements db.TxDB.
-func (p *Postgres) CreateTx(ctx context.Context, userID, broker, account string, tx *apiv1.Tx, instrumentID string) error {
+func (p *Postgres) CreateTx(ctx context.Context, userID, broker, account string, tx *apiv1.Tx, instrumentID string, shareCountBasis *time.Time) error {
 	userUUID, err := uuid.Parse(userID)
 	if err != nil {
 		return fmt.Errorf("invalid user id: %w", err)
@@ -89,9 +89,9 @@ func (p *Postgres) CreateTx(ctx context.Context, userID, broker, account string,
 		return err
 	}
 	_, err = p.q.ExecContext(ctx, `
-		INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type, quantity, trading_currency, settlement_currency, unit_price, instrument_id)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-	`, userUUID, broker, account, ts, tx.InstrumentDescription, txTypeStr, tx.Quantity, nullStr(tx.TradingCurrency), nullStr(tx.SettlementCurrency), nullFloat(tx.UnitPrice), instUUID)
+		INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type, quantity, trading_currency, settlement_currency, unit_price, instrument_id, share_count_basis)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::date)
+	`, userUUID, broker, account, ts, tx.InstrumentDescription, txTypeStr, tx.Quantity, nullStr(tx.TradingCurrency), nullStr(tx.SettlementCurrency), nullFloat(tx.UnitPrice), instUUID, shareCountBasis)
 	if err != nil {
 		return fmt.Errorf("create tx: %w", err)
 	}

--- a/server/db/postgres/txs_test.go
+++ b/server/db/postgres/txs_test.go
@@ -134,10 +134,10 @@ func TestCreateTx_AppendOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ensure instrument: %v", err)
 	}
-	if err := p.CreateTx(ctx, userID, "IBKR", "", tx1, instID); err != nil {
+	if err := p.CreateTx(ctx, userID, "IBKR", "", tx1, instID, nil); err != nil {
 		t.Fatalf("first create: %v", err)
 	}
-	if err := p.CreateTx(ctx, userID, "IBKR", "", tx2, instID); err != nil {
+	if err := p.CreateTx(ctx, userID, "IBKR", "", tx2, instID, nil); err != nil {
 		t.Fatalf("second create: %v", err)
 	}
 	holdings, _, _ := p.ComputeHoldings(ctx, userID, nil, "", nil)
@@ -175,7 +175,7 @@ func TestListTxs_BrokerFilterAndOrder(t *testing.T) {
 			t.Fatalf("broker to str: %v", err)
 		}
 		tx := &apiv1.Tx{Timestamp: timestamppb.New(now.Add(s.offset)), InstrumentDescription: "ORD", Type: apiv1.TxType_BUYSTOCK, Quantity: s.qty}
-		if err := p.CreateTx(ctx, userID, brokerStr, "", tx, instID); err != nil {
+		if err := p.CreateTx(ctx, userID, brokerStr, "", tx, instID, nil); err != nil {
 			t.Fatalf("create tx: %v", err)
 		}
 	}
@@ -245,7 +245,7 @@ func TestListTxs_TiedTimestampsPageBoundary(t *testing.T) {
 	const total = 6
 	for i := 0; i < total; i++ {
 		tx := &apiv1.Tx{Timestamp: ts, InstrumentDescription: "TIE", Type: apiv1.TxType_BUYSTOCK, Quantity: float64(i + 1)}
-		if err := p.CreateTx(ctx, userID, "IBKR", "", tx, instID); err != nil {
+		if err := p.CreateTx(ctx, userID, "IBKR", "", tx, instID, nil); err != nil {
 			t.Fatalf("create tx %d: %v", i, err)
 		}
 	}
@@ -378,15 +378,15 @@ func TestListTxsByPortfolio_ANDBetweenCategories(t *testing.T) {
 		t.Fatalf("ensure instrument: %v", err)
 	}
 	// Tx1: IBKR, account "B" -> matches broker but NOT account -> excluded
-	if err := p.CreateTx(ctx, userID, "IBKR", "B", &apiv1.Tx{Timestamp: ts, InstrumentDescription: "X", Type: apiv1.TxType_BUYSTOCK, Quantity: 1, Account: "B"}, instID); err != nil {
+	if err := p.CreateTx(ctx, userID, "IBKR", "B", &apiv1.Tx{Timestamp: ts, InstrumentDescription: "X", Type: apiv1.TxType_BUYSTOCK, Quantity: 1, Account: "B"}, instID, nil); err != nil {
 		t.Fatalf("create tx1: %v", err)
 	}
 	// Tx2: SCHB, account "A" -> matches account but NOT broker -> excluded
-	if err := p.CreateTx(ctx, userID, "SCHB", "A", &apiv1.Tx{Timestamp: ts, InstrumentDescription: "X", Type: apiv1.TxType_BUYSTOCK, Quantity: 2, Account: "A"}, instID); err != nil {
+	if err := p.CreateTx(ctx, userID, "SCHB", "A", &apiv1.Tx{Timestamp: ts, InstrumentDescription: "X", Type: apiv1.TxType_BUYSTOCK, Quantity: 2, Account: "A"}, instID, nil); err != nil {
 		t.Fatalf("create tx2: %v", err)
 	}
 	// Tx3: IBKR, account "A" -> matches both -> included
-	if err := p.CreateTx(ctx, userID, "IBKR", "A", &apiv1.Tx{Timestamp: ts, InstrumentDescription: "X", Type: apiv1.TxType_BUYSTOCK, Quantity: 3, Account: "A"}, instID); err != nil {
+	if err := p.CreateTx(ctx, userID, "IBKR", "A", &apiv1.Tx{Timestamp: ts, InstrumentDescription: "X", Type: apiv1.TxType_BUYSTOCK, Quantity: 3, Account: "A"}, instID, nil); err != nil {
 		t.Fatalf("create tx3: %v", err)
 	}
 	txs, _, err := p.ListTxsByPortfolio(ctx, port.GetId(), nil, nil, nil, false, 50, "")

--- a/server/service/ingestion/server.go
+++ b/server/service/ingestion/server.go
@@ -85,9 +85,10 @@ func (s *Server) CreateTx(ctx context.Context, req *ingestionv1.CreateTxRequest)
 	// Wrap single tx in UpsertTxsRequest for uniform payload format.
 	brokerStr, _ := brokerToString(req.Broker)
 	wrapped := &ingestionv1.UpsertTxsRequest{
-		Broker:   req.Broker,
-		Source:   req.GetSource(),
-		Txs:     []*apiv1.Tx{req.Tx},
+		Broker:          req.Broker,
+		Source:          req.GetSource(),
+		Txs:             []*apiv1.Tx{req.Tx},
+		ShareCountBasis: req.GetShareCountBasis(),
 	}
 	payload, err := proto.Marshal(wrapped)
 	if err != nil {

--- a/server/service/ingestion/worker.go
+++ b/server/service/ingestion/worker.go
@@ -239,7 +239,7 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 	if bulk {
 		storeErr = database.ReplaceTxsInPeriod(ctx, userID, broker, req.PeriodFrom, req.PeriodTo, txsToProcess, instrumentIDs, shareCountBasis)
 	} else {
-		storeErr = database.CreateTx(ctx, userID, broker, txsToProcess[0].GetAccount(), txsToProcess[0], instrumentIDs[0])
+		storeErr = database.CreateTx(ctx, userID, broker, txsToProcess[0].GetAccount(), txsToProcess[0], instrumentIDs[0], shareCountBasis)
 	}
 	if storeErr != nil {
 		log.Printf("ingestion job %s: %v", j.JobID, storeErr)


### PR DESCRIPTION
Depends on #259 -> #258 -> #257 -> #256 -> #255. Review the last commit only, or wait for the stack to merge down.

Sixth PR from the bitemporality audit. Closes the declaration gap the earlier PRs left, and amends issue 0043 with a prerequisite found while working out whether the assertion would catch this.

## The gap

A broker that post-adjusts a historical row — showing post-split quantities on a trade that predates the split — had no way to say so outside the extension path. `UpsertTxsParams.shareCountBasis` existed but no web caller set it, the CSV had no header for it, and `CreateTx` did not accept one at all. So the row was recorded as as-traded and the recompute applied the split a second time: a real 100-share holding reported as 400 would be stored as 1600 after a 4:1 split.

To be clear about scope, since this came up in review: this only bites when a broker restates a row for a split that happened **after** the transaction. The ordinary case — each row reflecting the splits before its own date — is as-traded and was already handled correctly. No broker in the system does the problematic thing today.

## Declaring, not reversing

The knowledge belongs to the converter: it knows how its broker reports, and it is shared by the web upload and the extension, so declaring it there covers both routes from one place.

The alternative — having the converter reverse the broker's arithmetic — was considered and rejected:

- It needs the split table, which lives server-side as admin-owned reference data (adr/0005). Converters are pure synchronous functions shared with the extension; making them async and networked breaks that contract.
- It would store numbers the broker never printed, so the row no longer reconciles against the statement.
- It reintroduces rounding on any non-whole split, where declaring never touches the values.

Declaring leaves the values exactly as supplied and lets `split_factor_at` find no split after the declared date.

## Changes

- `StandardParseResult.shareCountBasis`, forwarded by both the web upload modal and the extension.
- Standard CSV reads `# share_count_basis=YYYY-MM-DD` from a comment line, matching the price CSV's `# exported_at=`. Other `#` lines are now skipped rather than parsed as rows.
- `CreateTxRequest.share_count_basis` and the corresponding `db.CreateTx` parameter.
- **Retires `BrokerRecipe.restatesHistoricalQuantities`**, added in #258. With the converter declaring, the recipe flag was a second mechanism for the same fact.

No converter sets it. Every broker handled today reports as-traded.

## Issue 0043 amendment

Working out whether a holding assertion would catch a double-adjusted quantity surfaced a prerequisite: `declared_qty` has no stated denomination, while the computed side of the comparison is `SUM(t.split_adjusted_quantity)` — today's share count. For any instrument that has split since `as_of_date`, a correct portfolio would fail the assertion by the split factor, burying real errors in false positives.

0043 now records that the declaration needs its own `share_count_basis`, and that once denominated consistently the assertion is the only thing in the system that detects a transaction stored on the wrong basis.

## Verification

`make test` — exit 0, zero failures. Four new CSV parser tests cover the undeclared default, a valid declaration, a malformed date, and unrelated comment lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)