### PR TITLE
Record the share count a transaction is denominated in

### DIFF
--- a/client/lib/ingestion-api.ts
+++ b/client/lib/ingestion-api.ts
@@ -27,6 +27,12 @@ export interface UpsertTxsParams {
   periodTo?: Timestamp;
   txs: Tx[];
   filename?: string;
+  /**
+   * The share count the uploaded quantities and unit prices are denominated
+   * in, as "YYYY-MM-DD". Omit for an as-traded source, which is every CSV
+   * export the client handles. See docs/spec/bitemporality.md.
+   */
+  shareCountBasis?: string;
 }
 
 export async function upsertTxs(params: UpsertTxsParams): Promise<IngestionResponse> {
@@ -38,6 +44,7 @@ export async function upsertTxs(params: UpsertTxsParams): Promise<IngestionRespo
     periodTo: params.periodTo,
     txs: params.txs,
     filename: params.filename ?? "",
+    shareCountBasis: params.shareCountBasis ?? "",
   });
   const resBytes = await unaryFetch(
     base,

--- a/docs/spec/bitemporality.md
+++ b/docs/spec/bitemporality.md
@@ -161,7 +161,6 @@ The model above is normative. These parts of the system do not yet comply:
 
 | Divergence | Issue |
 | --- | --- |
-| Transactions have no `share_count_basis`: they are adjusted against `timestamp`, so a broker that restates historical rows cannot say so | in flight |
 | Valuation pairs raw quantity with raw close while `TX_TYPE=SPLIT` rows are dropped at ingestion, so a forward split shows as a discontinuity | in flight |
 | No daily scheduler fires the blanket recompute, so a stored future-dated split never activates when its `ex_date` crosses | 0050 |
 | Corporate event export and import carry no knowledge time, so a re-import cannot reproduce the original adjustment state; `corporate_event_coverage` collapses every span's `last_fetched_at` on merge | 0051 |

--- a/docs/spec/broker-import-extension.md
+++ b/docs/spec/broker-import-extension.md
@@ -68,6 +68,7 @@ The window bounds are then materialised as local start-of-day and local end-of-d
 | `period_from`, `period_to` | The **requested** window from step 3 -- not the minimum and maximum of the parsed rows. |
 | `txs` | The converted transactions. |
 | `filename` | A synthetic name identifying the run, e.g. `fidelity-ext-2026-07-27.csv`. |
+| `share_count_basis` | Empty for an as-traded broker; the run date when the recipe sets `restatesHistoricalQuantities` (see Share count below). |
 
 Two of these need care.
 
@@ -77,7 +78,9 @@ Two of these need care.
 
 ### Share count
 
-The extension reads the broker's live web UI, which is the one import path where a broker could present historical rows restated into post-split terms. Ingestion currently assumes every row is as-traded -- quantities and prices denominated in the share count current on the row's own transaction date -- and no broker recipe has been found to violate that. A recipe for a broker that does restate must declare it rather than rely on the default; see [bitemporality.md](bitemporality.md#share-count-basis).
+The extension reads the broker's live web UI, which is the one import path where a broker could present historical rows restated into post-split terms.
+
+The default is as-traded: quantities and unit prices are denominated in the share count current on the row's own transaction date, and no recipe found so far violates that. A recipe for a broker that does restate sets `restatesHistoricalQuantities`, which makes the upload declare `share_count_basis` as the run date so the server does not apply splits the broker has already applied. The flag belongs to the recipe rather than the run because it is a property of the broker. Getting it wrong in either direction scales historical quantities by the split factor; see [bitemporality.md](bitemporality.md#share-count-basis).
 
 ### Account scope
 

--- a/docs/spec/csv-format.md
+++ b/docs/spec/csv-format.md
@@ -8,7 +8,7 @@ Header names are case-insensitive. Supported column names:
 
 | Column                   | Required | Description |
 | ------------------------ | -------- | ----------- |
-| `date` or `timestamp`    | Yes      | Transaction date/time. ISO 8601 (e.g. `2024-01-15` or `2024-01-15T14:30:00Z`) or `YYYY-MM-DD`. |
+| `date` or `timestamp`    | Yes      | Transaction date/time. ISO 8601 (e.g. `2024-01-15` or `2024-01-15T14:30:00Z`) or `YYYY-MM-DD`. Also the share count the row's quantity and unit price are denominated in, unless the upload declares otherwise (see [bitemporality.md](bitemporality.md#share-count-basis)). |
 | `instrument_description`| Yes      | Broker's instrument description (e.g. symbol, name, or broker-specific text). |
 | `type`                  | Yes      | OFX-style transaction type: see allowed values below. |
 | `quantity`              | Yes      | Signed number: positive for buys/adds, negative for sells/reductions. |

--- a/extension/src/background/sync.test.ts
+++ b/extension/src/background/sync.test.ts
@@ -100,6 +100,15 @@ describe("sync", () => {
     expect(req.source).toBe("Fidelity:web:fidelity-csv");
   });
 
+  it("leaves the share count undeclared for an as-traded broker", async () => {
+    await run();
+    const req = upsertTxs.mock.calls[0]![2] as { shareCountBasis: string };
+    // Declaring a basis on an as-traded export would tell the server the
+    // quantities are already post-split, and historical rows spanning a split
+    // would be left unadjusted.
+    expect(req.shareCountBasis).toBe("");
+  });
+
   it("asks only for the most recent transaction of that broker", async () => {
     await run();
     expect(listTxs.mock.calls[0]![2]).toMatchObject({

--- a/extension/src/background/sync.ts
+++ b/extension/src/background/sync.ts
@@ -159,6 +159,11 @@ export async function sync(opts: SyncOptions): Promise<SyncResult> {
       periodTo: timestampFromDate(win.to),
       txs: parsed.txs,
       filename: `${recipe.id}-${formatDate(win.to, "yyyy-MM-dd")}.json`,
+      // Only declared when the broker restates: an as-traded export is
+      // denominated per row, which is what the server assumes by default.
+      shareCountBasis: recipe.restatesHistoricalQuantities
+        ? formatDate(new Date(startedAt), "yyyy-MM-dd")
+        : "",
     });
     jobId = res.jobId;
   } catch (e) {

--- a/extension/src/brokers/types.ts
+++ b/extension/src/brokers/types.ts
@@ -60,6 +60,19 @@ export interface BrokerRecipe {
   /** Token pattern for {{from}} and {{to}}; see formatDate. */
   dateFormat: string;
   export: ExportRequest;
+  /**
+   * True when the broker restates historical rows into current share terms --
+   * showing post-split quantities on pre-split trades. The extension reads the
+   * broker's live web UI, so this is the one import path where it can happen.
+   *
+   * Defaults to false, the as-traded assumption: a broker log line accounts
+   * only for events prior to the trade. Setting it makes the upload declare
+   * that its quantities are denominated as of the run, so the server does not
+   * apply splits that the broker has already applied. Getting it wrong in
+   * either direction scales historical quantities by the split factor.
+   * See docs/spec/bitemporality.md.
+   */
+  restatesHistoricalQuantities?: boolean;
   /** Turns the captured payload into standard transactions. */
   convert: (payload: string, options?: Record<string, unknown>) => StandardParseResult;
 }

--- a/proto/ingestion/v1/ingestion.proto
+++ b/proto/ingestion/v1/ingestion.proto
@@ -37,6 +37,13 @@ message UpsertTxsRequest {
   repeated portfoliodb.api.v1.Tx txs = 5;
   // Original filename of the uploaded CSV file.
   string filename = 6;
+  // The share count the quantities and unit prices in this upload are
+  // denominated in, as "YYYY-MM-DD". Optional; when empty each row falls back
+  // to its own transaction date, the as-traded assumption. Set it only for a
+  // source that restates historical rows into current share terms, such as a
+  // broker web UI that shows post-split quantities on pre-split trades.
+  // See docs/spec/bitemporality.md.
+  string share_count_basis = 7;
 }
 
 // CreateTxRequest appends one transaction.

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -206,7 +206,9 @@ type PortfolioDB interface {
 
 // TxDB provides transaction write and list.
 type TxDB interface {
-	ReplaceTxsInPeriod(ctx context.Context, userID, broker string, periodFrom, periodTo *timestamppb.Timestamp, txs []*apiv1.Tx, instrumentIDs []string) error
+	// shareCountBasis is the date the uploaded quantities and unit prices are
+	// denominated in. nil means as-traded: each row uses its own timestamp.
+	ReplaceTxsInPeriod(ctx context.Context, userID, broker string, periodFrom, periodTo *timestamppb.Timestamp, txs []*apiv1.Tx, instrumentIDs []string, shareCountBasis *time.Time) error
 	CreateTx(ctx context.Context, userID, broker, account string, tx *apiv1.Tx, instrumentID string) error
 	ListTxs(ctx context.Context, userID string, broker *apiv1.Broker, account string, periodFrom, periodTo *timestamppb.Timestamp, descending bool, pageSize int32, pageToken string) ([]*apiv1.PortfolioTx, string, error)
 	ListTxsByPortfolio(ctx context.Context, portfolioID string, broker *apiv1.Broker, periodFrom, periodTo *timestamppb.Timestamp, descending bool, pageSize int32, pageToken string) ([]*apiv1.PortfolioTx, string, error)

--- a/server/db/postgres/corporate_events.go
+++ b/server/db/postgres/corporate_events.go
@@ -600,9 +600,8 @@ func (p *Postgres) ApplyOptionSplit(ctx context.Context, params db.OptionSplitPa
 // RecomputeSplitAdjustments implements db.CorporateEventDB. Two UPDATEs (one
 // for eod_prices, one for txs) recompute the split_adjusted_* columns from raw
 // values multiplied by the cumulative split factor for splits with ex_date
-// strictly after the row's reference date (share_count_basis for prices,
-// timestamp::date for txs). Idempotent: factor is recomputed from scratch
-// each call. When instrumentID is empty, every instrument with at least one
+// strictly after the row's share_count_basis. Idempotent: factor is recomputed
+// from scratch each call. When instrumentID is empty, every instrument with at least one
 // stock_splits row is recomputed in the same transaction.
 func (p *Postgres) RecomputeSplitAdjustments(ctx context.Context, instrumentID string) error {
 	var (
@@ -655,7 +654,7 @@ func (p *Postgres) RecomputeSplitAdjustments(ctx context.Context, instrumentID s
 				split_adjusted_unit_price = CASE WHEN t.unit_price IS NULL THEN NULL
 					ELSE t.unit_price / f.factor END
 			FROM (
-				SELECT id, split_factor_at(instrument_id, timestamp::date) AS factor
+				SELECT id, split_factor_at(instrument_id, share_count_basis) AS factor
 				FROM txs
 				WHERE instrument_id IS NOT NULL
 				  AND instrument_id %s

--- a/server/db/postgres/corporate_events_test.go
+++ b/server/db/postgres/corporate_events_test.go
@@ -1055,3 +1055,60 @@ func assertBasis(t *testing.T, p *Postgres, instID string, priceDate, want time.
 			got.Format("2006-01-02"), want.Format("2006-01-02"))
 	}
 }
+
+// TestRecomputeSplitAdjustments_TxsUseDeclaredBasis covers the two transaction
+// sources. A broker log line is as-traded -- it accounts only for events prior
+// to the trade -- so a pre-split buy is adjusted. A source that restates its
+// history into current share terms declares that, and must not be adjusted
+// again.
+func TestRecomputeSplitAdjustments_TxsUseDeclaredBasis(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID := setupUser(t, p)
+	instID := setupInstrument(t, p, "AAPL")
+
+	asTraded := insertTxWithBasis(t, p, userID, instID, d(2020, 8, 28), 100, nil)
+	today := time.Now().UTC().Truncate(24 * time.Hour)
+	restated := insertTxWithBasis(t, p, userID, instID, d(2020, 8, 28), 400, &today)
+
+	if err := p.UpsertStockSplits(ctx, []db.StockSplit{
+		{InstrumentID: instID, ExDate: d(2020, 8, 31), SplitFrom: "1", SplitTo: "4", DataProvider: "test"},
+	}); err != nil {
+		t.Fatalf("upsert splits: %v", err)
+	}
+	if err := p.RecomputeSplitAdjustments(ctx, instID); err != nil {
+		t.Fatalf("recompute: %v", err)
+	}
+
+	if got := adjustedQty(t, p, asTraded); !approxEq(got, 400) {
+		t.Errorf("as-traded tx: got %v want %v", got, 400.0)
+	}
+	if got := adjustedQty(t, p, restated); !approxEq(got, 400) {
+		t.Errorf("restated tx adjusted a second time: got %v want %v", got, 400.0)
+	}
+}
+
+func insertTxWithBasis(t *testing.T, p *Postgres, userID, instID string, ts time.Time, qty float64, basis *time.Time) string {
+	t.Helper()
+	var id string
+	err := p.q.QueryRowContext(context.Background(), `
+		INSERT INTO txs (user_id, broker, account, timestamp, instrument_description,
+			tx_type, quantity, instrument_id, share_count_basis)
+		VALUES ($1::uuid, 'IBKR', '', $2, 'AAPL', 'BUYSTOCK', $3, $4::uuid, $5::date)
+		RETURNING id
+	`, userID, ts, qty, instID, basis).Scan(&id)
+	if err != nil {
+		t.Fatalf("insert tx: %v", err)
+	}
+	return id
+}
+
+func adjustedQty(t *testing.T, p *Postgres, txID string) float64 {
+	t.Helper()
+	var v float64
+	if err := p.q.QueryRowContext(context.Background(),
+		`SELECT split_adjusted_quantity FROM txs WHERE id = $1::uuid`, txID).Scan(&v); err != nil {
+		t.Fatalf("read split_adjusted_quantity: %v", err)
+	}
+	return v
+}

--- a/server/db/postgres/holdings_test.go
+++ b/server/db/postgres/holdings_test.go
@@ -39,7 +39,7 @@ func TestComputeHoldings_instrumentNameOverTxDescription(t *testing.T) {
 	txs := []*apiv1.Tx{
 		{Timestamp: ts, InstrumentDescription: "MSFT MICROSOFT CORP", Type: apiv1.TxType_INCOME, Quantity: 137.08, Account: ""},
 	}
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{cashID}); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{cashID}, nil); err != nil {
 		t.Fatalf("replace: %v", err)
 	}
 
@@ -75,7 +75,7 @@ func TestComputeHoldings_signedQuantity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ensure instrument: %v", err)
 	}
-	err = p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{instID})
+	err = p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{instID}, nil)
 	if err != nil {
 		t.Fatalf("replace: %v", err)
 	}

--- a/server/db/postgres/instruments_test.go
+++ b/server/db/postgres/instruments_test.go
@@ -42,7 +42,7 @@ func TestEnsureInstrument_mergeWhenMultipleInstrumentsMatch(t *testing.T) {
 		{Timestamp: ts1, InstrumentDescription: "StockA", Type: apiv1.TxType_BUYSTOCK, Quantity: 10, Account: ""},
 		{Timestamp: ts2, InstrumentDescription: "StockB", Type: apiv1.TxType_BUYSTOCK, Quantity: 5, Account: ""},
 	}
-	err = p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{idA, idB})
+	err = p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{idA, idB}, nil)
 	if err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}

--- a/server/db/postgres/price_cache_test.go
+++ b/server/db/postgres/price_cache_test.go
@@ -53,7 +53,7 @@ func insertTxs(t *testing.T, p *Postgres, userID, instID string, txs []*apiv1.Tx
 	}
 	from := timestamppb.New(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))
 	to := timestamppb.New(time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "TEST", from, to, txs, ids); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "TEST", from, to, txs, ids, nil); err != nil {
 		t.Fatalf("insert txs: %v", err)
 	}
 }

--- a/server/db/postgres/txs.go
+++ b/server/db/postgres/txs.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"fmt"
+	"time"
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/google/uuid"
@@ -14,7 +15,7 @@ var psql = sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
 
 
 // ReplaceTxsInPeriod implements db.TxDB.
-func (p *Postgres) ReplaceTxsInPeriod(ctx context.Context, userID, broker string, periodFrom, periodTo *timestamppb.Timestamp, txs []*apiv1.Tx, instrumentIDs []string) error {
+func (p *Postgres) ReplaceTxsInPeriod(ctx context.Context, userID, broker string, periodFrom, periodTo *timestamppb.Timestamp, txs []*apiv1.Tx, instrumentIDs []string, shareCountBasis *time.Time) error {
 	userUUID, err := uuid.Parse(userID)
 	if err != nil {
 		return fmt.Errorf("invalid user id: %w", err)
@@ -58,9 +59,9 @@ func (p *Postgres) ReplaceTxsInPeriod(ctx context.Context, userID, broker string
 			}
 			acc := t.GetAccount()
 			_, err = exec.ExecContext(ctx, `
-				INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type, quantity, trading_currency, settlement_currency, unit_price, instrument_id)
-				VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
-			`, userUUID, broker, acc, ts, t.InstrumentDescription, txTypeStr, t.Quantity, nullStr(t.TradingCurrency), nullStr(t.SettlementCurrency), nullFloat(t.UnitPrice), instUUID)
+				INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type, quantity, trading_currency, settlement_currency, unit_price, instrument_id, share_count_basis)
+				VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::date)
+			`, userUUID, broker, acc, ts, t.InstrumentDescription, txTypeStr, t.Quantity, nullStr(t.TradingCurrency), nullStr(t.SettlementCurrency), nullFloat(t.UnitPrice), instUUID, shareCountBasis)
 			if err != nil {
 				return fmt.Errorf("insert tx: %w", err)
 			}

--- a/server/db/postgres/txs_test.go
+++ b/server/db/postgres/txs_test.go
@@ -29,7 +29,7 @@ func TestReplaceTxsInPeriod_and_ComputeHoldings(t *testing.T) {
 		t.Fatalf("ensure instrument: %v", err)
 	}
 	instrumentIDs := []string{instID, instID}
-	err = p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, instrumentIDs)
+	err = p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, instrumentIDs, nil)
 	if err != nil {
 		t.Fatalf("replace: %v", err)
 	}
@@ -76,7 +76,7 @@ func TestReplaceTxsInPeriod_PreservesSyntheticInitializeTx(t *testing.T) {
 	oldTx := []*apiv1.Tx{
 		{Timestamp: timestamppb.New(now.Add(-80 * time.Minute)), InstrumentDescription: "MSFT", Type: apiv1.TxType_BUYSTOCK, Quantity: 5, Account: ""},
 	}
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, oldTx, []string{instID}); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, oldTx, []string{instID}, nil); err != nil {
 		t.Fatalf("seed real tx: %v", err)
 	}
 
@@ -85,7 +85,7 @@ func TestReplaceTxsInPeriod_PreservesSyntheticInitializeTx(t *testing.T) {
 		{Timestamp: timestamppb.New(now.Add(-60 * time.Minute)), InstrumentDescription: "MSFT", Type: apiv1.TxType_BUYSTOCK, Quantity: 7, Account: ""},
 		{Timestamp: timestamppb.New(now.Add(-20 * time.Minute)), InstrumentDescription: "MSFT", Type: apiv1.TxType_SELLSTOCK, Quantity: -2, Account: ""},
 	}
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, newTxs, []string{instID, instID}); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, newTxs, []string{instID, instID}, nil); err != nil {
 		t.Fatalf("replace: %v", err)
 	}
 
@@ -326,7 +326,7 @@ func TestListTxsByPortfolio_ComputeHoldingsForPortfolio(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ensure instrument: %v", err)
 	}
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txList, []string{instID, instID}); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txList, []string{instID, instID}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 	txs, tok, err = p.ListTxsByPortfolio(ctx, port.GetId(), nil, nil, nil, false, 50, "")

--- a/server/db/postgres/valuation_test.go
+++ b/server/db/postgres/valuation_test.go
@@ -34,7 +34,7 @@ func TestGetPortfolioValuation_Basic(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{instID}); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{instID}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -139,7 +139,7 @@ func TestGetPortfolioValuation_DifferentDescriptionsNetToZero(t *testing.T) {
 	}
 	from := timestamppb.New(transferDate.Add(-1 * time.Hour))
 	to := timestamppb.New(sellDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{instID, instID}); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{instID, instID}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -208,7 +208,7 @@ func TestGetPortfolioValuation_UnpricedDeduplication(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{instID, instID}); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{instID, instID}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -255,7 +255,7 @@ func TestGetPortfolioValuation_MultipleInstruments(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{instA, instB}); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{instA, instB}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -303,7 +303,7 @@ func TestGetUserValuation_Basic(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{instID}); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{instID}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -392,7 +392,7 @@ func TestGetUserValuation_FXConversion_DisplayUSD(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{instID}); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{instID}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -447,7 +447,7 @@ func TestGetUserValuation_FXConversion_CrossRate(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{instID}); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{instID}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -501,7 +501,7 @@ func TestGetUserValuation_FXConversion_MissingRate(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{instID}); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{instID}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -553,7 +553,7 @@ func TestGetUserValuation_FXConversion_USDDisplayNonUSD(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{instID}); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{instID}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -606,7 +606,7 @@ func TestGetUserValuation_FXConversion_MissingBaseRate(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{instID}); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{instID}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -670,7 +670,7 @@ func TestGetUserValuation_CashInDisplayCurrency(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{usdInstID}); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{usdInstID}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -722,7 +722,7 @@ func TestGetUserValuation_CashInForeignCurrency(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{gbpInstID}); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{gbpInstID}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -763,7 +763,7 @@ func TestGetUserValuation_CashForeignMissingFXRate(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{gbpInstID}); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{gbpInstID}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -824,7 +824,7 @@ func TestGetUserValuation_CashForeignCurrency_NonUSDDisplay(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{eurInstID}); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{eurInstID}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -39,8 +39,14 @@ CREATE INDEX idx_portfolio_filters_portfolio ON portfolio_filters (portfolio_id)
 
 -- Transactions. No natural key (broker statements often supply date only). Bulk idempotency
 -- by replace-by-period (user_id, broker, period). Single-tx ingestion is append-only.
+-- share_count_basis is the date at which the share count the raw quantity and
+-- unit_price are denominated in was current. It defaults to timestamp::date --
+-- the as-traded assumption, that a broker log line accounts only for events
+-- prior to the trade. A source that restates historical rows (a broker's live
+-- web UI showing post-split quantities) declares its own on the upload.
+-- See docs/spec/bitemporality.md.
 -- split_adjusted_quantity / split_adjusted_unit_price hold the values that result
--- from applying every stock split with ex_date > timestamp::date for the tx's
+-- from applying every stock split with ex_date > share_count_basis for the tx's
 -- instrument. They equal the raw quantity/unit_price when no later split exists.
 -- They are recomputed idempotently from the raw columns whenever splits change
 -- (see RecomputeTxSplitAdjustments).
@@ -58,6 +64,7 @@ CREATE TABLE txs (
   settlement_currency       TEXT,
   unit_price                DOUBLE PRECISION,
   split_adjusted_unit_price DOUBLE PRECISION,
+  share_count_basis         DATE NOT NULL,
   synthetic_purpose         TEXT CHECK (synthetic_purpose IS NULL OR synthetic_purpose = 'INITIALIZE'),
   created_at                TIMESTAMPTZ NOT NULL DEFAULT now()
 );
@@ -475,6 +482,11 @@ CREATE UNIQUE INDEX idx_unhandled_ce_dedup
 CREATE OR REPLACE FUNCTION default_split_adjusted_tx() RETURNS TRIGGER AS $$
 BEGIN
   IF TG_OP = 'INSERT' THEN
+    -- As-traded is the default denomination: a row with no declared basis is
+    -- assumed to be expressed in the share count current on its own date.
+    IF NEW.share_count_basis IS NULL THEN
+      NEW.share_count_basis := NEW.timestamp::date;
+    END IF;
     IF NEW.split_adjusted_quantity IS NULL THEN
       NEW.split_adjusted_quantity := NEW.quantity;
     END IF;

--- a/server/service/ingestion/worker.go
+++ b/server/service/ingestion/worker.go
@@ -157,6 +157,21 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 	broker, _ := brokerToStr(req.Broker)
 	bulk := req.PeriodFrom != nil && req.PeriodTo != nil
 
+	// The denomination of the whole upload. Absent means as-traded: each row is
+	// expressed in the share count current on its own transaction date.
+	var shareCountBasis *time.Time
+	if b := req.GetShareCountBasis(); b != "" {
+		parsed, err := time.Parse("2006-01-02", b)
+		if err != nil {
+			_ = database.AppendValidationErrors(ctx, j.JobID, []*apiv1.ValidationError{
+				{RowIndex: -1, Field: "share_count_basis", Message: fmt.Sprintf("invalid date %q: want YYYY-MM-DD", b)},
+			})
+			_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_FAILED)
+			return false, ""
+		}
+		shareCountBasis = &parsed
+	}
+
 	// Validate.
 	errs := ValidateTxs(txs)
 	if len(errs) > 0 {
@@ -222,7 +237,7 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 	// Store transactions.
 	var storeErr error
 	if bulk {
-		storeErr = database.ReplaceTxsInPeriod(ctx, userID, broker, req.PeriodFrom, req.PeriodTo, txsToProcess, instrumentIDs)
+		storeErr = database.ReplaceTxsInPeriod(ctx, userID, broker, req.PeriodFrom, req.PeriodTo, txsToProcess, instrumentIDs, shareCountBasis)
 	} else {
 		storeErr = database.CreateTx(ctx, userID, broker, txsToProcess[0].GetAccount(), txsToProcess[0], instrumentIDs[0])
 	}

--- a/server/service/ingestion/worker_test.go
+++ b/server/service/ingestion/worker_test.go
@@ -3,6 +3,7 @@ package ingestion
 import (
 	"context"
 	"testing"
+	"time"
 
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
 	ingestionv1 "github.com/leedenison/portfoliodb/proto/ingestion/v1"
@@ -93,7 +94,7 @@ func TestProcessBulk_AppendsIdentificationErrorsWhenBrokerDescriptionOnly(t *tes
 		ListInstrumentsByIDs(gomock.Any(), []string{"broker-only-id"}).
 		Return([]*db.InstrumentRow{{ID: "broker-only-id"}}, nil)
 	database.EXPECT().
-		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", gomock.Any(), gomock.Any(), gomock.Any(), []string{"broker-only-id"}).
+		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", gomock.Any(), gomock.Any(), gomock.Any(), []string{"broker-only-id"}, gomock.Any()).
 		Return(nil)
 	database.EXPECT().
 		InstrumentsWithSplits(gomock.Any(), gomock.Any()).
@@ -155,7 +156,7 @@ func TestProcessBulk_BatchCache_ResolvesSameDescriptionOnce(t *testing.T) {
 		ListInstrumentsByIDs(gomock.Any(), []string{"cached-inst-id"}).
 		Return([]*db.InstrumentRow{{ID: "cached-inst-id"}}, nil)
 	database.EXPECT().
-		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", gomock.Any(), gomock.Any(), gomock.Any(), []string{"cached-inst-id", "cached-inst-id"}).
+		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", gomock.Any(), gomock.Any(), gomock.Any(), []string{"cached-inst-id", "cached-inst-id"}, gomock.Any()).
 		Return(nil)
 	database.EXPECT().
 		InstrumentsWithSplits(gomock.Any(), gomock.Any()).
@@ -217,8 +218,8 @@ func TestProcessBulk_DropsTxTypeSplitTransactions(t *testing.T) {
 		ListInstrumentsByIDs(gomock.Any(), []string{"aapl-id"}).
 		Return([]*db.InstrumentRow{{ID: "aapl-id"}}, nil)
 	database.EXPECT().
-		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", gomock.Any(), gomock.Any(), gomock.Len(1), []string{"aapl-id"}).
-		DoAndReturn(func(_ context.Context, _, _ string, _, _ *timestamppb.Timestamp, storedTxs []*apiv1.Tx, ids []string) error {
+		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", gomock.Any(), gomock.Any(), gomock.Len(1), []string{"aapl-id"}, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _ string, _, _ *timestamppb.Timestamp, storedTxs []*apiv1.Tx, ids []string, _ *time.Time) error {
 			if len(storedTxs) != 1 || storedTxs[0].InstrumentDescription != "AAPL" || storedTxs[0].Type != apiv1.TxType_BUYSTOCK {
 				t.Errorf("ReplaceTxsInPeriod called with %d txs, expected 1 (AAPL BUYSTOCK)", len(storedTxs))
 			}
@@ -357,7 +358,7 @@ func TestProcessBulk_StockEtfEquivalence(t *testing.T) {
 		ListInstrumentsByIDs(gomock.Any(), []string{"spy-etf-id"}).
 		Return([]*db.InstrumentRow{{ID: "spy-etf-id", AssetClass: strPtr(db.AssetClassETF)}}, nil)
 	database.EXPECT().
-		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", gomock.Any(), gomock.Any(), gomock.Any(), []string{"spy-etf-id"}).
+		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", gomock.Any(), gomock.Any(), gomock.Any(), []string{"spy-etf-id"}, gomock.Any()).
 		Return(nil)
 	database.EXPECT().
 		InstrumentsWithSplits(gomock.Any(), gomock.Any()).
@@ -531,7 +532,7 @@ func TestProcessBulk_TransferToStockAllowed(t *testing.T) {
 		ListInstrumentsByIDs(gomock.Any(), []string{"msft-id"}).
 		Return([]*db.InstrumentRow{{ID: "msft-id", AssetClass: strPtr(db.AssetClassStock)}}, nil)
 	database.EXPECT().
-		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", gomock.Any(), gomock.Any(), gomock.Any(), []string{"msft-id"}).
+		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", gomock.Any(), gomock.Any(), gomock.Any(), []string{"msft-id"}, gomock.Any()).
 		Return(nil)
 	database.EXPECT().
 		InstrumentsWithSplits(gomock.Any(), gomock.Any()).


### PR DESCRIPTION
Replaces #258, which GitHub closed automatically when its base branch was deleted on merge and would not let me reopen after the rebase. Same branch, same commit, rebased onto main; the parents (#255-#257) are now merged.

Fourth of five PRs from the bitemporality audit. Behaviour-preserving: it makes an existing assumption explicit and overridable rather than changing what any current source does.

## The assumption

Transactions were adjusted against `timestamp::date`. That encodes the as-traded assumption — a broker log line accounts only for events prior to the trade, whatever has happened since — without ever stating it, and with no way for a source to say otherwise.

The assumption is correct for every source today. But it is a property of the *source*, not of the schema, and one import path can violate it: the extension reads the broker's live web UI, which is exactly where a broker might show post-split quantities on pre-split trades.

## The change

- `txs.share_count_basis`, defaulting to `timestamp::date` via the existing BEFORE INSERT trigger. The tx recompute reads the column.
- `UpsertTxsRequest.share_count_basis` — one denomination for the whole statement, not per row, mirroring `ImportPricesRequest`.
- `BrokerRecipe.restatesHistoricalQuantities` on the extension side.

## A deviation from the plan, deliberately

The plan said the extension should send `share_count_basis` from the run's start time. That would be a bug: it declares the quantities are *already* post-split, so historical rows spanning a split would be left unadjusted. It is the exact mirror of the defect #257 fixes.

Whether a broker restates is a property of the broker, so the declaration sits on the recipe and defaults to false. No current recipe sets it — Fidelity's export is as-traded. A test asserts the field stays empty for an as-traded broker, with the reason in a comment, so a future recipe author has to make the choice consciously.

## Verification

`make test` — exit 0, zero failures. New db-layer test covers both sources: an as-traded pre-split buy of 100 becomes 400 after a 4:1 split; a restated row already recorded as 400 stays 400 rather than becoming 1600.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
