### PR TITLE
Close M07 and M11 issues completed in the codebase

### DIFF
--- a/docs/issues/0021-instrument-identity-ui.md
+++ b/docs/issues/0021-instrument-identity-ui.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Implement UI for showing instrument identities and errors that occurred
 milestone: M07
 dependencies: [0019]

--- a/docs/issues/0027-display-currency-schema.md
+++ b/docs/issues/0027-display-currency-schema.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Schema changes for display currency
 milestone: M11
 ---

--- a/docs/issues/0028-display-currency-preference-api.md
+++ b/docs/issues/0028-display-currency-preference-api.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Add display_currency user preference gRPC API and settings UI
 milestone: M11
 dependencies: [0027]

--- a/docs/issues/0029-fx-gaps-price-cache.md
+++ b/docs/issues/0029-fx-gaps-price-cache.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Implement FXGaps in the price cache DB layer
 milestone: M11
 dependencies: [0027]

--- a/docs/issues/0030-massive-fx-fetching.md
+++ b/docs/issues/0030-massive-fx-fetching.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Extend Massive price plugin for FX rate fetching
 milestone: M11
 dependencies: [0027]

--- a/docs/issues/0031-fx-price-fetcher-worker.md
+++ b/docs/issues/0031-fx-price-fetcher-worker.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Extend price fetcher worker to call FXGaps and fetch FX rates
 milestone: M11
 dependencies: [0029, 0030]

--- a/docs/issues/0032-valuation-display-currency.md
+++ b/docs/issues/0032-valuation-display-currency.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Update valuation queries to convert holdings to display currency
 milestone: M11
 dependencies: [0027, 0029]

--- a/docs/issues/0033-performance-chart-currency-ui.md
+++ b/docs/issues/0033-performance-chart-currency-ui.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Update performance chart UI to pass display currency and show currency label
 milestone: M11
 dependencies: [0028, 0032]


### PR DESCRIPTION
An audit of `docs/issues/` found eight open issues whose work has already landed. This marks them closed. M07 and M11 now have no open issues.

## M11 - display currency

| Issue | Where it landed |
|---|---|
| 0027 Schema changes for display currency | `display_currency` on `users` (`001_initial.sql`), FX instruments seeded in `002_seed_currency_instruments.sql`, `FX` asset class and `FX_PAIR` identifier type in the proto |
| 0028 Preference API and settings UI | `GetDisplayCurrency` / `SetDisplayCurrency`, `server/service/api/display_currency.go`, `client/app/settings/page.tsx` |
| 0029 FXGaps in the price cache DB layer | `server/db/postgres/price_cache.go` |
| 0030 Massive plugin FX rate fetching | `FX_PAIR` handling and `RewriteFXPair` in `server/plugins/massive/price/plugin.go` |
| 0031 Price fetcher worker calls FXGaps | `server/pricefetcher/worker.go` |
| 0032 Valuation converts to display currency | `GetPortfolioValuation` in `server/db/postgres/valuation.go` |
| 0033 Performance chart currency label | `client/app/components/performance-chart.tsx` |

## M07 - identification

| Issue | Where it landed |
|---|---|
| 0021 Instrument identity and error UI | Identities on `client/app/admin/instruments/page.tsx`; identification errors on `client/app/uploads/page.tsx` and in `upload-modal.tsx` |

## Not included

Three issues were considered and left open:

- 0017 (filter instrument export by broker and exchange) is only half done - `ExportInstrumentsRequest` filters by exchange and asset class but not broker.
- 0024 (manual price entry) is arguably covered by admin price CSV import, but there is no per-price entry form; left open pending a call on intent.
- 0025 (identity CSV CLI) was never built and is superseded by the admin UI from 0026; it needs a decision on closing as obsolete rather than done.

Docs only - no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)