### PR TITLE
Preserve knowledge time across corporate-event export, import and coverage merge

### DIFF
--- a/client/lib/json/corporate-events.test.ts
+++ b/client/lib/json/corporate-events.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+import { create } from "@bufbuild/protobuf";
+import { timestampFromDate } from "@bufbuild/protobuf/wkt";
+import { AssetClass, ExportCorporateEventRowSchema, SplitRowSchema } from "@/gen/api/v1/api_pb";
+import type { ExportCorporateEventRow } from "@/gen/api/v1/api_pb";
+import { splitsToJson, parseSplitsJson } from "./corporate-events";
+
+function makeSplitRow(firstKnownAt?: Date): ExportCorporateEventRow {
+  return create(ExportCorporateEventRowSchema, {
+    identifierType: "MIC_TICKER",
+    identifierValue: "AAPL",
+    identifierDomain: "XNAS",
+    assetClass: AssetClass.STOCK,
+    dataProvider: "massive",
+    event: {
+      case: "split",
+      value: create(SplitRowSchema, {
+        exDate: "2020-08-31",
+        splitFrom: "1",
+        splitTo: "4",
+        firstKnownAt: firstKnownAt ? timestampFromDate(firstKnownAt) : undefined,
+      }),
+    },
+  });
+}
+
+describe("splitsToJson", () => {
+  it("serializes knowledge time as an ISO 8601 instant", () => {
+    const knownAt = new Date("2015-03-04T09:30:00.000Z");
+    const out = JSON.parse(splitsToJson([makeSplitRow(knownAt)]));
+    expect(out[0].first_known_at).toBe("2015-03-04T09:30:00.000Z");
+  });
+
+  it("omits knowledge time when the row carries none", () => {
+    const out = JSON.parse(splitsToJson([makeSplitRow()]));
+    expect(out[0]).not.toHaveProperty("first_known_at");
+  });
+});
+
+describe("parseSplitsJson", () => {
+  it("round-trips knowledge time", () => {
+    const knownAt = new Date("2015-03-04T09:30:00.000Z");
+    const { splits, errors } = parseSplitsJson(splitsToJson([makeSplitRow(knownAt)]));
+    expect(errors).toEqual([]);
+    expect(splits).toHaveLength(1);
+    expect(splits[0].firstKnownAt?.toISOString()).toBe(knownAt.toISOString());
+  });
+
+  it("accepts a file with no knowledge time, leaving the server to stamp it", () => {
+    const { splits, errors } = parseSplitsJson(splitsToJson([makeSplitRow()]));
+    expect(errors).toEqual([]);
+    expect(splits[0].firstKnownAt).toBeUndefined();
+  });
+
+  it("reports an unparseable knowledge time rather than dropping it", () => {
+    const json = JSON.stringify([
+      {
+        identifier_type: "MIC_TICKER",
+        identifier_value: "AAPL",
+        ex_date: "2020-08-31",
+        split_from: "1",
+        split_to: "4",
+        first_known_at: "not-a-timestamp",
+      },
+    ]);
+    const { splits, errors } = parseSplitsJson(json);
+    expect(splits).toHaveLength(0);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].field).toBe("first_known_at");
+  });
+});

--- a/client/lib/json/corporate-events.ts
+++ b/client/lib/json/corporate-events.ts
@@ -3,6 +3,7 @@
  * Format: array of split objects with identifier context.
  */
 
+import { timestampDate } from "@bufbuild/protobuf/wkt";
 import { AssetClass } from "@/gen/api/v1/api_pb";
 import type { ExportCorporateEventRow, SplitRow } from "@/gen/api/v1/api_pb";
 import type { CorporateSplitImportRow } from "@/lib/portfolio-api";
@@ -17,6 +18,9 @@ interface SerializedSplit {
   ex_date: string;
   split_from: string;
   split_to: string;
+  // Knowledge time as an ISO 8601 instant: when the exporting instance first
+  // learned of the split. Absent in files written before it was recorded.
+  first_known_at?: string;
 }
 
 /** Serialize split export rows to JSON string. */
@@ -35,6 +39,7 @@ export function splitsToJson(rows: ExportCorporateEventRow[]): string {
       if (r.identifierDomain) obj.identifier_domain = r.identifierDomain;
       const ac = assetClassToStr(r.assetClass);
       if (ac) obj.asset_class = ac;
+      if (split.firstKnownAt) obj.first_known_at = timestampDate(split.firstKnownAt).toISOString();
       return obj;
     });
   return JSON.stringify(serialized, null, 2) + "\n";
@@ -117,6 +122,18 @@ export function parseSplitsJson(json: string): SplitParseResult {
     if (domain) row.identifierDomain = domain;
     const ac = assetClassFromStr(String(obj.asset_class ?? ""));
     if (ac !== AssetClass.UNSPECIFIED) row.assetClass = ac;
+
+    // Knowledge time is optional: a file that omits it is imported with the
+    // server's fallback rather than rejected. An unparseable value is an
+    // error, since silently dropping it would restamp the split.
+    if (obj.first_known_at != null && obj.first_known_at !== "") {
+      const knownAt = new Date(String(obj.first_known_at));
+      if (Number.isNaN(knownAt.getTime())) {
+        errors.push({ rowIndex: i, field: "first_known_at", message: "Must be an ISO 8601 timestamp" });
+        continue;
+      }
+      row.firstKnownAt = knownAt;
+    }
 
     splits.push(row);
   }

--- a/client/lib/portfolio-api.ts
+++ b/client/lib/portfolio-api.ts
@@ -668,6 +668,7 @@ export interface CorporateSplitImportRow {
   exDate: string;               // YYYY-MM-DD
   splitFrom: string;            // decimal numeric string
   splitTo: string;              // decimal numeric string
+  firstKnownAt?: Date;          // knowledge time; omitted means "stamp on arrival"
 }
 
 /**
@@ -689,6 +690,7 @@ export async function importCorporateEventSplits(rows: CorporateSplitImportRow[]
           exDate: r.exDate,
           splitFrom: r.splitFrom,
           splitTo: r.splitTo,
+          firstKnownAt: r.firstKnownAt ? timestampFromDate(r.firstKnownAt) : undefined,
         }),
       },
     }),

--- a/docs/issues/0051-corporate-event-knowledge-time-loss.md
+++ b/docs/issues/0051-corporate-event-knowledge-time-loss.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Preserve knowledge time across corporate-event export, import and coverage merge
 ---
 

--- a/docs/spec/bitemporality.md
+++ b/docs/spec/bitemporality.md
@@ -58,7 +58,7 @@ source can revise what it told us.
 knowledge timestamp can be:
 
 - **`first_known_at`** -- when we first learned this fact. Set on insert and
-  **never overwritten**, including when the fact itself is revised. This is the
+  **never moved forward**, including when the fact itself is revised. This is the
   column that answers "did we know about the split when we resolved that option?"
 - **`last_fetched_at`** -- when we last asked the source. Fetch bookkeeping;
   overwritten on every refresh by design. It answers "how stale is this?", never
@@ -69,7 +69,7 @@ knowledge timestamp can be:
 | `stock_splits` | `first_known_at` | First known. Compared against `instruments.identified_at` to decide whether an option's OCC symbol still needs retroactive adjustment. |
 | `cash_dividends` | `first_known_at` | First known. |
 | `eod_prices` | `last_fetched_at` | Staleness only. It carries no semantics about the price itself -- that is what `share_count_basis` is for. |
-| `corporate_event_coverage` | `last_fetched_at` | When the span was last confirmed. Collapsed to the merge time when spans merge. |
+| `corporate_event_coverage` | `last_fetched_at` | When the span was last confirmed. Merging spans keeps the oldest constituent's, since a union is only as freshly confirmed as its stalest part. |
 | `inflation_indices` | `last_fetched_at` | Staleness only. |
 | `price_fetch_blocks` | `first_blocked_at` | First known. |
 | `corporate_event_fetch_blocks` | `first_blocked_at` | First known. |
@@ -77,9 +77,16 @@ knowledge timestamp can be:
 | `txs`, `users`, `portfolios`, `instruments`, `ingestion_jobs`, `unhandled_corporate_events`, `holding_declarations`, `service_accounts` | `created_at` | Row audit. Not queried. |
 | `holding_declarations` | `updated_at` | Row audit. |
 
-On the wire, `ImportPricesRequest.exported_at` is a client-declared knowledge
-time: it states when the supplied data was current, and drives OCC split
-adjustment during instrument resolution. See [prices.md](prices.md).
+On the wire, `ImportPricesRequest.exported_at` and
+`ImportCorporateEventsRequest.exported_at` are client-declared knowledge times:
+they state when the supplied data was current, and drive OCC split adjustment
+during instrument resolution. See [prices.md](prices.md) and
+[corporate-events.md](corporate-events.md).
+
+Corporate events also carry knowledge time per row: `SplitRow.first_known_at`
+and `CashDividendRow.first_known_at` make an export/import round trip lossless.
+An importing row resolves its knowledge time from the row, else the request's
+`exported_at`, else the time it is stored.
 
 ## Share count basis
 
@@ -112,8 +119,10 @@ basis to today's. See [corporate-events.md](corporate-events.md#adjustment).
 1. **Every stored fact records its valid time.** Knowledge time is recorded
    wherever the source can revise the fact.
 2. **A knowledge-time column is named for what it means** -- `first_known_at` or
-   `last_fetched_at`, never the ambiguous `fetched_at`. A `first_known_at` is
-   never included in an `ON CONFLICT DO UPDATE` set.
+   `last_fetched_at`, never the ambiguous `fetched_at`. A `first_known_at` never
+   moves forward: revising the fact leaves it alone, and on conflict it takes
+   the earlier of the stored and supplied values. A stamp can only ever be at or
+   after the moment the world knew, so the earlier of two is the better one.
 3. **Share-denominated values record their share count basis, declared by the
    source.** Basis is never inferred from a knowledge timestamp and never
    assumed by the storage layer.
@@ -162,7 +171,6 @@ The model above is normative. These parts of the system do not yet comply:
 | Divergence | Issue |
 | --- | --- |
 | No daily scheduler fires the blanket recompute, so a stored future-dated split never activates when its `ex_date` crosses | 0050 |
-| Corporate event export and import carry no knowledge time, so a re-import cannot reproduce the original adjustment state; `corporate_event_coverage` collapses every span's `last_fetched_at` on merge | 0051 |
 | A revised inflation index overwrites the prior value, so a previously published real-return figure cannot be reproduced | 0052 |
 | Instrument identity has no valid-time dimension: `instruments.valid_from` / `valid_to` are never queried, `instrument_identifiers` cannot express ticker reuse, and a merge leaves no record of what was believed before | 0053 |
 | There is no knowledge-time as-of query, so a past valuation cannot be reproduced | 0054 |

--- a/docs/spec/corporate-events.md
+++ b/docs/spec/corporate-events.md
@@ -11,7 +11,7 @@ Two event tables in PostgreSQL, both keyed by `(instrument_id, ex_date)`:
 
 Plus two auxiliary tables:
 
-- **`corporate_event_coverage`** — per `(instrument_id, plugin_id)`, the closed date intervals that have been queried successfully. Adjacent and overlapping intervals merge on insert. Coverage is the source of truth for "which date ranges have we already asked this plugin about" — see [Fetch model](#fetch-model) below.
+- **`corporate_event_coverage`** — per `(instrument_id, plugin_id)`, the closed date intervals that have been queried successfully. Adjacent and overlapping intervals merge on insert; the merged row keeps the oldest constituent `last_fetched_at`, since a union is only as freshly confirmed as its stalest part. Coverage is the source of truth for "which date ranges have we already asked this plugin about" — see [Fetch model](#fetch-model) below.
 - **`corporate_event_fetch_blocks`** — `(instrument_id, plugin_id, reason, first_blocked_at)`. A plugin returning a permanent error (404, 403, subscription limit) for an instrument lands here so the fetcher does not retry indefinitely.
 
 The `eod_prices` and `txs` tables also gain `split_adjusted_*` columns alongside the raw OHLCV / quantity / unit_price values, so both views are debuggable side by side. See [Adjustment](#adjustment) below.
@@ -25,6 +25,12 @@ Three sources feed `stock_splits` and `cash_dividends`. All three write through 
 | External market data plugins | plugin id (e.g. `"massive"`, `"eodhd"`) | Background fetcher worker (`server/corporateevents`) |
 | Admin CSV / JSON import | `"import"` | `ImportCorporateEvents` admin RPC |
 | Broker statement parsers (planned) | `"import"` | Client-side per-broker parsers; submit through `ImportCorporateEvents` |
+
+### Export and import
+
+`ExportCorporateEvents` and `ImportCorporateEvents` are a lossless round trip, knowledge time included. `SplitRow` and `CashDividendRow` carry `first_known_at` in both directions, and an importing row resolves its knowledge time from the row, else `ImportCorporateEventsRequest.exported_at`, else the time it is stored. A stored `first_known_at` only ever moves backwards, so re-importing a split learned of years ago restores its original stamp rather than pushing it forward to import time. That matters because the stamp gates retroactive OCC adjustment of options on the underlying (see [Adjustment](#adjustment) and docs/spec/bitemporality.md): restamping a historical split makes every existing option look identified-before-we-knew and re-adjusts symbols that were already correct.
+
+`exported_at` also stamps imported `corporate_event_coverage` spans, so an imported span records when it was actually confirmed rather than when it was imported.
 
 The broker statement parsers are deferred follow-up work. They live entirely in client converters; broker tx logs that contain SPLIT entries should be parsed by the converter for the broker's specific format and submitted via `ImportCorporateEvents`. The server-side `TX_TYPE=SPLIT` filter in `server/service/ingestion/hints.go` continues to drop SPLIT txs at ingestion; corporate events are admin-only shared data, never derived from user txs (see adr/0005-corporate-events-design.md).
 

--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -8,6 +8,7 @@ import {
   ApiService,
   AssetClass,
   JobStatus,
+  type ExportCorporateEventRow,
   type GetJobResponse,
   type ImportCorporateEventRow,
 } from "../gen/api/v1/api_pb";
@@ -80,6 +81,18 @@ export async function importCorporateEventsAndWait(
   throw new Error(
     `corporate event import job ${jobId} did not complete within ${timeoutMs}ms`,
   );
+}
+
+/** Drain the ExportCorporateEvents stream into an array. */
+export async function exportCorporateEvents(
+  sessionId: string,
+): Promise<ExportCorporateEventRow[]> {
+  const headers = { Cookie: `${COOKIE_NAME}=${sessionId}` };
+  const rows: ExportCorporateEventRow[] = [];
+  for await (const row of client.exportCorporateEvents({}, { headers })) {
+    rows.push(row);
+  }
+  return rows;
 }
 
 /** Trigger the corporate event fetcher worker to run one cycle. */

--- a/e2e/tests/corporate-event-roundtrip.spec.ts
+++ b/e2e/tests/corporate-event-roundtrip.spec.ts
@@ -1,0 +1,148 @@
+import { test, expect } from "@playwright/test";
+import { create } from "@bufbuild/protobuf";
+import { timestampDate, timestampFromDate } from "@bufbuild/protobuf/wkt";
+import { seedSession, closeRedis } from "../helpers/auth";
+import { resetAndSeedBase, seedFixture, rawQuery, closeDB } from "../helpers/db";
+import {
+  exportCorporateEvents,
+  importCorporateEventsAndWait,
+} from "../helpers/api";
+import {
+  AssetClass,
+  ImportCorporateEventRowSchema,
+  JobStatus,
+  SplitRowSchema,
+} from "../gen/api/v1/api_pb";
+
+// ---------------------------------------------------------------------------
+// A PortfolioDB-to-PortfolioDB round trip must not restamp knowledge time.
+//
+// stock_splits.first_known_at decides whether an option on the underlying
+// still needs retroactive OCC adjustment, so a re-import that stamps the
+// import time makes every existing option look identified-before-we-knew and
+// re-adjusts symbols that were already correct.
+//
+// The instruments are seeded pre-identified so the import resolves through the
+// DB and never reaches an identifier plugin -- no cassette needed.
+// ---------------------------------------------------------------------------
+test.describe("corporate event export/import round trip", () => {
+  let adminSession: string;
+
+  const KNOWN_AT = new Date("2015-03-04T09:30:00.000Z");
+
+  test.beforeAll(async () => {
+    await resetAndSeedBase();
+    await seedFixture("instruments.sql");
+    adminSession = await seedSession("admin");
+  });
+
+  test.afterAll(async () => {
+    await closeRedis();
+    await closeDB();
+  });
+
+  test("knowledge time survives export and re-import", async () => {
+    // Import a split we learned of in 2015.
+    const first = await importCorporateEventsAndWait(adminSession, [
+      create(ImportCorporateEventRowSchema, {
+        identifierType: "MIC_TICKER",
+        identifierValue: "AMZN",
+        identifierDomain: "",
+        assetClass: AssetClass.STOCK,
+        event: {
+          case: "split",
+          value: create(SplitRowSchema, {
+            exDate: "2022-06-06",
+            splitFrom: "1",
+            splitTo: "20",
+            firstKnownAt: timestampFromDate(KNOWN_AT),
+          }),
+        },
+      }),
+    ]);
+    expect(first.status).toBe(JobStatus.SUCCESS);
+
+    const stored = await rawQuery(
+      `SELECT s.first_known_at, s.split_to::text AS split_to
+         FROM stock_splits s
+         WHERE s.instrument_id = 'e2e00000-0000-0000-0000-000000000101'`,
+    );
+    expect(stored).toHaveLength(1);
+    expect(new Date((stored[0] as { first_known_at: Date }).first_known_at).toISOString()).toBe(
+      KNOWN_AT.toISOString(),
+    );
+
+    // Export, and confirm knowledge time reaches the wire.
+    const exported = await exportCorporateEvents(adminSession);
+    const splitRows = exported.filter((r) => r.event.case === "split");
+    expect(splitRows).toHaveLength(1);
+    const exportedSplit = splitRows[0].event.value as {
+      exDate: string;
+      splitFrom: string;
+      splitTo: string;
+      firstKnownAt?: Parameters<typeof timestampDate>[0];
+    };
+    expect(exportedSplit.firstKnownAt).toBeDefined();
+    expect(timestampDate(exportedSplit.firstKnownAt!).toISOString()).toBe(
+      KNOWN_AT.toISOString(),
+    );
+
+    // Re-import the exported rows verbatim, as a restore would.
+    const second = await importCorporateEventsAndWait(
+      adminSession,
+      splitRows.map((r) =>
+        create(ImportCorporateEventRowSchema, {
+          identifierType: r.identifierType,
+          identifierValue: r.identifierValue,
+          identifierDomain: r.identifierDomain,
+          assetClass: r.assetClass,
+          event: { case: "split", value: r.event.value as never },
+        }),
+      ),
+    );
+    expect(second.status).toBe(JobStatus.SUCCESS);
+
+    const after = await rawQuery(
+      `SELECT first_known_at
+         FROM stock_splits
+         WHERE instrument_id = 'e2e00000-0000-0000-0000-000000000101'`,
+    );
+    expect(after).toHaveLength(1);
+    expect(new Date((after[0] as { first_known_at: Date }).first_known_at).toISOString()).toBe(
+      KNOWN_AT.toISOString(),
+    );
+  });
+
+  test("a split with no declared knowledge time is stamped on arrival", async () => {
+    const before = Date.now();
+    const job = await importCorporateEventsAndWait(adminSession, [
+      create(ImportCorporateEventRowSchema, {
+        identifierType: "MIC_TICKER",
+        identifierValue: "NVDA",
+        identifierDomain: "",
+        assetClass: AssetClass.STOCK,
+        event: {
+          case: "split",
+          value: create(SplitRowSchema, {
+            exDate: "2024-06-10",
+            splitFrom: "1",
+            splitTo: "10",
+          }),
+        },
+      }),
+    ]);
+    expect(job.status).toBe(JobStatus.SUCCESS);
+
+    const rows = await rawQuery(
+      `SELECT first_known_at
+         FROM stock_splits
+         WHERE instrument_id = 'e2e00000-0000-0000-0000-000000000102'`,
+    );
+    expect(rows).toHaveLength(1);
+    const stamped = new Date(
+      (rows[0] as { first_known_at: Date }).first_known_at,
+    ).getTime();
+    expect(stamped).toBeGreaterThanOrEqual(before - 60_000);
+    expect(stamped).toBeLessThanOrEqual(Date.now() + 60_000);
+  });
+});

--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -998,6 +998,13 @@ message SplitRow {
   string ex_date = 1;     // YYYY-MM-DD effective/execution date
   string split_from = 2;  // decimal numeric string
   string split_to = 3;    // decimal numeric string
+  // Knowledge time: when the exporting instance first learned of this split.
+  // It gates retroactive adjustment of options on the underlying, so a
+  // round-trip that drops it re-adjusts symbols that were already correct.
+  // On import it is optional and falls back to the request's exported_at,
+  // then to the time the row is stored. A stored first_known_at only ever
+  // moves backwards. See docs/spec/bitemporality.md.
+  google.protobuf.Timestamp first_known_at = 4;
 }
 
 // CashDividendRow is one cash dividend row used by both export and import.
@@ -1011,6 +1018,12 @@ message CashDividendRow {
   string amount = 5;             // decimal numeric string per share
   string currency = 6;
   string frequency = 7;          // optional: "annual", "semi-annual", "quarterly", "monthly"
+  string type = 8;               // "CD" (regular) or "SC" (special cash); empty means "CD"
+  // Knowledge time: when the exporting instance first learned of this
+  // dividend. On import it is optional and falls back to the request's
+  // exported_at, then to the time the row is stored. A stored first_known_at
+  // only ever moves backwards. See docs/spec/bitemporality.md.
+  google.protobuf.Timestamp first_known_at = 9;
 }
 
 // ExportCorporateEventRow is one corporate event with its instrument
@@ -1060,6 +1073,12 @@ message ImportCorporateEventCoverage {
 message ImportCorporateEventsRequest {
   repeated ImportCorporateEventRow events = 1;
   repeated ImportCorporateEventCoverage coverage = 2;
+  // Knowledge time: when the supplied data was current. OCC symbols are
+  // split-adjusted to this point during instrument resolution, imported
+  // coverage records it as last_fetched_at, and events that do not carry
+  // their own first_known_at fall back to it. Mirrors
+  // ImportPricesRequest.exported_at.
+  google.protobuf.Timestamp exported_at = 3;
 }
 
 message ImportCorporateEventsResponse {

--- a/server/corporateevents/worker.go
+++ b/server/corporateevents/worker.go
@@ -246,7 +246,7 @@ func processInstrument(ctx context.Context, database db.DB, plugins []pluginEntr
 					}
 				}
 			}
-			if err := database.UpsertCorporateEventCoverage(ctx, inst.ID, pe.id, gap.From, gap.To); err != nil {
+			if err := database.UpsertCorporateEventCoverage(ctx, inst.ID, pe.id, gap.From, gap.To, nil); err != nil {
 				if log != nil {
 					log.ErrorContext(ctx, "corporate event fetch: upsert coverage",
 						"plugin", pe.id, "instrument", inst.ID, "err", err)

--- a/server/corporateevents/worker_test.go
+++ b/server/corporateevents/worker_test.go
@@ -232,7 +232,7 @@ func TestRunCycle_EmptyResultRecordsCoverage(t *testing.T) {
 	mockDB.EXPECT().ListCorporateEventCoverage(gomock.Any(), []string{instID}).Return(nil, nil)
 
 	// Coverage MUST be recorded for the empty success.
-	mockDB.EXPECT().UpsertCorporateEventCoverage(gomock.Any(), instID, "high", gomock.Any(), gomock.Any()).Return(nil)
+	mockDB.EXPECT().UpsertCorporateEventCoverage(gomock.Any(), instID, "high", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 	// No upserts for splits/dividends (empty result).
 	// No call into the low-precedence plugin.
@@ -286,7 +286,7 @@ func TestRunCycle_SplitsLandTriggerRecompute(t *testing.T) {
 	mockDB.EXPECT().ListCorporateEventCoverage(gomock.Any(), []string{instID}).Return(nil, nil)
 
 	mockDB.EXPECT().UpsertStockSplits(gomock.Any(), gomock.Any()).Return(nil)
-	mockDB.EXPECT().UpsertCorporateEventCoverage(gomock.Any(), instID, "massive", gomock.Any(), gomock.Any()).Return(nil)
+	mockDB.EXPECT().UpsertCorporateEventCoverage(gomock.Any(), instID, "massive", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().RecomputeSplitAdjustments(gomock.Any(), instID).Return(nil)
 	// After splits land, the worker lists splits and options for the underlying.
 	mockDB.EXPECT().ListStockSplits(gomock.Any(), instID).Return([]db.StockSplit{
@@ -344,7 +344,7 @@ func TestRunCycle_PermanentErrorCreatesBlock(t *testing.T) {
 	mockDB.EXPECT().ListCorporateEventCoverage(gomock.Any(), []string{instID}).Return(nil, nil)
 
 	mockDB.EXPECT().CreateCorporateEventFetchBlock(gomock.Any(), instID, "broken", "404 not found").Return(nil)
-	mockDB.EXPECT().UpsertCorporateEventCoverage(gomock.Any(), instID, "good", gomock.Any(), gomock.Any()).Return(nil)
+	mockDB.EXPECT().UpsertCorporateEventCoverage(gomock.Any(), instID, "good", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 	runCycle(ctx, mockDB, reg, nil, nil, nil)
 
@@ -412,7 +412,7 @@ func TestRunCycle_SpecialDividendRoutedToUnhandled(t *testing.T) {
 			}
 			return nil
 		})
-	mockDB.EXPECT().UpsertCorporateEventCoverage(gomock.Any(), instID, "massive", gomock.Any(), gomock.Any()).Return(nil)
+	mockDB.EXPECT().UpsertCorporateEventCoverage(gomock.Any(), instID, "massive", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 
 	runCycle(ctx, mockDB, reg, nil, nil, nil)
 }

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -679,7 +679,10 @@ type StockSplit struct {
 	SplitFrom    string // numeric, e.g. "1"
 	SplitTo      string // numeric, e.g. "2"
 	DataProvider string
-	// FirstKnownAt is when we first learned of this split. Never overwritten.
+	// FirstKnownAt is when we first learned of this split. Honoured on insert
+	// when set; on conflict it only ever moves backwards, so a re-import of an
+	// older stamp restores it and a newer one is ignored. Zero means "stamp it
+	// with the current time".
 	FirstKnownAt time.Time
 }
 
@@ -698,7 +701,9 @@ type CashDividend struct {
 	Frequency       string // empty when unknown
 	Type            string // "CD" or "SC"; empty = "CD"
 	DataProvider    string
-	// FirstKnownAt is when we first learned of this dividend. Never overwritten.
+	// FirstKnownAt is when we first learned of this dividend. Honoured on
+	// insert when set; on conflict it only ever moves backwards. Zero means
+	// "stamp it with the current time".
 	FirstKnownAt time.Time
 }
 
@@ -752,7 +757,9 @@ type OptionSplitParams struct {
 // split_adjusted_* columns on eod_prices and txs from the raw values.
 type CorporateEventDB interface {
 	// UpsertStockSplits inserts or updates the supplied stock_splits rows.
-	// On conflict (instrument_id, ex_date), all non-key columns are overwritten.
+	// On conflict (instrument_id, ex_date), all non-key columns are overwritten
+	// except FirstKnownAt, which takes the earlier of the stored and supplied
+	// values. A zero FirstKnownAt is stamped with the current time on insert.
 	UpsertStockSplits(ctx context.Context, splits []StockSplit) error
 	// ListStockSplits returns every stock split for the given instrument
 	// ordered ascending by ex_date.
@@ -763,7 +770,9 @@ type CorporateEventDB interface {
 	DeleteStockSplit(ctx context.Context, instrumentID string, exDate time.Time) error
 
 	// UpsertCashDividends inserts or updates the supplied cash_dividends rows.
-	// On conflict (instrument_id, ex_date), all non-key columns are overwritten.
+	// On conflict (instrument_id, ex_date), all non-key columns are overwritten
+	// except FirstKnownAt, which takes the earlier of the stored and supplied
+	// values. A zero FirstKnownAt is stamped with the current time on insert.
 	UpsertCashDividends(ctx context.Context, dividends []CashDividend) error
 	// ListCashDividends returns every cash dividend for the given instrument
 	// ordered ascending by ex_date.
@@ -774,8 +783,10 @@ type CorporateEventDB interface {
 	// UpsertCorporateEventCoverage records that (instrumentID, pluginID) has
 	// been queried for the closed interval [from, to]. Existing rows for the
 	// same (instrument, plugin) that are adjacent or overlap with [from, to]
-	// are merged into a single row.
-	UpsertCorporateEventCoverage(ctx context.Context, instrumentID, pluginID string, from, to time.Time) error
+	// are merged into a single row, which keeps the oldest constituent
+	// LastFetchedAt. lastFetchedAt is when the supplied span was confirmed;
+	// nil means now.
+	UpsertCorporateEventCoverage(ctx context.Context, instrumentID, pluginID string, from, to time.Time, lastFetchedAt *time.Time) error
 	// ListCorporateEventCoverage returns coverage rows for the given
 	// instruments. When instrumentIDs is empty all coverage rows are returned.
 	// Rows are sorted by (instrument_id, plugin_id, covered_from).
@@ -862,6 +873,7 @@ type ExportStockSplit struct {
 	ExDate           time.Time
 	SplitFrom        string // numeric as decimal string
 	SplitTo          string
+	FirstKnownAt     time.Time
 }
 
 // ExportCashDividend is one cash dividend row with the best identifier for
@@ -880,4 +892,5 @@ type ExportCashDividend struct {
 	Currency         string
 	Frequency        string
 	Type             string
+	FirstKnownAt     time.Time
 }

--- a/server/db/postgres/corporate_events.go
+++ b/server/db/postgres/corporate_events.go
@@ -23,23 +23,32 @@ func (p *Postgres) UpsertStockSplits(ctx context.Context, splits []db.StockSplit
 	froms := make([]string, len(splits))
 	tos := make([]string, len(splits))
 	providers := make([]string, len(splits))
+	knownAts := make([]*time.Time, len(splits))
 	for i, s := range splits {
 		instIDs[i] = s.InstrumentID
 		exDates[i] = s.ExDate
 		froms[i] = s.SplitFrom
 		tos[i] = s.SplitTo
 		providers[i] = s.DataProvider
+		if !s.FirstKnownAt.IsZero() {
+			t := s.FirstKnownAt
+			knownAts[i] = &t
+		}
 	}
 	_, err := p.q.ExecContext(ctx, `
 		INSERT INTO stock_splits (instrument_id, ex_date, split_from, split_to, data_provider, first_known_at)
-		SELECT unnest($1::uuid[]), unnest($2::date[]),
-			unnest($3::numeric[]), unnest($4::numeric[]),
-			unnest($5::text[]), now()
+		SELECT instrument_id, ex_date, split_from, split_to, data_provider,
+			COALESCE(first_known_at, now())
+		FROM unnest($1::uuid[], $2::date[], $3::numeric[], $4::numeric[],
+			$5::text[], $6::timestamptz[])
+			AS t(instrument_id, ex_date, split_from, split_to, data_provider, first_known_at)
 		ON CONFLICT (instrument_id, ex_date) DO UPDATE SET
-			split_from    = EXCLUDED.split_from,
-			split_to      = EXCLUDED.split_to,
-			data_provider = EXCLUDED.data_provider
-	`, pq.Array(instIDs), pq.Array(exDates), pq.Array(froms), pq.Array(tos), pq.Array(providers))
+			split_from     = EXCLUDED.split_from,
+			split_to       = EXCLUDED.split_to,
+			data_provider  = EXCLUDED.data_provider,
+			first_known_at = LEAST(stock_splits.first_known_at, EXCLUDED.first_known_at)
+	`, pq.Array(instIDs), pq.Array(exDates), pq.Array(froms), pq.Array(tos), pq.Array(providers),
+		pq.Array(knownAts))
 	if err != nil {
 		return fmt.Errorf("upsert stock splits: %w", err)
 	}
@@ -101,6 +110,7 @@ func (p *Postgres) UpsertCashDividends(ctx context.Context, dividends []db.CashD
 	frequencies := make([]sql.NullString, len(dividends))
 	types := make([]string, len(dividends))
 	providers := make([]string, len(dividends))
+	knownAts := make([]*time.Time, len(dividends))
 	for i, d := range dividends {
 		instIDs[i] = d.InstrumentID
 		exDates[i] = d.ExDate
@@ -117,16 +127,24 @@ func (p *Postgres) UpsertCashDividends(ctx context.Context, dividends []db.CashD
 			types[i] = "CD"
 		}
 		providers[i] = d.DataProvider
+		if !d.FirstKnownAt.IsZero() {
+			t := d.FirstKnownAt
+			knownAts[i] = &t
+		}
 	}
 	_, err := p.q.ExecContext(ctx, `
 		INSERT INTO cash_dividends (
 			instrument_id, ex_date, pay_date, record_date, declaration_date,
 			amount, currency, frequency, type, data_provider, first_known_at
 		)
-		SELECT unnest($1::uuid[]), unnest($2::date[]),
-			unnest($3::date[]), unnest($4::date[]), unnest($5::date[]),
-			unnest($6::numeric[]), unnest($7::text[]), unnest($8::text[]),
-			unnest($9::text[]), unnest($10::text[]), now()
+		SELECT instrument_id, ex_date, pay_date, record_date, declaration_date,
+			amount, currency, frequency, type, data_provider,
+			COALESCE(first_known_at, now())
+		FROM unnest($1::uuid[], $2::date[], $3::date[], $4::date[], $5::date[],
+			$6::numeric[], $7::text[], $8::text[], $9::text[], $10::text[],
+			$11::timestamptz[])
+			AS t(instrument_id, ex_date, pay_date, record_date, declaration_date,
+				amount, currency, frequency, type, data_provider, first_known_at)
 		ON CONFLICT (instrument_id, ex_date) DO UPDATE SET
 			pay_date         = EXCLUDED.pay_date,
 			record_date      = EXCLUDED.record_date,
@@ -135,11 +153,12 @@ func (p *Postgres) UpsertCashDividends(ctx context.Context, dividends []db.CashD
 			currency         = EXCLUDED.currency,
 			frequency        = EXCLUDED.frequency,
 			type             = EXCLUDED.type,
-			data_provider    = EXCLUDED.data_provider
+			data_provider    = EXCLUDED.data_provider,
+			first_known_at   = LEAST(cash_dividends.first_known_at, EXCLUDED.first_known_at)
 	`, pq.Array(instIDs), pq.Array(exDates),
 		pq.Array(payDates), pq.Array(recordDates), pq.Array(declDates),
 		pq.Array(amounts), pq.Array(currencies), pq.Array(frequencies),
-		pq.Array(types), pq.Array(providers))
+		pq.Array(types), pq.Array(providers), pq.Array(knownAts))
 	if err != nil {
 		return fmt.Errorf("upsert cash dividends: %w", err)
 	}
@@ -211,7 +230,11 @@ func (p *Postgres) DeleteCashDividend(ctx context.Context, instrumentID string, 
 // spanning the union. Two intervals are adjacent when one ends the day before
 // the other begins. The whole operation runs in a single transaction so
 // concurrent inserts cannot leave partial state.
-func (p *Postgres) UpsertCorporateEventCoverage(ctx context.Context, instrumentID, pluginID string, from, to time.Time) error {
+//
+// The merged row keeps the oldest constituent last_fetched_at, since the union
+// is only as freshly confirmed as its stalest part. lastFetchedAt is when the
+// supplied span was confirmed; nil means now.
+func (p *Postgres) UpsertCorporateEventCoverage(ctx context.Context, instrumentID, pluginID string, from, to time.Time, lastFetchedAt *time.Time) error {
 	if to.Before(from) {
 		return fmt.Errorf("upsert corporate event coverage: covered_to %s before covered_from %s", to, from)
 	}
@@ -226,17 +249,21 @@ func (p *Postgres) UpsertCorporateEventCoverage(ctx context.Context, instrumentI
 		// insert one merged row. CTE data-modifying statements share a
 		// snapshot in PostgreSQL so DELETE and INSERT cannot see one
 		// another -- run them as separate statements inside the transaction.
-		var newFrom, newTo time.Time
+		//
+		// LEAST ignores NULL, so with no touching rows the merged fetch time
+		// is just the supplied one (or now()).
+		var newFrom, newTo, newFetched time.Time
 		err := exec.QueryRowContext(ctx, `
 			SELECT
 				LEAST($3::date,  COALESCE(MIN(covered_from), $3::date)),
-				GREATEST($4::date, COALESCE(MAX(covered_to),   $4::date))
+				GREATEST($4::date, COALESCE(MAX(covered_to),   $4::date)),
+				LEAST(COALESCE($5::timestamptz, now()), MIN(last_fetched_at))
 			FROM corporate_event_coverage
 			WHERE instrument_id = $1
 			  AND plugin_id     = $2
 			  AND covered_from <= ($4::date + 1)
 			  AND covered_to   >= ($3::date - 1)
-		`, id, pluginID, from, to).Scan(&newFrom, &newTo)
+		`, id, pluginID, from, to, lastFetchedAt).Scan(&newFrom, &newTo, &newFetched)
 		if err != nil {
 			return fmt.Errorf("upsert corporate event coverage: compute merge: %w", err)
 		}
@@ -251,8 +278,8 @@ func (p *Postgres) UpsertCorporateEventCoverage(ctx context.Context, instrumentI
 		}
 		if _, err := exec.ExecContext(ctx, `
 			INSERT INTO corporate_event_coverage (instrument_id, plugin_id, covered_from, covered_to, last_fetched_at)
-			VALUES ($1, $2, $3, $4, now())
-		`, id, pluginID, newFrom, newTo); err != nil {
+			VALUES ($1, $2, $3, $4, $5)
+		`, id, pluginID, newFrom, newTo, newFetched); err != nil {
 			return fmt.Errorf("upsert corporate event coverage: insert merged: %w", err)
 		}
 		return nil
@@ -355,7 +382,8 @@ func (p *Postgres) ListStockSplitsForExport(ctx context.Context) ([]db.ExportSto
 	q := `
 		SELECT best_id.identifier_type, best_id.value, COALESCE(best_id.domain, '') AS domain,
 			COALESCE(i.asset_class, '') AS asset_class,
-			s.data_provider, s.ex_date, s.split_from::text, s.split_to::text
+			s.data_provider, s.ex_date, s.split_from::text, s.split_to::text,
+			s.first_known_at
 		FROM stock_splits s
 		JOIN instruments i ON i.id = s.instrument_id
 		` + bestIdentifierJoin + `
@@ -370,7 +398,8 @@ func (p *Postgres) ListStockSplitsForExport(ctx context.Context) ([]db.ExportSto
 	for rows.Next() {
 		var r db.ExportStockSplit
 		if err := rows.Scan(&r.IdentifierType, &r.IdentifierValue, &r.IdentifierDomain,
-			&r.AssetClass, &r.DataProvider, &r.ExDate, &r.SplitFrom, &r.SplitTo); err != nil {
+			&r.AssetClass, &r.DataProvider, &r.ExDate, &r.SplitFrom, &r.SplitTo,
+			&r.FirstKnownAt); err != nil {
 			return nil, fmt.Errorf("list stock splits for export scan: %w", err)
 		}
 		out = append(out, r)
@@ -384,7 +413,7 @@ func (p *Postgres) ListCashDividendsForExport(ctx context.Context) ([]db.ExportC
 		SELECT best_id.identifier_type, best_id.value, COALESCE(best_id.domain, '') AS domain,
 			COALESCE(i.asset_class, '') AS asset_class,
 			d.data_provider, d.ex_date, d.pay_date, d.record_date, d.declaration_date,
-			d.amount::text, d.currency, d.frequency, d.type
+			d.amount::text, d.currency, d.frequency, d.type, d.first_known_at
 		FROM cash_dividends d
 		JOIN instruments i ON i.id = d.instrument_id
 		` + bestIdentifierJoin + `
@@ -402,7 +431,7 @@ func (p *Postgres) ListCashDividendsForExport(ctx context.Context) ([]db.ExportC
 		var freq sql.NullString
 		if err := rows.Scan(&r.IdentifierType, &r.IdentifierValue, &r.IdentifierDomain,
 			&r.AssetClass, &r.DataProvider, &r.ExDate, &pay, &rec, &decl,
-			&r.Amount, &r.Currency, &freq, &r.Type); err != nil {
+			&r.Amount, &r.Currency, &freq, &r.Type, &r.FirstKnownAt); err != nil {
 			return nil, fmt.Errorf("list cash dividends for export scan: %w", err)
 		}
 		if pay.Valid {

--- a/server/db/postgres/corporate_events_test.go
+++ b/server/db/postgres/corporate_events_test.go
@@ -157,6 +157,136 @@ func TestUpsertCashDividends_TypeDefaultsToCD(t *testing.T) {
 	}
 }
 
+func TestUpsertStockSplits_PreservesKnowledgeTime(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	instID := setupInstrument(t, p, "AAPL")
+
+	split := db.StockSplit{
+		InstrumentID: instID, ExDate: d(2020, 8, 31),
+		SplitFrom: "1", SplitTo: "4", DataProvider: "massive",
+	}
+	if err := p.UpsertStockSplits(ctx, []db.StockSplit{split}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	past := backdate(t, p,
+		`UPDATE stock_splits SET first_known_at = $1 WHERE instrument_id = $2`, instID)
+
+	// The provider revises the ratio. When we first learned of the split does
+	// not change just because the ratio did -- ProcessOptionSplits compares it
+	// against instruments.identified_at.
+	split.SplitTo = "5"
+	split.DataProvider = "eodhd"
+	if err := p.UpsertStockSplits(ctx, []db.StockSplit{split}); err != nil {
+		t.Fatalf("re-upsert: %v", err)
+	}
+
+	got, err := p.ListStockSplits(ctx, instID)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 split, got %d", len(got))
+	}
+	if got[0].SplitTo != "5" {
+		t.Errorf("ratio not revised: %q", got[0].SplitTo)
+	}
+	if !got[0].FirstKnownAt.Equal(past) {
+		t.Errorf("knowledge time moved on revision: want %s, got %s", past, got[0].FirstKnownAt)
+	}
+}
+
+// A supplied knowledge time is honoured on insert, and on conflict it only
+// moves backwards. This is what makes an export/import round trip lossless:
+// re-importing a split we learned of years ago must not restamp it with the
+// import time, which would make every option look identified-before-we-knew.
+func TestUpsertStockSplits_KnowledgeTimeOnlyMovesBackwards(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	instID := setupInstrument(t, p, "AAPL")
+
+	original := time.Date(2015, time.March, 4, 9, 30, 0, 0, time.UTC)
+	split := db.StockSplit{
+		InstrumentID: instID, ExDate: d(2020, 8, 31),
+		SplitFrom: "1", SplitTo: "4", DataProvider: "import",
+		FirstKnownAt: original,
+	}
+	if err := p.UpsertStockSplits(ctx, []db.StockSplit{split}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	got, err := p.ListStockSplits(ctx, instID)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 1 || !got[0].FirstKnownAt.Equal(original) {
+		t.Fatalf("supplied knowledge time not honoured on insert: %+v", got)
+	}
+
+	// A later stamp loses.
+	split.FirstKnownAt = time.Date(2026, time.July, 29, 0, 0, 0, 0, time.UTC)
+	if err := p.UpsertStockSplits(ctx, []db.StockSplit{split}); err != nil {
+		t.Fatalf("re-upsert later: %v", err)
+	}
+	got, _ = p.ListStockSplits(ctx, instID)
+	if !got[0].FirstKnownAt.Equal(original) {
+		t.Errorf("later stamp won: want %s, got %s", original, got[0].FirstKnownAt)
+	}
+
+	// An earlier stamp wins.
+	earlier := time.Date(2014, time.June, 9, 0, 0, 0, 0, time.UTC)
+	split.FirstKnownAt = earlier
+	if err := p.UpsertStockSplits(ctx, []db.StockSplit{split}); err != nil {
+		t.Fatalf("re-upsert earlier: %v", err)
+	}
+	got, _ = p.ListStockSplits(ctx, instID)
+	if !got[0].FirstKnownAt.Equal(earlier) {
+		t.Errorf("earlier stamp lost: want %s, got %s", earlier, got[0].FirstKnownAt)
+	}
+
+	// A zero stamp leaves the stored value alone rather than restamping now().
+	split.FirstKnownAt = time.Time{}
+	if err := p.UpsertStockSplits(ctx, []db.StockSplit{split}); err != nil {
+		t.Fatalf("re-upsert zero: %v", err)
+	}
+	got, _ = p.ListStockSplits(ctx, instID)
+	if !got[0].FirstKnownAt.Equal(earlier) {
+		t.Errorf("zero stamp overwrote stored value: want %s, got %s", earlier, got[0].FirstKnownAt)
+	}
+}
+
+func TestUpsertCashDividends_KnowledgeTimeOnlyMovesBackwards(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	instID := setupInstrument(t, p, "AAPL")
+
+	original := time.Date(2015, time.March, 4, 9, 30, 0, 0, time.UTC)
+	div := db.CashDividend{
+		InstrumentID: instID, ExDate: d(2024, 2, 9),
+		Amount: "0.24", Currency: "USD", DataProvider: "import",
+		FirstKnownAt: original,
+	}
+	if err := p.UpsertCashDividends(ctx, []db.CashDividend{div}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	got, err := p.ListCashDividends(ctx, instID)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 1 || !got[0].FirstKnownAt.Equal(original) {
+		t.Fatalf("supplied knowledge time not honoured on insert: %+v", got)
+	}
+
+	div.FirstKnownAt = time.Date(2026, time.July, 29, 0, 0, 0, 0, time.UTC)
+	if err := p.UpsertCashDividends(ctx, []db.CashDividend{div}); err != nil {
+		t.Fatalf("re-upsert later: %v", err)
+	}
+	got, _ = p.ListCashDividends(ctx, instID)
+	if !got[0].FirstKnownAt.Equal(original) {
+		t.Errorf("later stamp won: want %s, got %s", original, got[0].FirstKnownAt)
+	}
+}
+
 func TestUpsertCorporateEventCoverage_MergeAdjacent(t *testing.T) {
 	p := testDBTx(t)
 	ctx := context.Background()
@@ -169,7 +299,7 @@ func TestUpsertCorporateEventCoverage_MergeAdjacent(t *testing.T) {
 		{d(2024, 1, 11), d(2024, 1, 20)},
 		{d(2024, 2, 1), d(2024, 2, 10)},
 	} {
-		if err := p.UpsertCorporateEventCoverage(ctx, instID, "massive", iv.from, iv.to); err != nil {
+		if err := p.UpsertCorporateEventCoverage(ctx, instID, "massive", iv.from, iv.to, nil); err != nil {
 			t.Fatalf("upsert coverage %v: %v", iv, err)
 		}
 	}
@@ -199,7 +329,7 @@ func TestUpsertCorporateEventCoverage_MergeOverlapping(t *testing.T) {
 		{d(2024, 1, 1), d(2024, 1, 15)},
 		{d(2024, 1, 10), d(2024, 1, 20)},
 	} {
-		if err := p.UpsertCorporateEventCoverage(ctx, instID, "massive", iv.from, iv.to); err != nil {
+		if err := p.UpsertCorporateEventCoverage(ctx, instID, "massive", iv.from, iv.to, nil); err != nil {
 			t.Fatalf("upsert: %v", err)
 		}
 	}
@@ -213,16 +343,48 @@ func TestUpsertCorporateEventCoverage_MergeOverlapping(t *testing.T) {
 	}
 }
 
+// Merging spans must not restamp the union as freshly confirmed. The fetcher
+// extends coverage by a day at a time at the trailing edge, so a span covering
+// years would otherwise claim to have been confirmed today on every cycle.
+func TestUpsertCorporateEventCoverage_MergeKeepsOldestFetchTime(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	instID := setupInstrument(t, p, "AAPL")
+
+	old := time.Date(2020, time.March, 1, 12, 0, 0, 0, time.UTC)
+	if err := p.UpsertCorporateEventCoverage(ctx, instID, "massive", d(2015, 1, 1), d(2020, 2, 29), &old); err != nil {
+		t.Fatalf("upsert historical span: %v", err)
+	}
+	// A fresh trailing-edge fetch that abuts the historical span.
+	if err := p.UpsertCorporateEventCoverage(ctx, instID, "massive", d(2020, 3, 1), d(2020, 3, 1), nil); err != nil {
+		t.Fatalf("upsert trailing edge: %v", err)
+	}
+
+	got, err := p.ListCorporateEventCoverage(ctx, []string{instID})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 merged interval, got %d: %+v", len(got), got)
+	}
+	if !got[0].CoveredFrom.Equal(d(2015, 1, 1)) || !got[0].CoveredTo.Equal(d(2020, 3, 1)) {
+		t.Errorf("merged interval: %+v", got[0])
+	}
+	if !got[0].LastFetchedAt.Equal(old) {
+		t.Errorf("merge restamped the union: want %s, got %s", old, got[0].LastFetchedAt)
+	}
+}
+
 func TestUpsertCorporateEventCoverage_PerPlugin(t *testing.T) {
 	p := testDBTx(t)
 	ctx := context.Background()
 	instID := setupInstrument(t, p, "AAPL")
 
 	// Different plugins should not be merged together.
-	if err := p.UpsertCorporateEventCoverage(ctx, instID, "massive", d(2024, 1, 1), d(2024, 1, 31)); err != nil {
+	if err := p.UpsertCorporateEventCoverage(ctx, instID, "massive", d(2024, 1, 1), d(2024, 1, 31), nil); err != nil {
 		t.Fatalf("upsert massive: %v", err)
 	}
-	if err := p.UpsertCorporateEventCoverage(ctx, instID, "eodhd", d(2024, 1, 15), d(2024, 2, 15)); err != nil {
+	if err := p.UpsertCorporateEventCoverage(ctx, instID, "eodhd", d(2024, 1, 15), d(2024, 2, 15), nil); err != nil {
 		t.Fatalf("upsert eodhd: %v", err)
 	}
 
@@ -521,8 +683,10 @@ func TestListStockSplitsForExport_BestIdentifier(t *testing.T) {
 		t.Fatalf("ensure instrument: %v", err)
 	}
 
+	knownAt := time.Date(2015, time.March, 4, 9, 30, 0, 0, time.UTC)
 	if err := p.UpsertStockSplits(ctx, []db.StockSplit{
-		{InstrumentID: instID, ExDate: d(2020, 8, 31), SplitFrom: "1", SplitTo: "4", DataProvider: "test"},
+		{InstrumentID: instID, ExDate: d(2020, 8, 31), SplitFrom: "1", SplitTo: "4", DataProvider: "test",
+			FirstKnownAt: knownAt},
 	}); err != nil {
 		t.Fatalf("upsert: %v", err)
 	}
@@ -545,6 +709,10 @@ func TestListStockSplitsForExport_BestIdentifier(t *testing.T) {
 	}
 	if rows[0].SplitFrom != "1" || rows[0].SplitTo != "4" {
 		t.Errorf("split: %+v", rows[0])
+	}
+	// Knowledge time must reach the wire, or a round trip restamps the split.
+	if !rows[0].FirstKnownAt.Equal(knownAt) {
+		t.Errorf("first known at: want %s, got %s", knownAt, rows[0].FirstKnownAt)
 	}
 }
 
@@ -574,7 +742,9 @@ func TestListCashDividendsForExport_RoundTrip(t *testing.T) {
 			Amount:          "0.24",
 			Currency:        "USD",
 			Frequency:       "quarterly",
+			Type:            "SC",
 			DataProvider:    "test",
+			FirstKnownAt:    time.Date(2024, time.February, 2, 8, 0, 0, 0, time.UTC),
 		},
 	}); err != nil {
 		t.Fatalf("upsert: %v", err)
@@ -602,6 +772,15 @@ func TestListCashDividendsForExport_RoundTrip(t *testing.T) {
 	}
 	if r.DeclarationDate == nil || !r.DeclarationDate.Equal(decl) {
 		t.Errorf("declaration date: %+v", r.DeclarationDate)
+	}
+	// Type distinguishes a special cash dividend from a regular one, and is
+	// what routes special dividends to unhandled events on re-import.
+	if r.Type != "SC" {
+		t.Errorf("type: want SC, got %q", r.Type)
+	}
+	want := time.Date(2024, time.February, 2, 8, 0, 0, 0, time.UTC)
+	if !r.FirstKnownAt.Equal(want) {
+		t.Errorf("first known at: want %s, got %s", want, r.FirstKnownAt)
 	}
 }
 

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -383,9 +383,10 @@ CREATE TABLE stock_splits (
   split_from     NUMERIC     NOT NULL CHECK (split_from > 0),
   split_to       NUMERIC     NOT NULL CHECK (split_to   > 0),
   data_provider  TEXT        NOT NULL,
-  -- When we first learned of this split. Never overwritten, including when the
-  -- ratio is revised: it is compared against instruments.identified_at to decide
-  -- whether an option still needs retroactive adjustment.
+  -- When we first learned of this split. It only ever moves backwards: revising
+  -- the ratio leaves it alone, and an import supplying an earlier stamp restores
+  -- that one. It is compared against instruments.identified_at to decide whether
+  -- an option still needs retroactive adjustment.
   first_known_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   PRIMARY KEY (instrument_id, ex_date)
 );
@@ -406,8 +407,8 @@ CREATE TABLE cash_dividends (
   frequency        TEXT,
   type             TEXT        NOT NULL DEFAULT 'CD',
   data_provider    TEXT        NOT NULL,
-  -- When we first learned of this dividend. Never overwritten, including when
-  -- the amount is revised.
+  -- When we first learned of this dividend. Only ever moves backwards, as for
+  -- stock_splits.first_known_at.
   first_known_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
   PRIMARY KEY (instrument_id, ex_date)
 );
@@ -426,8 +427,9 @@ CREATE TABLE corporate_event_coverage (
   plugin_id      TEXT        NOT NULL,
   covered_from   DATE        NOT NULL,
   covered_to     DATE        NOT NULL CHECK (covered_to >= covered_from),
-  -- Staleness only: when this span was last confirmed. Merging spans collapses
-  -- it to the merge time.
+  -- Staleness only: when this span was last confirmed. A merged span keeps the
+  -- oldest constituent value, since a union is only as freshly confirmed as its
+  -- stalest part.
   last_fetched_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   PRIMARY KEY (instrument_id, plugin_id, covered_from)
 );

--- a/server/service/api/corporate_events.go
+++ b/server/service/api/corporate_events.go
@@ -36,9 +36,10 @@ func (s *Server) ExportCorporateEvents(req *apiv1.ExportCorporateEventsRequest, 
 			DataProvider:     r.DataProvider,
 			Event: &apiv1.ExportCorporateEventRow_Split{
 				Split: &apiv1.SplitRow{
-					ExDate:    r.ExDate.Format("2006-01-02"),
-					SplitFrom: r.SplitFrom,
-					SplitTo:   r.SplitTo,
+					ExDate:       r.ExDate.Format("2006-01-02"),
+					SplitFrom:    r.SplitFrom,
+					SplitTo:      r.SplitTo,
+					FirstKnownAt: timestamppb.New(r.FirstKnownAt),
 				},
 			},
 		}
@@ -53,10 +54,12 @@ func (s *Server) ExportCorporateEvents(req *apiv1.ExportCorporateEventsRequest, 
 	}
 	for _, r := range dividends {
 		div := &apiv1.CashDividendRow{
-			ExDate:    r.ExDate.Format("2006-01-02"),
-			Amount:    r.Amount,
-			Currency:  r.Currency,
-			Frequency: r.Frequency,
+			ExDate:       r.ExDate.Format("2006-01-02"),
+			Amount:       r.Amount,
+			Currency:     r.Currency,
+			Frequency:    r.Frequency,
+			Type:         r.Type,
+			FirstKnownAt: timestamppb.New(r.FirstKnownAt),
 		}
 		if r.PayDate != nil {
 			div.PayDate = r.PayDate.Format("2006-01-02")

--- a/server/service/api/export_corporate_events_test.go
+++ b/server/service/api/export_corporate_events_test.go
@@ -1,0 +1,83 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	dbpkg "github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/testutil"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+)
+
+func TestExportCorporateEvents_NonAdmin_PermissionDenied(t *testing.T) {
+	srv, _ := newAPIServerWithMock(t)
+	stream := &exportCorporateEventStreamMock{ctx: authCtx("user-1", "sub|1")}
+	err := srv.ExportCorporateEvents(&apiv1.ExportCorporateEventsRequest{}, stream)
+	testutil.RequireGRPCCode(t, err, codes.PermissionDenied)
+}
+
+// Knowledge time and dividend type must reach the wire: without them a
+// PortfolioDB-to-PortfolioDB round trip restamps every split with the import
+// time and turns special cash dividends into regular ones.
+func TestExportCorporateEvents_CarriesKnowledgeTimeAndDividendType(t *testing.T) {
+	srv, db := newAPIServerWithMock(t)
+	splitKnownAt := time.Date(2015, 3, 4, 9, 30, 0, 0, time.UTC)
+	divKnownAt := time.Date(2024, 2, 2, 8, 0, 0, 0, time.UTC)
+
+	db.EXPECT().ListStockSplitsForExport(gomock.Any()).Return([]dbpkg.ExportStockSplit{
+		{
+			IdentifierType:   "MIC_TICKER",
+			IdentifierValue:  "AAPL",
+			IdentifierDomain: "XNAS",
+			AssetClass:       "STOCK",
+			DataProvider:     "massive",
+			ExDate:           time.Date(2020, 8, 31, 0, 0, 0, 0, time.UTC),
+			SplitFrom:        "1",
+			SplitTo:          "4",
+			FirstKnownAt:     splitKnownAt,
+		},
+	}, nil)
+	db.EXPECT().ListCashDividendsForExport(gomock.Any()).Return([]dbpkg.ExportCashDividend{
+		{
+			IdentifierType:   "MIC_TICKER",
+			IdentifierValue:  "AAPL",
+			IdentifierDomain: "XNAS",
+			AssetClass:       "STOCK",
+			DataProvider:     "massive",
+			ExDate:           time.Date(2024, 2, 9, 0, 0, 0, 0, time.UTC),
+			Amount:           "0.24",
+			Currency:         "USD",
+			Type:             "SC",
+			FirstKnownAt:     divKnownAt,
+		},
+	}, nil)
+
+	stream := &exportCorporateEventStreamMock{ctx: adminCtx("user-1", "sub|1")}
+	if err := srv.ExportCorporateEvents(&apiv1.ExportCorporateEventsRequest{}, stream); err != nil {
+		t.Fatalf("ExportCorporateEvents: %v", err)
+	}
+	if len(stream.sent) != 2 {
+		t.Fatalf("expected 2 rows streamed, got %d", len(stream.sent))
+	}
+
+	split := stream.sent[0].GetSplit()
+	if split == nil {
+		t.Fatalf("first row is not a split: %+v", stream.sent[0])
+	}
+	if got := split.GetFirstKnownAt().AsTime(); !got.Equal(splitKnownAt) {
+		t.Errorf("split first_known_at: want %s, got %s", splitKnownAt, got)
+	}
+
+	div := stream.sent[1].GetDividend()
+	if div == nil {
+		t.Fatalf("second row is not a dividend: %+v", stream.sent[1])
+	}
+	if div.GetType() != "SC" {
+		t.Errorf("dividend type: want SC, got %q", div.GetType())
+	}
+	if got := div.GetFirstKnownAt().AsTime(); !got.Equal(divKnownAt) {
+		t.Errorf("dividend first_known_at: want %s, got %s", divKnownAt, got)
+	}
+}

--- a/server/service/api/server_test.go
+++ b/server/service/api/server_test.go
@@ -84,6 +84,29 @@ func (e *exportPriceStreamMock) SendMsg(m interface{}) error {
 	return nil
 }
 
+// exportCorporateEventStreamMock provides a stream with configurable context
+// for ExportCorporateEvents tests.
+type exportCorporateEventStreamMock struct {
+	ctx  context.Context
+	sent []*apiv1.ExportCorporateEventRow
+}
+
+func (e *exportCorporateEventStreamMock) Context() context.Context   { return e.ctx }
+func (e *exportCorporateEventStreamMock) RecvMsg(m interface{}) error { return nil }
+func (e *exportCorporateEventStreamMock) Send(m *apiv1.ExportCorporateEventRow) error {
+	e.sent = append(e.sent, m)
+	return nil
+}
+func (e *exportCorporateEventStreamMock) SendHeader(m metadata.MD) error { return nil }
+func (e *exportCorporateEventStreamMock) SetHeader(m metadata.MD) error  { return nil }
+func (e *exportCorporateEventStreamMock) SetTrailer(m metadata.MD)       {}
+func (e *exportCorporateEventStreamMock) SendMsg(m interface{}) error {
+	if row, ok := m.(*apiv1.ExportCorporateEventRow); ok {
+		e.sent = append(e.sent, row)
+	}
+	return nil
+}
+
 func TestAPI_Unauthenticated(t *testing.T) {
 	srv, _ := newAPIServerWithMock(t)
 	ctx := context.Background()

--- a/server/service/ingestion/corporate_event_worker.go
+++ b/server/service/ingestion/corporate_event_worker.go
@@ -13,6 +13,7 @@ import (
 	"github.com/leedenison/portfoliodb/server/identifier"
 	"github.com/leedenison/portfoliodb/server/service/identification"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // processCorporateEventImport loads a persisted ImportCorporateEventsRequest,
@@ -43,6 +44,16 @@ func processCorporateEventImport(ctx context.Context, database db.DB, pluginRegi
 	rows := req.GetEvents()
 	_ = database.SetJobTotalCount(ctx, j.JobID, int32(len(rows)))
 
+	// Knowledge time declared for the whole request: OCC symbols are
+	// split-adjusted to this point during resolution, events that carry no
+	// first_known_at of their own fall back to it, and imported coverage
+	// records it as last_fetched_at. Mirrors the price import path.
+	var eventsAsOf *time.Time
+	if ts := req.GetExportedAt(); ts != nil {
+		t := ts.AsTime()
+		eventsAsOf = &t
+	}
+
 	resolveCache := make(map[string]*resolveEntry)
 	var valErrs []*apiv1.ValidationError
 	var splits []db.StockSplit
@@ -61,7 +72,7 @@ func processCorporateEventImport(ctx context.Context, database db.DB, pluginRegi
 			continue
 		}
 
-		result, err := resolveCorporateEventRow(ctx, database, pluginRegistry, resolveCache, row)
+		result, err := resolveCorporateEventRow(ctx, database, pluginRegistry, resolveCache, row, eventsAsOf)
 		if err != nil {
 			valErrs = append(valErrs, &apiv1.ValidationError{
 				RowIndex: int32(i),
@@ -84,7 +95,7 @@ func processCorporateEventImport(ctx context.Context, database db.DB, pluginRegi
 
 		switch ev := row.GetEvent().(type) {
 		case *apiv1.ImportCorporateEventRow_Split:
-			s, vErr := buildSplit(instID, ev.Split, i)
+			s, vErr := buildSplit(instID, ev.Split, i, eventsAsOf)
 			if vErr != nil {
 				valErrs = append(valErrs, vErr)
 				_ = database.IncrJobProcessedCount(ctx, j.JobID)
@@ -93,7 +104,7 @@ func processCorporateEventImport(ctx context.Context, database db.DB, pluginRegi
 			splits = append(splits, s)
 			splitInstruments[instID] = true
 		case *apiv1.ImportCorporateEventRow_Dividend:
-			d, vErr := buildDividend(instID, ev.Dividend, i)
+			d, vErr := buildDividend(instID, ev.Dividend, i, eventsAsOf)
 			if vErr != nil {
 				valErrs = append(valErrs, vErr)
 				_ = database.IncrJobProcessedCount(ctx, j.JobID)
@@ -139,7 +150,7 @@ func processCorporateEventImport(ctx context.Context, database db.DB, pluginRegi
 	// accumulated alongside the per-event errors so the caller sees
 	// everything via AppendValidationErrors. A hard DB error from the
 	// coverage upsert still fails the job.
-	covCount, covErrs, err := writeImportCoverage(ctx, database, req.GetCoverage(), resolveCache, pluginRegistry)
+	covCount, covErrs, err := writeImportCoverage(ctx, database, req.GetCoverage(), resolveCache, pluginRegistry, eventsAsOf)
 	if err != nil {
 		if len(valErrs) > 0 || len(covErrs) > 0 {
 			_ = database.AppendValidationErrors(ctx, j.JobID, append(valErrs, covErrs...))
@@ -179,15 +190,16 @@ func processCorporateEventImport(ctx context.Context, database db.DB, pluginRegi
 // caching the result so a CSV with thousands of dividends for the same
 // ticker invokes the identifier plugins at most once. The asset class
 // passed to the resolver is the row's declared asset class -- the same
-// hint used by the price import path.
-func resolveCorporateEventRow(ctx context.Context, database db.DB, pluginRegistry *identifier.Registry, cache map[string]*resolveEntry, row *apiv1.ImportCorporateEventRow) (identification.ResolveResult, error) {
+// hint used by the price import path, as is asOf, which split-adjusts OCC
+// symbols to the request's declared knowledge time.
+func resolveCorporateEventRow(ctx context.Context, database db.DB, pluginRegistry *identifier.Registry, cache map[string]*resolveEntry, row *apiv1.ImportCorporateEventRow, asOf *time.Time) (identification.ResolveResult, error) {
 	key := row.GetIdentifierType() + "\x00" + row.GetIdentifierDomain() + "\x00" + row.GetIdentifierValue()
 	if entry, ok := cache[key]; ok {
 		return entry.result, entry.err
 	}
 	acStr := db.AssetClassToStr(row.GetAssetClass())
 	result, err := resolveOrIdentifyInstrument(ctx, database, pluginRegistry,
-		row.GetIdentifierType(), row.GetIdentifierDomain(), row.GetIdentifierValue(), acStr, "", nil)
+		row.GetIdentifierType(), row.GetIdentifierDomain(), row.GetIdentifierValue(), acStr, "", asOf)
 	cache[key] = &resolveEntry{result: result, err: err}
 	return result, err
 }
@@ -196,7 +208,11 @@ func resolveCorporateEventRow(ctx context.Context, database db.DB, pluginRegistr
 // required; split_from and split_to must parse as positive arbitrary-precision
 // decimals (the underlying NUMERIC column accepts any decimal). Validation
 // uses big.Rat so values like "0.000001" round-trip without precision loss.
-func buildSplit(instID string, s *apiv1.SplitRow, rowIndex int) (db.StockSplit, *apiv1.ValidationError) {
+//
+// Knowledge time comes from the row, else from the request's exported_at
+// (asOf), else stays zero for the DB to stamp. Preserving it matters because
+// it gates retroactive adjustment of options on the underlying.
+func buildSplit(instID string, s *apiv1.SplitRow, rowIndex int, asOf *time.Time) (db.StockSplit, *apiv1.ValidationError) {
 	if s == nil {
 		return db.StockSplit{}, &apiv1.ValidationError{RowIndex: int32(rowIndex), Field: "split", Message: "missing split payload"}
 	}
@@ -218,14 +234,29 @@ func buildSplit(instID string, s *apiv1.SplitRow, rowIndex int) (db.StockSplit, 
 		SplitFrom:    s.GetSplitFrom(),
 		SplitTo:      s.GetSplitTo(),
 		DataProvider: db.CorporateEventProviderImport,
+		FirstKnownAt: knowledgeTime(s.GetFirstKnownAt(), asOf),
 	}, nil
+}
+
+// knowledgeTime resolves a row's knowledge time: the row's own value, else
+// the request-level exported_at, else zero, which leaves the DB to stamp the
+// storage time.
+func knowledgeTime(rowTS *timestamppb.Timestamp, asOf *time.Time) time.Time {
+	if rowTS != nil {
+		return rowTS.AsTime()
+	}
+	if asOf != nil {
+		return *asOf
+	}
+	return time.Time{}
 }
 
 // buildDividend converts a proto CashDividendRow into a db.CashDividend.
 // ex_date, amount and currency are required; pay/record/declaration dates and
 // frequency pass through when supplied. Amount is validated as an arbitrary-
-// precision non-negative decimal via big.Rat.
-func buildDividend(instID string, d *apiv1.CashDividendRow, rowIndex int) (db.CashDividend, *apiv1.ValidationError) {
+// precision non-negative decimal via big.Rat. Knowledge time follows the same
+// row / request / storage-time fallback as buildSplit.
+func buildDividend(instID string, d *apiv1.CashDividendRow, rowIndex int, asOf *time.Time) (db.CashDividend, *apiv1.ValidationError) {
 	if d == nil {
 		return db.CashDividend{}, &apiv1.ValidationError{RowIndex: int32(rowIndex), Field: "dividend", Message: "missing dividend payload"}
 	}
@@ -246,7 +277,9 @@ func buildDividend(instID string, d *apiv1.CashDividendRow, rowIndex int) (db.Ca
 		Amount:       d.GetAmount(),
 		Currency:     d.GetCurrency(),
 		Frequency:    d.GetFrequency(),
+		Type:         d.GetType(),
 		DataProvider: db.CorporateEventProviderImport,
+		FirstKnownAt: knowledgeTime(d.GetFirstKnownAt(), asOf),
 	}
 	if t, err := time.Parse("2006-01-02", d.GetPayDate()); err == nil {
 		out.PayDate = &t
@@ -261,7 +294,9 @@ func buildDividend(instID string, d *apiv1.CashDividendRow, rowIndex int) (db.Ca
 }
 
 // writeImportCoverage records each coverage row tagged data_provider="import"
-// against the resolved instrument. Returns the number of coverage rows
+// against the resolved instrument, stamping the span with the request's
+// declared knowledge time (asOf) so an imported span does not claim to have
+// been confirmed at import time. Returns the number of coverage rows
 // successfully written, the per-row validation errors collected (bad dates,
 // unresolvable identifiers), and any hard DB error from the underlying
 // upsert. Per-row errors do not abort the loop; only a hard error does.
@@ -269,7 +304,7 @@ func buildDividend(instID string, d *apiv1.CashDividendRow, rowIndex int) (db.Ca
 // Coverage entries use RowIndex = -1 because the coverage list is separate
 // from the events list, so a per-row index would not be meaningful to the
 // caller; the Field name carries the location ("coverage.from" etc).
-func writeImportCoverage(ctx context.Context, database db.DB, coverage []*apiv1.ImportCorporateEventCoverage, cache map[string]*resolveEntry, pluginRegistry *identifier.Registry) (int, []*apiv1.ValidationError, error) {
+func writeImportCoverage(ctx context.Context, database db.DB, coverage []*apiv1.ImportCorporateEventCoverage, cache map[string]*resolveEntry, pluginRegistry *identifier.Registry, asOf *time.Time) (int, []*apiv1.ValidationError, error) {
 	var (
 		written int
 		errs    []*apiv1.ValidationError
@@ -301,7 +336,7 @@ func writeImportCoverage(ctx context.Context, database db.DB, coverage []*apiv1.
 			// plugin registry is passed through so the resolution rules
 			// match the per-event resolution above.
 			result, rerr := resolveOrIdentifyInstrument(ctx, database, pluginRegistry,
-				c.GetIdentifierType(), c.GetIdentifierDomain(), c.GetIdentifierValue(), "", "", nil)
+				c.GetIdentifierType(), c.GetIdentifierDomain(), c.GetIdentifierValue(), "", "", asOf)
 			entry = &resolveEntry{result: result, err: rerr}
 			cache[key] = entry
 		}
@@ -325,7 +360,7 @@ func writeImportCoverage(ctx context.Context, database db.DB, coverage []*apiv1.
 			})
 			continue
 		}
-		if err := database.UpsertCorporateEventCoverage(ctx, entry.result.InstrumentID, db.CorporateEventProviderImport, from, to); err != nil {
+		if err := database.UpsertCorporateEventCoverage(ctx, entry.result.InstrumentID, db.CorporateEventProviderImport, from, to, asOf); err != nil {
 			return written, errs, err
 		}
 		written++

--- a/server/service/ingestion/corporate_event_worker_test.go
+++ b/server/service/ingestion/corporate_event_worker_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/leedenison/portfoliodb/server/identifier"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // TestProcessCorporateEventImport_HappyPath verifies that a mixed split +
@@ -26,7 +27,13 @@ func TestProcessCorporateEventImport_HappyPath(t *testing.T) {
 	database.EXPECT().SaveProviderIdentifiers(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	registry := identifier.NewRegistry()
 
+	// The split carries its own knowledge time; the dividend does not and so
+	// falls back to the request's exported_at.
+	splitKnownAt := time.Date(2015, 3, 4, 9, 30, 0, 0, time.UTC)
+	exportedAt := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+
 	req := &apiv1.ImportCorporateEventsRequest{
+		ExportedAt: timestamppb.New(exportedAt),
 		Events: []*apiv1.ImportCorporateEventRow{
 			{
 				IdentifierType:   "MIC_TICKER",
@@ -35,6 +42,7 @@ func TestProcessCorporateEventImport_HappyPath(t *testing.T) {
 				AssetClass:       apiv1.AssetClass_ASSET_CLASS_STOCK,
 				Event: &apiv1.ImportCorporateEventRow_Split{Split: &apiv1.SplitRow{
 					ExDate: "2020-08-31", SplitFrom: "1", SplitTo: "4",
+					FirstKnownAt: timestamppb.New(splitKnownAt),
 				}},
 			},
 			{
@@ -48,6 +56,7 @@ func TestProcessCorporateEventImport_HappyPath(t *testing.T) {
 					Amount:    "0.24",
 					Currency:  "USD",
 					Frequency: "quarterly",
+					Type:      "SC",
 				}},
 			},
 		},
@@ -95,6 +104,10 @@ func TestProcessCorporateEventImport_HappyPath(t *testing.T) {
 			if splits[0].DataProvider != db.CorporateEventProviderImport {
 				t.Errorf("provider: %s", splits[0].DataProvider)
 			}
+			// The row's own knowledge time wins over the request's.
+			if !splits[0].FirstKnownAt.Equal(splitKnownAt) {
+				t.Errorf("first known at: want %s, got %s", splitKnownAt, splits[0].FirstKnownAt)
+			}
 			return nil
 		})
 	database.EXPECT().UpsertCashDividends(gomock.Any(), gomock.Any()).DoAndReturn(
@@ -108,11 +121,20 @@ func TestProcessCorporateEventImport_HappyPath(t *testing.T) {
 			if divs[0].PayDate == nil || !divs[0].PayDate.Equal(time.Date(2024, 2, 15, 0, 0, 0, 0, time.UTC)) {
 				t.Errorf("pay date: %+v", divs[0].PayDate)
 			}
+			if divs[0].Type != "SC" {
+				t.Errorf("type: want SC, got %q", divs[0].Type)
+			}
+			// No row-level knowledge time, so the request's exported_at stands in.
+			if !divs[0].FirstKnownAt.Equal(exportedAt) {
+				t.Errorf("first known at: want %s, got %s", exportedAt, divs[0].FirstKnownAt)
+			}
 			return nil
 		})
+	// Imported coverage is stamped with the request's knowledge time rather
+	// than claiming to have been confirmed at import time.
 	database.EXPECT().UpsertCorporateEventCoverage(gomock.Any(), "inst-aapl", db.CorporateEventProviderImport,
 		time.Date(2014, 1, 1, 0, 0, 0, 0, time.UTC),
-		time.Date(2024, 12, 31, 0, 0, 0, 0, time.UTC)).Return(nil)
+		time.Date(2024, 12, 31, 0, 0, 0, 0, time.UTC), &exportedAt).Return(nil)
 	database.EXPECT().RecomputeSplitAdjustments(gomock.Any(), "inst-aapl").Return(nil)
 	database.EXPECT().ListStockSplits(gomock.Any(), "inst-aapl").Return([]db.StockSplit{
 		{InstrumentID: "inst-aapl", ExDate: time.Date(2020, 8, 31, 0, 0, 0, 0, time.UTC), SplitFrom: "1", SplitTo: "4", DataProvider: "import"},
@@ -424,5 +446,33 @@ func TestProcessCorporateEventImport_RejectsHintDiff(t *testing.T) {
 	}
 	if !strings.Contains(capturedErrs[0].Message, "SecurityType") {
 		t.Errorf("expected message to mention SecurityType, got %s", capturedErrs[0].Message)
+	}
+}
+
+// A file with no knowledge time anywhere leaves FirstKnownAt zero, which the
+// db layer reads as "stamp it with the storage time" -- the behaviour before
+// knowledge time was on the wire.
+func TestBuildEvent_KnowledgeTimeFallsBackToStorageTime(t *testing.T) {
+	split, vErr := buildSplit("inst-aapl", &apiv1.SplitRow{
+		ExDate: "2020-08-31", SplitFrom: "1", SplitTo: "4",
+	}, 0, nil)
+	if vErr != nil {
+		t.Fatalf("buildSplit: %+v", vErr)
+	}
+	if !split.FirstKnownAt.IsZero() {
+		t.Errorf("split knowledge time: want zero, got %s", split.FirstKnownAt)
+	}
+
+	div, vErr := buildDividend("inst-aapl", &apiv1.CashDividendRow{
+		ExDate: "2024-02-09", Amount: "0.24", Currency: "USD",
+	}, 0, nil)
+	if vErr != nil {
+		t.Fatalf("buildDividend: %+v", vErr)
+	}
+	if !div.FirstKnownAt.IsZero() {
+		t.Errorf("dividend knowledge time: want zero, got %s", div.FirstKnownAt)
+	}
+	if div.Type != "" {
+		t.Errorf("type: want empty (db defaults to CD), got %q", div.Type)
 	}
 }


### PR DESCRIPTION
Closes issue 0051.

`stock_splits.first_known_at` gates retroactive OCC adjustment of options on the underlying ([option_splits.go:71](https://github.com/leedenison/portfoliodb/blob/main/server/corporateevents/option_splits.go#L71)), so losing it changes behaviour, not just auditability. Two paths lost it.

## Export and import

`SplitRow` and `CashDividendRow` now carry `first_known_at` in both directions, and `ImportCorporateEventsRequest` gains `exported_at` as a request-level fallback -- also passed into instrument resolution, where the corporate-event worker previously passed `nil` while the price worker passed `pricesAsOf`. An importing row resolves its knowledge time from the row, else `exported_at`, else the storage time.

On conflict both upserts take `LEAST(stored, supplied)`. A stamp can only ever be at or after the moment the world knew, so the earlier of two is the better proxy, and a re-imported historical split no longer restamps itself with the import time. This narrows `bitemporality.md` rule 2 from "never in an `ON CONFLICT DO UPDATE` set" to the invariant it was protecting: a `first_known_at` never moves forward.

## Coverage merge

`UpsertCorporateEventCoverage` deleted the touching spans and inserted the union stamped `now()`, so a one-day trailing-edge fetch restamped a decade-long span as confirmed today on every cycle. The merged row now keeps the oldest constituent value. Nothing reads that column yet, so this is correctness for future staleness-driven refresh rather than a change to current fetch behaviour.

## Also folded in

`cash_dividends.type` (CD/SC) was selected by the export query but dropped by the handler and never set on import, so every re-imported dividend landed as `CD` -- and special dividends are routed to unhandled events by type. It now round-trips.

## Notes for review

- **No schema change.** Every column already existed; only comments in `001_initial.sql` changed.
- Postgres rejects set-returning functions inside `COALESCE`, so both upserts now unnest in `FROM` rather than in the select list. `make db-test` caught this.
- `splitsToJson` filters to splits only, so the admin JSON file still never carries dividends -- the dividend `type` and `first_known_at` round-trip through the gRPC API only. Pre-existing, left alone.

## Testing

`make server-test client-test db-test integration-test extension-test e2e-test` all pass (29 e2e tests).

New e2e spec `corporate-event-roundtrip.spec.ts` imports a split declaring `first_known_at` of 2015, exports it, re-imports the exported rows verbatim, and asserts the stamp did not move. Confirmed it bites: with `FirstKnownAt` dropped from `buildSplit` it fails with `Expected "2015-03-04T09:30:00.000Z" / Received "2026-07-29T15:19:35.103Z"`.

Instruments are seeded pre-identified so resolution never reaches an identifier plugin, so the new spec needs no cassette.

## Unrelated finding

`scripts/server-ready.sh` probes with `grpc-health-probe`, which only `Dockerfile.dev` installs -- not `Dockerfile.e2e`. Because the `e2e-test` recipe chains with `;` rather than `&&`, the failure is swallowed and readiness degrades to a ~20s sleep, printing "portfoliodb gRPC not ready" on every e2e run. Harmless but accidental; out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)