### PR TITLE
Make the E2E readiness probe actually work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,7 +110,7 @@ e2e-test: $(STAMP_DIR)/generate
 	@$(COMPOSE_E2E) --profile test down --remove-orphans 2>/dev/null; \
 		$(COMPOSE_E2E) up -d --build --force-recreate; \
 		echo "Waiting for portfoliodb (gRPC)..."; \
-		scripts/server-ready.sh "$(COMPOSE_E2E)"; \
+		scripts/server-ready.sh "$(COMPOSE_E2E)" && \
 		HOST_UID=$$(id -u) HOST_GID=$$(id -g) $(COMPOSE_E2E) --profile test run --rm playwright npx playwright test; \
 		rc=$$?; $(COMPOSE_E2E) --profile test down; exit $$rc
 
@@ -127,7 +127,7 @@ e2e-test-record: $(STAMP_DIR)/generate
 	@$(COMPOSE_E2E) --profile test down --remove-orphans 2>/dev/null; \
 		VCR_MODE=$(VCR_SUITES) $(COMPOSE_E2E) up -d --build --force-recreate; \
 		echo "Waiting for portfoliodb (gRPC)..."; \
-		scripts/server-ready.sh "$(COMPOSE_E2E)"; \
+		scripts/server-ready.sh "$(COMPOSE_E2E)" || { $(COMPOSE_E2E) --profile test down; exit 1; }; \
 		logdir="/tmp/e2e-record-$$(date +%Y%m%d-%H%M%S)"; mkdir -p "$$logdir"; \
 		HOST_UID=$$(id -u) HOST_GID=$$(id -g) VCR_MODE=$(VCR_SUITES) $(COMPOSE_E2E) --profile test run --rm playwright \
 			sh -c 'npx playwright test 2>&1; echo $$? > /e2e/.e2e-rc' | tee "$$logdir/playwright.log"; \

--- a/docker/server/Dockerfile.e2e
+++ b/docker/server/Dockerfile.e2e
@@ -2,7 +2,8 @@ FROM golang:1.25-alpine AS builder
 WORKDIR /app
 RUN go install github.com/bufbuild/buf/cmd/buf@latest \
     && go install google.golang.org/protobuf/cmd/protoc-gen-go@latest \
-    && go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+    && go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest \
+    && go install github.com/grpc-ecosystem/grpc-health-probe@latest
 COPY go.mod go.sum ./
 RUN go mod download
 COPY proto/ proto/
@@ -15,6 +16,8 @@ RUN go build -tags e2e -ldflags "-X main.buildRevision=$BUILD_REV" -o /portfolio
 FROM alpine:3.19
 RUN apk --no-cache add ca-certificates
 COPY --from=builder /portfoliodb /portfoliodb
+# scripts/server-ready.sh probes gRPC health from inside this container.
+COPY --from=builder /go/bin/grpc-health-probe /usr/local/bin/grpc-health-probe
 COPY server/migrations /migrations
 EXPOSE 50051
 ENTRYPOINT ["/portfoliodb"]

--- a/scripts/server-ready.sh
+++ b/scripts/server-ready.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 # Wait for portfoliodb gRPC server to report SERVING via grpc_health_probe. Exits 0 when ready, 1 after max tries.
 # Probes from inside the portfoliodb container so no host-side grpc tooling is required.
+# The server image must therefore ship grpc-health-probe -- see docker/server/Dockerfile.dev
+# and docker/server/Dockerfile.e2e.
 # Usage: scripts/server-ready.sh <compose-cmd> [max_tries]
 #   e.g. scripts/server-ready.sh "docker compose -p portfoliodb-dev -f docker/docker-compose.yml -f docker/docker-compose.dev.yml --env-file .env"
 set -e


### PR DESCRIPTION
Found while running the e2e suite for #263. Independent of that PR -- no overlapping files.

## The bug

`scripts/server-ready.sh` probes gRPC health from inside the portfoliodb container, so no host-side gRPC tooling is needed. But only `Dockerfile.dev` installs `grpc-health-probe`; `Dockerfile.e2e` builds a slim alpine image without it:

```
$ docker compose ... exec -T portfoliodb grpc-health-probe -addr=localhost:50051
OCI runtime exec failed: exec: "grpc-health-probe": executable file not found in $PATH
```

So the probe failed on every attempt and the script exited 1 after burning its 20 tries. Because the `e2e-test` recipe chained with `;` rather than `&&`, that failure was swallowed -- readiness silently degraded to a bare ~20s sleep while printing "portfoliodb gRPC not ready" on every run. It works today only because 20s happens to be long enough.

## The fix

- Install `grpc-health-probe` in the e2e image so the probe does what it claims.
- Chain readiness to the Playwright run with `&&` in `e2e-test`, so an unready server fails the target instead of handing Playwright a dead endpoint. `rc` capture and teardown are unchanged, so the stack is still torn down and the failure still propagates.
- `e2e-test-record` tears the stack down on the readiness-failure path rather than leaving it running.
- Note the image dependency in the script header so the next person changing a server Dockerfile sees it.

`make run` (dev) was never affected -- the dev image has the probe.

## Testing

- Probe present and readiness passes: `command -v grpc-health-probe` -> `/usr/local/bin/grpc-health-probe`, `scripts/server-ready.sh` -> rc=0.
- `make e2e-test` passes (27 tests), and no longer prints "portfoliodb gRPC not ready".
- Failure path: with the stack down, `scripts/server-ready.sh "$COMPOSE_E2E" 1` exits 1, and the `&&` chain skips the test run while still propagating rc=1 to teardown.

CI does not currently run the e2e target, so this is a local-dev fix only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)