### PR TITLE
Close 0052: inflation index revisions are not tracked

### DIFF
--- a/docs/adr/0016-bitemporal-time-model.md
+++ b/docs/adr/0016-bitemporal-time-model.md
@@ -48,11 +48,23 @@ correctly is the prerequisite for that work and is worth doing on its own; the
 consequence, accepted here, is that every derived value is as-of now and two
 identical valuation requests may legitimately differ across days.
 
+Inflation indices looked like the cheapest place to pilot versioned history --
+the valid time is a fixed month while the value can legitimately change -- and
+were rejected too. Nothing consumes them beyond gap detection and the admin
+listing, so the real-return figure whose reproducibility would justify the
+history does not yet exist. ONS, the only implemented provider, does not revise
+CPI or CPIH once published; it rebases, and a real return is a ratio of two index
+values, which a rebasing leaves unchanged. Storing vintages nobody reads, of
+revisions that mostly do not change the answer, is not worth the schema.
+
 ## Consequences
 
 - Constrains 0002 (ingestion by replacement), 0005 (corporate events) and 0014
   (extension import): each is a place where a source can restate, and each must
   now declare rather than assume.
+- A revised inflation index silently replaces its predecessor. There is no record
+  that a revision happened, and no way to reproduce a real return computed from
+  the earlier value.
 - Valuation must pair split-adjusted quantity with split-adjusted close. Pairing
   raw quantity with raw close is only correct if the split transaction itself is
   stored, and 0005 deliberately drops `TX_TYPE=SPLIT` rows.

--- a/docs/issues/0052-inflation-index-revisions.md
+++ b/docs/issues/0052-inflation-index-revisions.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Preserve prior vintages of revised inflation index values
 ---
 
@@ -17,10 +17,18 @@ This is the clearest revision case in the system: the valid time (`month`) is
 fixed while the value legitimately changes, which is exactly the shape a
 knowledge-time dimension exists to record.
 
-## Design
+## Resolution
 
-Widen the key to include a knowledge time, or move superseded values to a
-history table, so that the current value is a cheap lookup and the prior ones
-remain readable. Likely a prerequisite for 0054.
+Closed without building the vintage store. The system uses the latest published
+figure and does not record that an earlier one existed.
 
-See docs/spec/bitemporality.md.
+Nothing consumes the stored values beyond gap detection and the admin listing --
+there is no real-return metric, so the figure whose reproducibility motivated
+this cannot yet be produced. ONS, the only implemented provider, does not revise
+CPI or CPIH once published; it rebases periodically, and a real return is a ratio
+of two index values, which a rebasing leaves unchanged. The fetch worker also
+only requests months it has no data for, so a revision to a covered month would
+never reach the upsert without a re-fetch window that no consumer justifies.
+
+The reasoning is recorded in adr/0016-bitemporal-time-model.md and the resulting
+behaviour in spec/bitemporality.md.

--- a/docs/issues/0054-knowledge-time-as-of-queries.md
+++ b/docs/issues/0054-knowledge-time-as-of-queries.md
@@ -1,7 +1,7 @@
 ---
 status: open
 title: Knowledge-time as-of queries: reproduce a past valuation
-dependencies: [0051, 0052, 0053]
+dependencies: [0051, 0053]
 ---
 
 Allow a caller to ask what PortfolioDB believed on a given date, not only what
@@ -23,10 +23,11 @@ point "why did this change?" needs an answer.
 ## Design
 
 Needs versioned history on the facts that restate -- prices, splits, instrument
-identity, and transactions -- which is why it depends on 0051, 0052 and 0053.
-Transaction ingestion is knowledge-lossy by replacement
-(see adr/0002-transaction-ingestion-model.md), so that model has to be revisited
-too.
+identity, and transactions -- which is why it depends on 0051 and 0053.
+Inflation indices were deliberately left unversioned (see 0052), so versioning
+them would fall to this work. Transaction ingestion is knowledge-lossy by
+replacement (see adr/0002-transaction-ingestion-model.md), so that model has to
+be revisited too.
 
 A cheaper partial answer worth considering first: stamp each valuation response
 with the wall-clock time it was computed and the split state it reflects, so that

--- a/docs/spec/bitemporality.md
+++ b/docs/spec/bitemporality.md
@@ -64,6 +64,11 @@ knowledge timestamp can be:
   overwritten on every refresh by design. It answers "how stale is this?", never
   "when did we learn it?"
 
+Inflation index values are the deliberate exception: they are not versioned. A
+revised `index_value` replaces its predecessor in place and leaves no record that
+a revision occurred, which follows from rule 8 below
+(see adr/0016-bitemporal-time-model.md).
+
 | Table | Column | Kind |
 | --- | --- | --- |
 | `stock_splits` | `first_known_at` | First known. Compared against `instruments.identified_at` to decide whether an option's OCC symbol still needs retroactive adjustment. |
@@ -117,7 +122,8 @@ basis to today's. See [corporate-events.md](corporate-events.md#adjustment).
 ## Rules
 
 1. **Every stored fact records its valid time.** Knowledge time is recorded
-   wherever the source can revise the fact.
+   wherever the source can revise the fact, except for inflation index values
+   (see [Knowledge time](#knowledge-time)).
 2. **A knowledge-time column is named for what it means** -- `first_known_at` or
    `last_fetched_at`, never the ambiguous `fetched_at`. A `first_known_at` never
    moves forward: revising the fact leaves it alone, and on conflict it takes
@@ -171,7 +177,6 @@ The model above is normative. These parts of the system do not yet comply:
 | Divergence | Issue |
 | --- | --- |
 | No daily scheduler fires the blanket recompute, so a stored future-dated split never activates when its `ex_date` crosses | 0050 |
-| A revised inflation index overwrites the prior value, so a previously published real-return figure cannot be reproduced | 0052 |
 | Instrument identity has no valid-time dimension: `instruments.valid_from` / `valid_to` are never queried, `instrument_identifiers` cannot express ticker reuse, and a merge leaves no record of what was believed before | 0053 |
 | There is no knowledge-time as-of query, so a past valuation cannot be reproduced | 0054 |
 | `identified_at` is bumped by every `EnsureInstrument` call, not only by split-aware re-identification, which can disarm the retroactive option-split guard | 0055 |

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -285,8 +285,9 @@ CREATE TABLE inflation_indices (
   index_value   NUMERIC     NOT NULL,              -- relative to base_year July=100
   base_year     INT         NOT NULL,              -- year where July = 100
   data_provider TEXT        NOT NULL,              -- plugin ID
-  -- Staleness only: overwritten on every refresh. A revised index value
-  -- replaces the previous one and the prior vintage is not retained.
+  -- Staleness only: overwritten on every refresh. Index values are not
+  -- versioned by design: a revision replaces its predecessor in place and
+  -- leaves no record. See docs/spec/bitemporality.md.
   last_fetched_at TIMESTAMPTZ NOT NULL DEFAULT now(),
   PRIMARY KEY (currency, month)
 );


### PR DESCRIPTION
Closes issue 0052 without building the vintage store, and records the position as a decision rather than an outstanding defect.

## Why

- **Nothing consumes the data.** `inflation_indices` is read only by `computeGapRange` for gap detection and by the `/admin/inflation` listing. There is no real-return metric in the proto, the service, or `docs/spec/performance.md`, so the figure whose reproducibility motivated the issue cannot yet be produced.
- **The revisions are not routine.** ONS is the only implemented plugin, and ONS CPI/CPIH are not revised once published. Rebasing does restate the series, but a real return is a ratio `index(t2)/index(t1)` and is invariant under rebasing.
- **The worker cannot see a revision anyway.** `computeGapRange` fetches only from the first missing month onward, so once coverage is complete no month is ever re-fetched.
- ADR 0016 already accepted this trade for the larger cases (prices, splits, transactions), and rule 8 of `bitemporality.md` states that derived values are as-of now.

## Changes

- `docs/issues/0052-...` -- `status: closed`, `Design` replaced with a `Resolution` section.
- `docs/issues/0054-...` -- `0052` removed from `dependencies`; notes that versioning inflation indices would fall to that work.
- `docs/spec/bitemporality.md` -- 0052 removed from Known divergences; the behaviour stated normatively under Knowledge time, with rule 1 pointing at the exception.
- `docs/adr/0016-...` -- reasoning added to the existing "No knowledge-time as-of queries" section, plus a Consequences entry. No new ADR: the decision is easy to reverse and belongs to the same family.
- `server/migrations/001_initial.sql` -- comment on `inflation_indices.last_fetched_at` reworded from an admission of a defect to a statement of intent. Comment text only; no DDL change.

## Testing

Documentation only -- no schema, Go, proto or client change. `make test` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)