### PR TITLE
Close 0053: instrument identity stays current state

### DIFF
--- a/docs/adr/0004-instrument-resolution-and-merge.md
+++ b/docs/adr/0004-instrument-resolution-and-merge.md
@@ -21,3 +21,28 @@ later back a periodic sweep. Because the identifier set an instrument can have i
 open-ended (some instruments have no CUSIP, plugin coverage varies), the system
 does **not** treat "only one standard identifier known" as an error — merge-on-
 conflict is what reconciles instruments once a shared identifier appears.
+
+## Identity is current state, not a time-varying fact
+
+Resolution answers "which instrument holds this identifier now", never "which
+instrument held it on the transaction date", and the merge keeps no record of
+the loser. Giving identity a valid-time dimension was considered and rejected
+(see 0053).
+
+No identifier plugin returns instrument validity dates, so
+`instruments.valid_from` / `valid_to` are NULL for everything the system
+resolves for itself and a resolution filter on them would filter on nothing.
+Making ticker reuse representable means a validity interval on
+`instrument_identifiers`, which replaces the uniqueness indexes with a GiST
+exclusion constraint, gives the name-denormalising trigger a vintage to choose,
+and threads an as-of date through every identifier lookup and both batch
+resolution caches — the whole of the hottest path in ingestion, for data no
+source supplies. Nothing reads the merge history either: holdings and valuation
+follow from the current instrument set, and the only consumer is the deferred
+knowledge-time as-of query (0054, and see 0016-bitemporal-time-model.md).
+
+The accepted consequence is that a reused ticker or CUSIP silently rewrites how
+every historical transaction that resolved through it is interpreted, and that a
+merge destroys the loser's canonical fields along with its cascaded prices,
+splits, dividends and coverage rows. Those derive from external sources and come
+back on re-fetch; the identity judgement does not.

--- a/docs/adr/0016-bitemporal-time-model.md
+++ b/docs/adr/0016-bitemporal-time-model.md
@@ -65,6 +65,10 @@ revisions that mostly do not change the answer, is not worth the schema.
 - A revised inflation index silently replaces its predecessor. There is no record
   that a revision happened, and no way to reproduce a real return computed from
   the earlier value.
+- Instrument identity is current state for the same reason, decided in
+  0004-instrument-resolution-and-merge.md: a reused identifier rewrites how every
+  transaction that resolved through it is interpreted, and a merge leaves no
+  record of the loser.
 - Valuation must pair split-adjusted quantity with split-adjusted close. Pairing
   raw quantity with raw close is only correct if the split transaction itself is
   stored, and 0005 deliberately drops `TX_TYPE=SPLIT` rows.

--- a/docs/issues/0053-instrument-identity-time-dimension.md
+++ b/docs/issues/0053-instrument-identity-time-dimension.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Give instrument identity a time dimension
 ---
 
@@ -19,14 +19,38 @@ nothing records what was believed before:
   transaction with no audit trail, so holdings computed last month may not
   reproduce.
 
-## Design
+## Resolution
 
-- Query `valid_from` / `valid_to` during resolution so an identifier resolves to
-  the instrument that held it at the transaction's date, not merely to whatever
-  holds it now.
-- Give `instrument_identifiers` a validity interval so ticker reuse is
-  representable.
-- Record merges rather than deleting the loser outright.
+Closed without giving identity a time dimension. An identifier resolves to
+whichever instrument holds it now, and a merge still deletes the loser.
 
-See adr/0004-instrument-resolution-and-merge.md and
-docs/spec/bitemporality.md.
+Nothing supplies the valid time the design would query. No identifier plugin
+returns `valid_from` or `valid_to`; they are set only through the admin
+`ImportInstruments` payload and are NULL for every instrument the system
+resolves for itself. Filtering resolution on them would filter on nothing.
+
+The cost lands on the resolution path, which is the hottest code in ingestion. A
+validity interval on `instrument_identifiers` means replacing the four
+uniqueness indexes with a GiST exclusion constraint and a new `btree_gist`
+dependency, teaching the trigger that denormalises `instruments.name` to pick a
+vintage, adding an as-of argument to every identifier lookup and to
+`EnsureInstrument`, and adding the date to both batch resolution caches -- plus
+proto, import/export and admin UI. That is the whole path, for data no source
+provides.
+
+Nothing reads the history a merge record would keep. Holdings and valuation
+follow from the current instrument set and no API reports what an instrument
+used to be. The one consumer is 0054, deferred for the same reason in
+adr/0016-bitemporal-time-model.md.
+
+Merge stays lossy, and that is accepted: transactions and identifiers move to
+the survivor, but the loser's canonical fields and its cascaded prices, splits,
+dividends and coverage rows are deleted. Those derive from external sources and
+are recoverable by re-fetch.
+
+The knowledge-time defect on identity that does matter is tracked separately in
+0055: `identified_at` is bumped by every `EnsureInstrument` call, which can
+disarm the retroactive option-split guard.
+
+The reasoning is recorded in adr/0004-instrument-resolution-and-merge.md and the
+resulting behaviour in spec/identifiers.md and spec/bitemporality.md.

--- a/docs/issues/0054-knowledge-time-as-of-queries.md
+++ b/docs/issues/0054-knowledge-time-as-of-queries.md
@@ -1,7 +1,7 @@
 ---
 status: open
 title: Knowledge-time as-of queries: reproduce a past valuation
-dependencies: [0051, 0053]
+dependencies: [0051]
 ---
 
 Allow a caller to ask what PortfolioDB believed on a given date, not only what
@@ -23,9 +23,11 @@ point "why did this change?" needs an answer.
 ## Design
 
 Needs versioned history on the facts that restate -- prices, splits, instrument
-identity, and transactions -- which is why it depends on 0051 and 0053.
-Inflation indices were deliberately left unversioned (see 0052), so versioning
-them would fall to this work. Transaction ingestion is knowledge-lossy by
+identity, and transactions -- which is why it depends on 0051. Instrument
+identity and inflation indices were both deliberately left as current state (see
+0053 and 0052), so versioning them would fall to this work; for identity that
+means a validity interval on `instrument_identifiers` and a merge that records
+the loser rather than deleting it. Transaction ingestion is knowledge-lossy by
 replacement (see adr/0002-transaction-ingestion-model.md), so that model has to
 be revisited too.
 

--- a/docs/spec/bitemporality.md
+++ b/docs/spec/bitemporality.md
@@ -39,7 +39,7 @@ clock every read API means by "as of".
 | `stock_splits` | `ex_date` | The effective / execution date. |
 | `cash_dividends` | `ex_date`, `pay_date`, `record_date`, `declaration_date` | Four distinct points in the dividend's life. `declaration_date` is when the issuer announced it -- the world's knowledge time, but PortfolioDB's valid time, because what we know is that the announcement happened on that date. |
 | `holding_declarations` | `as_of_date` | The date the user's declaration refers to. |
-| `instruments` | `valid_from`, `valid_to`, `expiry` | When the instrument was tradeable. |
+| `instruments` | `valid_from`, `valid_to`, `expiry` | When the instrument was tradeable. Descriptive only for `valid_from` / `valid_to` -- see [Instrument identity](#instrument-identity) below. |
 | `corporate_event_coverage` | `covered_from`, `covered_to` | The valid-time interval a plugin was asked about. |
 | `inflation_indices` | `month` | The month the index value describes. |
 | `ingestion_jobs` | `period_from`, `period_to` | The valid-time window a bulk upload replaces. |
@@ -47,6 +47,17 @@ clock every read API means by "as of".
 
 Date ranges are half-open `[from, to)` with midnight-UTC values, matching
 PostgreSQL's `daterange` default (see adr/0007-calendar-day-valuation.md).
+
+### Instrument identity
+
+Instrument identity is the deliberate exception: it is current state, not a
+time-varying fact. `instrument_identifiers` carries no validity interval, so an
+identifier resolves to whichever instrument holds it now rather than to the one
+that held it on the transaction's date, and ticker reuse is not representable.
+`instruments.valid_from` and `valid_to` describe when the instrument was
+tradeable and no query filters on them. A merge deletes the loser outright,
+leaving no record of what was believed before
+(see adr/0004-instrument-resolution-and-merge.md).
 
 ## Knowledge time
 
@@ -121,9 +132,10 @@ basis to today's. See [corporate-events.md](corporate-events.md#adjustment).
 
 ## Rules
 
-1. **Every stored fact records its valid time.** Knowledge time is recorded
-   wherever the source can revise the fact, except for inflation index values
-   (see [Knowledge time](#knowledge-time)).
+1. **Every stored fact records its valid time**, except instrument identity,
+   which is current state (see [Instrument identity](#instrument-identity)).
+   Knowledge time is recorded wherever the source can revise the fact, except
+   for inflation index values (see [Knowledge time](#knowledge-time)).
 2. **A knowledge-time column is named for what it means** -- `first_known_at` or
    `last_fetched_at`, never the ambiguous `fetched_at`. A `first_known_at` never
    moves forward: revising the fact leaves it alone, and on conflict it takes
@@ -164,7 +176,7 @@ passed. It is normal, not exceptional.
 | A split arrives for an option's underlying | The option's OCC symbol, strike and contract terms | `ProcessOptionSplits`, gated on `first_known_at` vs `identified_at` |
 | A bulk upload replaces a period | Every transaction in that broker and period | Holdings and valuation follow from the transaction set; nothing is materialised |
 | A transaction earlier than the current earliest arrives, or history between the start date and a declaration changes | The derived INITIALIZE transaction | See [fixed-point.md](fixed-point.md) |
-| Instrument identity changes or two instruments merge | Which transactions roll up to which instrument | Holdings and valuation follow; see [identifiers.md](identifiers.md) |
+| Instrument identity changes or two instruments merge | Which transactions roll up to which instrument | Holdings and valuation follow; the prior identity is not retained -- see [identifiers.md](identifiers.md) |
 
 Restatement of a user-visible quantity should be surfaced rather than applied
 silently -- see [fixed-point.md](fixed-point.md), which sets the same requirement
@@ -177,7 +189,6 @@ The model above is normative. These parts of the system do not yet comply:
 | Divergence | Issue |
 | --- | --- |
 | No daily scheduler fires the blanket recompute, so a stored future-dated split never activates when its `ex_date` crosses | 0050 |
-| Instrument identity has no valid-time dimension: `instruments.valid_from` / `valid_to` are never queried, `instrument_identifiers` cannot express ticker reuse, and a merge leaves no record of what was believed before | 0053 |
 | There is no knowledge-time as-of query, so a past valuation cannot be reproduced | 0054 |
 | `identified_at` is bumped by every `EnsureInstrument` call, not only by split-aware re-identification, which can disarm the retroactive option-split guard | 0055 |
 | Date intervals are half-open in some API messages and closed in others | 0056 |

--- a/docs/spec/identifiers.md
+++ b/docs/spec/identifiers.md
@@ -85,6 +85,8 @@ PortfolioDB should periodically attempt to identify instruments in case datasour
 
 Re-identification and merge change shared reference data retroactively: which instrument a historical transaction rolls up to can differ from what it was last month, and holdings computed then may not reproduce. See [bitemporality.md](bitemporality.md#retroactive-restatement).
 
+**Identity is current state.** Identifiers carry no validity interval, so the (identifier_type, domain, value) triple is unique for all time and a reused ticker or CUSIP is not representable: resolution answers "which instrument holds this identifier now", never "which instrument held it on the transaction's date". `instruments.valid_from` and `valid_to` record when the instrument was tradeable and no query filters on them. A merge deletes the loser -- its canonical fields, and the prices, splits, dividends and coverage rows that cascade from it, are gone, and nothing records what was believed before. Those cascaded rows derive from external sources and return on re-fetch. See adr/0004-instrument-resolution-and-merge.md.
+
 ### User override
 
 A user may believe the system has mis-identified an instrument. It should be possible for a user to override the identity for their portfolio. They do this by ensuring that the client provides an external identifier hint for the transactions they want to override.  This will then be looked up directly rather than using identifiers extracted from the description.  Admin users can correct shared instrument identities in the admin UI.

--- a/server/db/postgres/instruments.go
+++ b/server/db/postgres/instruments.go
@@ -18,6 +18,7 @@ import (
 var errIdentifierExists = errors.New("identifier already exists for another instrument")
 
 // mergeInstruments merges mergedAway into survivor inside the same transaction: updates all txs pointing at mergedAway to survivor, moves identifier rows to survivor (or keeps survivor's if duplicate), then deletes mergedAway. exec must be a transaction.
+// The delete is deliberate and lossy: mergedAway's canonical fields and its cascaded prices, splits, dividends and coverage rows go with it, and nothing records the prior identity. See docs/adr/0004-instrument-resolution-and-merge.md.
 func mergeInstruments(ctx context.Context, exec queryable, survivor, mergedAway uuid.UUID) error {
 	if survivor == mergedAway {
 		return nil

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -132,6 +132,9 @@ CREATE TABLE instruments (
   name         TEXT,
   exchange     TEXT NOT NULL DEFAULT '',
   underlying_id UUID REFERENCES instruments (id),
+  -- When the instrument was tradeable. Descriptive only: no query filters on
+  -- these, and no identifier plugin supplies them. Identity is resolved as
+  -- current state. See docs/spec/bitemporality.md.
   valid_from   DATE,
   valid_to     DATE,
   cik          TEXT,
@@ -164,6 +167,9 @@ CREATE INDEX idx_instruments_underlying_id ON instruments (underlying_id);
 -- domain: optional; for BROKER_DESCRIPTION = source (e.g. 'Fidelity:web:fidelity-csv'); for TICKER = exchange code when present.
 -- canonical = false only for BROKER_DESCRIPTION identifiers; canonical = true for standard identifiers.
 -- Surrogate PK so domain can be NULL (PostgreSQL PK columns are NOT NULL).
+-- Identifiers carry no validity interval by design: the triple is unique for all
+-- time, so ticker reuse is not representable and a merge deletes the loser
+-- rather than closing its interval. See docs/adr/0004-instrument-resolution-and-merge.md.
 CREATE TABLE instrument_identifiers (
   id              UUID NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
   instrument_id   UUID NOT NULL REFERENCES instruments (id) ON DELETE CASCADE,


### PR DESCRIPTION
Depends on #265 (base branch is `close-0052-inflation-revisions`) -- both edit `docs/spec/bitemporality.md` and `docs/issues/0054-knowledge-time-as-of-queries.md`. Rebase onto main once #265 merges.

Issue 0053 asked that instrument identity become a time-varying fact: resolution filtering on `valid_from`/`valid_to`, a validity interval on `instrument_identifiers` so ticker reuse is representable, and a merge that records the loser instead of deleting it. This closes it without building any of that, and records the position as a decision rather than an outstanding defect.

## Why

- **Nothing supplies the valid time.** No identifier plugin returns instrument validity dates. `instruments.valid_from` / `valid_to` are set only through the admin `ImportInstruments` payload and are NULL for everything the system resolves for itself, so a resolution filter on them would filter on nothing.
- **The cost lands on the hottest path.** A validity interval on `instrument_identifiers` means replacing the four uniqueness indexes with a GiST exclusion constraint and a new `btree_gist` dependency, teaching the trigger that denormalises `instruments.name` to pick a vintage, adding an as-of argument to every identifier lookup and to `EnsureInstrument`, and adding the date to both batch resolution caches -- plus proto, import/export and admin UI.
- **Nothing reads the history.** Holdings and valuation follow from the current instrument set and no API reports what an instrument used to be. The one consumer is 0054, deferred for the same reason in `adr/0016-bitemporal-time-model.md`.

## Accepted consequences, now stated rather than implicit

A reused ticker or CUSIP silently rewrites how every historical transaction that resolved through it is interpreted. A merge destroys the loser's canonical fields along with its cascaded prices, splits, dividends and coverage rows -- those derive from external sources and return on re-fetch; the identity judgement does not.

The knowledge-time defect on identity that does matter stays open as 0055.

## Changes

- `docs/issues/0053-*.md` -- `status: closed`; `## Design` replaced by `## Resolution`.
- `docs/issues/0054-*.md` -- dependency on 0053 dropped; identity versioning re-homed into its Design.
- `docs/adr/0004-instrument-resolution-and-merge.md` -- new section carrying the rationale.
- `docs/adr/0016-bitemporal-time-model.md` -- consequence bullet.
- `docs/spec/bitemporality.md` -- rule 1 gains the exception, a new "Instrument identity" subsection states the behaviour, and the 0053 row leaves the divergences table.
- `docs/spec/identifiers.md` -- "Identity is current state" paragraph.
- `server/migrations/001_initial.sql`, `server/db/postgres/instruments.go` -- comments only.

Documentation only: no schema, proto or client change. `go build ./server/...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)