### PR TITLE
Close 0054: past valuations are not reproducible

### DIFF
--- a/docs/adr/0004-instrument-resolution-and-merge.md
+++ b/docs/adr/0004-instrument-resolution-and-merge.md
@@ -38,8 +38,9 @@ exclusion constraint, gives the name-denormalising trigger a vintage to choose,
 and threads an as-of date through every identifier lookup and both batch
 resolution caches — the whole of the hottest path in ingestion, for data no
 source supplies. Nothing reads the merge history either: holdings and valuation
-follow from the current instrument set, and the only consumer is the deferred
-knowledge-time as-of query (0054, and see 0016-bitemporal-time-model.md).
+follow from the current instrument set, and the only consumer would have been the
+knowledge-time as-of query, itself declined (0054, and see
+0016-bitemporal-time-model.md).
 
 The accepted consequence is that a reused ticker or CUSIP silently rewrites how
 every historical transaction that resolved through it is interpreted, and that a

--- a/docs/adr/0016-bitemporal-time-model.md
+++ b/docs/adr/0016-bitemporal-time-model.md
@@ -39,14 +39,23 @@ the name is a claim the write path must honour.
 
 ## No knowledge-time as-of queries
 
-There is no way to ask "what did we believe on 2024-01-01?", and adding one is
-deferred. Answering it needs versioned history on prices, splits and
-transactions -- a large, invasive cost for a benefit only audit and
-reproducibility need, and transaction ingestion is already knowledge-lossy by
-replacement (see 0002-transaction-ingestion-model.md). Recording the three clocks
-correctly is the prerequisite for that work and is worth doing on its own; the
-consequence, accepted here, is that every derived value is as-of now and two
-identical valuation requests may legitimately differ across days.
+There is no way to ask "what did we believe on 2024-01-01?", and there will not
+be. Answering it needs versioned history on prices, splits and transactions -- a
+large, invasive cost for a benefit only audit and reproducibility need, and
+transaction ingestion is already knowledge-lossy by replacement (see
+0002-transaction-ingestion-model.md). Recording the three clocks correctly is
+worth doing on its own; the consequence, accepted here, is that every derived
+value is as-of now and two identical valuation requests may legitimately differ
+across days.
+
+This started as a deferral and was settled when the prerequisites were declined
+one by one -- inflation index vintages (0052) and the identity time dimension
+(0053) -- leaving a single large piece of work justified only by a query for
+figures PortfolioDB does not report to anyone. The issue tracking it, 0054, is
+closed. Should a figure ever need defending, the cheaper starting point is to
+stamp each valuation response with its compute time and the split state it
+reflects, which makes a difference between two runs explainable without making it
+reproducible.
 
 Inflation indices looked like the cheapest place to pilot versioned history --
 the valid time is a fixed month while the value can legitimately change -- and
@@ -69,6 +78,9 @@ revisions that mostly do not change the answer, is not worth the schema.
   0004-instrument-resolution-and-merge.md: a reused identifier rewrites how every
   transaction that resolved through it is interpreted, and a merge leaves no
   record of the loser.
+- A figure PortfolioDB reported in the past cannot be reproduced, and no tracked
+  work will make it possible. A caller comparing two runs of the same request has
+  nothing in the response explaining a difference.
 - Valuation must pair split-adjusted quantity with split-adjusted close. Pairing
   raw quantity with raw close is only correct if the split transaction itself is
   stored, and 0005 deliberately drops `TX_TYPE=SPLIT` rows.

--- a/docs/issues/0053-instrument-identity-time-dimension.md
+++ b/docs/issues/0053-instrument-identity-time-dimension.md
@@ -40,8 +40,7 @@ provides.
 
 Nothing reads the history a merge record would keep. Holdings and valuation
 follow from the current instrument set and no API reports what an instrument
-used to be. The one consumer is 0054, deferred for the same reason in
-adr/0016-bitemporal-time-model.md.
+used to be. The one consumer was 0054, itself since closed for the same reason.
 
 Merge stays lossy, and that is accepted: transactions and identifiers move to
 the survivor, but the loser's canonical fields and its cascaded prices, splits,

--- a/docs/issues/0054-knowledge-time-as-of-queries.md
+++ b/docs/issues/0054-knowledge-time-as-of-queries.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Knowledge-time as-of queries: reproduce a past valuation
 dependencies: [0051]
 ---
@@ -20,20 +20,29 @@ adr/0016-bitemporal-time-model.md. It stops being defensible once a figure has
 been reported to a tax authority or compared against a broker statement, at which
 point "why did this change?" needs an answer.
 
-## Design
+## Resolution
 
-Needs versioned history on the facts that restate -- prices, splits, instrument
-identity, and transactions -- which is why it depends on 0051. Instrument
-identity and inflation indices were both deliberately left as current state (see
-0053 and 0052), so versioning them would fall to this work; for identity that
-means a validity interval on `instrument_identifiers` and a merge that records
-the loser rather than deleting it. Transaction ingestion is knowledge-lossy by
-replacement (see adr/0002-transaction-ingestion-model.md), so that model has to
-be revisited too.
+Closed without building knowledge-time as-of queries. Every `as_of` in the API
+stays valid time, and a past valuation cannot be reproduced.
 
-A cheaper partial answer worth considering first: stamp each valuation response
-with the wall-clock time it was computed and the split state it reflects, so that
-a difference between two runs is at least explainable even when it is not
-reproducible.
+The cost is versioned history on every fact that restates -- prices, splits,
+instrument identity and transactions. That is four subsystems, each on the
+ingestion or valuation path, and transaction ingestion is knowledge-lossy by
+replacement (see adr/0002-transaction-ingestion-model.md), so the ingestion model
+would have to change as well.
 
-See docs/spec/bitemporality.md.
+The prerequisites were each declined on their own merits as they came up:
+inflation index vintages (0052) and the identity time dimension (0053). What
+remained was a single large piece of work whose only justification was this
+query, for a system that does not report figures to a tax authority. Rule 8 of
+spec/bitemporality.md already states the resulting behaviour -- derived values
+are as-of now, and two identical valuation requests may legitimately differ
+across days.
+
+If the need arises, the cheaper partial answer is the place to start rather than
+versioned history: stamp each valuation response with the wall-clock time it was
+computed and the split state it reflects, so that a difference between two runs
+is at least explainable even when it is not reproducible.
+
+The reasoning is recorded in adr/0016-bitemporal-time-model.md and the resulting
+behaviour in spec/bitemporality.md.

--- a/docs/spec/bitemporality.md
+++ b/docs/spec/bitemporality.md
@@ -189,7 +189,6 @@ The model above is normative. These parts of the system do not yet comply:
 | Divergence | Issue |
 | --- | --- |
 | No daily scheduler fires the blanket recompute, so a stored future-dated split never activates when its `ex_date` crosses | 0050 |
-| There is no knowledge-time as-of query, so a past valuation cannot be reproduced | 0054 |
 | `identified_at` is bumped by every `EnsureInstrument` call, not only by split-aware re-identification, which can disarm the retroactive option-split guard | 0055 |
 | Date intervals are half-open in some API messages and closed in others | 0056 |
 | Holding declarations permit one assertion per holding, so a corrected declaration destroys the prior one | 0043 |


### PR DESCRIPTION
Issue 0054 asked for knowledge-time as-of queries so a caller could ask what PortfolioDB believed on a given date, not only what was true on it. This closes it without building them, and settles in the ADR what had been recorded as a deferral.

## Why

- **The cost spans four subsystems.** Answering the query needs versioned history on every fact that restates -- prices, splits, instrument identity and transactions -- each on the ingestion or valuation path. Transaction ingestion is knowledge-lossy by replacement (`adr/0002`), so that model would have to change as well.
- **The prerequisites were each declined on their own merits** as they came up: inflation index vintages (0052) and the identity time dimension (0053). What remained was a single large piece of work whose only justification was this query, for a system that does not report figures to a tax authority.
- **The behaviour is already normative.** Rule 8 of `spec/bitemporality.md` states that derived values are as-of now and that two identical valuation requests may legitimately differ across days, so the divergence row is removed rather than replaced.

## Accepted consequence

A figure PortfolioDB reported in the past cannot be reproduced, and no tracked work will make it possible. A caller comparing two runs of the same request has nothing in the response explaining a difference. If that ever needs answering, the resolution records the cheaper starting point -- stamp each valuation response with its compute time and the split state it reflects, which makes a difference explainable without making it reproducible. No issue is opened for that; it is a note for whoever needs it.

## Changes

- `docs/issues/0054-*.md` -- `status: closed`; `## Design` replaced by `## Resolution`. Motivation left untouched.
- `docs/adr/0016-bitemporal-time-model.md` -- the "No knowledge-time as-of queries" section changes from a deferral to a settled decision, and gains a consequence bullet.
- `docs/spec/bitemporality.md` -- the 0054 row leaves the divergences table.
- `docs/issues/0053-*.md`, `docs/adr/0004-instrument-resolution-and-merge.md` -- two references that described 0054 as deferred now say it was declined.

Documentation only: no schema, Go, proto or client change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)