### PR TITLE
Close 0055: make the option split pass query-driven and retryable

### DIFF
--- a/docs/issues/0053-instrument-identity-time-dimension.md
+++ b/docs/issues/0053-instrument-identity-time-dimension.md
@@ -47,9 +47,10 @@ the survivor, but the loser's canonical fields and its cascaded prices, splits,
 dividends and coverage rows are deleted. Those derive from external sources and
 are recoverable by re-fetch.
 
-The knowledge-time defect on identity that does matter is tracked separately in
-0055: `identified_at` is bumped by every `EnsureInstrument` call, which can
-disarm the retroactive option-split guard.
+The one time dimension identity does carry is `identity_as_of`, the point in
+market time the stored identity reflects, which gates retroactive option split
+adjustment. That is a single timestamp on the current identity, not a history of
+it; see 0055 and adr/0017-option-identity-reflects-ex-date.md.
 
 The reasoning is recorded in adr/0004-instrument-resolution-and-merge.md and the
 resulting behaviour in spec/identifiers.md and spec/bitemporality.md.

--- a/docs/issues/0055-option-split-guard-identified-at.md
+++ b/docs/issues/0055-option-split-guard-identified-at.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Harden the retroactive option-split guard against identified_at churn
 ---
 
@@ -23,11 +23,37 @@ The guard is fragile in both directions:
 - The adjustment pass only runs when splits landed in that same cycle, so a
   transient failure is never retried.
 
-## Design
+## Resolution
 
-Separate "when we last ran identification" from "the knowledge state the stored
-identity reflects" -- the latter is what the guard needs and it should only move
-when the identity is actually re-derived against known splits. Make the
-adjustment pass idempotent and retryable rather than tied to one cycle.
+Fixed, and the comparison turned out to be on the wrong clock as well.
 
-See docs/spec/bitemporality.md.
+`identified_at` is now `instruments.identity_as_of` -- the point in market time
+the stored identity reflects -- and the guard compares it against the split's
+`ex_date` rather than its `first_known_at`. OCC adjusts a contract on the
+effective date, and providers list the pre-split symbol until then, so an
+identity derived before the ex_date does not reflect the split however long we
+had known it was coming. The old comparison marked such an identity
+already-correct and skipped the adjustment permanently. It also put the guard on
+the same clock as `AdjustOCCForKnownSplits`, which had always filtered purely on
+`ex_date`. The reasoning is in adr/0017-option-identity-reflects-ex-date.md.
+
+The column now moves only when the identity is genuinely re-derived: a plugin
+identification, or the adjustment itself. `EnsureInstrument` never writes it, on
+create or on match, because it cannot know the provenance of the identifiers it
+was handed; each caller stamps what it knows, and the column only ever moves
+forward so a stale file cannot drag it backwards.
+
+The pass is now query-driven. `ListPendingOptionSplits` returns every option
+whose identity predates an effective split on its underlying, so the work list is
+a function of stored state rather than of which splits happened to arrive in the
+current cycle. It runs once per cycle, unconditionally: a failed adjustment
+leaves the option pending and the next cycle retries it, where previously
+coverage had already been written and the pass was never reached again. A
+future-dated split is simply not pending until its ex_date passes.
+
+Each option is adjusted once by the cumulative factor of all its pending splits.
+The previous per-split loop read the option row once and never refreshed it, so
+two splits divided the original strike twice and left the option carrying an OCC
+identifier per split -- reachable whenever a backfill landed two historical
+splits together. A split that cannot be applied blocks its option rather than
+being skipped over, and leaves it pending for a later run.

--- a/docs/spec/bitemporality.md
+++ b/docs/spec/bitemporality.md
@@ -183,7 +183,7 @@ passed. It is normal, not exceptional.
 | Trigger | Restates | Recompute |
 | --- | --- | --- |
 | A new split arrives, or a stored split's `ex_date` crosses today | `split_adjusted_*` on every price and tx for the instrument | `RecomputeSplitAdjustments` per instrument, plus a daily blanket pass for crossings -- see [corporate-events.md](corporate-events.md#daily-scheduler-planned) |
-| A split arrives for an option's underlying | The option's OCC symbol, strike and contract terms | `ProcessOptionSplits`, gated on `identity_as_of` vs `ex_date` |
+| A split arrives for an option's underlying, or a stored one's `ex_date` crosses today | The option's OCC symbol, strike and contract terms | `ProcessPendingOptionSplits`, driven by `identity_as_of` vs `ex_date` |
 | A bulk upload replaces a period | Every transaction in that broker and period | Holdings and valuation follow from the transaction set; nothing is materialised |
 | A transaction earlier than the current earliest arrives, or history between the start date and a declaration changes | The derived INITIALIZE transaction | See [fixed-point.md](fixed-point.md) |
 | Instrument identity changes or two instruments merge | Which transactions roll up to which instrument | Holdings and valuation follow; the prior identity is not retained -- see [identifiers.md](identifiers.md) |
@@ -199,7 +199,6 @@ The model above is normative. These parts of the system do not yet comply:
 | Divergence | Issue |
 | --- | --- |
 | No daily scheduler fires the blanket recompute, so a stored future-dated split never activates when its `ex_date` crosses | 0050 |
-| The option-split adjustment pass runs only when a split landed in the same fetch cycle, so a transient failure is never retried | 0055 |
 | Date intervals are half-open in some API messages and closed in others | 0056 |
 | Holding declarations permit one assertion per holding, so a corrected declaration destroys the prior one | 0043 |
 | Corporate actions adjust totals rather than lots | 0044 |

--- a/docs/spec/corporate-events.md
+++ b/docs/spec/corporate-events.md
@@ -127,11 +127,15 @@ The cost-basis invariant `qty × price == split_adjusted_quantity × split_adjus
 
 ### Option contracts
 
-A split on an option's underlying restates the option itself: OCC adjusts the contract on the ex_date, so its symbol and strike change. `ProcessOptionSplits` applies that adjustment retroactively to stored options, replacing the OCC identifier and strike and recomputing the option's `split_adjusted_*` values.
+A split on an option's underlying restates the option itself: OCC adjusts the contract on the ex_date, so its symbol and strike change. `ProcessPendingOptionSplits` applies that adjustment retroactively to stored options, replacing the OCC identifier and strike and recomputing the option's `split_adjusted_*` values.
 
 Whether an option still needs adjusting is decided by comparing `instruments.identity_as_of` -- the point in market time its stored identity reflects -- against the split's `ex_date`. An identity derived on or after the ex_date already carries the adjusted symbol and is left alone; one derived before it does not, however long the split had been known, because providers list the pre-split symbol until the ex_date. Knowledge time is not consulted. See adr/0017-option-identity-reflects-ex-date.md.
 
-Non-whole-forward splits (reverse splits, fractional ratios) are not applied: they are routed to `unhandled_corporate_events` for manual review. `contract_multiplier` is never adjusted automatically.
+The pass derives its work list from that comparison rather than from which splits arrived in the current fetch cycle, and runs once per cycle regardless of whether any did. That makes it idempotent and self-retrying: applying the adjustment advances `identity_as_of` in the same transaction, which is what removes the option from the list, so an adjustment that failed is simply still pending next time. A future-dated split is not pending until its `ex_date` passes, at which point the next run picks it up.
+
+An option is adjusted once, by the cumulative factor of all its pending splits, so a backfill landing several historical splits together compounds them correctly instead of repeatedly dividing the original strike.
+
+Non-whole-forward splits (reverse splits, fractional ratios) are not applied: they are routed to `unhandled_corporate_events` for manual review, and they block their option entirely rather than being skipped over, since adjusting only the splits either side would produce a strike matching no real contract. The option stays pending so it is picked up once the event is resolved. `contract_multiplier` is never adjusted automatically.
 
 The instruments fetched each cycle come from `HeldEventBearingInstruments`: direct STOCK and ETF holdings, plus the underlyings of held OPTION and FUTURE positions.
 

--- a/server/corporateevents/option_splits.go
+++ b/server/corporateevents/option_splits.go
@@ -52,7 +52,11 @@ func ProcessPendingOptionSplits(ctx context.Context, database db.DB, underlyingI
 
 	var adjusted []*db.InstrumentRow
 	for _, p := range pending {
-		var factor float64 = 1
+		// Compound as exact rationals and convert once. Every ratio the
+		// IsWholeForwardSplit guard admits is a whole number, so float
+		// multiplication would happen to be exact today, but that stops holding
+		// the moment the guard admits a fractional ratio.
+		factorRat := new(big.Rat).SetInt64(1)
 		unhandled := false
 		for _, s := range p.Splits {
 			if !identification.IsWholeForwardSplit(s.SplitFrom, s.SplitTo) {
@@ -69,10 +73,9 @@ func ProcessPendingOptionSplits(ctx context.Context, database db.DB, underlyingI
 			}
 			from, _ := new(big.Rat).SetString(s.SplitFrom)
 			to, _ := new(big.Rat).SetString(s.SplitTo)
-			ratio := new(big.Rat).Quo(to, from)
-			f, _ := ratio.Float64()
-			factor *= f
+			factorRat.Mul(factorRat, new(big.Rat).Quo(to, from))
 		}
+		factor, _ := factorRat.Float64()
 		// A pending split we cannot apply blocks the whole option: adjusting
 		// only the splits either side of it would silently produce a strike
 		// that matches no real contract. Leaving identity_as_of untouched keeps

--- a/server/corporateevents/option_splits.go
+++ b/server/corporateevents/option_splits.go
@@ -6,81 +6,105 @@ import (
 	"fmt"
 	"log/slog"
 	"math/big"
-	"sort"
 	"time"
 
-	"github.com/leedenison/portfoliodb/server/clock"
 	"github.com/leedenison/portfoliodb/server/db"
 	"github.com/leedenison/portfoliodb/server/derivative"
 	"github.com/leedenison/portfoliodb/server/service/identification"
 )
 
-// ProcessOptionSplits adjusts options on the given underlying after new stock
-// splits land. For each option and each applicable split:
-//   - If identity_as_of >= split.ex_date: skip (the identity already reflects it)
-//   - If factor is not a whole forward split: insert unhandled event, skip
-//   - Otherwise: update OCC identifier and strike
+// ProcessPendingOptionSplits adjusts every option whose stored identity predates
+// an effective split on its underlying. underlyingID == "" sweeps every option;
+// a non-empty value restricts the sweep to one underlying.
 //
-// Splits are processed in chronological order. timer may be nil (uses
-// time.Now).
-func ProcessOptionSplits(ctx context.Context, database db.DB, underlyingID string, splits []db.StockSplit, log *slog.Logger, timer *clock.Timer) []*db.InstrumentRow {
-	options, err := database.ListOptionsByUnderlying(ctx, underlyingID)
+// The work list comes from the database, not from the caller: which splits an
+// option still needs is a function of its identity_as_of against each split's
+// ex_date, not of which splits happened to arrive in this fetch cycle. That
+// makes the pass idempotent, safe to run on every cycle, and self-retrying --
+// an option whose adjustment failed is simply still pending next time.
+//
+// Each option is adjusted once, by the cumulative factor of all its pending
+// splits, in a single transaction. Applying them one at a time against a row
+// read before the first write would compound the wrong strike and leave the
+// option carrying an OCC identifier per split.
+//
+// There is no clock parameter: the future-dated split cutoff is applied by the
+// query against CURRENT_DATE, so a split fetched by the lookahead is simply not
+// pending until it takes effect.
+func ProcessPendingOptionSplits(ctx context.Context, database db.DB, underlyingID string, log *slog.Logger) []*db.InstrumentRow {
+	pending, err := database.ListPendingOptionSplits(ctx, underlyingID)
 	if err != nil {
 		if log != nil {
-			log.ErrorContext(ctx, "option splits: list options", "underlying", underlyingID, "err", err)
+			log.ErrorContext(ctx, "option splits: list pending", "underlying", underlyingID, "err", err)
 		}
 		return nil
 	}
-	if len(options) == 0 {
-		return nil
+
+	// Non-whole splits are reported once per (underlying, ex_date) listing every
+	// option they block, matching the shape of the event this pass has always
+	// raised.
+	type blockedSplit struct {
+		split   db.StockSplit
+		options []*db.InstrumentRow
 	}
+	blocked := make(map[string]*blockedSplit)
+	var blockedOrder []string
 
-	// Sort splits chronologically.
-	sorted := make([]db.StockSplit, len(splits))
-	copy(sorted, splits)
-	sort.Slice(sorted, func(i, j int) bool { return sorted[i].ExDate.Before(sorted[j].ExDate) })
-
-	today := timer.Now().UTC().Truncate(24 * time.Hour)
-
-	for _, split := range sorted {
-		if split.ExDate.After(today) {
-			continue // Don't process future-dated splits.
+	var adjusted []*db.InstrumentRow
+	for _, p := range pending {
+		var factor float64 = 1
+		unhandled := false
+		for _, s := range p.Splits {
+			if !identification.IsWholeForwardSplit(s.SplitFrom, s.SplitTo) {
+				key := s.InstrumentID + "\x00" + s.ExDate.Format(time.RFC3339)
+				b, ok := blocked[key]
+				if !ok {
+					b = &blockedSplit{split: s}
+					blocked[key] = b
+					blockedOrder = append(blockedOrder, key)
+				}
+				b.options = append(b.options, p.Option)
+				unhandled = true
+				continue
+			}
+			from, _ := new(big.Rat).SetString(s.SplitFrom)
+			to, _ := new(big.Rat).SetString(s.SplitTo)
+			ratio := new(big.Rat).Quo(to, from)
+			f, _ := ratio.Float64()
+			factor *= f
 		}
-
-		if !identification.IsWholeForwardSplit(split.SplitFrom, split.SplitTo) {
-			// Route non-standard splits to a single unhandled event on the
-			// underlying, listing all affected option IDs in the data field.
-			insertUnhandledUnderlyingSplit(ctx, database, underlyingID, options, split, "non-standard split ratio", log)
+		// A pending split we cannot apply blocks the whole option: adjusting
+		// only the splits either side of it would silently produce a strike
+		// that matches no real contract. Leaving identity_as_of untouched keeps
+		// the option pending, so it is picked up again once the event is
+		// resolved.
+		if unhandled {
 			continue
 		}
-
-		from, _ := new(big.Rat).SetString(split.SplitFrom)
-		to, _ := new(big.Rat).SetString(split.SplitTo)
-		ratio := new(big.Rat).Quo(to, from)
-		factor, _ := ratio.Float64()
-
-		for _, opt := range options {
-			processOneOptionSplit(ctx, database, opt, split, factor, log)
+		if applyOptionSplits(ctx, database, p.Option, p.Splits, factor, log) {
+			adjusted = append(adjusted, p.Option)
 		}
 	}
-	return options
+
+	for _, key := range blockedOrder {
+		b := blocked[key]
+		insertUnhandledUnderlyingSplit(ctx, database, b.split.InstrumentID, b.options, b.split, "non-standard split ratio", log)
+	}
+	return adjusted
 }
 
-func processOneOptionSplit(ctx context.Context, database db.DB, opt *db.InstrumentRow, split db.StockSplit, factor float64, log *slog.Logger) {
-	// Already correct: the identity was derived on or after the split took
-	// effect. Providers list the pre-split OCC symbol until the ex_date, so an
-	// identity derived before then does not reflect the split however long we
-	// had known it was coming. A NULL identity_as_of predates every split.
-	// See docs/adr/0017-option-identity-reflects-ex-date.md.
-	if opt.IdentityAsOf != nil && !opt.IdentityAsOf.Before(split.ExDate) {
-		return
-	}
+// applyOptionSplits rewrites one option's OCC symbol and strike for the
+// cumulative factor of its pending splits. Returns true when the adjustment was
+// applied. splits is used only for reporting; factor already accounts for all of
+// them.
+func applyOptionSplits(ctx context.Context, database db.DB, opt *db.InstrumentRow, splits []db.StockSplit, factor float64, log *slog.Logger) bool {
+	split := splits[len(splits)-1] // most recent, for unhandled-event context
 
 	if opt.Strike == nil || opt.Expiry == nil || opt.PutCall == nil {
 		if log != nil {
 			log.WarnContext(ctx, "option splits: missing option fields", "option", opt.ID)
 		}
-		return
+		return false
 	}
 
 	// Find the current OCC identifier.
@@ -95,7 +119,7 @@ func processOneOptionSplit(ctx context.Context, database db.DB, opt *db.Instrume
 		if log != nil {
 			log.WarnContext(ctx, "option splits: no OCC identifier", "option", opt.ID)
 		}
-		return
+		return false
 	}
 
 	newStrike := *opt.Strike / factor
@@ -104,17 +128,20 @@ func processOneOptionSplit(ctx context.Context, database db.DB, opt *db.Instrume
 	parsed, ok := derivative.ParseOptionTicker(currentOCC)
 	if !ok {
 		insertUnhandledOptionSplit(ctx, database, opt, split, fmt.Sprintf("unparseable OCC identifier %q", currentOCC), log)
-		return
+		return false
 	}
 
 	newOCC, ok := derivative.BuildOCCCompact(parsed.Symbol, parsed.Expiry, parsed.PutCall, newStrike)
 	if !ok {
 		insertUnhandledOptionSplit(ctx, database, opt, split, fmt.Sprintf("cannot build OCC with adjusted strike %.4f", newStrike), log)
-		return
+		return false
 	}
 
 	// All mutations run in a single transaction via ApplyOptionSplit so
-	// partial failure cannot leave the option in an inconsistent state.
+	// partial failure cannot leave the option in an inconsistent state. That
+	// transaction also advances identity_as_of, which is what removes the option
+	// from the pending set. A failure here leaves it pending, so the next cycle
+	// retries it.
 	params := db.OptionSplitParams{
 		InstrumentID: opt.ID,
 		OldOCCValue:  currentOCC,
@@ -126,15 +153,16 @@ func processOneOptionSplit(ctx context.Context, database db.DB, opt *db.Instrume
 		if log != nil {
 			log.ErrorContext(ctx, "option splits: apply", "option", opt.ID, "err", err)
 		}
-		return
+		return false
 	}
 
 	if log != nil {
 		log.InfoContext(ctx, "option splits: adjusted",
 			"option", opt.ID, "old_occ", currentOCC, "new_occ", newOCC,
 			"old_strike", *opt.Strike, "new_strike", newStrike,
-			"split", fmt.Sprintf("%s:%s", split.SplitFrom, split.SplitTo))
+			"splits", len(splits), "factor", factor)
 	}
+	return true
 }
 
 // insertUnhandledUnderlyingSplit inserts a single unhandled event on the

--- a/server/corporateevents/option_splits_test.go
+++ b/server/corporateevents/option_splits_test.go
@@ -2,24 +2,21 @@ package corporateevents
 
 import (
 	"context"
+	"errors"
+	"strings"
 	"testing"
 	"time"
 
-	"github.com/leedenison/portfoliodb/server/clock"
 	"github.com/leedenison/portfoliodb/server/db"
 	"github.com/leedenison/portfoliodb/server/db/mock"
 	"go.uber.org/mock/gomock"
 )
 
-func floatPtr(f float64) *float64 { return &f }
+func floatPtr(f float64) *float64    { return &f }
 func timePtr(t time.Time) *time.Time { return &t }
 
 func date(year int, month time.Month, day int) time.Time {
 	return time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
-}
-
-func fixedTimer(t time.Time) *clock.Timer {
-	return &clock.Timer{NowFunc: func() time.Time { return t }}
 }
 
 // makeOption builds an InstrumentRow for an option with the given OCC, strike,
@@ -46,35 +43,39 @@ func makeOptionUnidentified(id, occ string, strike float64) *db.InstrumentRow {
 	}
 }
 
-// TestProcessOptionSplits_IdentityPredatesExDate verifies the identity was
-// derived before the split took effect, so the stored OCC is the pre-split one
-// and the adjustment must be applied.
-func TestProcessOptionSplits_IdentityPredatesExDate(t *testing.T) {
+func split(underlyingID string, exDate time.Time, from, to string) db.StockSplit {
+	return db.StockSplit{
+		InstrumentID: underlyingID,
+		ExDate:       exDate,
+		SplitFrom:    from,
+		SplitTo:      to,
+		DataProvider: "eodhd",
+		FirstKnownAt: exDate,
+	}
+}
+
+// Which splits are pending for an option is decided by the SQL predicate in
+// ListPendingOptionSplits, not by this package -- see the integration tests in
+// server/db/postgres for identity_as_of against ex_date. These tests cover what
+// the pass does with the work list it is handed.
+
+func TestProcessPendingOptionSplits_SingleSplit(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 	mockDB := mock.NewMockDB(ctrl)
 	ctx := context.Background()
 
-	optID := "opt-1111"
-	underlyingID := "und-2222"
-
-	// Identity as of Jan 1, split effective Jan 15 → identity predates it → apply.
-	opt := makeOption(optID, "AAPL  250117C00200000", 200.0, date(2025, 1, 1))
-
-	split := db.StockSplit{
-		InstrumentID: underlyingID,
-		ExDate:       date(2025, 1, 15),
-		SplitFrom:    "1",
-		SplitTo:      "2",
-		DataProvider: "eodhd",
-		FirstKnownAt: date(2025, 2, 1),
-	}
-
-	mockDB.EXPECT().ListOptionsByUnderlying(gomock.Any(), underlyingID).Return([]*db.InstrumentRow{opt}, nil)
+	opt := makeOption("opt-1111", "AAPL  250117C00200000", 200.0, date(2025, 1, 1))
+	mockDB.EXPECT().ListPendingOptionSplits(gomock.Any(), "und-2222").Return(
+		[]db.PendingOptionSplits{{
+			Option: opt,
+			Splits: []db.StockSplit{split("und-2222", date(2025, 1, 15), "1", "2")},
+		}}, nil)
 
 	mockDB.EXPECT().ApplyOptionSplit(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, p db.OptionSplitParams) error {
-			if p.InstrumentID != optID {
-				t.Errorf("instrument id = %q, want %q", p.InstrumentID, optID)
+			if p.InstrumentID != "opt-1111" {
+				t.Errorf("instrument id = %q, want opt-1111", p.InstrumentID)
 			}
 			if p.OldOCCValue != "AAPL  250117C00200000" {
 				t.Errorf("old OCC = %q", p.OldOCCValue)
@@ -88,344 +89,251 @@ func TestProcessOptionSplits_IdentityPredatesExDate(t *testing.T) {
 			return nil
 		})
 
-	timer := fixedTimer(date(2025, 3, 1)) // after ex_date
-	ProcessOptionSplits(ctx, mockDB, underlyingID, []db.StockSplit{split}, nil, timer)
+	adjusted := ProcessPendingOptionSplits(ctx, mockDB, "und-2222", nil)
+	if len(adjusted) != 1 {
+		t.Fatalf("adjusted = %d options, want 1", len(adjusted))
+	}
 }
 
-// TestProcessOptionSplits_IdentityAfterExDate verifies the identity was derived
-// after the split took effect, so the stored OCC is already the post-split one
-// and must be left alone.
-func TestProcessOptionSplits_IdentityAfterExDate(t *testing.T) {
+// TestProcessPendingOptionSplits_CompoundsMultipleSplits covers the bug the
+// per-split loop had: the option row is read once, so applying two splits in
+// sequence divided the ORIGINAL strike twice and inserted an OCC identifier per
+// split, leaving the option carrying both. Adjusting once by the cumulative
+// factor is correct by construction.
+func TestProcessPendingOptionSplits_CompoundsMultipleSplits(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 	mockDB := mock.NewMockDB(ctrl)
 	ctx := context.Background()
 
-	optID := "opt-3333"
-	underlyingID := "und-4444"
+	opt := makeOption("opt-multi", "AAPL  250117C00400000", 400.0, date(2024, 1, 1))
+	mockDB.EXPECT().ListPendingOptionSplits(gomock.Any(), "").Return(
+		[]db.PendingOptionSplits{{
+			Option: opt,
+			Splits: []db.StockSplit{
+				split("und-multi", date(2024, 6, 1), "1", "2"), // 2:1
+				split("und-multi", date(2024, 9, 1), "1", "4"), // 4:1
+			},
+		}}, nil)
 
-	// Identity as of Mar 1, split effective Jan 15 → already reflects it → skip.
-	opt := makeOption(optID, "AAPL250117C00100000", 100.0, date(2025, 3, 1))
-
-	split := db.StockSplit{
-		InstrumentID: underlyingID,
-		ExDate:       date(2025, 1, 15),
-		SplitFrom:    "1",
-		SplitTo:      "2",
-		DataProvider: "eodhd",
-		FirstKnownAt: date(2025, 2, 1),
-	}
-
-	mockDB.EXPECT().ListOptionsByUnderlying(gomock.Any(), underlyingID).Return([]*db.InstrumentRow{opt}, nil)
-	// ApplyOptionSplit must NOT be called.
-
-	timer := fixedTimer(date(2025, 3, 1))
-	ProcessOptionSplits(ctx, mockDB, underlyingID, []db.StockSplit{split}, nil, timer)
-}
-
-// TestProcessOptionSplits_IdentityOnExDate pins the inclusive boundary: an
-// identity derived on the ex_date itself sees the adjusted contract, because the
-// new terms apply from the open that day.
-func TestProcessOptionSplits_IdentityOnExDate(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	mockDB := mock.NewMockDB(ctrl)
-	ctx := context.Background()
-
-	underlyingID := "und-boundary"
-	opt := makeOption("opt-boundary", "AAPL250117C00100000", 100.0, date(2025, 1, 15))
-
-	split := db.StockSplit{
-		InstrumentID: underlyingID,
-		ExDate:       date(2025, 1, 15),
-		SplitFrom:    "1",
-		SplitTo:      "2",
-		DataProvider: "eodhd",
-		FirstKnownAt: date(2025, 1, 5),
-	}
-
-	mockDB.EXPECT().ListOptionsByUnderlying(gomock.Any(), underlyingID).Return([]*db.InstrumentRow{opt}, nil)
-	// ApplyOptionSplit must NOT be called.
-
-	ProcessOptionSplits(ctx, mockDB, underlyingID, []db.StockSplit{split}, nil, fixedTimer(date(2025, 3, 1)))
-}
-
-// TestProcessOptionSplits_KnownBeforeButNotYetEffective is the regression test
-// for issue 0055. The split was known on Jan 5 and the option was identified on
-// Mar 1 -- so under the old first_known_at guard it looked already-correct and
-// was skipped forever. But the split does not take effect until Jun 1, so the
-// identity derived in March carries the PRE-split OCC and does need adjusting.
-func TestProcessOptionSplits_KnownBeforeButNotYetEffective(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	mockDB := mock.NewMockDB(ctrl)
-	ctx := context.Background()
-
-	optID := "opt-0055"
-	underlyingID := "und-0055"
-
-	opt := makeOption(optID, "AAPL  250117C00200000", 200.0, date(2025, 3, 1))
-
-	split := db.StockSplit{
-		InstrumentID: underlyingID,
-		ExDate:       date(2025, 6, 1),
-		SplitFrom:    "1",
-		SplitTo:      "2",
-		DataProvider: "eodhd",
-		FirstKnownAt: date(2025, 1, 5), // known well before the identity was derived
-	}
-
-	mockDB.EXPECT().ListOptionsByUnderlying(gomock.Any(), underlyingID).Return([]*db.InstrumentRow{opt}, nil)
+	// Exactly one call: strike 400 / (2 * 4) = 50.
 	mockDB.EXPECT().ApplyOptionSplit(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, p db.OptionSplitParams) error {
-			if p.NewStrike != 100.0 {
-				t.Errorf("new strike = %f, want 100", p.NewStrike)
+			if p.NewStrike != 50.0 {
+				t.Errorf("new strike = %f, want 50 (400 / (2*4))", p.NewStrike)
+			}
+			if p.NewOCC.Value != "AAPL250117C00050000" {
+				t.Errorf("new OCC = %q, want AAPL250117C00050000", p.NewOCC.Value)
+			}
+			if p.OldOCCValue != "AAPL  250117C00400000" {
+				t.Errorf("old OCC = %q, want the original", p.OldOCCValue)
 			}
 			return nil
-		})
+		}).Times(1)
 
-	// Now past the ex_date.
-	ProcessOptionSplits(ctx, mockDB, underlyingID, []db.StockSplit{split}, nil, fixedTimer(date(2025, 7, 1)))
+	if adjusted := ProcessPendingOptionSplits(ctx, mockDB, "", nil); len(adjusted) != 1 {
+		t.Fatalf("adjusted = %d options, want 1", len(adjusted))
+	}
 }
 
-// TestProcessOptionSplits_NilIdentityAsOf verifies a NULL identity_as_of is
-// treated as predating every split, so the adjustment applies.
-func TestProcessOptionSplits_NilIdentityAsOf(t *testing.T) {
+// TestProcessPendingOptionSplits_ApplyFailureNotReported verifies a failed
+// adjustment is not counted as done. identity_as_of is advanced inside
+// ApplyOptionSplit's transaction, so a failure leaves the option pending and the
+// next cycle retries it -- the retry half of issue 0055.
+func TestProcessPendingOptionSplits_ApplyFailureNotReported(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 	mockDB := mock.NewMockDB(ctrl)
 	ctx := context.Background()
 
-	underlyingID := "und-nil"
-	opt := makeOptionUnidentified("opt-nil", "AAPL  250117C00200000", 200.0)
+	opt := makeOption("opt-fail", "AAPL  250117C00200000", 200.0, date(2025, 1, 1))
+	mockDB.EXPECT().ListPendingOptionSplits(gomock.Any(), "").Return(
+		[]db.PendingOptionSplits{{
+			Option: opt,
+			Splits: []db.StockSplit{split("und-fail", date(2025, 1, 15), "1", "2")},
+		}}, nil)
+	mockDB.EXPECT().ApplyOptionSplit(gomock.Any(), gomock.Any()).Return(errors.New("deadlock"))
 
-	split := db.StockSplit{
-		InstrumentID: underlyingID,
-		ExDate:       date(2025, 1, 15),
-		SplitFrom:    "1",
-		SplitTo:      "2",
-		DataProvider: "eodhd",
-		FirstKnownAt: date(2025, 2, 1),
+	if adjusted := ProcessPendingOptionSplits(ctx, mockDB, "", nil); len(adjusted) != 0 {
+		t.Errorf("adjusted = %d options, want 0 after a failed apply", len(adjusted))
 	}
-
-	mockDB.EXPECT().ListOptionsByUnderlying(gomock.Any(), underlyingID).Return([]*db.InstrumentRow{opt}, nil)
-	mockDB.EXPECT().ApplyOptionSplit(gomock.Any(), gomock.Any()).Return(nil)
-
-	ProcessOptionSplits(ctx, mockDB, underlyingID, []db.StockSplit{split}, nil, fixedTimer(date(2025, 3, 1)))
 }
 
-// TestProcessOptionSplits_FutureSplitSkipped verifies case 3: the split
-// ex_date is in the future. The split should be skipped. After advancing
-// time past the ex_date, the split should be applied.
-func TestProcessOptionSplits_FutureSplitSkipped(t *testing.T) {
+// TestProcessPendingOptionSplits_OneFailureDoesNotBlockOthers verifies the pass
+// keeps going after a per-option failure.
+func TestProcessPendingOptionSplits_OneFailureDoesNotBlockOthers(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 	mockDB := mock.NewMockDB(ctrl)
 	ctx := context.Background()
 
-	optID := "opt-5555"
-	underlyingID := "und-6666"
+	bad := makeOption("opt-bad", "AAPL  250117C00200000", 200.0, date(2025, 1, 1))
+	good := makeOption("opt-good", "AAPL  250117C00300000", 300.0, date(2025, 1, 1))
+	s := []db.StockSplit{split("und-x", date(2025, 1, 15), "1", "2")}
+	mockDB.EXPECT().ListPendingOptionSplits(gomock.Any(), "").Return(
+		[]db.PendingOptionSplits{{Option: bad, Splits: s}, {Option: good, Splits: s}}, nil)
 
-	// Identity as of Jan 1, split effective Jun 1 (identity predates it).
-	opt := makeOption(optID, "AAPL  250117C00400000", 400.0, date(2025, 1, 1))
-
-	split := db.StockSplit{
-		InstrumentID: underlyingID,
-		ExDate:       date(2025, 6, 1), // future
-		SplitFrom:    "1",
-		SplitTo:      "4",
-		DataProvider: "eodhd",
-		FirstKnownAt: date(2025, 1, 5),
-	}
-
-	mockDB.EXPECT().ListOptionsByUnderlying(gomock.Any(), underlyingID).Return([]*db.InstrumentRow{opt}, nil)
-	// No ApplyOptionSplit expected: split is future-dated.
-
-	timer := fixedTimer(date(2025, 3, 1)) // before ex_date
-	ProcessOptionSplits(ctx, mockDB, underlyingID, []db.StockSplit{split}, nil, timer)
-}
-
-// TestProcessOptionSplits_FutureThenAdvance verifies that after time
-// advances past the ex_date, a previously future-dated split is applied.
-func TestProcessOptionSplits_FutureThenAdvance(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	mockDB := mock.NewMockDB(ctrl)
-	ctx := context.Background()
-
-	optID := "opt-7777"
-	underlyingID := "und-8888"
-
-	opt := makeOption(optID, "AAPL  250117C00400000", 400.0, date(2025, 1, 1))
-
-	split := db.StockSplit{
-		InstrumentID: underlyingID,
-		ExDate:       date(2025, 6, 1),
-		SplitFrom:    "1",
-		SplitTo:      "4",
-		DataProvider: "eodhd",
-		FirstKnownAt: date(2025, 1, 5),
-	}
-
-	// First call: future-dated, skip. Second call: time advanced, apply.
-	mockDB.EXPECT().ListOptionsByUnderlying(gomock.Any(), underlyingID).Return([]*db.InstrumentRow{opt}, nil).Times(2)
 	mockDB.EXPECT().ApplyOptionSplit(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, p db.OptionSplitParams) error {
-			if p.NewOCC.Value != "AAPL250117C00100000" {
-				t.Errorf("new OCC = %q, want AAPL250117C00100000", p.NewOCC.Value)
-			}
-			if p.NewStrike != 100.0 {
-				t.Errorf("new strike = %f, want 100", p.NewStrike)
+			if p.InstrumentID == "opt-bad" {
+				return errors.New("deadlock")
 			}
 			return nil
-		})
+		}).Times(2)
 
-	// Phase 1: before ex_date — no processing.
-	timer := fixedTimer(date(2025, 3, 1))
-	ProcessOptionSplits(ctx, mockDB, underlyingID, []db.StockSplit{split}, nil, timer)
-
-	// Phase 2: after ex_date — split applied.
-	timer = fixedTimer(date(2025, 7, 1))
-	ProcessOptionSplits(ctx, mockDB, underlyingID, []db.StockSplit{split}, nil, timer)
+	adjusted := ProcessPendingOptionSplits(ctx, mockDB, "", nil)
+	if len(adjusted) != 1 || adjusted[0].ID != "opt-good" {
+		t.Errorf("adjusted = %v, want just opt-good", adjusted)
+	}
 }
 
-// TestProcessOptionSplits_NonWholeForwardSplit verifies that non-standard
-// splits (reverse or fractional) are routed to unhandled_corporate_events.
-func TestProcessOptionSplits_NonWholeForwardSplit(t *testing.T) {
+// TestProcessPendingOptionSplits_NonWholeSplitBlocksOption verifies a split we
+// cannot apply stops the whole option rather than being skipped over. Applying
+// the splits either side of it would produce a strike matching no real contract,
+// and leaving identity_as_of untouched keeps the option pending for a later run.
+func TestProcessPendingOptionSplits_NonWholeSplitBlocksOption(t *testing.T) {
 	tests := []struct {
 		name      string
 		from, to  string
-		wantType  string
+		eventType string
 	}{
 		{"reverse split", "2", "1", "REVERSE_SPLIT"},
 		{"fractional split", "2", "3", "NON_WHOLE_SPLIT"},
 	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
 			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
 			mockDB := mock.NewMockDB(ctrl)
 			ctx := context.Background()
 
-			underlyingID := "und-9999"
-			opt := makeOption("opt-aaaa", "AAPL  250117C00200000", 200.0, date(2025, 1, 1))
+			opt := makeOption("opt-nw", "AAPL  250117C00200000", 200.0, date(2025, 1, 1))
+			mockDB.EXPECT().ListPendingOptionSplits(gomock.Any(), "").Return(
+				[]db.PendingOptionSplits{{
+					Option: opt,
+					Splits: []db.StockSplit{
+						split("und-nw", date(2025, 1, 15), tc.from, tc.to),
+						// A whole split alongside it must NOT be applied either.
+						split("und-nw", date(2025, 2, 1), "1", "2"),
+					},
+				}}, nil)
 
-			split := db.StockSplit{
-				InstrumentID: underlyingID,
-				ExDate:       date(2025, 1, 15),
-				SplitFrom:    tt.from,
-				SplitTo:      tt.to,
-				DataProvider: "eodhd",
-				FirstKnownAt: date(2025, 2, 1),
-			}
-
-			mockDB.EXPECT().ListOptionsByUnderlying(gomock.Any(), underlyingID).Return([]*db.InstrumentRow{opt}, nil)
+			// No ApplyOptionSplit: the option is blocked.
 			mockDB.EXPECT().InsertUnhandledCorporateEvent(gomock.Any(), gomock.Any()).DoAndReturn(
-				func(_ context.Context, ev db.UnhandledCorporateEvent) error {
-					if ev.EventType != tt.wantType {
-						t.Errorf("event type = %q, want %q", ev.EventType, tt.wantType)
+				func(_ context.Context, e db.UnhandledCorporateEvent) error {
+					if e.InstrumentID != "und-nw" {
+						t.Errorf("event instrument = %q, want the underlying und-nw", e.InstrumentID)
 					}
-					if ev.InstrumentID != underlyingID {
-						t.Errorf("instrument = %q, want %q", ev.InstrumentID, underlyingID)
+					if e.EventType != tc.eventType {
+						t.Errorf("event type = %q, want %q", e.EventType, tc.eventType)
 					}
 					return nil
 				})
 
-			timer := fixedTimer(date(2025, 3, 1))
-			ProcessOptionSplits(ctx, mockDB, underlyingID, []db.StockSplit{split}, nil, timer)
+			if adjusted := ProcessPendingOptionSplits(ctx, mockDB, "", nil); len(adjusted) != 0 {
+				t.Errorf("adjusted = %d options, want 0", len(adjusted))
+			}
 		})
 	}
 }
 
-// TestProcessOptionSplits_NoOCC verifies that options without an OCC
-// identifier are skipped gracefully (no panic, no ApplyOptionSplit call).
-func TestProcessOptionSplits_NoOCC(t *testing.T) {
+// TestProcessPendingOptionSplits_NonWholeSplitReportedOncePerSplit verifies the
+// unhandled event is raised once for the underlying, listing every option it
+// blocks, rather than once per option.
+func TestProcessPendingOptionSplits_NonWholeSplitReportedOncePerSplit(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 	mockDB := mock.NewMockDB(ctrl)
 	ctx := context.Background()
 
-	underlyingID := "und-bbbb"
-	expiry := date(2025, 1, 17)
-	putCall := "C"
-	opt := &db.InstrumentRow{
-		ID:           "opt-cccc",
-		Strike:       floatPtr(200.0),
-		Expiry:       &expiry,
-		PutCall:      &putCall,
-		IdentityAsOf: timePtr(date(2025, 1, 1)),
-		Identifiers:  []db.IdentifierInput{{Type: "MIC_TICKER", Value: "AAPL"}}, // no OCC
-	}
+	s := []db.StockSplit{split("und-shared", date(2025, 1, 15), "2", "3")}
+	mockDB.EXPECT().ListPendingOptionSplits(gomock.Any(), "").Return(
+		[]db.PendingOptionSplits{
+			{Option: makeOption("opt-a", "AAPL  250117C00200000", 200.0, date(2025, 1, 1)), Splits: s},
+			{Option: makeOption("opt-b", "AAPL  250117C00300000", 300.0, date(2025, 1, 1)), Splits: s},
+		}, nil)
 
-	split := db.StockSplit{
-		InstrumentID: underlyingID,
-		ExDate:       date(2025, 1, 15),
-		SplitFrom:    "1",
-		SplitTo:      "2",
-		DataProvider: "eodhd",
-		FirstKnownAt: date(2025, 2, 1),
-	}
+	mockDB.EXPECT().InsertUnhandledCorporateEvent(gomock.Any(), gomock.Any()).DoAndReturn(
+		func(_ context.Context, e db.UnhandledCorporateEvent) error {
+			if !strings.Contains(string(e.Data), "opt-a") || !strings.Contains(string(e.Data), "opt-b") {
+				t.Errorf("event data %s should list both blocked options", e.Data)
+			}
+			return nil
+		}).Times(1)
 
-	mockDB.EXPECT().ListOptionsByUnderlying(gomock.Any(), underlyingID).Return([]*db.InstrumentRow{opt}, nil)
-	// No ApplyOptionSplit or InsertUnhandledCorporateEvent expected.
-
-	timer := fixedTimer(date(2025, 3, 1))
-	ProcessOptionSplits(ctx, mockDB, underlyingID, []db.StockSplit{split}, nil, timer)
+	ProcessPendingOptionSplits(ctx, mockDB, "", nil)
 }
 
-// TestProcessOptionSplits_UnparseableOCC verifies that options with a
-// malformed OCC identifier produce an unhandled corporate event.
-func TestProcessOptionSplits_UnparseableOCC(t *testing.T) {
+func TestProcessPendingOptionSplits_NoOCC(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 	mockDB := mock.NewMockDB(ctrl)
 	ctx := context.Background()
 
-	underlyingID := "und-dddd"
-	optID := "opt-eeee"
-	expiry := date(2025, 1, 17)
-	putCall := "C"
-	opt := &db.InstrumentRow{
-		ID:           optID,
-		Strike:       floatPtr(200.0),
-		Expiry:       &expiry,
-		PutCall:      &putCall,
-		IdentityAsOf: timePtr(date(2025, 1, 1)),
-		Identifiers:  []db.IdentifierInput{{Type: "OCC", Value: "NOTAVALIDOCC", Canonical: true}},
-	}
+	opt := makeOption("opt-noocc", "", 200.0, date(2025, 1, 1))
+	opt.Identifiers = []db.IdentifierInput{{Type: "MIC_TICKER", Domain: "XNAS", Value: "AAPL", Canonical: true}}
+	mockDB.EXPECT().ListPendingOptionSplits(gomock.Any(), "").Return(
+		[]db.PendingOptionSplits{{
+			Option: opt,
+			Splits: []db.StockSplit{split("und-noocc", date(2025, 1, 15), "1", "2")},
+		}}, nil)
+	// No ApplyOptionSplit and no unhandled event: nothing to rewrite.
 
-	split := db.StockSplit{
-		InstrumentID: underlyingID,
-		ExDate:       date(2025, 1, 15),
-		SplitFrom:    "1",
-		SplitTo:      "2",
-		DataProvider: "eodhd",
-		FirstKnownAt: date(2025, 2, 1),
+	if adjusted := ProcessPendingOptionSplits(ctx, mockDB, "", nil); len(adjusted) != 0 {
+		t.Errorf("adjusted = %d options, want 0", len(adjusted))
 	}
+}
 
-	mockDB.EXPECT().ListOptionsByUnderlying(gomock.Any(), underlyingID).Return([]*db.InstrumentRow{opt}, nil)
+func TestProcessPendingOptionSplits_UnparseableOCC(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockDB := mock.NewMockDB(ctrl)
+	ctx := context.Background()
+
+	opt := makeOption("opt-bad-occ", "NOTAVALIDOCC", 200.0, date(2025, 1, 1))
+	mockDB.EXPECT().ListPendingOptionSplits(gomock.Any(), "").Return(
+		[]db.PendingOptionSplits{{
+			Option: opt,
+			Splits: []db.StockSplit{split("und-bad", date(2025, 1, 15), "1", "2")},
+		}}, nil)
+
 	mockDB.EXPECT().InsertUnhandledCorporateEvent(gomock.Any(), gomock.Any()).DoAndReturn(
-		func(_ context.Context, ev db.UnhandledCorporateEvent) error {
-			if ev.InstrumentID != optID {
-				t.Errorf("instrument = %q, want %q", ev.InstrumentID, optID)
+		func(_ context.Context, e db.UnhandledCorporateEvent) error {
+			if e.InstrumentID != "opt-bad-occ" {
+				t.Errorf("event instrument = %q, want the option", e.InstrumentID)
 			}
 			return nil
 		})
 
-	timer := fixedTimer(date(2025, 3, 1))
-	ProcessOptionSplits(ctx, mockDB, underlyingID, []db.StockSplit{split}, nil, timer)
+	if adjusted := ProcessPendingOptionSplits(ctx, mockDB, "", nil); len(adjusted) != 0 {
+		t.Errorf("adjusted = %d options, want 0", len(adjusted))
+	}
 }
 
-// TestProcessOptionSplits_NoOptions verifies that when no options exist
-// on the underlying, the function returns cleanly with no DB calls.
-func TestProcessOptionSplits_NoOptions(t *testing.T) {
+// TestProcessPendingOptionSplits_NothingPending is the steady state: running the
+// pass on every cycle when there is no work must touch nothing.
+func TestProcessPendingOptionSplits_NothingPending(t *testing.T) {
 	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
 	mockDB := mock.NewMockDB(ctrl)
 	ctx := context.Background()
 
-	underlyingID := "und-ffff"
-	split := db.StockSplit{
-		InstrumentID: underlyingID,
-		ExDate:       date(2025, 1, 15),
-		SplitFrom:    "1",
-		SplitTo:      "2",
-		DataProvider: "eodhd",
-		FirstKnownAt: date(2025, 2, 1),
+	mockDB.EXPECT().ListPendingOptionSplits(gomock.Any(), "").Return(nil, nil)
+
+	if adjusted := ProcessPendingOptionSplits(ctx, mockDB, "", nil); len(adjusted) != 0 {
+		t.Errorf("adjusted = %d options, want 0", len(adjusted))
 	}
+}
 
-	mockDB.EXPECT().ListOptionsByUnderlying(gomock.Any(), underlyingID).Return(nil, nil)
+func TestProcessPendingOptionSplits_ListError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockDB := mock.NewMockDB(ctrl)
+	ctx := context.Background()
 
-	timer := fixedTimer(date(2025, 3, 1))
-	ProcessOptionSplits(ctx, mockDB, underlyingID, []db.StockSplit{split}, nil, timer)
+	mockDB.EXPECT().ListPendingOptionSplits(gomock.Any(), "").Return(nil, errors.New("connection refused"))
+
+	if adjusted := ProcessPendingOptionSplits(ctx, mockDB, "", nil); adjusted != nil {
+		t.Errorf("adjusted = %v, want nil on a query error", adjusted)
+	}
 }

--- a/server/corporateevents/worker.go
+++ b/server/corporateevents/worker.go
@@ -64,6 +64,25 @@ func runCycle(ctx context.Context, database db.DB, registry *Registry, counter t
 		}
 	}()
 
+	// Adjust every option whose identity predates an effective split on its
+	// underlying. Deferred so it runs at the end of the cycle -- after any fetch,
+	// so it sees splits that just landed -- but also on the early returns below,
+	// because it needs neither a plugin nor a held instrument: splits can arrive
+	// through ImportCorporateEvents, and an adjustment that failed then would
+	// otherwise never be retried on an installation with no fetch plugins
+	// enabled.
+	//
+	// It is deliberately not gated on whether a split landed in this cycle.
+	// Coverage is written as soon as events are persisted, so a pass that failed
+	// after that point would never see the plugin called again. Driving it off
+	// the stored identity instead makes it retry on its own, and picks up a
+	// future-dated split once its ex_date passes.
+	defer func() {
+		if ctx.Err() == nil {
+			ProcessPendingOptionSplits(ctx, database, "", log)
+		}
+	}()
+
 	held, err := database.HeldEventBearingInstruments(ctx)
 	if err != nil {
 		if log != nil {
@@ -259,33 +278,14 @@ func processInstrument(ctx context.Context, database db.DB, plugins []pluginEntr
 		_ = filled
 	}
 
+	// Options on this underlying are handled by the once-per-cycle pass in
+	// runCycle, which finds its own work and so does not depend on a split
+	// having landed in this cycle.
 	if splitsLanded {
 		if err := database.RecomputeSplitAdjustments(ctx, inst.ID); err != nil {
 			if log != nil {
 				log.ErrorContext(ctx, "corporate event fetch: recompute split adjustments",
 					"instrument", inst.ID, "err", err)
-			}
-		}
-
-		// Process option contracts on this underlying.
-		allSplits, err := database.ListStockSplits(ctx, inst.ID)
-		if err != nil {
-			if log != nil {
-				log.ErrorContext(ctx, "corporate event fetch: list splits for options",
-					"instrument", inst.ID, "err", err)
-			}
-		} else {
-			options := ProcessOptionSplits(ctx, database, inst.ID, allSplits, log, nil)
-			// Recompute split-adjusted values for options on this underlying.
-			// split_factor_at looks up splits via underlying_id, so option txs
-			// need recomputing whenever the underlying's splits change.
-			for _, opt := range options {
-				if rerr := database.RecomputeSplitAdjustments(ctx, opt.ID); rerr != nil {
-					if log != nil {
-						log.ErrorContext(ctx, "corporate event fetch: recompute option adjustments",
-							"option", opt.ID, "err", rerr)
-					}
-				}
 			}
 		}
 	}

--- a/server/corporateevents/worker_test.go
+++ b/server/corporateevents/worker_test.go
@@ -188,6 +188,45 @@ func TestRegistry_RegisterAndGet(t *testing.T) {
 // TestRunCycle_EmptyResultRecordsCoverage verifies that a successful fetch
 // returning zero events still records coverage and stops the precedence walk.
 // This is the key behavioural difference vs the price worker.
+// TestRunCycle_OptionPassRunsWithNoPluginsEnabled verifies the pass survives the
+// cycle's early returns. Splits can arrive through ImportCorporateEvents without
+// any fetch plugin, so an adjustment that failed then must still be retried on
+// an installation that has none enabled.
+func TestRunCycle_OptionPassRunsWithNoPluginsEnabled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockDB := mock.NewMockDB(ctrl)
+	ctx := context.Background()
+
+	instID := "44444444-4444-4444-4444-444444444444"
+	mockDB.EXPECT().HeldEventBearingInstruments(gomock.Any()).Return([]db.HeldInstrument{
+		{InstrumentID: instID, EarliestTxDate: d(2014, 1, 1)},
+	}, nil)
+	// No corporate event plugins configured: the fetch half returns early.
+	mockDB.EXPECT().ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryCorporateEvent).Return(nil, nil)
+
+	opt := makeOption("opt-no-plugins", "AAPL  250117C00200000", 200.0, date(2025, 1, 1))
+	mockDB.EXPECT().ListPendingOptionSplits(gomock.Any(), "").Return([]db.PendingOptionSplits{{
+		Option: opt,
+		Splits: []db.StockSplit{split(instID, date(2025, 1, 15), "1", "2")},
+	}}, nil)
+	mockDB.EXPECT().ApplyOptionSplit(gomock.Any(), gomock.Any()).Return(nil)
+
+	runCycle(ctx, mockDB, NewRegistry(), nil, nil, nil)
+}
+
+// TestRunCycle_OptionPassRunsWithNothingHeld verifies the same for the other
+// early return: a pending option need not currently be held.
+func TestRunCycle_OptionPassRunsWithNothingHeld(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockDB := mock.NewMockDB(ctrl)
+	ctx := context.Background()
+
+	mockDB.EXPECT().HeldEventBearingInstruments(gomock.Any()).Return(nil, nil)
+	mockDB.EXPECT().ListPendingOptionSplits(gomock.Any(), "").Return(nil, nil)
+
+	runCycle(ctx, mockDB, NewRegistry(), nil, nil, nil)
+}
+
 func TestRunCycle_EmptyResultRecordsCoverage(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	mockDB := mock.NewMockDB(ctrl)
@@ -224,8 +263,8 @@ func TestRunCycle_EmptyResultRecordsCoverage(t *testing.T) {
 	mockDB.EXPECT().BlockedCorporateEventPluginsForInstruments(gomock.Any(), []string{instID}).Return(nil, nil)
 	mockDB.EXPECT().ListInstrumentsByIDs(gomock.Any(), []string{instID}).Return([]*db.InstrumentRow{
 		{
-			ID:         instID,
-			AssetClass: strPtr("STOCK"),
+			ID:          instID,
+			AssetClass:  strPtr("STOCK"),
 			Identifiers: []db.IdentifierInput{{Type: "MIC_TICKER", Value: "AAPL"}},
 		},
 	}, nil)
@@ -237,6 +276,9 @@ func TestRunCycle_EmptyResultRecordsCoverage(t *testing.T) {
 	// No upserts for splits/dividends (empty result).
 	// No call into the low-precedence plugin.
 	// No recompute (no splits landed).
+
+	// The option pass runs once per cycle regardless of what landed.
+	mockDB.EXPECT().ListPendingOptionSplits(gomock.Any(), "").Return(nil, nil)
 
 	runCycle(ctx, mockDB, reg, nil, nil, nil)
 
@@ -278,8 +320,8 @@ func TestRunCycle_SplitsLandTriggerRecompute(t *testing.T) {
 	mockDB.EXPECT().BlockedCorporateEventPluginsForInstruments(gomock.Any(), []string{instID}).Return(nil, nil)
 	mockDB.EXPECT().ListInstrumentsByIDs(gomock.Any(), []string{instID}).Return([]*db.InstrumentRow{
 		{
-			ID:         instID,
-			AssetClass: strPtr("STOCK"),
+			ID:          instID,
+			AssetClass:  strPtr("STOCK"),
 			Identifiers: []db.IdentifierInput{{Type: "MIC_TICKER", Value: "AAPL"}},
 		},
 	}, nil)
@@ -288,17 +330,65 @@ func TestRunCycle_SplitsLandTriggerRecompute(t *testing.T) {
 	mockDB.EXPECT().UpsertStockSplits(gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().UpsertCorporateEventCoverage(gomock.Any(), instID, "massive", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	mockDB.EXPECT().RecomputeSplitAdjustments(gomock.Any(), instID).Return(nil)
-	// After splits land, the worker lists splits and options for the underlying.
-	mockDB.EXPECT().ListStockSplits(gomock.Any(), instID).Return([]db.StockSplit{
-		{InstrumentID: instID, ExDate: d(2024, 6, 9), SplitFrom: "1", SplitTo: "7"},
-	}, nil)
-	mockDB.EXPECT().ListOptionsByUnderlying(gomock.Any(), instID).Return(nil, nil)
+	// The option pass runs once for the cycle, across all underlyings.
+	mockDB.EXPECT().ListPendingOptionSplits(gomock.Any(), "").Return(nil, nil)
 
 	runCycle(ctx, mockDB, reg, nil, nil, nil)
 
 	if plugin.calls != 1 {
 		t.Errorf("expected 1 call, got %d", plugin.calls)
 	}
+}
+
+// TestRunCycle_OptionPassRunsWithoutSplitsLanding is the retry half of issue
+// 0055. The pass used to sit inside "if splitsLanded", so an option whose
+// adjustment failed after coverage was written was never revisited: the next
+// cycle saw no gap, never called the plugin, and never set the flag. It now runs
+// every cycle and finds its own work.
+func TestRunCycle_OptionPassRunsWithoutSplitsLanding(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockDB := mock.NewMockDB(ctrl)
+	ctx := context.Background()
+
+	instID := "33333333-3333-3333-3333-333333333333"
+
+	// A plugin that returns nothing: no splits land this cycle.
+	plugin := &stubPlugin{
+		name:         "massive",
+		idTypes:      []string{"MIC_TICKER"},
+		assetClasses: map[string]bool{"STOCK": true, "ETF": true},
+		result:       &Events{},
+	}
+	reg := NewRegistry()
+	reg.Register("massive", plugin)
+
+	mockDB.EXPECT().HeldEventBearingInstruments(gomock.Any()).Return([]db.HeldInstrument{
+		{InstrumentID: instID, EarliestTxDate: d(2014, 1, 1)},
+	}, nil)
+	mockDB.EXPECT().ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryCorporateEvent).Return([]db.PluginConfigRow{
+		{PluginID: "massive", Precedence: 10, Config: []byte("{}")},
+	}, nil)
+	mockDB.EXPECT().BlockedCorporateEventPluginsForInstruments(gomock.Any(), []string{instID}).Return(nil, nil)
+	mockDB.EXPECT().ListInstrumentsByIDs(gomock.Any(), []string{instID}).Return([]*db.InstrumentRow{
+		{
+			ID:          instID,
+			AssetClass:  strPtr("STOCK"),
+			Identifiers: []db.IdentifierInput{{Type: "MIC_TICKER", Value: "AAPL"}},
+		},
+	}, nil)
+	mockDB.EXPECT().ListCorporateEventCoverage(gomock.Any(), []string{instID}).Return(nil, nil)
+	mockDB.EXPECT().UpsertCorporateEventCoverage(gomock.Any(), instID, "massive", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	// No UpsertStockSplits and no RecomputeSplitAdjustments: nothing landed.
+
+	// The assertion: the option pass still runs, and picks up work left over
+	// from an earlier cycle.
+	opt := makeOption("opt-left-over", "AAPL  250117C00200000", 200.0, date(2025, 1, 1))
+	mockDB.EXPECT().ListPendingOptionSplits(gomock.Any(), "").Return([]db.PendingOptionSplits{{
+		Option: opt,
+		Splits: []db.StockSplit{split(instID, date(2025, 1, 15), "1", "2")},
+	}}, nil)
+	mockDB.EXPECT().ApplyOptionSplit(gomock.Any(), gomock.Any()).Return(nil)
+	runCycle(ctx, mockDB, reg, nil, nil, nil)
 }
 
 // TestRunCycle_PermanentErrorCreatesBlock verifies that ErrPermanent results
@@ -336,8 +426,8 @@ func TestRunCycle_PermanentErrorCreatesBlock(t *testing.T) {
 	mockDB.EXPECT().BlockedCorporateEventPluginsForInstruments(gomock.Any(), []string{instID}).Return(nil, nil)
 	mockDB.EXPECT().ListInstrumentsByIDs(gomock.Any(), []string{instID}).Return([]*db.InstrumentRow{
 		{
-			ID:         instID,
-			AssetClass: strPtr("STOCK"),
+			ID:          instID,
+			AssetClass:  strPtr("STOCK"),
 			Identifiers: []db.IdentifierInput{{Type: "MIC_TICKER", Value: "AAPL"}},
 		},
 	}, nil)
@@ -345,6 +435,9 @@ func TestRunCycle_PermanentErrorCreatesBlock(t *testing.T) {
 
 	mockDB.EXPECT().CreateCorporateEventFetchBlock(gomock.Any(), instID, "broken", "404 not found").Return(nil)
 	mockDB.EXPECT().UpsertCorporateEventCoverage(gomock.Any(), instID, "good", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+
+	// The option pass runs once per cycle regardless of what landed.
+	mockDB.EXPECT().ListPendingOptionSplits(gomock.Any(), "").Return(nil, nil)
 
 	runCycle(ctx, mockDB, reg, nil, nil, nil)
 
@@ -386,8 +479,8 @@ func TestRunCycle_SpecialDividendRoutedToUnhandled(t *testing.T) {
 	mockDB.EXPECT().BlockedCorporateEventPluginsForInstruments(gomock.Any(), []string{instID}).Return(nil, nil)
 	mockDB.EXPECT().ListInstrumentsByIDs(gomock.Any(), []string{instID}).Return([]*db.InstrumentRow{
 		{
-			ID:         instID,
-			AssetClass: strPtr("STOCK"),
+			ID:          instID,
+			AssetClass:  strPtr("STOCK"),
 			Identifiers: []db.IdentifierInput{{Type: "MIC_TICKER", Value: "AAPL"}},
 		},
 	}, nil)
@@ -413,6 +506,9 @@ func TestRunCycle_SpecialDividendRoutedToUnhandled(t *testing.T) {
 			return nil
 		})
 	mockDB.EXPECT().UpsertCorporateEventCoverage(gomock.Any(), instID, "massive", gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+
+	// The option pass runs once per cycle regardless of what landed.
+	mockDB.EXPECT().ListPendingOptionSplits(gomock.Any(), "").Return(nil, nil)
 
 	runCycle(ctx, mockDB, reg, nil, nil, nil)
 }
@@ -444,12 +540,15 @@ func TestRunCycle_BlockedPluginSkipped(t *testing.T) {
 		map[string]map[string]bool{instID: {"blocked": true}}, nil)
 	mockDB.EXPECT().ListInstrumentsByIDs(gomock.Any(), []string{instID}).Return([]*db.InstrumentRow{
 		{
-			ID:         instID,
-			AssetClass: strPtr("STOCK"),
+			ID:          instID,
+			AssetClass:  strPtr("STOCK"),
 			Identifiers: []db.IdentifierInput{{Type: "MIC_TICKER", Value: "AAPL"}},
 		},
 	}, nil)
 	mockDB.EXPECT().ListCorporateEventCoverage(gomock.Any(), []string{instID}).Return(nil, nil)
+
+	// The option pass runs once per cycle regardless of what landed.
+	mockDB.EXPECT().ListPendingOptionSplits(gomock.Any(), "").Return(nil, nil)
 
 	runCycle(ctx, mockDB, reg, nil, nil, nil)
 

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -600,9 +600,6 @@ type InstrumentDB interface {
 	// ListInstruments returns instruments sorted alphabetically by display name (ticker, then name, then broker description). If search is non-empty, only instruments with at least one identifier value matching (case-insensitive substring) are returned. If assetClasses is non-empty, only instruments with matching asset_class are returned. Returns (rows, totalCount, nextPageToken, error).
 	ListInstruments(ctx context.Context, search string, assetClasses []string, pageSize int32, pageToken string) ([]*InstrumentRow, int32, string, error)
 
-	// ListOptionsByUnderlying returns all OPTION instruments with the given
-	// underlying_id, including their identifiers.
-	ListOptionsByUnderlying(ctx context.Context, underlyingID string) ([]*InstrumentRow, error)
 	// DeleteInstrumentIdentifier removes a single identifier row by
 	// (instrument_id, identifier_type, value). Returns nil when no row exists.
 	DeleteInstrumentIdentifier(ctx context.Context, instrumentID, identifierType, value string) error
@@ -681,6 +678,14 @@ type IgnoredAssetClassDB interface {
 // halves of the split ratio (factor = SplitTo / SplitFrom). They are stored as
 // strings so that NUMERIC values from the database round-trip without loss of
 // precision; conversion to float happens at the math boundary.
+// PendingOptionSplits is one option contract together with the splits on its
+// underlying that its stored identity does not yet reflect, ordered ascending by
+// ex_date. Splits is never empty.
+type PendingOptionSplits struct {
+	Option *InstrumentRow
+	Splits []StockSplit
+}
+
 type StockSplit struct {
 	InstrumentID string
 	ExDate       time.Time
@@ -776,6 +781,17 @@ type CorporateEventDB interface {
 	// nil even when no row exists; callers that need an "exists" signal should
 	// check ListStockSplits first.
 	DeleteStockSplit(ctx context.Context, instrumentID string, exDate time.Time) error
+
+	// ListPendingOptionSplits returns every option whose stored identity
+	// predates an effective split on its underlying, with the splits that still
+	// need applying, ordered ascending by ex_date. underlyingID == "" covers
+	// every option; a non-empty value restricts the sweep to one underlying.
+	//
+	// This is the work list for the retroactive option split pass. It is derived
+	// from identity_as_of against ex_date rather than from which splits happened
+	// to arrive in the current fetch cycle, so the pass is idempotent, safe to
+	// run every cycle, and retries anything a previous run failed to apply.
+	ListPendingOptionSplits(ctx context.Context, underlyingID string) ([]PendingOptionSplits, error)
 
 	// UpsertCashDividends inserts or updates the supplied cash_dividends rows.
 	// On conflict (instrument_id, ex_date), all non-key columns are overwritten

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -603,6 +603,12 @@ type InstrumentDB interface {
 	// DeleteInstrumentIdentifier removes a single identifier row by
 	// (instrument_id, identifier_type, value). Returns nil when no row exists.
 	DeleteInstrumentIdentifier(ctx context.Context, instrumentID, identifierType, value string) error
+	// DeleteInstrumentIdentifiersByType removes every identifier of the given
+	// type for an instrument, whatever its value or domain. Use it when a type
+	// is single-valued for the instrument and is being replaced, so the write
+	// does not depend on knowing the value currently stored. Returns nil when no
+	// row exists.
+	DeleteInstrumentIdentifiersByType(ctx context.Context, instrumentID, identifierType string) error
 	// InsertInstrumentIdentifier inserts a single identifier row.
 	InsertInstrumentIdentifier(ctx context.Context, instrumentID string, input IdentifierInput) error
 	// UpdateInstrumentStrike updates the strike on an existing option instrument.
@@ -759,10 +765,13 @@ type UnhandledCorporateEvent struct {
 // contract after a stock split on its underlying.
 type OptionSplitParams struct {
 	InstrumentID string
-	OldOCCValue  string
-	NewOCC       IdentifierInput
-	NewStrike    float64
-	NewName      string
+	// OldOCCValue is the symbol the caller read. It is reported, not acted on:
+	// every OCC identifier on the instrument is replaced regardless, so the write
+	// converges even if the stored symbol has moved on since the read.
+	OldOCCValue string
+	NewOCC      IdentifierInput
+	NewStrike   float64
+	NewName     string
 }
 
 // CorporateEventDB provides storage for stock splits, cash dividends, fetch

--- a/server/db/postgres/corporate_events.go
+++ b/server/db/postgres/corporate_events.go
@@ -84,6 +84,91 @@ func (p *Postgres) ListStockSplits(ctx context.Context, instrumentID string) ([]
 	return out, rows.Err()
 }
 
+// ListPendingOptionSplits implements db.CorporateEventDB.
+//
+// The predicate is the whole of the pass's state. ex_date <= CURRENT_DATE is the
+// future-date guard: a split fetched by the lookahead sits inert until it takes
+// effect, and is picked up by the first run after it does. identity_as_of <
+// ex_date is the correctness guard: the stored OCC symbol reflects a split only
+// if it was derived on or after the split took effect, and a NULL predates every
+// split. Together they make the work list self-describing, so the pass needs no
+// record of which cycle a split arrived in and re-running it is a no-op.
+func (p *Postgres) ListPendingOptionSplits(ctx context.Context, underlyingID string) ([]db.PendingOptionSplits, error) {
+	var (
+		filter string
+		args   []any
+	)
+	if underlyingID != "" {
+		id, err := uuid.Parse(underlyingID)
+		if err != nil {
+			return nil, fmt.Errorf("list pending option splits: invalid underlying id %q: %w", underlyingID, err)
+		}
+		filter = "AND o.underlying_id = $1"
+		args = append(args, id)
+	}
+	rows, err := p.q.QueryContext(ctx, fmt.Sprintf(`
+		SELECT o.id, s.instrument_id, s.ex_date, s.split_from::text, s.split_to::text,
+		       s.data_provider, s.first_known_at
+		FROM instruments o
+		JOIN stock_splits s ON s.instrument_id = o.underlying_id
+		WHERE o.asset_class = 'OPTION'
+		  AND s.ex_date <= CURRENT_DATE
+		  AND (o.identity_as_of IS NULL OR o.identity_as_of < s.ex_date)
+		  %s
+		ORDER BY o.id, s.ex_date
+	`, filter), args...)
+	if err != nil {
+		return nil, fmt.Errorf("list pending option splits: %w", err)
+	}
+	defer rows.Close()
+
+	splitsByOption := make(map[uuid.UUID][]db.StockSplit)
+	var order []uuid.UUID
+	for rows.Next() {
+		var optID, underlying uuid.UUID
+		var s db.StockSplit
+		if err := rows.Scan(&optID, &underlying, &s.ExDate, &s.SplitFrom, &s.SplitTo, &s.DataProvider, &s.FirstKnownAt); err != nil {
+			return nil, fmt.Errorf("list pending option splits scan: %w", err)
+		}
+		s.InstrumentID = underlying.String()
+		if _, seen := splitsByOption[optID]; !seen {
+			order = append(order, optID)
+		}
+		splitsByOption[optID] = append(splitsByOption[optID], s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	if len(order) == 0 {
+		return nil, nil
+	}
+
+	// Hydrate the option rows separately: the pass needs their identifiers to
+	// find the OCC symbol, and ListInstrumentsByIDs already loads those.
+	ids := make([]string, len(order))
+	for i, id := range order {
+		ids[i] = id.String()
+	}
+	instRows, err := p.ListInstrumentsByIDs(ctx, ids)
+	if err != nil {
+		return nil, fmt.Errorf("list pending option splits: load options: %w", err)
+	}
+	byID := make(map[string]*db.InstrumentRow, len(instRows))
+	for _, r := range instRows {
+		byID[r.ID] = r
+	}
+
+	out := make([]db.PendingOptionSplits, 0, len(order))
+	for _, id := range order {
+		opt, ok := byID[id.String()]
+		if !ok {
+			continue
+		}
+		out = append(out, db.PendingOptionSplits{Option: opt, Splits: splitsByOption[id]})
+	}
+	return out, nil
+}
+
 // DeleteStockSplit implements db.CorporateEventDB.
 func (p *Postgres) DeleteStockSplit(ctx context.Context, instrumentID string, exDate time.Time) error {
 	_, err := p.q.ExecContext(ctx, `

--- a/server/db/postgres/corporate_events.go
+++ b/server/db/postgres/corporate_events.go
@@ -680,15 +680,21 @@ func (p *Postgres) BlockedCorporateEventPluginsForInstruments(ctx context.Contex
 }
 
 // ApplyOptionSplit implements db.CorporateEventDB. All mutations run in a
-// single transaction: delete old OCC, insert new OCC, update strike,
+// single transaction: replace the OCC identifier, update strike,
 // recompute split-adjusted tx values, advance identity_as_of. The split_factor_at
 // SQL function looks up splits via the underlying_id FK, so no derived split
 // row is needed on the option instrument.
 func (p *Postgres) ApplyOptionSplit(ctx context.Context, params db.OptionSplitParams) error {
 	return p.runInTx(ctx, func(tx queryable) error {
 		txp := &Postgres{q: tx}
-		if err := txp.DeleteInstrumentIdentifier(ctx, params.InstrumentID, "OCC", params.OldOCCValue); err != nil {
-			return fmt.Errorf("apply option split: delete old OCC: %w", err)
+		// Every OCC identifier goes, not just the value the caller read. An
+		// option has exactly one OCC, and deleting by value leaves a stale one
+		// behind when two runs of the pass overlap: the loser's delete matches
+		// nothing, its insert of a different adjusted symbol succeeds, and the
+		// option ends up resolving under both. Deleting by type makes the
+		// operation converge whatever the caller last saw.
+		if err := txp.DeleteInstrumentIdentifiersByType(ctx, params.InstrumentID, "OCC"); err != nil {
+			return fmt.Errorf("apply option split: delete OCC identifiers: %w", err)
 		}
 		if err := txp.InsertInstrumentIdentifier(ctx, params.InstrumentID, params.NewOCC); err != nil {
 			return fmt.Errorf("apply option split: insert new OCC: %w", err)

--- a/server/db/postgres/corporate_events_test.go
+++ b/server/db/postgres/corporate_events_test.go
@@ -594,7 +594,7 @@ func TestRecomputeSplitAdjustments_FutureSplitNotApplied(t *testing.T) {
 	// Insert a split with ex_date in the future. The key assertion is
 	// that this row sits in stock_splits but does NOT scale the price,
 	// because split_factor_at filters splits with ex_date > current_date.
-	future := time.Now().UTC().Truncate(24 * time.Hour).AddDate(1, 0, 0)
+	future := time.Now().UTC().Truncate(24*time.Hour).AddDate(1, 0, 0)
 	if err := p.UpsertStockSplits(ctx, []db.StockSplit{
 		{InstrumentID: instID, ExDate: future, SplitFrom: "1", SplitTo: "2", DataProvider: "test"},
 	}); err != nil {
@@ -1027,7 +1027,6 @@ func TestInsertUnhandledCorporateEvent_Dedup(t *testing.T) {
 	}
 }
 
-
 // backdate rewrites a knowledge timestamp to a fixed past value so that a
 // subsequent write either preserves it or is caught clobbering it. Tests run
 // inside one transaction, where now() is frozen at transaction start, so
@@ -1292,3 +1291,230 @@ func adjustedQty(t *testing.T, p *Postgres, txID string) float64 {
 	}
 	return v
 }
+
+// setupOption creates an option on the given underlying with an OCC identifier
+// and option fields. identityAsOf nil leaves identity_as_of NULL.
+func setupOption(t *testing.T, p *Postgres, underlyingID, occ string, strike float64, identityAsOf *time.Time) string {
+	t.Helper()
+	ctx := context.Background()
+	optFields := &db.OptionFields{Strike: strike, Expiry: d(2025, 1, 17), PutCall: "C"}
+	id, err := p.EnsureInstrument(ctx, "OPTION", "", "USD", occ, "", "", []db.IdentifierInput{
+		{Type: "OCC", Value: occ, Canonical: true},
+	}, underlyingID, nil, nil, optFields)
+	if err != nil {
+		t.Fatalf("ensure option %s: %v", occ, err)
+	}
+	if identityAsOf != nil {
+		if err := p.SetIdentityAsOf(ctx, id, *identityAsOf); err != nil {
+			t.Fatalf("set identity_as_of: %v", err)
+		}
+	}
+	return id
+}
+
+// TestListPendingOptionSplits_Predicate covers the rule that decides whether an
+// option still needs adjusting. The comparison is identity_as_of against
+// ex_date, never against a knowledge time: providers list the pre-split OCC
+// symbol until the ex_date, so an identity derived before then does not reflect
+// the split however long the split had been known. See
+// docs/adr/0017-option-identity-reflects-ex-date.md.
+func TestListPendingOptionSplits_Predicate(t *testing.T) {
+	past := d(2024, 6, 1)
+	tests := []struct {
+		name         string
+		identityAsOf *time.Time
+		exDate       time.Time
+		wantPending  bool
+	}{
+		{
+			name:         "identity predates ex_date",
+			identityAsOf: timePtrCE(d(2024, 1, 1)),
+			exDate:       past,
+			wantPending:  true,
+		},
+		{
+			name:         "identity after ex_date",
+			identityAsOf: timePtrCE(d(2024, 12, 1)),
+			exDate:       past,
+			wantPending:  false,
+		},
+		{
+			name:         "identity on ex_date is already adjusted",
+			identityAsOf: timePtrCE(past),
+			exDate:       past,
+			wantPending:  false,
+		},
+		{
+			name:         "null identity predates every split",
+			identityAsOf: nil,
+			exDate:       past,
+			wantPending:  true,
+		},
+		{
+			name:         "future-dated split is not yet effective",
+			identityAsOf: timePtrCE(d(2024, 1, 1)),
+			exDate:       time.Now().UTC().AddDate(1, 0, 0).Truncate(24 * time.Hour),
+			wantPending:  false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := testDBTx(t)
+			ctx := context.Background()
+
+			underlyingID := setupInstrument(t, p, "PRED-UNDERLYING")
+			optID := setupOption(t, p, underlyingID, "AAPL  250117C00200000", 200, tc.identityAsOf)
+			if err := p.UpsertStockSplits(ctx, []db.StockSplit{
+				{InstrumentID: underlyingID, ExDate: tc.exDate, SplitFrom: "1", SplitTo: "2", DataProvider: "massive"},
+			}); err != nil {
+				t.Fatalf("upsert split: %v", err)
+			}
+
+			pending, err := p.ListPendingOptionSplits(ctx, "")
+			if err != nil {
+				t.Fatalf("ListPendingOptionSplits: %v", err)
+			}
+			found := false
+			for _, pd := range pending {
+				if pd.Option.ID == optID {
+					found = true
+				}
+			}
+			if found != tc.wantPending {
+				t.Errorf("pending = %v, want %v", found, tc.wantPending)
+			}
+		})
+	}
+}
+
+// TestListPendingOptionSplits_KnownBeforeButNotYetEffective is the regression
+// test for issue 0055 at the query level. The split was known long before the
+// option was identified, but did not take effect until afterwards, so the stored
+// OCC is the pre-split one and the option is still pending. The old guard
+// compared first_known_at and skipped it permanently.
+func TestListPendingOptionSplits_KnownBeforeButNotYetEffective(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+
+	underlyingID := setupInstrument(t, p, "KNOWN-EARLY")
+	identity := d(2024, 3, 1)
+	optID := setupOption(t, p, underlyingID, "AAPL  250117C00200000", 200, &identity)
+
+	// Learned in January, effective in June, identity derived in March.
+	if err := p.UpsertStockSplits(ctx, []db.StockSplit{{
+		InstrumentID: underlyingID,
+		ExDate:       d(2024, 6, 1),
+		SplitFrom:    "1",
+		SplitTo:      "2",
+		DataProvider: "massive",
+		FirstKnownAt: d(2024, 1, 5),
+	}}); err != nil {
+		t.Fatalf("upsert split: %v", err)
+	}
+
+	pending, err := p.ListPendingOptionSplits(ctx, "")
+	if err != nil {
+		t.Fatalf("ListPendingOptionSplits: %v", err)
+	}
+	if len(pending) != 1 || pending[0].Option.ID != optID {
+		t.Fatalf("pending = %v, want the option to still need adjusting", pending)
+	}
+}
+
+// TestListPendingOptionSplits_MultipleAndFilter covers grouping, ordering, and
+// the underlying filter. Splits come back oldest first so the pass can compound
+// them, and the option arrives with its identifiers loaded so the pass can find
+// the OCC symbol.
+func TestListPendingOptionSplits_MultipleAndFilter(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+
+	undA := setupInstrument(t, p, "MULTI-A")
+	undB := setupInstrument(t, p, "MULTI-B")
+	optA := setupOption(t, p, undA, "AAPL  250117C00400000", 400, nil)
+	setupOption(t, p, undB, "MSFT  250117C00300000", 300, nil)
+
+	if err := p.UpsertStockSplits(ctx, []db.StockSplit{
+		{InstrumentID: undA, ExDate: d(2024, 9, 1), SplitFrom: "1", SplitTo: "4", DataProvider: "massive"},
+		{InstrumentID: undA, ExDate: d(2024, 6, 1), SplitFrom: "1", SplitTo: "2", DataProvider: "massive"},
+		{InstrumentID: undB, ExDate: d(2024, 7, 1), SplitFrom: "1", SplitTo: "3", DataProvider: "massive"},
+	}); err != nil {
+		t.Fatalf("upsert splits: %v", err)
+	}
+
+	all, err := p.ListPendingOptionSplits(ctx, "")
+	if err != nil {
+		t.Fatalf("ListPendingOptionSplits: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("pending options = %d, want 2", len(all))
+	}
+
+	filtered, err := p.ListPendingOptionSplits(ctx, undA)
+	if err != nil {
+		t.Fatalf("ListPendingOptionSplits filtered: %v", err)
+	}
+	if len(filtered) != 1 || filtered[0].Option.ID != optA {
+		t.Fatalf("filtered = %v, want just the option on undA", filtered)
+	}
+	if len(filtered[0].Splits) != 2 {
+		t.Fatalf("splits = %d, want 2", len(filtered[0].Splits))
+	}
+	if !filtered[0].Splits[0].ExDate.Equal(d(2024, 6, 1)) {
+		t.Errorf("splits not ordered by ex_date ascending: %v", filtered[0].Splits[0].ExDate)
+	}
+	if filtered[0].Splits[0].InstrumentID != undA {
+		t.Errorf("split instrument = %q, want the underlying %q", filtered[0].Splits[0].InstrumentID, undA)
+	}
+	var hasOCC bool
+	for _, idn := range filtered[0].Option.Identifiers {
+		if idn.Type == "OCC" {
+			hasOCC = true
+		}
+	}
+	if !hasOCC {
+		t.Error("option identifiers not loaded; the pass needs the OCC symbol")
+	}
+}
+
+// TestListPendingOptionSplits_ClearedByApply verifies the pass is idempotent:
+// ApplyOptionSplit advances identity_as_of, which is what removes the option
+// from the work list, so a second run finds nothing.
+func TestListPendingOptionSplits_ClearedByApply(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+
+	underlyingID := setupInstrument(t, p, "IDEMPOTENT")
+	identity := d(2024, 1, 1)
+	optID := setupOption(t, p, underlyingID, "AAPL  250117C00200000", 200, &identity)
+	if err := p.UpsertStockSplits(ctx, []db.StockSplit{
+		{InstrumentID: underlyingID, ExDate: d(2024, 6, 1), SplitFrom: "1", SplitTo: "2", DataProvider: "massive"},
+	}); err != nil {
+		t.Fatalf("upsert split: %v", err)
+	}
+
+	pending, err := p.ListPendingOptionSplits(ctx, "")
+	if err != nil || len(pending) != 1 {
+		t.Fatalf("first run: pending = %v, err = %v", pending, err)
+	}
+
+	if err := p.ApplyOptionSplit(ctx, db.OptionSplitParams{
+		InstrumentID: optID,
+		OldOCCValue:  "AAPL  250117C00200000",
+		NewOCC:       db.IdentifierInput{Type: "OCC", Value: "AAPL250117C00100000", Canonical: true},
+		NewStrike:    100,
+		NewName:      "AAPL250117C00100000",
+	}); err != nil {
+		t.Fatalf("ApplyOptionSplit: %v", err)
+	}
+
+	pending, err = p.ListPendingOptionSplits(ctx, "")
+	if err != nil {
+		t.Fatalf("second run: %v", err)
+	}
+	if len(pending) != 0 {
+		t.Errorf("pending after apply = %d, want 0", len(pending))
+	}
+}
+
+func timePtrCE(t time.Time) *time.Time { return &t }

--- a/server/db/postgres/corporate_events_test.go
+++ b/server/db/postgres/corporate_events_test.go
@@ -1517,4 +1517,68 @@ func TestListPendingOptionSplits_ClearedByApply(t *testing.T) {
 	}
 }
 
+// TestApplyOptionSplit_ConvergesOnStaleOldOCC covers two runs of the pass
+// overlapping on the same option. The pass is called from both the corporate
+// event fetch cycle and the corporate event import job, so a run can compute its
+// adjustment from a snapshot another run has already superseded.
+//
+// Run A sees only the 2:1 and plans 200 -> 100. The 4:1 then lands, so run B
+// sees both and plans 200 -> 25 from the same starting strike. A commits first.
+// B's OldOCCValue now names a symbol that no longer exists, and deleting by
+// value would match nothing while its insert of a different symbol succeeded --
+// leaving the option resolving under two OCCs, with nothing to clean it up since
+// identity_as_of has advanced. Replacing every OCC identifier makes the write
+// converge: whichever run commits last leaves one symbol, consistent with the
+// strike it wrote.
+func TestApplyOptionSplit_ConvergesOnStaleOldOCC(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+
+	underlyingID := setupInstrument(t, p, "RACE")
+	identity := d(2024, 1, 1)
+	optID := setupOption(t, p, underlyingID, "AAPL  250117C00200000", 200, &identity)
+
+	// Run A commits first: 2:1 only.
+	if err := p.ApplyOptionSplit(ctx, db.OptionSplitParams{
+		InstrumentID: optID,
+		OldOCCValue:  "AAPL  250117C00200000",
+		NewOCC:       db.IdentifierInput{Type: "OCC", Value: "AAPL250117C00100000", Canonical: true},
+		NewStrike:    100,
+		NewName:      "AAPL250117C00100000",
+	}); err != nil {
+		t.Fatalf("run A: %v", err)
+	}
+
+	// Run B commits second, still carrying the pre-A symbol it read.
+	if err := p.ApplyOptionSplit(ctx, db.OptionSplitParams{
+		InstrumentID: optID,
+		OldOCCValue:  "AAPL  250117C00200000", // stale
+		NewOCC:       db.IdentifierInput{Type: "OCC", Value: "AAPL250117C00025000", Canonical: true},
+		NewStrike:    25,
+		NewName:      "AAPL250117C00025000",
+	}); err != nil {
+		t.Fatalf("run B: %v", err)
+	}
+
+	inst, err := p.GetInstrument(ctx, optID)
+	if err != nil || inst == nil {
+		t.Fatalf("get instrument: %v", err)
+	}
+	var occs []string
+	for _, idn := range inst.Identifiers {
+		if idn.Type == "OCC" {
+			occs = append(occs, idn.Value)
+		}
+	}
+	if len(occs) != 1 {
+		t.Fatalf("OCC identifiers = %v, want exactly 1", occs)
+	}
+	if occs[0] != "AAPL250117C00025000" {
+		t.Errorf("OCC = %q, want the last writer's symbol", occs[0])
+	}
+	if inst.Strike == nil || *inst.Strike != 25 {
+		t.Errorf("strike = %v, want 25 to match the stored symbol", inst.Strike)
+	}
+}
+
 func timePtrCE(t time.Time) *time.Time { return &t }

--- a/server/db/postgres/instruments.go
+++ b/server/db/postgres/instruments.go
@@ -10,8 +10,8 @@ import (
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/google/uuid"
-	"github.com/lib/pq"
 	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/lib/pq"
 )
 
 // errIdentifierExists is returned when EnsureInstrument hits a unique violation (identifier already for another instrument).
@@ -31,7 +31,10 @@ func mergeInstruments(ctx context.Context, exec queryable, survivor, mergedAway 
 		return fmt.Errorf("list identifiers: %w", err)
 	}
 	defer rows.Close()
-	var toInsert []struct{ idType, domain, value string; canonical bool }
+	var toInsert []struct {
+		idType, domain, value string
+		canonical             bool
+	}
 	for rows.Next() {
 		var idType, val string
 		var domain sql.NullString
@@ -43,7 +46,10 @@ func mergeInstruments(ctx context.Context, exec queryable, survivor, mergedAway 
 		if domain.Valid {
 			d = domain.String
 		}
-		toInsert = append(toInsert, struct{ idType, domain, value string; canonical bool }{idType, d, val, canonical})
+		toInsert = append(toInsert, struct {
+			idType, domain, value string
+			canonical             bool
+		}{idType, d, val, canonical})
 	}
 	if err := rows.Err(); err != nil {
 		return err
@@ -584,41 +590,6 @@ func (p *Postgres) ValidateMIC(ctx context.Context, mic string) (bool, error) {
 		return false, fmt.Errorf("validate mic: %w", err)
 	}
 	return true, nil
-}
-
-// ListOptionsByUnderlying implements db.InstrumentDB.
-func (p *Postgres) ListOptionsByUnderlying(ctx context.Context, underlyingID string) ([]*db.InstrumentRow, error) {
-	uid, err := uuid.Parse(underlyingID)
-	if err != nil {
-		return nil, fmt.Errorf("list options by underlying: invalid id: %w", err)
-	}
-	var irows []instrumentRow
-	err = p.q.SelectContext(ctx, &irows, `
-		SELECT i.id, i.asset_class, i.exchange_mic, i.currency, i.name, i.exchange, i.underlying_id, i.valid_from, i.valid_to,
-		       i.cik, i.sic_code,
-		       i.strike, i.expiry, i.put_call, i.contract_multiplier, i.identity_as_of,
-		       e.name AS exchange_name, e.acronym AS exchange_acronym, e.country_code AS exchange_country_code
-		FROM instruments i
-		LEFT JOIN exchanges e ON e.mic = i.exchange_mic
-		WHERE i.underlying_id = $1 AND i.asset_class = 'OPTION'
-		ORDER BY i.id
-	`, uid)
-	if err != nil {
-		return nil, fmt.Errorf("list options by underlying: %w", err)
-	}
-	results := make([]*db.InstrumentRow, len(irows))
-	ids := make([]uuid.UUID, len(irows))
-	for i := range irows {
-		results[i] = irows[i].toDBRow()
-		ids[i] = irows[i].ID
-	}
-	if err := loadIdentifiers(ctx, p.q, ids, results); err != nil {
-		return nil, fmt.Errorf("list options by underlying identifiers: %w", err)
-	}
-	if err := loadProviderIdentifiers(ctx, p.q, ids, results); err != nil {
-		return nil, fmt.Errorf("list options by underlying provider identifiers: %w", err)
-	}
-	return results, nil
 }
 
 // DeleteInstrumentIdentifier implements db.InstrumentDB.

--- a/server/db/postgres/instruments.go
+++ b/server/db/postgres/instruments.go
@@ -608,6 +608,22 @@ func (p *Postgres) DeleteInstrumentIdentifier(ctx context.Context, instrumentID,
 	return nil
 }
 
+// DeleteInstrumentIdentifiersByType implements db.InstrumentDB.
+func (p *Postgres) DeleteInstrumentIdentifiersByType(ctx context.Context, instrumentID, identifierType string) error {
+	uid, err := uuid.Parse(instrumentID)
+	if err != nil {
+		return fmt.Errorf("delete instrument identifiers by type: invalid id: %w", err)
+	}
+	_, err = p.q.ExecContext(ctx, `
+		DELETE FROM instrument_identifiers
+		WHERE instrument_id = $1 AND identifier_type = $2
+	`, uid, identifierType)
+	if err != nil {
+		return fmt.Errorf("delete instrument identifiers by type: %w", err)
+	}
+	return nil
+}
+
 // InsertInstrumentIdentifier implements db.InstrumentDB.
 func (p *Postgres) InsertInstrumentIdentifier(ctx context.Context, instrumentID string, input db.IdentifierInput) error {
 	uid, err := uuid.Parse(instrumentID)

--- a/server/service/ingestion/corporate_event_worker.go
+++ b/server/service/ingestion/corporate_event_worker.go
@@ -171,15 +171,14 @@ func processCorporateEventImport(ctx context.Context, database db.DB, pluginRegi
 		if err := database.RecomputeSplitAdjustments(ctx, instID); err != nil {
 			log.Printf("corporate event import job %s: recompute %s: %v", j.JobID, instID, err)
 		}
-		allSplits, err := database.ListStockSplits(ctx, instID)
-		if err != nil {
-			log.Printf("corporate event import job %s: list splits %s: %v", j.JobID, instID, err)
-		} else {
-			options := corporateevents.ProcessOptionSplits(ctx, database, instID, allSplits, ingestionLog, nil)
-			for _, opt := range options {
-				_ = database.RecomputeSplitAdjustments(ctx, opt.ID)
-			}
-		}
+	}
+	// Adjust options whose identity predates an effective split, once for the
+	// whole import rather than per instrument. The pass derives its own work
+	// from the stored identity, so it also picks up anything an earlier run
+	// failed to apply. ApplyOptionSplit recomputes each adjusted option's
+	// split-adjusted values inside its own transaction.
+	if len(splitInstruments) > 0 {
+		corporateevents.ProcessPendingOptionSplits(ctx, database, "", ingestionLog)
 	}
 
 	_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_SUCCESS)

--- a/server/service/ingestion/corporate_event_worker_test.go
+++ b/server/service/ingestion/corporate_event_worker_test.go
@@ -136,10 +136,9 @@ func TestProcessCorporateEventImport_HappyPath(t *testing.T) {
 		time.Date(2014, 1, 1, 0, 0, 0, 0, time.UTC),
 		time.Date(2024, 12, 31, 0, 0, 0, 0, time.UTC), &exportedAt).Return(nil)
 	database.EXPECT().RecomputeSplitAdjustments(gomock.Any(), "inst-aapl").Return(nil)
-	database.EXPECT().ListStockSplits(gomock.Any(), "inst-aapl").Return([]db.StockSplit{
-		{InstrumentID: "inst-aapl", ExDate: time.Date(2020, 8, 31, 0, 0, 0, 0, time.UTC), SplitFrom: "1", SplitTo: "4", DataProvider: "import"},
-	}, nil)
-	database.EXPECT().ListOptionsByUnderlying(gomock.Any(), "inst-aapl").Return(nil, nil)
+	// The option pass runs once for the import, across all underlyings, and
+	// derives its own work rather than being handed this instrument's splits.
+	database.EXPECT().ListPendingOptionSplits(gomock.Any(), "").Return(nil, nil)
 	database.EXPECT().SetJobStatus(gomock.Any(), "job-ce-1", apiv1.JobStatus_SUCCESS).Return(nil)
 
 	if !processCorporateEventImport(context.Background(), database, registry, j) {


### PR DESCRIPTION
Second and final PR for issue 0055. #268 fixed the guard and the `identified_at` churn; this makes the pass itself retryable.

## The pass could not retry

It ran only inside `if splitsLanded`, so it depended on a split having been upserted in the same fetch cycle. Coverage is written as soon as events are persisted, so a pass that failed after that point was never reached again -- the next cycle saw no gap, never called the plugin, never set the flag, and the option stayed wrong permanently.

`ProcessPendingOptionSplits` now derives its work from `ListPendingOptionSplits`: every option whose `identity_as_of` predates an effective split on its underlying. That is a function of stored state, not of what arrived in this cycle.

```sql
WHERE o.asset_class = 'OPTION'
  AND s.ex_date <= CURRENT_DATE
  AND (o.identity_as_of IS NULL OR o.identity_as_of < s.ex_date)
```

Applying the adjustment advances `identity_as_of` inside the same transaction, which is what removes the option from the list. So re-running is a no-op, and a failure simply leaves the option pending. A future-dated split is not pending until its `ex_date` passes.

## It runs in a defer

The pass sits in a `defer` at the top of `runCycle` rather than at the end of the body, so it survives the cycle's early returns. It needs neither a fetch plugin nor a held instrument: splits can arrive through `ImportCorporateEvents`, and an adjustment that failed then would otherwise never be retried on an installation with no plugins enabled. Being a defer, it still runs *after* the fetch, so it sees splits that just landed.

## Multi-split correctness

Each option is adjusted once, by the cumulative factor of all its pending splits. The previous per-split loop read the option row once and never refreshed it, so two splits divided the **original** strike twice and left the option carrying an OCC identifier per split. Reachable whenever a backfill landed two historical splits together; `TestProcessPendingOptionSplits_CompoundsMultipleSplits` pins it -- strike 400 becomes 50 for a 2:1 then 4:1, in a single `ApplyOptionSplit` call.

A split that cannot be applied now blocks its option rather than being skipped over -- adjusting the splits either side would produce a strike matching no real contract -- and leaves it pending for a later run.

## Tests moved, not just changed

The guard moved from Go into the query predicate, so its tests moved from the mock-based suite to the postgres one where the real SQL runs. `TestListPendingOptionSplits_Predicate` covers identity before, on and after the ex_date, a NULL identity, and a future-dated split; `_KnownBeforeButNotYetEffective` is the 0055 case at the query level; `_ClearedByApply` pins idempotence end to end.

The unit tests now cover what the pass does with a work list it is handed: compounding, a failed apply not being reported as done, one option's failure not blocking others, non-whole splits blocking and being reported once per underlying.

New worker tests: the pass runs on a cycle where no splits landed, with no plugins enabled, and with nothing held.

`make server-test`, `make db-test` and `make client-test` all pass.

## Also

`ListOptionsByUnderlying` had no remaining callers and is removed. `ListStockSplits` is kept -- it has no production caller either, but it is the read-back used throughout the corporate-event integration tests and is referenced by `DeleteStockSplit`'s contract.

0055 is closed and its divergence row leaves `bitemporality.md`, taking the table down to four.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
