### PR TITLE
Name half-open interval bounds `before` (0056, 1/6)

### DIFF
--- a/cli/google/formula.go
+++ b/cli/google/formula.go
@@ -69,14 +69,14 @@ func gapToColumns(pg *apiv1.PriceGap) ([]sheetColumn, error) {
 		if err != nil {
 			continue
 		}
-		to, err := time.Parse("2006-01-02", gap.GetTo())
+		before, err := time.Parse("2006-01-02", gap.GetBefore())
 		if err != nil {
 			continue
 		}
-		for _, c := range chunkRange(from, to) {
+		for _, c := range chunkRange(from, before) {
 			cols = append(cols, sheetColumn{
 				Header:  header,
-				Formula: googleFinanceFormula(ticker, c.from, c.to),
+				Formula: googleFinanceFormula(ticker, c.from, c.before),
 			})
 		}
 	}
@@ -84,28 +84,28 @@ func gapToColumns(pg *apiv1.PriceGap) ([]sheetColumn, error) {
 }
 
 type dateChunk struct {
-	from, to time.Time
+	from, before time.Time
 }
 
-// chunkRange splits a [from, to) range into segments of at most maxChunkDays.
-func chunkRange(from, to time.Time) []dateChunk {
+// chunkRange splits a [from, before) range into segments of at most maxChunkDays.
+func chunkRange(from, before time.Time) []dateChunk {
 	var chunks []dateChunk
-	for from.Before(to) {
+	for from.Before(before) {
 		end := from.AddDate(0, 0, maxChunkDays)
-		if end.After(to) {
-			end = to
+		if end.After(before) {
+			end = before
 		}
-		chunks = append(chunks, dateChunk{from: from, to: end})
+		chunks = append(chunks, dateChunk{from: from, before: end})
 		from = end
 	}
 	return chunks
 }
 
 // googleFinanceFormula returns a GOOGLEFINANCE formula string.
-// to is exclusive; the formula end date is to-1 day.
-func googleFinanceFormula(ticker string, from, to time.Time) string {
-	// GOOGLEFINANCE end date is inclusive, so subtract 1 day from our exclusive 'to'.
-	end := to.AddDate(0, 0, -1)
+// before is exclusive; the formula end date is before-1 day.
+func googleFinanceFormula(ticker string, from, before time.Time) string {
+	// GOOGLEFINANCE end date is inclusive, so subtract 1 day from our exclusive bound.
+	end := before.AddDate(0, 0, -1)
 	return fmt.Sprintf(`=GOOGLEFINANCE("%s","close",DATE(%d,%d,%d),DATE(%d,%d,%d),"DAILY")`,
 		ticker,
 		from.Year(), from.Month(), from.Day(),

--- a/cli/google/formula_test.go
+++ b/cli/google/formula_test.go
@@ -10,44 +10,44 @@ import (
 
 func TestChunkRange(t *testing.T) {
 	tests := []struct {
-		name       string
-		from, to   time.Time
-		wantChunks int
+		name         string
+		from, before time.Time
+		wantChunks   int
 	}{
 		{
 			name:       "short range (30 days)",
 			from:       date(2024, 1, 1),
-			to:         date(2024, 1, 31),
+			before:     date(2024, 1, 31),
 			wantChunks: 1,
 		},
 		{
 			name:       "exactly 365 days (non-leap year)",
 			from:       date(2023, 1, 1),
-			to:         date(2024, 1, 1), // 365 days (2023 is not a leap year)
+			before:     date(2024, 1, 1), // 365 days (2023 is not a leap year)
 			wantChunks: 1,
 		},
 		{
 			name:       "over 365 days splits into 2",
 			from:       date(2023, 1, 1),
-			to:         date(2024, 1, 2),
+			before:     date(2024, 1, 2),
 			wantChunks: 2,
 		},
 		{
 			name:       "about 2 years",
 			from:       date(2023, 1, 1),
-			to:         date(2024, 12, 31),
+			before:     date(2024, 12, 31),
 			wantChunks: 2,
 		},
 		{
 			name:       "empty range",
 			from:       date(2024, 1, 1),
-			to:         date(2024, 1, 1),
+			before:     date(2024, 1, 1),
 			wantChunks: 0,
 		},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			chunks := chunkRange(tc.from, tc.to)
+			chunks := chunkRange(tc.from, tc.before)
 			if len(chunks) != tc.wantChunks {
 				t.Fatalf("want %d chunks, got %d", tc.wantChunks, len(chunks))
 			}
@@ -56,12 +56,12 @@ func TestChunkRange(t *testing.T) {
 				if !chunks[0].from.Equal(tc.from) {
 					t.Fatalf("first chunk starts at %s, want %s", chunks[0].from, tc.from)
 				}
-				if !chunks[len(chunks)-1].to.Equal(tc.to) {
-					t.Fatalf("last chunk ends at %s, want %s", chunks[len(chunks)-1].to, tc.to)
+				if !chunks[len(chunks)-1].before.Equal(tc.before) {
+					t.Fatalf("last chunk ends at %s, want %s", chunks[len(chunks)-1].before, tc.before)
 				}
 				for i := 1; i < len(chunks); i++ {
-					if !chunks[i].from.Equal(chunks[i-1].to) {
-						t.Fatalf("gap between chunk %d end (%s) and chunk %d start (%s)", i-1, chunks[i-1].to, i, chunks[i].from)
+					if !chunks[i].from.Equal(chunks[i-1].before) {
+						t.Fatalf("gap between chunk %d end (%s) and chunk %d start (%s)", i-1, chunks[i-1].before, i, chunks[i].from)
 					}
 				}
 			}
@@ -73,19 +73,19 @@ func TestGoogleFinanceFormula(t *testing.T) {
 	tests := []struct {
 		name         string
 		ticker       string
-		from, to     time.Time
+		from, before time.Time
 		wantContains []string
 	}{
 		{
 			name:   "stock",
 			ticker: "NASDAQ:AAPL",
 			from:   date(2024, 1, 1),
-			to:     date(2024, 7, 1),
+			before: date(2024, 7, 1),
 			wantContains: []string{
 				`=GOOGLEFINANCE("NASDAQ:AAPL"`,
 				`"close"`,
 				`DATE(2024,1,1)`,
-				`DATE(2024,6,30)`, // to is exclusive, so end date is June 30
+				`DATE(2024,6,30)`, // before is exclusive, so end date is June 30
 				`"DAILY"`,
 			},
 		},
@@ -93,7 +93,7 @@ func TestGoogleFinanceFormula(t *testing.T) {
 			name:   "FX pair",
 			ticker: "CURRENCY:GBPUSD",
 			from:   date(2024, 3, 15),
-			to:     date(2024, 4, 15),
+			before: date(2024, 4, 15),
 			wantContains: []string{
 				`"CURRENCY:GBPUSD"`,
 				`DATE(2024,3,15)`,
@@ -103,7 +103,7 @@ func TestGoogleFinanceFormula(t *testing.T) {
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := googleFinanceFormula(tc.ticker, tc.from, tc.to)
+			got := googleFinanceFormula(tc.ticker, tc.from, tc.before)
 			for _, want := range tc.wantContains {
 				if !strings.Contains(got, want) {
 					t.Errorf("formula %q missing %q", got, want)
@@ -121,7 +121,7 @@ func TestGenerateFormulas_StockAndFX(t *testing.T) {
 			AssetClass:   apiv1.AssetClass_ASSET_CLASS_STOCK,
 			Name:         "Apple Inc",
 			Gaps: []*apiv1.DateRange{
-				{From: "2024-01-01", To: "2024-07-01"},
+				{From: "2024-01-01", Before: "2024-07-01"},
 			},
 		},
 	}
@@ -132,7 +132,7 @@ func TestGenerateFormulas_StockAndFX(t *testing.T) {
 			AssetClass:   apiv1.AssetClass_ASSET_CLASS_FX,
 			Name:         "GBPUSD",
 			Gaps: []*apiv1.DateRange{
-				{From: "2024-01-01", To: "2024-04-01"},
+				{From: "2024-01-01", Before: "2024-04-01"},
 			},
 		},
 	}
@@ -172,7 +172,7 @@ func TestGenerateFormulas_YearChunking(t *testing.T) {
 			AssetClass:   apiv1.AssetClass_ASSET_CLASS_STOCK,
 			Name:         "IBM",
 			Gaps: []*apiv1.DateRange{
-				{From: "2023-01-01", To: "2024-12-31"}, // ~2 years, fits in 2 chunks
+				{From: "2023-01-01", Before: "2024-12-31"}, // ~2 years, fits in 2 chunks
 			},
 		},
 	}
@@ -195,7 +195,7 @@ func TestGenerateFormulas_SkipsUnmappable(t *testing.T) {
 			AssetClass:   apiv1.AssetClass_ASSET_CLASS_STOCK,
 			Name:         "Apple ISIN",
 			Gaps: []*apiv1.DateRange{
-				{From: "2024-01-01", To: "2024-07-01"},
+				{From: "2024-01-01", Before: "2024-07-01"},
 			},
 		},
 	}
@@ -216,8 +216,8 @@ func TestGenerateFormulas_MultipleGapRanges(t *testing.T) {
 			Identifier:   &apiv1.InstrumentIdentifier{Type: apiv1.IdentifierType_MIC_TICKER, Domain: "XNAS", Value: "TSLA"},
 			AssetClass:   apiv1.AssetClass_ASSET_CLASS_STOCK,
 			Gaps: []*apiv1.DateRange{
-				{From: "2024-01-01", To: "2024-03-01"},
-				{From: "2024-06-01", To: "2024-09-01"},
+				{From: "2024-01-01", Before: "2024-03-01"},
+				{From: "2024-06-01", Before: "2024-09-01"},
 			},
 		},
 	}
@@ -268,7 +268,7 @@ func TestGenerateFormulas_OpenfIGITickerWithExchange(t *testing.T) {
 			AssetClass:   apiv1.AssetClass_ASSET_CLASS_STOCK,
 			Exchange:     "XNAS",
 			Name:         "Microsoft",
-			Gaps:         []*apiv1.DateRange{{From: "2024-01-01", To: "2024-04-01"}},
+			Gaps:         []*apiv1.DateRange{{From: "2024-01-01", Before: "2024-04-01"}},
 		},
 	}
 

--- a/cli/google/main.go
+++ b/cli/google/main.go
@@ -191,7 +191,7 @@ func buildCoverage(rpcCtx context.Context, apiClient apiv1.ApiServiceClient) []*
 					IdentifierValue:  ident.GetValue(),
 					IdentifierDomain: ident.GetDomain(),
 					From:             gap.GetFrom(),
-					To:               gap.GetTo(),
+					Before:           gap.GetBefore(),
 				})
 			}
 		}

--- a/docs/adr/0007-calendar-day-valuation.md
+++ b/docs/adr/0007-calendar-day-valuation.md
@@ -15,6 +15,6 @@ with no application-level fill logic. Both are core TimescaleDB functions (not t
 toolkit) and are available in the `timescale/timescaledb:latest-pg16` image the
 project already runs, so this adds no new dependency.
 
-Date ranges throughout the cache use the half-open `[From, To)` convention with
-midnight-UTC values, matching PostgreSQL's `daterange` default so range
-arithmetic composes cleanly with the database.
+Date ranges throughout the cache are half-open with midnight-UTC values so range
+arithmetic composes cleanly with the database (see
+adr/0018-half-open-date-intervals.md).

--- a/docs/adr/0018-half-open-date-intervals.md
+++ b/docs/adr/0018-half-open-date-intervals.md
@@ -1,0 +1,31 @@
+# Half-open date intervals named `[from, before)`
+
+Every date interval in PortfolioDB -- wire API, database columns, and Go and
+TypeScript internals -- is half-open `[from, before)` with midnight-UTC bounds,
+and the exclusive bound is always named `before` (`date_before`,
+`period_before`, `covered_before`, `Before`). Half-open is chosen because it
+matches PostgreSQL's `daterange` default and because abutting intervals compose
+without arithmetic: the end of one is the start of the next.
+
+The convention was previously stated but not carried consistently -- some
+messages were half-open and others closed, with nothing in a field's name to
+say which. The `before` suffix, rather than a documented `to`, is the decision
+here: a comment is only read when someone goes looking, whereas a name is read
+at every call site, and renaming turns any call site whose meaning changed into
+a compile error rather than a silent off-by-one at a boundary date.
+
+## Consequences
+
+Closed intervals survive only where an external system demands one: the price
+and corporate-event provider plugins, the GOOGLEFINANCE formula builder, and the
+broker URL templates in the extension. Each converts on the last line before the
+outbound call and carries a comment naming the provider's convention.
+
+`instruments.valid_from` / `valid_to` are a deliberate exemption. Providers
+supply `valid_to` as an inclusive last trading date, no query filters on either
+bound, and restating them half-open would mean adding a day at every identity
+plugin boundary to no one's benefit.
+
+Human-facing UI keeps inclusive date pickers. The exclusive bound exists so
+machine intervals compose, not so users do arithmetic; the client converts once,
+at the request boundary.

--- a/docs/spec/bitemporality.md
+++ b/docs/spec/bitemporality.md
@@ -46,8 +46,17 @@ clock every read API means by "as of".
 | `ingestion_jobs` | `period_from`, `period_to` | The valid-time window a bulk upload replaces. |
 | `unhandled_corporate_events` | `ex_date` | The effective date of the event we could not handle. |
 
-Date ranges are half-open `[from, to)` with midnight-UTC values, matching
-PostgreSQL's `daterange` default (see adr/0007-calendar-day-valuation.md).
+Every date interval -- wire API, database column pair, or in-memory range -- is
+half-open `[from, before)` with midnight-UTC values, matching PostgreSQL's
+`daterange` default. The exclusive bound is always named `before`
+(`date_before`, `period_before`, `covered_before`, `Before`) so no caller has to
+consult a comment to know which end is included; the closed form survives only
+inside adapters for external providers that demand it
+(see adr/0018-half-open-date-intervals.md).
+
+`instruments.valid_from` / `valid_to` are the one exemption: providers supply
+`valid_to` as an inclusive last trading date and no query filters on either
+bound, so they stay closed and keep their names.
 
 ### Instrument identity
 

--- a/docs/spec/prices.md
+++ b/docs/spec/prices.md
@@ -53,15 +53,15 @@ A forward-filled synthetic row carries the value of the bar it copied, so it inh
 
 All components are implemented as Go functions in the database abstraction layer (`server/db`). The `PriceCacheDB` interface in `server/db/db.go` defines the contract; the Postgres implementation lives in `server/db/postgres/price_cache.go`.
 
-Date ranges use the half-open `[From, To)` convention with `time.Time` values at midnight UTC, matching PostgreSQL's `daterange` default (see adr/0007-calendar-day-valuation.md).
+Date ranges use the half-open `[From, Before)` convention with `time.Time` values at midnight UTC, matching PostgreSQL's `daterange` default (see adr/0018-half-open-date-intervals.md).
 
 ### Types
 
 ```go
-// DateRange is a half-open [From, To) date range. Both values are midnight UTC.
+// DateRange is a half-open [From, Before) date range. Both values are midnight UTC.
 type DateRange struct {
-    From time.Time // inclusive
-    To   time.Time // exclusive
+    From   time.Time // inclusive
+    Before time.Time // exclusive
 }
 
 // InstrumentDateRanges groups date ranges by instrument.
@@ -100,7 +100,7 @@ Compute the date ranges during which any user held a non-zero position in each i
 2. Compute the cumulative position per instrument using SQL window functions.
 3. In Go, iterate the daily positions and detect zero-crossings:
    - `held_from` = the date the position first becomes non-zero.
-   - `held_to` = the date the position returns to zero, OR today + 1 day (exclusive) if `ExtendToToday` is true and the position is still open.
+   - `held_before` = the date the position returns to zero, OR today + 1 day (exclusive) if `ExtendToToday` is true and the position is still open.
 4. Return the result as a slice of `InstrumentDateRanges`.
 
 ---
@@ -120,7 +120,7 @@ For each instrument present in the `eod_prices` table, return the date ranges fo
 ### SQL approach
 
 ```sql
-SELECT instrument_id, lower(r) AS range_from, upper(r) AS range_to
+SELECT instrument_id, lower(r) AS range_from, upper(r) AS range_before
 FROM (
     SELECT instrument_id,
         unnest(range_agg(daterange(price_date, price_date + 1))) AS r

--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -105,8 +105,12 @@ message Instrument {
   string name = 5;
   repeated InstrumentIdentifier identifiers = 6;
   string underlying_id = 7;   // UUID of underlying instrument when this is a derivative (OPTION/FUTURE).
-  google.protobuf.Timestamp valid_from = 8;  // When the instrument was available to trade (optional).
-  google.protobuf.Timestamp valid_to = 9;    // When the instrument ceased to be available (optional).
+  // When the instrument was available to trade (optional). Deliberately outside
+  // the half-open [from, before) rule the rest of this API follows: providers
+  // supply valid_to as a last trading date, inclusive, and no query filters on
+  // either bound. See docs/spec/bitemporality.md.
+  google.protobuf.Timestamp valid_from = 8;
+  google.protobuf.Timestamp valid_to = 9;    // When the instrument ceased to be available (optional), inclusive.
   Instrument underlying = 10; // Populated in ListTxs/GetHoldings so clients need not fetch separately.
   Exchange exchange_info = 11; // Rich exchange data from exchanges table JOIN; populated when exchange_mic is set.
   string cik = 12;            // SEC Central Index Key (optional).
@@ -732,14 +736,15 @@ message ImportPricesRequest {
   google.protobuf.Timestamp exported_at = 3;
 }
 
-// ImportCoverage declares that the caller intends to cover a date range for
-// an instrument. The server fills gaps within this range with synthetic prices.
+// ImportCoverage declares that the caller intends to cover a half-open
+// [from, before) date range for an instrument. The server fills gaps within
+// this range with synthetic prices.
 message ImportCoverage {
   string identifier_type = 1;
   string identifier_value = 2;
   string identifier_domain = 3;
-  string from = 4; // YYYY-MM-DD, inclusive
-  string to = 5;   // YYYY-MM-DD, exclusive
+  string from = 4;   // YYYY-MM-DD, inclusive
+  string before = 5; // YYYY-MM-DD, exclusive
 }
 
 message ImportPricesResponse {
@@ -901,10 +906,12 @@ message PriceGap {
   repeated DateRange gaps = 7;
 }
 
-// DateRange is a half-open [from, to) date range.
+// DateRange is a half-open [from, before) date range. Every date interval in
+// this API is half-open and names its exclusive bound `before`; see
+// docs/adr/0007-calendar-day-valuation.md.
 message DateRange {
-  string from = 1; // YYYY-MM-DD, inclusive
-  string to = 2;   // YYYY-MM-DD, exclusive
+  string from = 1;   // YYYY-MM-DD, inclusive
+  string before = 2; // YYYY-MM-DD, exclusive
 }
 
 message ListPriceGapsResponse {

--- a/server/corporateevents/worker.go
+++ b/server/corporateevents/worker.go
@@ -209,7 +209,7 @@ func processInstrument(ctx context.Context, database db.DB, plugins []pluginEntr
 			}
 
 			callCtx, callCancel := context.WithTimeout(ctx, pluginutil.TimeoutFromConfig(pe.config, DefaultPluginTimeout))
-			result, err := pe.plugin.FetchEvents(callCtx, pe.config, toPluginIdentifiers(ids), assetClass, gap.From, gap.To)
+			result, err := pe.plugin.FetchEvents(callCtx, pe.config, toPluginIdentifiers(ids), assetClass, gap.From, gap.Before)
 			callCancel()
 			if err != nil {
 				var permErr *ErrPermanent
@@ -265,7 +265,7 @@ func processInstrument(ctx context.Context, database db.DB, plugins []pluginEntr
 					}
 				}
 			}
-			if err := database.UpsertCorporateEventCoverage(ctx, inst.ID, pe.id, gap.From, gap.To, nil); err != nil {
+			if err := database.UpsertCorporateEventCoverage(ctx, inst.ID, pe.id, gap.From, gap.Before, nil); err != nil {
 				if log != nil {
 					log.ErrorContext(ctx, "corporate event fetch: upsert coverage",
 						"plugin", pe.id, "instrument", inst.ID, "err", err)
@@ -297,22 +297,24 @@ func processInstrument(ctx context.Context, database db.DB, plugins []pluginEntr
 // here -- they are already merged in the DB by UpsertCorporateEventCoverage.
 //
 // Implementation: convert closed intervals to half-open [from, to+1day),
-// reuse db.SubtractRanges, then convert back to closed.
+// reuse db.SubtractRanges, then convert back to closed. The returned
+// db.DateRange therefore carries an inclusive value in Before, because
+// corporate event coverage is the one interval still stored closed.
 func computeMissingIntervals(earliestTxDate, endDate time.Time, coverage []db.CorporateEventCoverage) []db.DateRange {
 	if !earliestTxDate.Before(endDate) && !earliestTxDate.Equal(endDate) {
 		return nil
 	}
-	needed := []db.DateRange{{From: earliestTxDate, To: endDate.Add(db.Day)}}
+	needed := []db.DateRange{{From: earliestTxDate, Before: endDate.Add(db.Day)}}
 	cached := make([]db.DateRange, 0, len(coverage))
 	for _, c := range coverage {
-		cached = append(cached, db.DateRange{From: c.CoveredFrom, To: c.CoveredTo.Add(db.Day)})
+		cached = append(cached, db.DateRange{From: c.CoveredFrom, Before: c.CoveredTo.Add(db.Day)})
 	}
 	cached = db.MergeRanges(cached)
 	gaps := db.SubtractRanges(needed, cached)
 	out := make([]db.DateRange, 0, len(gaps))
 	for _, g := range gaps {
 		// Convert half-open back to closed.
-		out = append(out, db.DateRange{From: g.From, To: g.To.Add(-db.Day)})
+		out = append(out, db.DateRange{From: g.From, Before: g.Before.Add(-db.Day)})
 	}
 	return out
 }

--- a/server/corporateevents/worker_test.go
+++ b/server/corporateevents/worker_test.go
@@ -22,7 +22,7 @@ func TestComputeMissingIntervals_NoCoverage(t *testing.T) {
 	if len(gaps) != 1 {
 		t.Fatalf("expected 1 gap, got %d", len(gaps))
 	}
-	if !gaps[0].From.Equal(d(2024, 1, 1)) || !gaps[0].To.Equal(d(2024, 1, 31)) {
+	if !gaps[0].From.Equal(d(2024, 1, 1)) || !gaps[0].Before.Equal(d(2024, 1, 31)) {
 		t.Errorf("unexpected gap: %+v", gaps[0])
 	}
 }
@@ -47,10 +47,10 @@ func TestComputeMissingIntervals_PartialCoverage(t *testing.T) {
 	if len(gaps) != 2 {
 		t.Fatalf("expected 2 gaps, got %+v", gaps)
 	}
-	if !gaps[0].From.Equal(d(2024, 1, 1)) || !gaps[0].To.Equal(d(2024, 1, 4)) {
+	if !gaps[0].From.Equal(d(2024, 1, 1)) || !gaps[0].Before.Equal(d(2024, 1, 4)) {
 		t.Errorf("first gap: %+v", gaps[0])
 	}
-	if !gaps[1].From.Equal(d(2024, 1, 11)) || !gaps[1].To.Equal(d(2024, 1, 31)) {
+	if !gaps[1].From.Equal(d(2024, 1, 11)) || !gaps[1].Before.Equal(d(2024, 1, 31)) {
 		t.Errorf("second gap: %+v", gaps[1])
 	}
 }

--- a/server/db/daterange.go
+++ b/server/db/daterange.go
@@ -8,7 +8,7 @@ import (
 // Day is a convenience for adding calendar days to a time.Time.
 const Day = 24 * time.Hour
 
-// MergeRanges merges overlapping or adjacent half-open [From, To) ranges.
+// MergeRanges merges overlapping or adjacent half-open [From, Before) ranges.
 // Input need not be sorted. Returns a sorted, non-overlapping slice.
 func MergeRanges(ranges []DateRange) []DateRange {
 	if len(ranges) <= 1 {
@@ -22,9 +22,9 @@ func MergeRanges(ranges []DateRange) []DateRange {
 	merged := []DateRange{sorted[0]}
 	for _, r := range sorted[1:] {
 		last := &merged[len(merged)-1]
-		if !r.From.After(last.To) {
-			if r.To.After(last.To) {
-				last.To = r.To
+		if !r.From.After(last.Before) {
+			if r.Before.After(last.Before) {
+				last.Before = r.Before
 			}
 		} else {
 			merged = append(merged, r)
@@ -45,24 +45,24 @@ func SubtractRanges(needed, cached []DateRange) []DateRange {
 	ci := 0
 	for _, n := range needed {
 		cur := n.From
-		for ci < len(cached) && cached[ci].To.Before(n.From) || ci < len(cached) && cached[ci].To.Equal(n.From) {
+		for ci < len(cached) && !cached[ci].Before.After(n.From) {
 			ci++
 		}
-		for j := ci; j < len(cached) && cached[j].From.Before(n.To); j++ {
+		for j := ci; j < len(cached) && cached[j].From.Before(n.Before); j++ {
 			c := cached[j]
 			if c.From.After(cur) {
-				end := n.To
+				end := n.Before
 				if c.From.Before(end) {
 					end = c.From
 				}
-				gaps = append(gaps, DateRange{From: cur, To: end})
+				gaps = append(gaps, DateRange{From: cur, Before: end})
 			}
-			if c.To.After(cur) {
-				cur = c.To
+			if c.Before.After(cur) {
+				cur = c.Before
 			}
 		}
-		if cur.Before(n.To) {
-			gaps = append(gaps, DateRange{From: cur, To: n.To})
+		if cur.Before(n.Before) {
+			gaps = append(gaps, DateRange{From: cur, Before: n.Before})
 		}
 	}
 	return gaps

--- a/server/db/daterange_test.go
+++ b/server/db/daterange_test.go
@@ -184,11 +184,11 @@ func assertRangesEqual(t *testing.T, want, got []DateRange) {
 		t.Fatalf("got %d ranges, want %d\ngot:  %v\nwant: %v", len(got), len(want), fmtRanges(got), fmtRanges(want))
 	}
 	for i := range want {
-		if !want[i].From.Equal(got[i].From) || !want[i].To.Equal(got[i].To) {
+		if !want[i].From.Equal(got[i].From) || !want[i].Before.Equal(got[i].Before) {
 			t.Errorf("range[%d]: got [%s, %s), want [%s, %s)",
 				i,
-				got[i].From.Format("2006-01-02"), got[i].To.Format("2006-01-02"),
-				want[i].From.Format("2006-01-02"), want[i].To.Format("2006-01-02"))
+				got[i].From.Format("2006-01-02"), got[i].Before.Format("2006-01-02"),
+				want[i].From.Format("2006-01-02"), want[i].Before.Format("2006-01-02"))
 		}
 	}
 }
@@ -199,7 +199,7 @@ func fmtRanges(rs []DateRange) string {
 		if i > 0 {
 			s += ", "
 		}
-		s += "[" + r.From.Format("2006-01-02") + ", " + r.To.Format("2006-01-02") + ")"
+		s += "[" + r.From.Format("2006-01-02") + ", " + r.Before.Format("2006-01-02") + ")"
 	}
 	return s + "]"
 }

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -64,10 +64,12 @@ type PriceFetchBlockDB interface {
 	DeletePriceFetchBlock(ctx context.Context, instrumentID, pluginID string) error
 }
 
-// DateRange is a half-open [From, To) date range. Both values are midnight UTC.
+// DateRange is a half-open [From, Before) date range. Both values are midnight
+// UTC. Every date interval in this codebase is half-open and names its
+// exclusive bound Before; see docs/adr/0007-calendar-day-valuation.md.
 type DateRange struct {
-	From time.Time // inclusive
-	To   time.Time // exclusive
+	From   time.Time // inclusive
+	Before time.Time // exclusive
 }
 
 // InstrumentDateRanges groups date ranges by instrument.
@@ -120,9 +122,9 @@ type PriceCacheDB interface {
 	// or the existing row is also synthetic.
 	UpsertPrices(ctx context.Context, prices []EODPrice) error
 	// UpsertPricesWithFill inserts real bars and generates synthetic LOCF prices
-	// for every date in [from, to) that has no real bar, all in a single SQL
+	// for every date in [from, before) that has no real bar, all in a single SQL
 	// statement. The last non-synthetic close before `from` seeds the forward-fill.
-	UpsertPricesWithFill(ctx context.Context, instrumentID, provider string, bars []EODPrice, from, to time.Time, fetchedAt *time.Time) error
+	UpsertPricesWithFill(ctx context.Context, instrumentID, provider string, bars []EODPrice, from, before time.Time, fetchedAt *time.Time) error
 }
 
 // PluginConfigDB provides unified plugin config CRUD for all categories.

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -66,7 +66,7 @@ type PriceFetchBlockDB interface {
 
 // DateRange is a half-open [From, Before) date range. Both values are midnight
 // UTC. Every date interval in this codebase is half-open and names its
-// exclusive bound Before; see docs/adr/0007-calendar-day-valuation.md.
+// exclusive bound Before; see docs/adr/0018-half-open-date-intervals.md.
 type DateRange struct {
 	From   time.Time // inclusive
 	Before time.Time // exclusive

--- a/server/db/postgres/price_cache.go
+++ b/server/db/postgres/price_cache.go
@@ -59,12 +59,12 @@ func (p *Postgres) HeldRanges(ctx context.Context, opts db.HeldRangesOpts) ([]db
 		if instID != curInst {
 			// Close open range for previous instrument.
 			if inRange {
-				to := today.Add(db.Day)
+				before := today.Add(db.Day)
 				if !opts.ExtendToToday {
 					// No extend: we don't know when position ended, use last tx date + 1.
-					to = rangeStart.Add(db.Day)
+					before = rangeStart.Add(db.Day)
 				}
-				ranges = append(ranges, db.DateRange{From: rangeStart, To: to})
+				ranges = append(ranges, db.DateRange{From: rangeStart, Before: before})
 				inRange = false
 			}
 			flush()
@@ -76,7 +76,7 @@ func (p *Postgres) HeldRanges(ctx context.Context, opts db.HeldRangesOpts) ([]db
 			rangeStart = txDate
 			inRange = true
 		} else if qtyIsZero(eodPos) && inRange {
-			ranges = append(ranges, db.DateRange{From: rangeStart, To: txDate})
+			ranges = append(ranges, db.DateRange{From: rangeStart, Before: txDate})
 			inRange = false
 		}
 	}
@@ -86,11 +86,11 @@ func (p *Postgres) HeldRanges(ctx context.Context, opts db.HeldRangesOpts) ([]db
 
 	// Close final open range.
 	if inRange {
-		to := today.Add(db.Day)
+		before := today.Add(db.Day)
 		if !opts.ExtendToToday {
-			to = rangeStart.Add(db.Day)
+			before = rangeStart.Add(db.Day)
 		}
-		ranges = append(ranges, db.DateRange{From: rangeStart, To: to})
+		ranges = append(ranges, db.DateRange{From: rangeStart, Before: before})
 	}
 	flush()
 
@@ -114,7 +114,7 @@ func (p *Postgres) PriceCoverage(ctx context.Context, instrumentIDs []string) ([
 	}
 
 	rows, err := p.q.QueryContext(ctx, `
-		SELECT instrument_id, lower(r) AS range_from, upper(r) AS range_to
+		SELECT instrument_id, lower(r) AS range_from, upper(r) AS range_before
 		FROM (
 			SELECT instrument_id,
 				unnest(range_agg(daterange(price_date, price_date + 1))) AS r
@@ -133,8 +133,8 @@ func (p *Postgres) PriceCoverage(ctx context.Context, instrumentIDs []string) ([
 	var order []string
 	for rows.Next() {
 		var instID uuid.UUID
-		var from, to time.Time
-		if err := rows.Scan(&instID, &from, &to); err != nil {
+		var from, before time.Time
+		if err := rows.Scan(&instID, &from, &before); err != nil {
 			return nil, fmt.Errorf("price coverage scan: %w", err)
 		}
 		id := instID.String()
@@ -144,7 +144,7 @@ func (p *Postgres) PriceCoverage(ctx context.Context, instrumentIDs []string) ([
 			byInst[id] = entry
 			order = append(order, id)
 		}
-		entry.Ranges = append(entry.Ranges, db.DateRange{From: from, To: to})
+		entry.Ranges = append(entry.Ranges, db.DateRange{From: from, Before: before})
 	}
 	if err := rows.Err(); err != nil {
 		return nil, fmt.Errorf("price coverage rows: %w", err)
@@ -478,10 +478,10 @@ func (p *Postgres) UpsertPrices(ctx context.Context, prices []db.EODPrice) error
 
 // UpsertPricesWithFill implements db.PriceCacheDB.
 // It inserts real bars and generates synthetic LOCF prices for every date in
-// [from, to) that has no real bar, all in a single SQL round-trip. The last
+// [from, before) that has no real bar, all in a single SQL round-trip. The last
 // non-synthetic close price before `from` seeds the forward-fill for dates
 // preceding the first real bar.
-func (p *Postgres) UpsertPricesWithFill(ctx context.Context, instrumentID, provider string, bars []db.EODPrice, from, to time.Time, fetchedAt *time.Time) error {
+func (p *Postgres) UpsertPricesWithFill(ctx context.Context, instrumentID, provider string, bars []db.EODPrice, from, before time.Time, fetchedAt *time.Time) error {
 	id, err := uuid.Parse(instrumentID)
 	if err != nil {
 		return fmt.Errorf("upsert prices with fill: invalid id %q: %w", instrumentID, err)
@@ -556,7 +556,7 @@ func (p *Postgres) UpsertPricesWithFill(ctx context.Context, instrumentID, provi
 				NULL::double precision AS badjclose
 			FROM seed s
 			UNION ALL
-			-- Every date in [from, to) with real bar if available.
+			-- Every date in [from, before) with real bar if available.
 			SELECT d::date, nb.bopen, nb.bhigh, nb.blow, nb.bclose, nb.bvolume, nb.bbasis, nb.badjclose
 			FROM generate_series($2::date, $3::date - interval '1 day', '1 day') d
 			LEFT JOIN new_bars nb ON nb.price_date = d::date
@@ -593,7 +593,7 @@ func (p *Postgres) UpsertPricesWithFill(ctx context.Context, instrumentID, provi
 			share_count_basis = EXCLUDED.share_count_basis,
 			adjusted_close = EXCLUDED.adjusted_close
 		WHERE eod_prices.synthetic = true OR EXCLUDED.synthetic = false
-	`, id, from, to, pq.Array(dates), pq.Array(opens), pq.Array(highs),
+	`, id, from, before, pq.Array(dates), pq.Array(opens), pq.Array(highs),
 		pq.Array(lows), pq.Array(closes), pq.Array(volumes), provider, fetchedAt,
 		pq.Array(bases), pq.Array(adjCloses))
 	if err != nil {

--- a/server/db/postgres/price_cache_test.go
+++ b/server/db/postgres/price_cache_test.go
@@ -94,11 +94,11 @@ func assertInstrumentRanges(t *testing.T, got []db.InstrumentDateRanges, instID 
 			instID, len(found.Ranges), len(want), fmtRanges(found.Ranges), fmtRanges(want))
 	}
 	for i := range want {
-		if !found.Ranges[i].From.Equal(want[i].From) || !found.Ranges[i].To.Equal(want[i].To) {
+		if !found.Ranges[i].From.Equal(want[i].From) || !found.Ranges[i].Before.Equal(want[i].Before) {
 			t.Errorf("instrument %s range[%d]: got [%s, %s), want [%s, %s)",
 				instID, i,
-				found.Ranges[i].From.Format("2006-01-02"), found.Ranges[i].To.Format("2006-01-02"),
-				want[i].From.Format("2006-01-02"), want[i].To.Format("2006-01-02"))
+				found.Ranges[i].From.Format("2006-01-02"), found.Ranges[i].Before.Format("2006-01-02"),
+				want[i].From.Format("2006-01-02"), want[i].Before.Format("2006-01-02"))
 		}
 	}
 }
@@ -109,7 +109,7 @@ func fmtRanges(rs []db.DateRange) string {
 		if i > 0 {
 			s += ", "
 		}
-		s += "[" + r.From.Format("2006-01-02") + ", " + r.To.Format("2006-01-02") + ")"
+		s += "[" + r.From.Format("2006-01-02") + ", " + r.Before.Format("2006-01-02") + ")"
 	}
 	return s + "]"
 }
@@ -132,7 +132,7 @@ func TestHeldRanges_BuySell(t *testing.T) {
 		t.Fatalf("held ranges: %v", err)
 	}
 	assertInstrumentRanges(t, got, instID, []db.DateRange{
-		{From: d(2024, 1, 10), To: d(2024, 3, 15)},
+		{From: d(2024, 1, 10), Before: d(2024, 3, 15)},
 	})
 }
 
@@ -153,7 +153,7 @@ func TestHeldRanges_OpenPosition(t *testing.T) {
 		t.Fatalf("held ranges: %v", err)
 	}
 	assertInstrumentRanges(t, got, instID, []db.DateRange{
-		{From: d(2024, 6, 1), To: today.Add(db.Day)},
+		{From: d(2024, 6, 1), Before: today.Add(db.Day)},
 	})
 }
 
@@ -173,7 +173,7 @@ func TestHeldRanges_OpenPositionNoExtend(t *testing.T) {
 	}
 	// Without extend, open position just gets +1 day from range start.
 	assertInstrumentRanges(t, got, instID, []db.DateRange{
-		{From: d(2024, 6, 1), To: d(2024, 6, 2)},
+		{From: d(2024, 6, 1), Before: d(2024, 6, 2)},
 	})
 }
 
@@ -195,8 +195,8 @@ func TestHeldRanges_CloseAndReopen(t *testing.T) {
 		t.Fatalf("held ranges: %v", err)
 	}
 	assertInstrumentRanges(t, got, instID, []db.DateRange{
-		{From: d(2024, 1, 10), To: d(2024, 2, 15)},
-		{From: d(2024, 4, 1), To: d(2024, 5, 1)},
+		{From: d(2024, 1, 10), Before: d(2024, 2, 15)},
+		{From: d(2024, 4, 1), Before: d(2024, 5, 1)},
 	})
 }
 
@@ -256,10 +256,10 @@ func TestHeldRanges_MultipleInstruments(t *testing.T) {
 		t.Fatalf("expected 2 instruments, got %d", len(got))
 	}
 	assertInstrumentRanges(t, got, inst1, []db.DateRange{
-		{From: d(2024, 1, 1), To: d(2024, 2, 1)},
+		{From: d(2024, 1, 1), Before: d(2024, 2, 1)},
 	})
 	assertInstrumentRanges(t, got, inst2, []db.DateRange{
-		{From: d(2024, 3, 1), To: d(2024, 4, 1)},
+		{From: d(2024, 3, 1), Before: d(2024, 4, 1)},
 	})
 }
 
@@ -294,8 +294,8 @@ func TestHeldRanges_MultipleUsers(t *testing.T) {
 		t.Fatalf("held ranges: %v", err)
 	}
 	assertInstrumentRanges(t, got, instID, []db.DateRange{
-		{From: d(2024, 1, 1), To: d(2024, 2, 1)},
-		{From: d(2024, 3, 1), To: d(2024, 4, 1)},
+		{From: d(2024, 1, 1), Before: d(2024, 2, 1)},
+		{From: d(2024, 3, 1), Before: d(2024, 4, 1)},
 	})
 }
 
@@ -329,7 +329,7 @@ func TestPriceCoverage_Contiguous(t *testing.T) {
 		t.Fatalf("price coverage: %v", err)
 	}
 	assertInstrumentRanges(t, got, instID, []db.DateRange{
-		{From: d(2024, 1, 1), To: d(2024, 1, 6)},
+		{From: d(2024, 1, 1), Before: d(2024, 1, 6)},
 	})
 }
 
@@ -351,8 +351,8 @@ func TestPriceCoverage_WithGap(t *testing.T) {
 		t.Fatalf("price coverage: %v", err)
 	}
 	assertInstrumentRanges(t, got, instID, []db.DateRange{
-		{From: d(2024, 1, 1), To: d(2024, 1, 4)},
-		{From: d(2024, 1, 10), To: d(2024, 1, 13)},
+		{From: d(2024, 1, 1), Before: d(2024, 1, 4)},
+		{From: d(2024, 1, 10), Before: d(2024, 1, 13)},
 	})
 }
 
@@ -373,8 +373,8 @@ func TestPriceCoverage_WeekendGapNotBridged(t *testing.T) {
 		t.Fatalf("price coverage: %v", err)
 	}
 	assertInstrumentRanges(t, got, instID, []db.DateRange{
-		{From: d(2024, 1, 5), To: d(2024, 1, 6)},
-		{From: d(2024, 1, 8), To: d(2024, 1, 9)},
+		{From: d(2024, 1, 5), Before: d(2024, 1, 6)},
+		{From: d(2024, 1, 8), Before: d(2024, 1, 9)},
 	})
 }
 
@@ -396,7 +396,7 @@ func TestPriceCoverage_FilterByInstrument(t *testing.T) {
 		t.Fatalf("expected 1 instrument, got %d", len(got))
 	}
 	assertInstrumentRanges(t, got, inst1, []db.DateRange{
-		{From: d(2024, 1, 1), To: d(2024, 1, 2)},
+		{From: d(2024, 1, 1), Before: d(2024, 1, 2)},
 	})
 }
 
@@ -412,7 +412,7 @@ func TestPriceCoverage_SingleDay(t *testing.T) {
 		t.Fatalf("price coverage: %v", err)
 	}
 	assertInstrumentRanges(t, got, instID, []db.DateRange{
-		{From: d(2024, 6, 15), To: d(2024, 6, 16)},
+		{From: d(2024, 6, 15), Before: d(2024, 6, 16)},
 	})
 }
 
@@ -448,7 +448,7 @@ func TestPriceGaps_NoPrices(t *testing.T) {
 	}
 	// With no prices, gaps = entire held range.
 	assertInstrumentRanges(t, got, instID, []db.DateRange{
-		{From: d(2024, 1, 10), To: d(2024, 2, 10)},
+		{From: d(2024, 1, 10), Before: d(2024, 2, 10)},
 	})
 }
 
@@ -497,8 +497,8 @@ func TestPriceGaps_PartialCoverage(t *testing.T) {
 		t.Fatalf("price gaps: %v", err)
 	}
 	assertInstrumentRanges(t, got, instID, []db.DateRange{
-		{From: d(2024, 1, 1), To: d(2024, 1, 3)},
-		{From: d(2024, 1, 6), To: d(2024, 1, 10)},
+		{From: d(2024, 1, 1), Before: d(2024, 1, 3)},
+		{From: d(2024, 1, 6), Before: d(2024, 1, 10)},
 	})
 }
 
@@ -548,7 +548,7 @@ func TestUpsertPrices_Insert(t *testing.T) {
 		t.Fatalf("coverage: %v", err)
 	}
 	assertInstrumentRanges(t, cov, instID, []db.DateRange{
-		{From: d(2024, 1, 1), To: d(2024, 1, 2)},
+		{From: d(2024, 1, 1), Before: d(2024, 1, 2)},
 	})
 }
 
@@ -954,10 +954,10 @@ func TestFXGaps_MixedCurrencies(t *testing.T) {
 	}
 
 	assertInstrumentRanges(t, got, eurFX, []db.DateRange{
-		{From: d(2024, 1, 10), To: d(2024, 2, 10)},
+		{From: d(2024, 1, 10), Before: d(2024, 2, 10)},
 	})
 	assertInstrumentRanges(t, got, gbpFX, []db.DateRange{
-		{From: d(2024, 1, 10), To: d(2024, 2, 10)},
+		{From: d(2024, 1, 10), Before: d(2024, 2, 10)},
 	})
 	// USD instrument should NOT produce any FX gaps.
 	assertInstrumentRanges(t, got, usdInst, nil)
@@ -988,8 +988,8 @@ func TestFXGaps_PartialCoverage(t *testing.T) {
 
 	// Gaps should be [Jan 10, Jan 13) and [Jan 16, Jan 20).
 	assertInstrumentRanges(t, got, eurFX, []db.DateRange{
-		{From: d(2024, 1, 10), To: d(2024, 1, 13)},
-		{From: d(2024, 1, 16), To: d(2024, 1, 20)},
+		{From: d(2024, 1, 10), Before: d(2024, 1, 13)},
+		{From: d(2024, 1, 16), Before: d(2024, 1, 20)},
 	})
 }
 
@@ -1046,7 +1046,7 @@ func TestFXGaps_MultipleInstrumentsSameCurrency(t *testing.T) {
 
 	// Should produce a single merged range for EUR/USD: [Jan 5, Jan 30).
 	assertInstrumentRanges(t, got, eurFX, []db.DateRange{
-		{From: d(2024, 1, 5), To: d(2024, 1, 30)},
+		{From: d(2024, 1, 5), Before: d(2024, 1, 30)},
 	})
 }
 
@@ -1075,7 +1075,7 @@ func TestFXGaps_DisplayCurrency_USDHoldings(t *testing.T) {
 
 	// Even though all holdings are USD, we need EUR/USD rates because display=EUR.
 	assertInstrumentRanges(t, got, eurFX, []db.DateRange{
-		{From: d(2024, 1, 10), To: d(2024, 2, 10)},
+		{From: d(2024, 1, 10), Before: d(2024, 2, 10)},
 	})
 }
 
@@ -1107,7 +1107,7 @@ func TestFXGaps_DisplayCurrency_SkipsSameCurrency(t *testing.T) {
 	// instrument currency == display currency.
 	// Source 1 produces [Jan 10, Feb 10) for EUR/USD. No extra from display.
 	assertInstrumentRanges(t, got, eurFX, []db.DateRange{
-		{From: d(2024, 1, 10), To: d(2024, 2, 10)},
+		{From: d(2024, 1, 10), Before: d(2024, 2, 10)},
 	})
 }
 
@@ -1149,7 +1149,7 @@ func TestFXGaps_DisplayCurrency_MixedHoldings(t *testing.T) {
 
 	// GBP/USD needed from source 1 (held GBP instrument): [Jan 10, Jan 20).
 	assertInstrumentRanges(t, got, gbpFX, []db.DateRange{
-		{From: d(2024, 1, 10), To: d(2024, 1, 20)},
+		{From: d(2024, 1, 10), Before: d(2024, 1, 20)},
 	})
 
 	// EUR/USD needed from source 2 (display=EUR):
@@ -1157,8 +1157,8 @@ func TestFXGaps_DisplayCurrency_MixedHoldings(t *testing.T) {
 	// - USD instrument [Feb 1, Feb 10) has currency != EUR (USD, absent from heldToCurrency) → need EUR/USD
 	// Merged: [Jan 10, Jan 20) + [Feb 1, Feb 10)
 	assertInstrumentRanges(t, got, eurFX, []db.DateRange{
-		{From: d(2024, 1, 10), To: d(2024, 1, 20)},
-		{From: d(2024, 2, 1), To: d(2024, 2, 10)},
+		{From: d(2024, 1, 10), Before: d(2024, 1, 20)},
+		{From: d(2024, 2, 1), Before: d(2024, 2, 10)},
 	})
 }
 

--- a/server/plugins/eodhd/price/plugin.go
+++ b/server/plugins/eodhd/price/plugin.go
@@ -69,7 +69,7 @@ func (p *Plugin) AcceptableExchanges() map[string]bool { return nil }
 
 func (p *Plugin) AcceptableCurrencies() map[string]bool { return nil }
 
-func (p *Plugin) FetchPrices(ctx context.Context, config []byte, identifiers []pricefetcher.Identifier, assetClass string, from, to time.Time) (*pricefetcher.FetchResult, error) {
+func (p *Plugin) FetchPrices(ctx context.Context, config []byte, identifiers []pricefetcher.Identifier, assetClass string, from, before time.Time) (*pricefetcher.FetchResult, error) {
 	symbol, fxDivisor := p.symbolForAssetClass(identifiers, assetClass)
 	if symbol == "" {
 		return nil, pricefetcher.ErrNoData
@@ -80,18 +80,18 @@ func (p *Plugin) FetchPrices(ctx context.Context, config []byte, identifiers []p
 		return nil, err
 	}
 
-	// to is exclusive in our convention; EODHD API is inclusive.
-	toInclusive := to.AddDate(0, 0, -1)
-	if toInclusive.Before(from) {
+	// Our upper bound is exclusive; the EODHD API is inclusive.
+	beforeInclusive := before.AddDate(0, 0, -1)
+	if beforeInclusive.Before(from) {
 		return nil, pricefetcher.ErrNoData
 	}
 
 	var allBars []client.EODBar
 	chunkStart := from
-	for chunkStart.Before(toInclusive) || chunkStart.Equal(toInclusive) {
+	for chunkStart.Before(beforeInclusive) || chunkStart.Equal(beforeInclusive) {
 		chunkEnd := chunkStart.AddDate(0, 0, maxChunkDays-1)
-		if chunkEnd.After(toInclusive) {
-			chunkEnd = toInclusive
+		if chunkEnd.After(beforeInclusive) {
+			chunkEnd = beforeInclusive
 		}
 		fromStr := chunkStart.Format("2006-01-02")
 		toStr := chunkEnd.Format("2006-01-02")

--- a/server/plugins/massive/price/plugin.go
+++ b/server/plugins/massive/price/plugin.go
@@ -74,7 +74,7 @@ func (p *Plugin) AcceptableCurrencies() map[string]bool {
 // API caps daily bar responses at ~250 results; 200 keeps us safely under.
 const maxChunkDays = 200
 
-func (p *Plugin) FetchPrices(ctx context.Context, config []byte, identifiers []pricefetcher.Identifier, assetClass string, from, to time.Time) (*pricefetcher.FetchResult, error) {
+func (p *Plugin) FetchPrices(ctx context.Context, config []byte, identifiers []pricefetcher.Identifier, assetClass string, from, before time.Time) (*pricefetcher.FetchResult, error) {
 	ticker, fxDivisor := tickerForAssetClass(identifiers, assetClass)
 	if ticker == "" {
 		return nil, pricefetcher.ErrNoData
@@ -85,18 +85,18 @@ func (p *Plugin) FetchPrices(ctx context.Context, config []byte, identifiers []p
 		return nil, err
 	}
 
-	// to is exclusive in our convention; Massive API is inclusive, so subtract one day.
-	toInclusive := to.AddDate(0, 0, -1)
-	if toInclusive.Before(from) {
+	// Our upper bound is exclusive; the Massive API is inclusive, so subtract one day.
+	beforeInclusive := before.AddDate(0, 0, -1)
+	if beforeInclusive.Before(from) {
 		return nil, pricefetcher.ErrNoData
 	}
 
 	var allBars []client.AggBar
 	chunkStart := from
-	for chunkStart.Before(toInclusive) || chunkStart.Equal(toInclusive) {
+	for chunkStart.Before(beforeInclusive) || chunkStart.Equal(beforeInclusive) {
 		chunkEnd := chunkStart.AddDate(0, 0, maxChunkDays-1)
-		if chunkEnd.After(toInclusive) {
-			chunkEnd = toInclusive
+		if chunkEnd.After(beforeInclusive) {
+			chunkEnd = beforeInclusive
 		}
 		fromStr := chunkStart.Format("2006-01-02")
 		toStr := chunkEnd.Format("2006-01-02")

--- a/server/pricefetcher/plugin.go
+++ b/server/pricefetcher/plugin.go
@@ -110,7 +110,7 @@ type Plugin interface {
 	// nil or empty = all. Instruments with a null currency always pass.
 	AcceptableCurrencies() map[string]bool
 
-	// FetchPrices fetches EOD bars for the given instrument over [from, to).
+	// FetchPrices fetches EOD bars for the given instrument over [from, before).
 	// identifiers contains only the types declared by SupportedIdentifierTypes.
 	// assetClass is the instrument's asset class so the plugin can adjust
 	// behavior (e.g. stock ticker vs option OCC symbol format).
@@ -120,7 +120,7 @@ type Plugin interface {
 	// providers (e.g. GBXUSD for British pence). Plugins must handle these
 	// by fetching the source pair and scaling the result. Use RewriteFXPair
 	// to detect derived pairs and ScaleBars to apply the conversion.
-	FetchPrices(ctx context.Context, config []byte, identifiers []Identifier, assetClass string, from, to time.Time) (*FetchResult, error)
+	FetchPrices(ctx context.Context, config []byte, identifiers []Identifier, assetClass string, from, before time.Time) (*FetchResult, error)
 
 	// DefaultConfig returns the plugin's default config JSON. Inserted on
 	// startup when no row exists so the admin can edit via the UI.

--- a/server/pricefetcher/worker.go
+++ b/server/pricefetcher/worker.go
@@ -181,7 +181,7 @@ func processGaps(ctx context.Context, database db.DB, plugins []pluginEntry, gap
 				gap := gap // copy for truncation
 				if pe.maxHistDays != nil && *pe.maxHistDays > 0 {
 					cutoff := time.Now().UTC().Truncate(db.Day).AddDate(0, 0, -*pe.maxHistDays)
-					if !gap.To.After(cutoff) {
+					if !gap.Before.After(cutoff) {
 						continue // entire gap older than history limit
 					}
 					if gap.From.Before(cutoff) {
@@ -193,7 +193,7 @@ func processGaps(ctx context.Context, database db.DB, plugins []pluginEntry, gap
 					assetClass = *inst.AssetClass
 				}
 					callCtx, callCancel := context.WithTimeout(ctx, pluginutil.TimeoutFromConfig(pe.config, DefaultPricePluginTimeout))
-				result, err := pe.plugin.FetchPrices(callCtx, pe.config, pfIDs, assetClass, gap.From, gap.To)
+				result, err := pe.plugin.FetchPrices(callCtx, pe.config, pfIDs, assetClass, gap.From, gap.Before)
 				callCancel()
 				if err != nil {
 					var permErr *ErrPermanent
@@ -218,7 +218,7 @@ func processGaps(ctx context.Context, database db.DB, plugins []pluginEntry, gap
 				}
 
 				prices := barsToEODPrices(ig.InstrumentID, pe.id, result.Bars, result.ShareCountBasis, now)
-				if err := database.UpsertPricesWithFill(ctx, ig.InstrumentID, pe.id, prices, gap.From, gap.To, nil); err != nil {
+				if err := database.UpsertPricesWithFill(ctx, ig.InstrumentID, pe.id, prices, gap.From, gap.Before, nil); err != nil {
 					if log != nil {
 						log.ErrorContext(ctx, "price fetch: upsert", "instrument", ig.InstrumentID, "err", err)
 					}

--- a/server/pricefetcher/worker_test.go
+++ b/server/pricefetcher/worker_test.go
@@ -143,7 +143,7 @@ func TestRunCycle_FXGapsProcessed(t *testing.T) {
 	// PriceGaps returns empty, FXGaps returns a gap for an FX instrument.
 	mockDB.EXPECT().PriceGaps(gomock.Any(), gomock.Any()).Return(nil, nil)
 	mockDB.EXPECT().FXGaps(gomock.Any(), gomock.Any()).Return([]db.InstrumentDateRanges{
-		{InstrumentID: fxInstID, Ranges: []db.DateRange{{From: from, To: to}}},
+		{InstrumentID: fxInstID, Ranges: []db.DateRange{{From: from, Before: to}}},
 	}, nil)
 	mockDB.EXPECT().ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryPrice).Return([]db.PluginConfigRow{
 		{PluginID: pluginID, Precedence: 10, Config: []byte("{}")},
@@ -175,12 +175,12 @@ type filterStub struct {
 	currencies   map[string]bool
 }
 
-func (s *filterStub) DisplayName() string                        { return "stub" }
-func (s *filterStub) SupportedIdentifierTypes() []string         { return nil }
-func (s *filterStub) AcceptableAssetClasses() map[string]bool    { return s.assetClasses }
-func (s *filterStub) AcceptableExchanges() map[string]bool       { return s.exchanges }
-func (s *filterStub) AcceptableCurrencies() map[string]bool      { return s.currencies }
-func (s *filterStub) DefaultConfig() []byte                      { return nil }
+func (s *filterStub) DisplayName() string                     { return "stub" }
+func (s *filterStub) SupportedIdentifierTypes() []string      { return nil }
+func (s *filterStub) AcceptableAssetClasses() map[string]bool { return s.assetClasses }
+func (s *filterStub) AcceptableExchanges() map[string]bool    { return s.exchanges }
+func (s *filterStub) AcceptableCurrencies() map[string]bool   { return s.currencies }
+func (s *filterStub) DefaultConfig() []byte                   { return nil }
 func (s *filterStub) FetchPrices(_ context.Context, _ []byte, _ []Identifier, _ string, _, _ time.Time) (*FetchResult, error) {
 	return nil, ErrNoData
 }
@@ -220,7 +220,7 @@ func TestRunCycle_BlockedPluginSkipped(t *testing.T) {
 
 	mockDB.EXPECT().FXGaps(gomock.Any(), gomock.Any()).Return(nil, nil)
 	mockDB.EXPECT().PriceGaps(gomock.Any(), gomock.Any()).Return([]db.InstrumentDateRanges{
-		{InstrumentID: instID, Ranges: []db.DateRange{{From: from, To: to}}},
+		{InstrumentID: instID, Ranges: []db.DateRange{{From: from, Before: to}}},
 	}, nil)
 	mockDB.EXPECT().ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryPrice).Return([]db.PluginConfigRow{
 		{PluginID: pluginID, Precedence: 10, Config: []byte("{}")},
@@ -265,7 +265,7 @@ func TestRunCycle_ErrPermanentCreatesBlock(t *testing.T) {
 
 	mockDB.EXPECT().FXGaps(gomock.Any(), gomock.Any()).Return(nil, nil)
 	mockDB.EXPECT().PriceGaps(gomock.Any(), gomock.Any()).Return([]db.InstrumentDateRanges{
-		{InstrumentID: instID, Ranges: []db.DateRange{{From: from, To: to}}},
+		{InstrumentID: instID, Ranges: []db.DateRange{{From: from, Before: to}}},
 	}, nil)
 	mockDB.EXPECT().ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryPrice).Return([]db.PluginConfigRow{
 		{PluginID: pluginID, Precedence: 10, Config: []byte("{}")},
@@ -314,7 +314,7 @@ func TestRunCycle_MaxHistoryTruncation(t *testing.T) {
 
 	mockDB.EXPECT().FXGaps(gomock.Any(), gomock.Any()).Return(nil, nil)
 	mockDB.EXPECT().PriceGaps(gomock.Any(), gomock.Any()).Return([]db.InstrumentDateRanges{
-		{InstrumentID: instID, Ranges: []db.DateRange{{From: from, To: to}}},
+		{InstrumentID: instID, Ranges: []db.DateRange{{From: from, Before: to}}},
 	}, nil)
 	mockDB.EXPECT().ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryPrice).Return([]db.PluginConfigRow{
 		{PluginID: pluginID, Precedence: 10, Config: []byte("{}"), MaxHistoryDays: &maxDays},
@@ -361,7 +361,7 @@ func TestRunCycle_MaxHistorySkipsOldGap(t *testing.T) {
 
 	mockDB.EXPECT().FXGaps(gomock.Any(), gomock.Any()).Return(nil, nil)
 	mockDB.EXPECT().PriceGaps(gomock.Any(), gomock.Any()).Return([]db.InstrumentDateRanges{
-		{InstrumentID: instID, Ranges: []db.DateRange{{From: from, To: to}}},
+		{InstrumentID: instID, Ranges: []db.DateRange{{From: from, Before: to}}},
 	}, nil)
 	mockDB.EXPECT().ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryPrice).Return([]db.PluginConfigRow{
 		{PluginID: pluginID, Precedence: 10, Config: []byte("{}"), MaxHistoryDays: &maxDays},
@@ -445,4 +445,3 @@ func TestRunWorker_DebounceCollapsesTriggers(t *testing.T) {
 		t.Errorf("expected exactly 2 cycles (1 running + 1 buffered), got %d", cycles)
 	}
 }
-

--- a/server/service/api/price_gaps.go
+++ b/server/service/api/price_gaps.go
@@ -90,16 +90,16 @@ func toPriceGapProtos(gaps []db.InstrumentDateRanges, instrMap map[string]*db.In
 		}
 		dateRanges := make([]*apiv1.DateRange, 0, len(g.Ranges))
 		for _, r := range g.Ranges {
-			to := r.To
-			if to.After(today) {
-				to = today
+			before := r.Before
+			if before.After(today) {
+				before = today
 			}
-			if !r.From.Before(to) {
+			if !r.From.Before(before) {
 				continue // empty range after clamping
 			}
 			dateRanges = append(dateRanges, &apiv1.DateRange{
-				From: r.From.Format("2006-01-02"),
-				To:   to.Format("2006-01-02"),
+				From:   r.From.Format("2006-01-02"),
+				Before: before.Format("2006-01-02"),
 			})
 		}
 		if len(dateRanges) == 0 {

--- a/server/service/api/price_gaps_test.go
+++ b/server/service/api/price_gaps_test.go
@@ -53,7 +53,7 @@ func TestListPriceGaps_Success(t *testing.T) {
 		{
 			InstrumentID: "inst-1",
 			Ranges: []dbpkg.DateRange{
-				{From: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), To: time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)},
+				{From: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), Before: time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC)},
 			},
 		},
 	}
@@ -61,7 +61,7 @@ func TestListPriceGaps_Success(t *testing.T) {
 		{
 			InstrumentID: "inst-fx",
 			Ranges: []dbpkg.DateRange{
-				{From: time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC), To: time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC)},
+				{From: time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC), Before: time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC)},
 			},
 		},
 	}
@@ -120,8 +120,8 @@ func TestListPriceGaps_Success(t *testing.T) {
 	if len(pg.GetGaps()) != 1 {
 		t.Fatalf("expected 1 gap range, got %d", len(pg.GetGaps()))
 	}
-	if pg.GetGaps()[0].GetFrom() != "2024-01-01" || pg.GetGaps()[0].GetTo() != "2024-06-01" {
-		t.Fatalf("unexpected gap range: %s - %s", pg.GetGaps()[0].GetFrom(), pg.GetGaps()[0].GetTo())
+	if pg.GetGaps()[0].GetFrom() != "2024-01-01" || pg.GetGaps()[0].GetBefore() != "2024-06-01" {
+		t.Fatalf("unexpected gap range: %s - %s", pg.GetGaps()[0].GetFrom(), pg.GetGaps()[0].GetBefore())
 	}
 
 	if len(resp.GetFxGaps()) != 1 {
@@ -152,8 +152,8 @@ func TestListPriceGaps_AssetClassFilter(t *testing.T) {
 		},
 	}
 	priceGaps := []dbpkg.InstrumentDateRanges{
-		{InstrumentID: "inst-stock", Ranges: []dbpkg.DateRange{{From: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), To: time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)}}},
-		{InstrumentID: "inst-etf", Ranges: []dbpkg.DateRange{{From: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), To: time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)}}},
+		{InstrumentID: "inst-stock", Ranges: []dbpkg.DateRange{{From: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), Before: time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)}}},
+		{InstrumentID: "inst-etf", Ranges: []dbpkg.DateRange{{From: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), Before: time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)}}},
 	}
 
 	db.EXPECT().PriceGaps(gomock.Any(), gomock.Any()).Return(priceGaps, nil)
@@ -187,7 +187,7 @@ func TestListPriceGaps_SkipsInstrumentsWithoutUsableIdentifier(t *testing.T) {
 		},
 	}
 	priceGaps := []dbpkg.InstrumentDateRanges{
-		{InstrumentID: "inst-no-id", Ranges: []dbpkg.DateRange{{From: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), To: time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)}}},
+		{InstrumentID: "inst-no-id", Ranges: []dbpkg.DateRange{{From: time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC), Before: time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)}}},
 	}
 
 	db.EXPECT().PriceGaps(gomock.Any(), gomock.Any()).Return(priceGaps, nil)

--- a/server/service/ingestion/price_worker.go
+++ b/server/service/ingestion/price_worker.go
@@ -186,14 +186,14 @@ func upsertWithCoverage(ctx context.Context, database db.DB, prices []db.EODPric
 	}
 
 	// Build map: instrument ID -> []coverage ranges.
-	type dateRange struct{ from, to time.Time }
+	type dateRange struct{ from, before time.Time }
 	instCoverage := make(map[string][]dateRange)
 	for _, c := range coverage {
 		from, err := time.Parse("2006-01-02", c.GetFrom())
 		if err != nil {
 			continue
 		}
-		to, err := time.Parse("2006-01-02", c.GetTo())
+		before, err := time.Parse("2006-01-02", c.GetBefore())
 		if err != nil {
 			continue
 		}
@@ -202,7 +202,7 @@ func upsertWithCoverage(ctx context.Context, database db.DB, prices []db.EODPric
 		if !ok || entry.err != nil || entry.result.InstrumentID == "" {
 			continue
 		}
-		instCoverage[entry.result.InstrumentID] = append(instCoverage[entry.result.InstrumentID], dateRange{from, to})
+		instCoverage[entry.result.InstrumentID] = append(instCoverage[entry.result.InstrumentID], dateRange{from, before})
 	}
 
 	// Group prices by instrument ID.
@@ -224,7 +224,7 @@ func upsertWithCoverage(ctx context.Context, database db.DB, prices []db.EODPric
 			// Filter prices within this range.
 			var inRange []db.EODPrice
 			for i, p := range instPrices {
-				if !p.PriceDate.Before(r.from) && p.PriceDate.Before(r.to) {
+				if !p.PriceDate.Before(r.from) && p.PriceDate.Before(r.before) {
 					inRange = append(inRange, p)
 					covered[i] = true
 				}
@@ -237,7 +237,7 @@ func upsertWithCoverage(ctx context.Context, database db.DB, prices []db.EODPric
 			if len(inRange) > 0 {
 				fetchedAt = inRange[0].LastFetchedAt
 			}
-			if err := database.UpsertPricesWithFill(ctx, instID, provider, inRange, r.from, r.to, fetchedAt); err != nil {
+			if err := database.UpsertPricesWithFill(ctx, instID, provider, inRange, r.from, r.before, fetchedAt); err != nil {
 				return err
 			}
 		}

--- a/server/service/ingestion/price_worker_test.go
+++ b/server/service/ingestion/price_worker_test.go
@@ -146,7 +146,7 @@ func TestProcessPriceImport_WithCoverage_UsesUpsertWithFill(t *testing.T) {
 				IdentifierValue:  "AAPL",
 				IdentifierDomain: "XNAS",
 				From:             "2024-01-01",
-				To:               "2024-04-01",
+				Before:           "2024-04-01",
 			},
 		},
 	}
@@ -202,7 +202,7 @@ func TestProcessPriceImport_WithCoverage_NoCoverageForInstrument_UsesPlanUpsert(
 				IdentifierType:  "FX_PAIR",
 				IdentifierValue: "GBPUSD",
 				From:            "2024-01-01",
-				To:              "2024-04-01",
+				Before:          "2024-04-01",
 			},
 		},
 	}


### PR DESCRIPTION
First of six PRs closing 0056. Establishes the `[from, before)` vocabulary where behaviour already complies, so the later PRs -- which change semantics -- produce compile errors at every call site rather than silent off-by-ones.

## What changes

- `DateRange.to` -> `before` and `ImportCoverage.to` -> `before` on the wire; both were already documented half-open.
- `db.DateRange.To` -> `Before`, `UpsertPricesWithFill`'s `to` param, and the `FetchPrices` plugin interface.
- The two price plugins' `toInclusive` locals become `beforeInclusive`, keeping the comment that names the provider's inclusive convention.
- `Instrument.valid_from` / `valid_to` documented as a deliberate exemption: providers supply an inclusive last trading date and no query filters on either bound.

No behaviour changes. `SubtractRanges`' loop guard is rewritten from `To.Before(x) || To.Equal(x)` to `!Before.After(x)` -- same predicate, one comparison.

## Docs

New `adr/0018-half-open-date-intervals.md` records why `before` rather than a documented `to`: a comment is read only when someone goes looking, a name is read at every call site. ADR 0007 now points at it; `bitemporality.md` states the rule normatively for the wire as well as the DB.

## Verification

`make server-test`, `make db-test`, `make client-test`, `make extension-test`, `make integration-test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)