### PR TITLE
Record how to merge a stack of PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -61,7 +61,21 @@ Prefer smaller, focused PRs to reduce review burden:
 
 Smaller PRs are easier to review, less likely to introduce bugs, and create cleaner git history.
 
-When merging PRs always squash the commits and remove the feature branch.
+### Merging
+
+Always squash: `gh pr merge <n> --squash`. **Never pass `--delete-branch`.** The
+repository has `delete_branch_on_merge` enabled, so the branch is removed as part
+of the merge, and that merge-linked deletion is what retargets any PR based on
+the branch. An explicit ref deletion is a plain branch deletion instead, which
+**closes** dependent PRs rather than retargeting them.
+
+Merge a stack parent first, one at a time, and let each merge retarget the next.
+
+CI runs on `pull_request` against `main`, and a retarget is an `edited` event the
+workflow does not listen for. So when a merge retargets the next PR in the stack
+and it needs no conflict resolution, its required checks will not have run --
+push to the branch to start them. When the retarget does leave conflicts,
+resolving them produces a push and CI runs on its own.
 
 ### Branching Workflow
 


### PR DESCRIPTION
Follow-up to the 0056 series (#270-#276), which hit two traps worth writing down in CLAUDE.md.

**`--delete-branch` closes dependent PRs.** It deletes the branch as a separate ref deletion after the merge, and a plain branch deletion closes any PR targeting it -- that is what happened to #271. The repository already has `delete_branch_on_merge` enabled, and it is that merge-linked deletion which retargets dependents to the merged PR's base. So the flag is both redundant and destructive here.

**A stacked PR gets no CI.** The workflow runs on `pull_request` against `main`, and the ruleset requiring `server-test`/`client-test`/`db-test` governs merges into `main`. A PR aimed at a feature branch is governed by nothing, so it reports `MERGEABLE`/`CLEAN` having never run a check. Retargeting does not start one either -- the workflow does not listen for `edited` -- so a cleanly retargeted PR needs a push, whereas one that needed conflicts resolved gets CI from that push for free.

Docs only; no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)