### PR TITLE
Open issues for price CSV basis and the option split expiry guard

### DIFF
--- a/docs/issues/0057-price-csv-share-count-basis.md
+++ b/docs/issues/0057-price-csv-share-count-basis.md
@@ -1,0 +1,38 @@
+---
+status: open
+title: Carry share_count_basis through the price CSV import and export
+---
+
+Let a price CSV declare which share count its values are denominated in, so a
+back-adjusted series is not adjusted a second time on import.
+
+## Motivation
+
+`ImportPriceRow.share_count_basis` exists and defaults to `price_date`, meaning
+as-traded. Nothing on the CSV path can set it: `csvToPrices` does not read a
+`share_count_basis` column, and `ExportPriceRow` has no such field, so the round
+trip cannot carry it either.
+
+A file holding a back-adjusted series therefore imports as as-traded, and
+`RecomputeSplitAdjustments` divides its pre-split rows by the split factor a
+second time while the matching transaction quantities are multiplied by it. The
+result is silently wrong rather than rejected: a NVDA holding before 2024-06-10
+values 10x low, AMZN, GOOG and GOOGL before their 2022 splits 20x, TSLA 3x.
+
+This is not hypothetical. GOOGLEFINANCE returns split-adjusted historical
+closes, so any price file built from it is back-adjusted, including the one the
+project's own manual-test data was derived from.
+
+## Design
+
+Mirror the two conventions the format already has, so the basis can be declared
+once for a whole file and overridden per row where a file mixes vintages:
+
+- A file-level `# share_count_basis=YYYY-MM-DD` comment header, exactly as the
+  standard transaction CSV already carries (see docs/spec/csv-format.md).
+- The per-row `share_count_basis` column, overriding the header for that row.
+
+Add `share_count_basis` to `ExportPriceRow` and emit both from `pricesToCsv` so
+the round trip is lossless.
+
+See docs/spec/bitemporality.md.

--- a/docs/issues/0058-option-split-expiry-guard.md
+++ b/docs/issues/0058-option-split-expiry-guard.md
@@ -1,0 +1,35 @@
+---
+status: open
+title: Do not retroactively restate options that expired before the split
+---
+
+`ListPendingOptionSplits` selects options whose identity predates an effective
+split on the underlying, without checking whether the option was still live on
+the ex_date.
+
+## Motivation
+
+The predicate is `ex_date <= CURRENT_DATE AND (identity_as_of IS NULL OR
+identity_as_of < ex_date)`. An option that expired *before* the ex_date satisfies
+it, so `ApplyOptionSplit` rewrites its OCC identifier and strike to a contract
+that never traded. OCC restates a contract on the effective date; one that had
+already expired was never restated.
+
+Importing a pre-split option price file makes this reachable, since the file's
+`exported_at` puts `identity_as_of` before the ex_date by design -- that is how
+the genuinely-restated contracts get picked up. Two NVDA puts expiring
+2024-03-15, before the 2024-06-10 split, would be rewritten from strikes 420 and
+510 to 42 and 51.
+
+Distinct from 0055, which concerned which clock the guard compares rather than
+which options it selects.
+
+## Design
+
+Add the expiry to the predicate. `instruments.expiry` is already NOT NULL for
+options via the check constraint in 001_initial.sql, so no schema change is
+needed.
+
+Consider whether an option expiring on the ex_date itself should be adjusted:
+OCC restates it, and it can still be exercised that day, so the comparison is
+likely `expiry >= ex_date` rather than `expiry > ex_date`.


### PR DESCRIPTION
Two issues found while investigating the manual-test price data in `local/`.

**0057 -- price CSV `share_count_basis`.** `ImportPriceRow.share_count_basis` exists and defaults to `price_date`, but nothing on the CSV path can set it: `csvToPrices` does not read the column and `ExportPriceRow` has no such field. A back-adjusted series therefore imports as as-traded and gets adjusted a second time once splits land -- silently wrong rather than rejected. GOOGLEFINANCE returns split-adjusted historical closes, so this affects any file built from it.

**0058 -- option split expiry guard.** `ListPendingOptionSplits` selects on `ex_date <= CURRENT_DATE AND identity_as_of < ex_date` with no expiry check, so an option that expired *before* the ex_date is still restated to an OCC symbol and strike that never traded. Reachable when importing a pre-split option price file, which is exactly the case where `identity_as_of` is deliberately put before the ex_date. Distinct from the closed 0055, which concerned which clock the guard compares rather than which options it selects.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)