### PR TITLE
Let price and corporate event imports declare coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,7 @@ Whenever you begin work in a new worktree you should:
 
 The informantion architecture of the user interface is described in docs/spec/information-architecture.md.  It describes key concepts for users (and admin users), how they relate to each other, the relative importance they carry for the user and gives the example of how the information architecture should impact global navigation.
 
-The CSV format specification for transaction uploads is documented in docs/spec/csv-format.md.
+The file formats for transaction, price and corporate event imports are documented in docs/spec/csv-format.md.
 
 Automated transaction import via the browser extension is specified in docs/spec/broker-import-extension.md.
 

--- a/client/app/admin/corporate-events/import-splits-modal.tsx
+++ b/client/app/admin/corporate-events/import-splits-modal.tsx
@@ -67,7 +67,7 @@ export function ImportSplitsModal({
     setPhase("processing");
     setImportError(null);
     try {
-      const id = await importCorporateEventSplits(parseResult.splits);
+      const id = await importCorporateEventSplits(parseResult.splits, parseResult.coverage);
       setJobId(id);
     } catch (err) {
       setImportError(err instanceof Error ? err.message : String(err));
@@ -186,7 +186,15 @@ export function ImportSplitsModal({
               <p className="text-sm text-text-primary">
                 Ready to import{" "}
                 <span className="font-semibold">{parseResult.splits.length}</span>{" "}
-                split{parseResult.splits.length !== 1 ? "s" : ""}.
+                split{parseResult.splits.length !== 1 ? "s" : ""}
+                {parseResult.coverage.length > 0 && (
+                  <>
+                    {" "}with{" "}
+                    <span className="font-semibold">{parseResult.coverage.length}</span>{" "}
+                    coverage span{parseResult.coverage.length !== 1 ? "s" : ""}
+                  </>
+                )}
+                .
               </p>
             )}
 

--- a/client/app/admin/prices/import-modal.tsx
+++ b/client/app/admin/prices/import-modal.tsx
@@ -68,7 +68,7 @@ export function ImportPricesModal({
     setPhase("processing");
     setImportError(null);
     try {
-      const id = await importPrices(parseResult.prices, parseResult.exportedAt);
+      const id = await importPrices(parseResult.prices, parseResult.exportedAt, parseResult.coverage);
       setJobId(id);
     } catch (err) {
       setImportError(err instanceof Error ? err.message : String(err));
@@ -187,7 +187,15 @@ export function ImportPricesModal({
               <p className="text-sm text-text-primary">
                 Ready to import{" "}
                 <span className="font-semibold">{parseResult.prices.length}</span>{" "}
-                price{parseResult.prices.length !== 1 ? "s" : ""}.
+                price{parseResult.prices.length !== 1 ? "s" : ""}
+                {parseResult.coverage.length > 0 && (
+                  <>
+                    {" "}with{" "}
+                    <span className="font-semibold">{parseResult.coverage.length}</span>{" "}
+                    coverage span{parseResult.coverage.length !== 1 ? "s" : ""}
+                  </>
+                )}
+                .
               </p>
             )}
 

--- a/client/lib/coverage.test.ts
+++ b/client/lib/coverage.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import { expandCoverage, isGlobal, validateCoverage } from "./coverage";
+import type { CoverageDecl, InstrumentRef } from "./coverage";
+
+function decl(overrides: Partial<CoverageDecl> = {}): CoverageDecl {
+  return { from: "2024-01-01", before: "2024-02-01", rowIndex: 1, ...overrides };
+}
+
+function ref(value: string, type = "MIC_TICKER", domain = "XNAS"): InstrumentRef {
+  return { identifierType: type, identifierValue: value, identifierDomain: domain };
+}
+
+describe("isGlobal", () => {
+  it("is true when no identifier field is set", () => {
+    expect(isGlobal(decl())).toBe(true);
+  });
+
+  it("is false when any identifier field is set", () => {
+    expect(isGlobal(decl({ identifierValue: "AAPL" }))).toBe(false);
+    expect(isGlobal(decl({ identifierDomain: "XNAS" }))).toBe(false);
+  });
+});
+
+describe("validateCoverage", () => {
+  it("accepts a global declaration", () => {
+    expect(validateCoverage(decl())).toEqual([]);
+  });
+
+  it("accepts a specific declaration", () => {
+    const errors = validateCoverage(
+      decl({ identifierType: "MIC_TICKER", identifierValue: "AAPL", identifierDomain: "XNAS" }),
+    );
+    expect(errors).toEqual([]);
+  });
+
+  it("accepts a specific declaration with an empty domain", () => {
+    const errors = validateCoverage(
+      decl({ identifierType: "OCC", identifierValue: "AAPL250117P00185000" }),
+    );
+    expect(errors).toEqual([]);
+  });
+
+  it("rejects an unknown identifier type", () => {
+    const errors = validateCoverage(decl({ identifierType: "SEDOL_ISH", identifierValue: "X" }));
+    expect(errors).toHaveLength(1);
+    expect(errors[0].field).toBe("identifier_type");
+  });
+
+  it("rejects a half-specified identifier rather than treating it as global", () => {
+    const missingValue = validateCoverage(decl({ identifierType: "MIC_TICKER" }));
+    expect(missingValue.map((e) => e.field)).toEqual(["identifier_value"]);
+
+    const domainOnly = validateCoverage(decl({ identifierDomain: "XNAS" }));
+    expect(domainOnly.map((e) => e.field)).toEqual(["identifier_type", "identifier_value"]);
+  });
+
+  it("rejects malformed dates", () => {
+    expect(validateCoverage(decl({ from: "2024-1-1" })).map((e) => e.field)).toEqual(["from"]);
+    expect(validateCoverage(decl({ before: "01/02/2024" })).map((e) => e.field)).toEqual(["before"]);
+  });
+
+  it("rejects an empty or inverted span", () => {
+    const empty = validateCoverage(decl({ from: "2024-01-01", before: "2024-01-01" }));
+    expect(empty.map((e) => e.field)).toEqual(["before"]);
+
+    const inverted = validateCoverage(decl({ from: "2024-02-01", before: "2024-01-01" }));
+    expect(inverted.map((e) => e.field)).toEqual(["before"]);
+  });
+
+  it("reports errors against the declaration's own row", () => {
+    const errors = validateCoverage(decl({ from: "nonsense", rowIndex: 7 }));
+    expect(errors[0].rowIndex).toBe(7);
+  });
+});
+
+describe("expandCoverage", () => {
+  it("fans a global out to every instrument", () => {
+    const { resolved, errors } = expandCoverage(
+      [decl()],
+      [ref("AAPL"), ref("MSFT")],
+    );
+    expect(errors).toEqual([]);
+    expect(resolved).toEqual([
+      { ...ref("AAPL"), from: "2024-01-01", before: "2024-02-01" },
+      { ...ref("MSFT"), from: "2024-01-01", before: "2024-02-01" },
+    ]);
+  });
+
+  it("emits nothing when there is no declaration", () => {
+    expect(expandCoverage([], [ref("AAPL")]).resolved).toEqual([]);
+  });
+
+  it("emits nothing for an instrument-free file", () => {
+    expect(expandCoverage([decl()], []).resolved).toEqual([]);
+  });
+
+  it("lets a specific declaration override the global for that instrument only", () => {
+    const { resolved } = expandCoverage(
+      [
+        decl(),
+        decl({ ...ref("MSFT"), from: "2024-03-01", before: "2024-04-01", rowIndex: 2 }),
+      ],
+      [ref("AAPL"), ref("MSFT")],
+    );
+    expect(resolved).toEqual([
+      { ...ref("AAPL"), from: "2024-01-01", before: "2024-02-01" },
+      { ...ref("MSFT"), from: "2024-03-01", before: "2024-04-01" },
+    ]);
+  });
+
+  it("keeps several spans for one instrument and still suppresses the global", () => {
+    const { resolved } = expandCoverage(
+      [
+        decl(),
+        decl({ ...ref("MSFT"), from: "2024-03-01", before: "2024-04-01", rowIndex: 2 }),
+        decl({ ...ref("MSFT"), from: "2024-06-01", before: "2024-07-01", rowIndex: 3 }),
+      ],
+      [ref("MSFT")],
+    );
+    expect(resolved).toEqual([
+      { ...ref("MSFT"), from: "2024-03-01", before: "2024-04-01" },
+      { ...ref("MSFT"), from: "2024-06-01", before: "2024-07-01" },
+    ]);
+  });
+
+  it("distinguishes instruments by their whole identifier triple", () => {
+    const { resolved } = expandCoverage(
+      [decl(), decl({ ...ref("AAPL", "MIC_TICKER", "XLON"), from: "2024-03-01", before: "2024-04-01", rowIndex: 2 })],
+      [ref("AAPL", "MIC_TICKER", "XNAS"), ref("AAPL", "MIC_TICKER", "XLON")],
+    );
+    expect(resolved).toEqual([
+      { ...ref("AAPL", "MIC_TICKER", "XNAS"), from: "2024-01-01", before: "2024-02-01" },
+      { ...ref("AAPL", "MIC_TICKER", "XLON"), from: "2024-03-01", before: "2024-04-01" },
+    ]);
+  });
+
+  it("emits one entry per instrument however many rows name it", () => {
+    const { resolved } = expandCoverage([decl()], [ref("AAPL"), ref("AAPL"), ref("AAPL")]);
+    expect(resolved).toHaveLength(1);
+  });
+
+  it("rejects a second global", () => {
+    const { errors } = expandCoverage(
+      [decl(), decl({ from: "2020-01-01", before: "2021-01-01", rowIndex: 4 })],
+      [ref("AAPL")],
+    );
+    expect(errors).toHaveLength(1);
+    expect(errors[0].rowIndex).toBe(4);
+    expect(errors[0].message).toMatch(/one global/i);
+  });
+
+  it("keeps a specific declaration for an instrument the file has no rows for", () => {
+    const { resolved, errors } = expandCoverage(
+      [decl({ ...ref("TSLA"), rowIndex: 2 })],
+      [ref("AAPL")],
+    );
+    expect(errors).toEqual([]);
+    expect(resolved).toEqual([{ ...ref("TSLA"), from: "2024-01-01", before: "2024-02-01" }]);
+  });
+});

--- a/client/lib/coverage.ts
+++ b/client/lib/coverage.ts
@@ -1,0 +1,158 @@
+/**
+ * Coverage declarations, shared by the price CSV and the corporate event JSON.
+ *
+ * A declaration is a half-open [from, before) span. It is either global -- no
+ * identifier, applying to every instrument in the file -- or specific to one
+ * instrument. The wire has no notion of a global: both ImportCoverage and
+ * ImportCorporateEventCoverage name an instrument, so expandCoverage resolves
+ * the global against the file's contents before the request is built.
+ *
+ * See docs/spec/csv-format.md for the syntax each format uses.
+ */
+
+import type { ParseError } from "@/lib/csv/standard";
+import { VALID_IDENTIFIER_TYPES } from "@/lib/identifiers";
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/** An instrument named by its identifier triple. */
+export interface InstrumentRef {
+  identifierType: string;
+  identifierValue: string;
+  identifierDomain: string;
+}
+
+/**
+ * One coverage declaration as written in a file. The identifier is either
+ * wholly absent, making the declaration global, or names one instrument.
+ */
+export interface CoverageDecl {
+  identifierType?: string;
+  identifierValue?: string;
+  identifierDomain?: string;
+  from: string;
+  before: string;
+  /** Where the declaration was written, for error reporting. */
+  rowIndex: number;
+}
+
+/** A declaration resolved to exactly one instrument, ready for the wire. */
+export interface ResolvedCoverage extends InstrumentRef {
+  from: string;
+  before: string;
+}
+
+/** True when the declaration names no instrument and so applies to all of them. */
+export function isGlobal(c: CoverageDecl): boolean {
+  return !c.identifierType && !c.identifierValue && !c.identifierDomain;
+}
+
+function refKey(r: Partial<InstrumentRef>): string {
+  return `${r.identifierType ?? ""}\x00${r.identifierValue ?? ""}\x00${r.identifierDomain ?? ""}`;
+}
+
+/**
+ * Validate one declaration. The only place the half-open convention and the
+ * all-or-nothing identifier rule are enforced.
+ */
+export function validateCoverage(c: CoverageDecl): ParseError[] {
+  const errors: ParseError[] = [];
+  const err = (field: string, message: string) =>
+    errors.push({ rowIndex: c.rowIndex, field, message });
+
+  if (!DATE_RE.test(c.from)) {
+    err("from", `Invalid date "${c.from}": expected YYYY-MM-DD`);
+  }
+  if (!DATE_RE.test(c.before)) {
+    err("before", `Invalid date "${c.before}": expected YYYY-MM-DD`);
+  }
+  // ISO dates compare correctly as strings. The span is half-open, so an empty
+  // span declares nothing and is more likely a typo than an intent.
+  if (errors.length === 0 && c.before <= c.from) {
+    err("before", `"${c.before}" must be after "${c.from}": the span is half-open [from, before)`);
+  }
+
+  if (!isGlobal(c)) {
+    // A partly-written identifier is a mistake, not a global declaration.
+    if (!c.identifierType) {
+      err("identifier_type", "Required unless the declaration is global (no identifier at all)");
+    } else if (!VALID_IDENTIFIER_TYPES.has(c.identifierType)) {
+      err("identifier_type", `Unknown identifier_type: ${c.identifierType}`);
+    }
+    if (!c.identifierValue) {
+      err("identifier_value", "Required unless the declaration is global (no identifier at all)");
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Resolve declarations against the instruments a file actually names, yielding
+ * one entry per instrument per span.
+ *
+ * A global applies to every instrument except those carrying a specific
+ * declaration, which overrides it outright rather than adding to it. Several
+ * specific declarations for one instrument all survive, since the wire accepts
+ * more than one span per instrument.
+ *
+ * A specific declaration naming an instrument the file has no rows for is kept.
+ * That is meaningful for corporate events, where coverage records what was
+ * asked about rather than what came back, and a no-op for prices, where the
+ * server only fills instruments the request supplies rows for.
+ */
+export function expandCoverage(
+  decls: CoverageDecl[],
+  instruments: InstrumentRef[],
+): { resolved: ResolvedCoverage[]; errors: ParseError[] } {
+  const errors: ParseError[] = [];
+  const globals = decls.filter(isGlobal);
+  const specifics = decls.filter((c) => !isGlobal(c));
+
+  // Which of two globals wins would be arbitrary, so refuse to choose.
+  for (const extra of globals.slice(1)) {
+    errors.push({
+      rowIndex: extra.rowIndex,
+      field: "coverage",
+      message: "Only one global coverage declaration is allowed per file",
+    });
+  }
+  const global = globals.length === 1 ? globals[0] : undefined;
+
+  const specificsByKey = new Map<string, CoverageDecl[]>();
+  for (const s of specifics) {
+    const key = refKey(s);
+    const existing = specificsByKey.get(key);
+    if (existing) existing.push(s);
+    else specificsByKey.set(key, [s]);
+  }
+
+  const resolved: ResolvedCoverage[] = [];
+  const seenKeys = new Set<string>();
+  for (const inst of instruments) {
+    const key = refKey(inst);
+    if (seenKeys.has(key)) continue;
+    seenKeys.add(key);
+
+    const own = specificsByKey.get(key);
+    if (own) {
+      for (const s of own) resolved.push({ ...inst, from: s.from, before: s.before });
+    } else if (global) {
+      resolved.push({ ...inst, from: global.from, before: global.before });
+    }
+  }
+
+  // Declarations for instruments the file has no rows for.
+  for (const s of specifics) {
+    if (seenKeys.has(refKey(s))) continue;
+    resolved.push({
+      identifierType: s.identifierType ?? "",
+      identifierValue: s.identifierValue ?? "",
+      identifierDomain: s.identifierDomain ?? "",
+      from: s.from,
+      before: s.before,
+    });
+  }
+
+  return { resolved, errors };
+}

--- a/client/lib/csv/prices.test.ts
+++ b/client/lib/csv/prices.test.ts
@@ -268,3 +268,91 @@ describe("csvToPrices", () => {
     expect(result.errors[0].rowIndex).toBe(3); // row 3 (1-based, header=1)
   });
 });
+
+describe("csvToPrices coverage headers", () => {
+  const HDR = "identifier_type,identifier_value,identifier_domain,price_date,open,high,low,close,adjusted_close,volume";
+  const ROWS = [
+    "MIC_TICKER,AAPL,XNAS,2024-01-15,,,,185.9,,",
+    "MIC_TICKER,MSFT,XNAS,2024-01-15,,,,400.1,,",
+  ];
+
+  it("yields no coverage when the file declares none", () => {
+    const result = csvToPrices([HDR, ...ROWS].join("\n"));
+    expect(result.errors).toEqual([]);
+    expect(result.coverage).toEqual([]);
+  });
+
+  it("expands a global declaration over every instrument in the file", () => {
+    const csv = ["# coverage=2024-01-01,2024-02-01", HDR, ...ROWS].join("\n");
+    const result = csvToPrices(csv);
+    expect(result.errors).toEqual([]);
+    expect(result.coverage).toHaveLength(2);
+    expect(result.coverage.map((c) => c.identifierValue)).toEqual(["AAPL", "MSFT"]);
+    expect(result.coverage[0].from).toBe("2024-01-01");
+    expect(result.coverage[0].before).toBe("2024-02-01");
+  });
+
+  it("lets a specific declaration override the global", () => {
+    const csv = [
+      "# coverage=2024-01-01,2024-02-01",
+      "# coverage=MIC_TICKER,MSFT,XNAS,2024-03-01,2024-04-01",
+      HDR,
+      ...ROWS,
+    ].join("\n");
+    const result = csvToPrices(csv);
+    expect(result.errors).toEqual([]);
+    expect(result.coverage).toEqual([
+      expect.objectContaining({ identifierValue: "AAPL", from: "2024-01-01", before: "2024-02-01" }),
+      expect.objectContaining({ identifierValue: "MSFT", from: "2024-03-01", before: "2024-04-01" }),
+    ]);
+  });
+
+  it("accepts an empty domain in the specific form", () => {
+    const csv = [
+      "# coverage=OCC,NVDA250620P00110000,,2024-06-11,2025-01-18",
+      HDR,
+      "OCC,NVDA250620P00110000,,2024-06-11,,,,14.45,,",
+    ].join("\n");
+    const result = csvToPrices(csv);
+    expect(result.errors).toEqual([]);
+    expect(result.coverage).toHaveLength(1);
+    expect(result.coverage[0].identifierDomain).toBe("");
+  });
+
+  it("coexists with exported_at and other comment lines", () => {
+    const csv = [
+      "# exported_at=2024-05-01T00:00:00.000Z",
+      "# just a note",
+      "# coverage=2024-01-01,2024-02-01",
+      HDR,
+      ...ROWS,
+    ].join("\n");
+    const result = csvToPrices(csv);
+    expect(result.errors).toEqual([]);
+    expect(result.exportedAt?.toISOString()).toBe("2024-05-01T00:00:00.000Z");
+    expect(result.coverage).toHaveLength(2);
+  });
+
+  it("reads declarations written below the data rows", () => {
+    const csv = [HDR, ...ROWS, "# coverage=2024-01-01,2024-02-01"].join("\n");
+    expect(csvToPrices(csv).coverage).toHaveLength(2);
+  });
+
+  it("rejects a field count matching neither form, naming the file line", () => {
+    const csv = [HDR, "# coverage=MIC_TICKER,AAPL,2024-01-01,2024-02-01", ...ROWS].join("\n");
+    const result = csvToPrices(csv);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].field).toBe("coverage");
+    expect(result.errors[0].rowIndex).toBe(2);
+    expect(result.coverage).toEqual([]);
+  });
+
+  it("reports a bad declaration without discarding the price rows", () => {
+    const csv = ["# coverage=2024-02-01,2024-01-01", HDR, ...ROWS].join("\n");
+    const result = csvToPrices(csv);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].field).toBe("before");
+    expect(result.prices).toHaveLength(2);
+    expect(result.coverage).toEqual([]);
+  });
+});

--- a/client/lib/csv/prices.ts
+++ b/client/lib/csv/prices.ts
@@ -4,19 +4,31 @@
 
 import Papa from "papaparse";
 import { create } from "@bufbuild/protobuf";
-import { ImportPriceRowSchema, IdentifierTypeSchema } from "@/gen/api/v1/api_pb";
-import type { ExportPriceRow, ImportPriceRow } from "@/gen/api/v1/api_pb";
+import { ImportPriceRowSchema, ImportCoverageSchema } from "@/gen/api/v1/api_pb";
+import type { ExportPriceRow, ImportPriceRow, ImportCoverage } from "@/gen/api/v1/api_pb";
 import type { ParseError } from "./standard";
 import { assetClassToStr, assetClassFromStr } from "@/lib/asset-class";
-
-/** Valid identifier type names from the proto IdentifierType enum (excluding UNSPECIFIED). */
-const VALID_IDENTIFIER_TYPES = new Set(
-  IdentifierTypeSchema.values
-    .filter((v) => v.number !== 0)
-    .map((v) => v.name),
-);
+import { VALID_IDENTIFIER_TYPES } from "@/lib/identifiers";
+import { expandCoverage, validateCoverage } from "@/lib/coverage";
+import type { CoverageDecl, InstrumentRef } from "@/lib/coverage";
 
 const HEADER = "identifier_type,identifier_value,identifier_domain,price_date,open,high,low,close,adjusted_close,volume,asset_class,currency";
+
+/** Comment line carrying the export's knowledge time. */
+const EXPORTED_AT_PREFIX = "# exported_at=";
+
+/**
+ * Comment line declaring a half-open [from, before) coverage span, in one of
+ * two forms:
+ *
+ *     # coverage=<from>,<before>
+ *     # coverage=<identifier_type>,<identifier_value>,<identifier_domain>,<from>,<before>
+ *
+ * The first is global and applies to every instrument in the file; the second
+ * names one instrument and overrides the global for it. The five-field form's
+ * order matches the data columns.
+ */
+const COVERAGE_PREFIX = "# coverage=";
 
 const REQUIRED_COLUMNS = new Set(["identifier_type", "identifier_value", "price_date", "close"]);
 
@@ -46,15 +58,46 @@ export function pricesToCsv(rows: ExportPriceRow[], exportedAt?: Date): string {
   ]);
   const csv = Papa.unparse({ fields: HEADER.split(","), data }, { newline: "\n" }) + "\n";
   if (exportedAt) {
-    return `# exported_at=${exportedAt.toISOString()}\n${csv}`;
+    return `${EXPORTED_AT_PREFIX}${exportedAt.toISOString()}\n${csv}`;
   }
   return csv;
 }
 
 export interface PriceParseResult {
   prices: ImportPriceRow[];
+  /** One entry per instrument per span, with any global already expanded. */
+  coverage: ImportCoverage[];
   errors: ParseError[];
   exportedAt?: Date;
+}
+
+/**
+ * Parse one "# coverage=" line. Returns undefined and records an error when
+ * the field count matches neither accepted form.
+ */
+function parseCoverageLine(body: string, rowIndex: number, errors: ParseError[]): CoverageDecl | undefined {
+  const fields = body.split(",").map((f) => f.trim());
+  if (fields.length === 2) {
+    return { from: fields[0], before: fields[1], rowIndex };
+  }
+  if (fields.length === 5) {
+    return {
+      identifierType: fields[0],
+      identifierValue: fields[1],
+      identifierDomain: fields[2],
+      from: fields[3],
+      before: fields[4],
+      rowIndex,
+    };
+  }
+  errors.push({
+    rowIndex,
+    field: "coverage",
+    message:
+      `Expected "<from>,<before>" or ` +
+      `"<identifier_type>,<identifier_value>,<identifier_domain>,<from>,<before>", got ${fields.length} fields`,
+  });
+  return undefined;
 }
 
 /** Parse CSV text into ImportPriceRow[] with validation. */
@@ -62,18 +105,28 @@ export function csvToPrices(text: string): PriceParseResult {
   const prices: ImportPriceRow[] = [];
   const errors: ParseError[] = [];
 
-  // Extract metadata from comment lines and strip them before parsing.
+  // Extract metadata from comment lines and strip them before parsing. Errors
+  // on these lines carry the file line number, since they have no data row.
   let exportedAt: Date | undefined;
+  const coverageDecls: CoverageDecl[] = [];
   const dataLines: string[] = [];
-  for (const line of text.split("\n")) {
-    const trimmed = line.trim();
-    if (trimmed.startsWith("# exported_at=")) {
-      const d = new Date(trimmed.slice("# exported_at=".length));
+  const fileLines = text.split("\n");
+  for (let i = 0; i < fileLines.length; i++) {
+    const trimmed = fileLines[i].trim();
+    if (trimmed.startsWith(EXPORTED_AT_PREFIX)) {
+      const d = new Date(trimmed.slice(EXPORTED_AT_PREFIX.length));
       if (!isNaN(d.getTime())) exportedAt = d;
+    } else if (trimmed.startsWith(COVERAGE_PREFIX)) {
+      const decl = parseCoverageLine(trimmed.slice(COVERAGE_PREFIX.length), i + 1, errors);
+      if (decl) {
+        const declErrors = validateCoverage(decl);
+        if (declErrors.length > 0) errors.push(...declErrors);
+        else coverageDecls.push(decl);
+      }
     } else if (trimmed.startsWith("#")) {
       continue;
     } else {
-      dataLines.push(line);
+      dataLines.push(fileLines[i]);
     }
   }
   const csvText = dataLines.join("\n");
@@ -81,7 +134,7 @@ export function csvToPrices(text: string): PriceParseResult {
   const parsed = Papa.parse<string[]>(csvText, { header: false, skipEmptyLines: true });
   const rows = parsed.data;
   if (rows.length === 0) {
-    return { prices, errors, exportedAt };
+    return { prices, coverage: [], errors, exportedAt };
   }
 
   const headerFields = rows[0].map((h) => h.trim().toLowerCase());
@@ -90,14 +143,17 @@ export function csvToPrices(text: string): PriceParseResult {
     colIdx.set(headerFields[i], i);
   }
 
-  // Validate required columns exist.
+  // Validate required columns exist. Only a missing column stops the parse --
+  // a bad comment line is reported without discarding the rows.
+  let missingColumns = false;
   for (const col of REQUIRED_COLUMNS) {
     if (!colIdx.has(col)) {
       errors.push({ rowIndex: 0, field: col, message: `missing required column: ${col}` });
+      missingColumns = true;
     }
   }
-  if (errors.length > 0) {
-    return { prices, errors, exportedAt };
+  if (missingColumns) {
+    return { prices, coverage: [], errors, exportedAt };
   }
 
   for (let i = 1; i < rows.length; i++) {
@@ -204,5 +260,16 @@ export function csvToPrices(text: string): PriceParseResult {
     prices.push(row);
   }
 
-  return { prices, errors, exportedAt };
+  // Resolve declarations against the instruments the rows actually name, so a
+  // global fans out to one wire entry each.
+  const instruments: InstrumentRef[] = prices.map((p) => ({
+    identifierType: p.identifierType,
+    identifierValue: p.identifierValue,
+    identifierDomain: p.identifierDomain,
+  }));
+  const expanded = expandCoverage(coverageDecls, instruments);
+  errors.push(...expanded.errors);
+  const coverage = expanded.resolved.map((c) => create(ImportCoverageSchema, c));
+
+  return { prices, coverage, errors, exportedAt };
 }

--- a/client/lib/identifiers.ts
+++ b/client/lib/identifiers.ts
@@ -1,0 +1,10 @@
+/** Identifier helpers shared by the import parsers. */
+
+import { IdentifierTypeSchema } from "@/gen/api/v1/api_pb";
+
+/** Valid identifier type names from the proto IdentifierType enum (excluding UNSPECIFIED). */
+export const VALID_IDENTIFIER_TYPES = new Set(
+  IdentifierTypeSchema.values
+    .filter((v) => v.number !== 0)
+    .map((v) => v.name),
+);

--- a/client/lib/json/corporate-events.test.ts
+++ b/client/lib/json/corporate-events.test.ts
@@ -69,3 +69,66 @@ describe("parseSplitsJson", () => {
     expect(errors[0].field).toBe("first_known_at");
   });
 });
+
+describe("parseSplitsJson coverage", () => {
+  const events = [
+    { identifier_type: "MIC_TICKER", identifier_value: "AAPL", identifier_domain: "XNAS", ex_date: "2020-08-31", split_from: "1", split_to: "4" },
+    { identifier_type: "MIC_TICKER", identifier_value: "TSLA", identifier_domain: "XNAS", ex_date: "2022-08-25", split_from: "1", split_to: "3" },
+  ];
+
+  it("accepts a bare array as events with no coverage", () => {
+    const { splits, coverage, errors } = parseSplitsJson(JSON.stringify(events));
+    expect(errors).toEqual([]);
+    expect(splits).toHaveLength(2);
+    expect(coverage).toEqual([]);
+  });
+
+  it("accepts the object form without coverage", () => {
+    const { splits, coverage, errors } = parseSplitsJson(JSON.stringify({ events }));
+    expect(errors).toEqual([]);
+    expect(splits).toHaveLength(2);
+    expect(coverage).toEqual([]);
+  });
+
+  it("expands a global declaration over every instrument in the file", () => {
+    const json = JSON.stringify({
+      events,
+      coverage: [{ from: "2022-01-01", before: "2026-07-30" }],
+    });
+    const { coverage, errors } = parseSplitsJson(json);
+    expect(errors).toEqual([]);
+    expect(coverage.map((c) => c.identifierValue)).toEqual(["AAPL", "TSLA"]);
+    expect(coverage[0].before).toBe("2026-07-30");
+  });
+
+  it("lets a specific declaration override the global", () => {
+    const json = JSON.stringify({
+      events,
+      coverage: [
+        { from: "2022-01-01", before: "2026-07-30" },
+        { identifier_type: "MIC_TICKER", identifier_value: "TSLA", identifier_domain: "XNAS", from: "2022-06-01", before: "2023-01-01" },
+      ],
+    });
+    const { coverage, errors } = parseSplitsJson(json);
+    expect(errors).toEqual([]);
+    expect(coverage).toEqual([
+      expect.objectContaining({ identifierValue: "AAPL", from: "2022-01-01", before: "2026-07-30" }),
+      expect.objectContaining({ identifierValue: "TSLA", from: "2022-06-01", before: "2023-01-01" }),
+    ]);
+  });
+
+  it("reports a bad declaration without discarding the events", () => {
+    const json = JSON.stringify({ events, coverage: [{ from: "2022-01-01", before: "2021-01-01" }] });
+    const { splits, coverage, errors } = parseSplitsJson(json);
+    expect(errors).toHaveLength(1);
+    expect(errors[0].field).toBe("before");
+    expect(splits).toHaveLength(2);
+    expect(coverage).toEqual([]);
+  });
+
+  it("rejects an object with no events array", () => {
+    const { errors } = parseSplitsJson(JSON.stringify({ coverage: [] }));
+    expect(errors).toHaveLength(1);
+    expect(errors[0].field).toBe("file");
+  });
+});

--- a/client/lib/json/corporate-events.ts
+++ b/client/lib/json/corporate-events.ts
@@ -1,14 +1,21 @@
 /**
  * JSON serialization for corporate event (split) export/import.
- * Format: array of split objects with identifier context.
+ *
+ * The canonical import shape is an object with "events" -- split objects with
+ * identifier context -- and an optional "coverage". A bare array of events is
+ * still accepted, and is what the exporter writes until it has coverage to
+ * serialize. See docs/spec/csv-format.md.
  */
 
+import { create } from "@bufbuild/protobuf";
 import { timestampDate } from "@bufbuild/protobuf/wkt";
-import { AssetClass } from "@/gen/api/v1/api_pb";
-import type { ExportCorporateEventRow, SplitRow } from "@/gen/api/v1/api_pb";
+import { AssetClass, ImportCorporateEventCoverageSchema } from "@/gen/api/v1/api_pb";
+import type { ExportCorporateEventRow, ImportCorporateEventCoverage, SplitRow } from "@/gen/api/v1/api_pb";
 import type { CorporateSplitImportRow } from "@/lib/portfolio-api";
 import { assetClassToStr, assetClassFromStr } from "@/lib/asset-class";
 import type { ParseError } from "@/lib/csv/standard";
+import { expandCoverage, validateCoverage } from "@/lib/coverage";
+import type { CoverageDecl, InstrumentRef } from "@/lib/coverage";
 
 interface SerializedSplit {
   identifier_type: string;
@@ -47,10 +54,57 @@ export function splitsToJson(rows: ExportCorporateEventRow[]): string {
 
 export interface SplitParseResult {
   splits: CorporateSplitImportRow[];
+  /** One entry per instrument per span, with any global already expanded. */
+  coverage: ImportCorporateEventCoverage[];
   errors: ParseError[];
 }
 
-/** Parse splits JSON back into importable rows. */
+/**
+ * Read the "coverage" array. Entries carrying no identifier keys are global and
+ * apply to every instrument in the file; see @/lib/coverage.
+ */
+function parseCoverageArray(raw: unknown, errors: ParseError[]): CoverageDecl[] {
+  if (raw == null) return [];
+  if (!Array.isArray(raw)) {
+    errors.push({ rowIndex: 0, field: "coverage", message: "Expected an array" });
+    return [];
+  }
+
+  const decls: CoverageDecl[] = [];
+  for (let i = 0; i < raw.length; i++) {
+    const item = raw[i];
+    if (typeof item !== "object" || item === null) {
+      errors.push({ rowIndex: i, field: "coverage", message: "Expected an object" });
+      continue;
+    }
+    const obj = item as Record<string, unknown>;
+    const decl: CoverageDecl = {
+      from: String(obj.from ?? ""),
+      before: String(obj.before ?? ""),
+      rowIndex: i,
+    };
+    // Absent and empty are the same thing here: either way the declaration
+    // names no instrument, which is what makes it global.
+    const type = String(obj.identifier_type ?? "");
+    const value = String(obj.identifier_value ?? "");
+    const domain = String(obj.identifier_domain ?? "");
+    if (type) decl.identifierType = type;
+    if (value) decl.identifierValue = value;
+    if (domain) decl.identifierDomain = domain;
+
+    const declErrors = validateCoverage(decl);
+    if (declErrors.length > 0) errors.push(...declErrors);
+    else decls.push(decl);
+  }
+  return decls;
+}
+
+/**
+ * Parse splits JSON back into importable rows.
+ *
+ * The canonical shape is an object with "events" and an optional "coverage".
+ * A bare array is accepted as events-only, which is what earlier exports wrote.
+ */
 export function parseSplitsJson(json: string): SplitParseResult {
   const errors: ParseError[] = [];
   let parsed: unknown;
@@ -60,21 +114,37 @@ export function parseSplitsJson(json: string): SplitParseResult {
   } catch (e) {
     return {
       splits: [],
+      coverage: [],
       errors: [{ rowIndex: 0, field: "file", message: `Invalid JSON: ${e instanceof Error ? e.message : String(e)}` }],
     };
   }
 
-  if (!Array.isArray(parsed)) {
+  let rawEvents: unknown;
+  let coverageDecls: CoverageDecl[] = [];
+  if (Array.isArray(parsed)) {
+    rawEvents = parsed;
+  } else if (typeof parsed === "object" && parsed !== null) {
+    const obj = parsed as Record<string, unknown>;
+    rawEvents = obj.events;
+    coverageDecls = parseCoverageArray(obj.coverage, errors);
+  }
+
+  if (!Array.isArray(rawEvents)) {
     return {
       splits: [],
-      errors: [{ rowIndex: 0, field: "file", message: "Expected a JSON array" }],
+      coverage: [],
+      errors: [
+        ...errors,
+        { rowIndex: 0, field: "file", message: 'Expected a JSON array, or an object with an "events" array' },
+      ],
     };
   }
+  const parsedEvents: unknown[] = rawEvents;
 
   const splits: CorporateSplitImportRow[] = [];
 
-  for (let i = 0; i < parsed.length; i++) {
-    const item = parsed[i];
+  for (let i = 0; i < parsedEvents.length; i++) {
+    const item = parsedEvents[i];
     if (typeof item !== "object" || item === null) {
       errors.push({ rowIndex: i, field: "item", message: "Expected an object" });
       continue;
@@ -138,5 +208,16 @@ export function parseSplitsJson(json: string): SplitParseResult {
     splits.push(row);
   }
 
-  return { splits, errors };
+  // Resolve declarations against the instruments the events actually name, so
+  // a global fans out to one wire entry each.
+  const instruments: InstrumentRef[] = splits.map((s) => ({
+    identifierType: s.identifierType,
+    identifierValue: s.identifierValue,
+    identifierDomain: s.identifierDomain ?? "",
+  }));
+  const expanded = expandCoverage(coverageDecls, instruments);
+  errors.push(...expanded.errors);
+  const coverage = expanded.resolved.map((c) => create(ImportCorporateEventCoverageSchema, c));
+
+  return { splits, coverage, errors };
 }

--- a/client/lib/portfolio-api.ts
+++ b/client/lib/portfolio-api.ts
@@ -119,6 +119,8 @@ import type {
   IdentificationError,
   IdentifierPluginConfig,
   ImportPriceRow,
+  ImportCoverage,
+  ImportCorporateEventCoverage,
   Instrument,
   PriceFetchBlock,
   PricePluginConfig,
@@ -651,10 +653,20 @@ export async function* exportPrices(): AsyncGenerator<ExportPriceRow> {
 }
 
 /** Import (upsert) prices (admin only). Returns a job ID for async processing. */
-export async function importPrices(prices: ImportPriceRow[], exportedAt?: Date): Promise<string> {
+/**
+ * Import EOD prices (admin only). Coverage entries name one instrument each --
+ * any global declaration in the source file is expanded by the parser -- and
+ * make the server fill non-trading days within the span by LOCF.
+ */
+export async function importPrices(
+  prices: ImportPriceRow[],
+  exportedAt?: Date,
+  coverage?: ImportCoverage[],
+): Promise<string> {
   const base = getBaseUrl();
   const req = create(ImportPricesRequestSchema, {
     prices,
+    coverage,
     exportedAt: exportedAt ? timestampFromDate(exportedAt) : undefined,
   });
   const resBytes = await unaryFetch(base, ApiServicePrefix + "ImportPrices", toBinary(ImportPricesRequestSchema, req), { credentials: "include" });
@@ -679,7 +691,10 @@ export interface CorporateSplitImportRow {
  * the server is idempotent on (instrument_id, ex_date) so re-importing
  * the same split is safe. Returns a job ID for async processing.
  */
-export async function importCorporateEventSplits(rows: CorporateSplitImportRow[]): Promise<string> {
+export async function importCorporateEventSplits(
+  rows: CorporateSplitImportRow[],
+  coverage?: ImportCorporateEventCoverage[],
+): Promise<string> {
   const base = getBaseUrl();
   const events = rows.map((r) =>
     create(ImportCorporateEventRowSchema, {
@@ -698,7 +713,7 @@ export async function importCorporateEventSplits(rows: CorporateSplitImportRow[]
       },
     }),
   );
-  const req = create(ImportCorporateEventsRequestSchema, { events });
+  const req = create(ImportCorporateEventsRequestSchema, { events, coverage });
   const resBytes = await unaryFetch(
     base,
     ApiServicePrefix + "ImportCorporateEvents",

--- a/docs/spec/csv-format.md
+++ b/docs/spec/csv-format.md
@@ -1,8 +1,12 @@
-# Standard CSV format
+# Import formats
+
+Three file formats feed the import APIs: a transaction CSV, a price CSV, and a corporate event JSON. They share the conventions for comment metadata and for [coverage declarations](#coverage-declarations).
+
+## Standard transaction CSV
 
 The **Standard** format is a CSV that directly represents the transaction fields expected by the API. Users can produce this CSV manually or use a broker-specific converter (when available) that outputs Standard format.
 
-## Columns
+### Columns
 
 Header names are case-insensitive. Supported column names:
 
@@ -21,7 +25,7 @@ Header names are case-insensitive. Supported column names:
 | `exchange_type`          | No       | Exchange code system: `MIC` (ISO 10383) or `OPENFIGI` (Bloomberg exchange code). Required when `exchange` is present. |
 | `exchange`               | No       | Exchange code value (e.g. "XNAS" for MIC, "US" for OPENFIGI). Populates the domain field on the identifier hint. Required when `exchange_type` is present. |
 
-## Transaction types (type column)
+### Transaction types (type column)
 
 Allowed values for `type` (OFX-style):
 `BUYDEBT`, `BUYFUTURE`, `BUYMF`, `BUYOPT`, `BUYOTHER`, `BUYSTOCK`,
@@ -29,7 +33,7 @@ Allowed values for `type` (OFX-style):
 `INCOME`, `INVEXPENSE`, `REINVEST`, `RETOFCAP`, `SPLIT`, `TRANSFER`,
 `JRNLFUND`, `JRNLSEC`, `MARGININTEREST`, `CLOSUREOPT`, `CASHFLOW`.
 
-## Identifier hints
+### Identifier hints
 
 Each row carries at most one identifier hint via `symbol_type` and `symbol`. Commonly used symbol types:
 
@@ -47,7 +51,7 @@ All IdentifierType enum values are accepted: `ISIN`, `CUSIP`, `SEDOL`, `CINS`, `
 
 The optional `exchange_type` and `exchange` columns provide a domain for resolution. They must both be present or both absent. For options, when no `symbol_type`/`symbol` hint is supplied, the system may extract an OCC symbol from the instrument description so that option contracts can be resolved via OpenFIGI OCC_SYMBOL.
 
-## Example
+### Example
 
 ```csv
 date,instrument_description,type,quantity,trading_currency,unit_price,account,symbol_type,symbol,exchange_type,exchange
@@ -57,7 +61,7 @@ date,instrument_description,type,quantity,trading_currency,unit_price,account,sy
 
 Any extra columns are ignored. Empty optional fields can be omitted or left blank.
 
-## Comment lines
+### Comment lines
 
 Lines beginning with `#` are metadata or commentary and are not parsed as rows. One key is recognised:
 
@@ -65,48 +69,135 @@ Lines beginning with `#` are metadata or commentary and are not parsed as rows. 
 
 It declares the share count the file's quantities and unit prices are denominated in. Omit it for an ordinary export, where each row reflects the splits that happened before its own transaction date and nothing after -- the as-traded convention the server assumes. Set it only when the source has post-adjusted historical rows for splits that happened *after* the transaction, in which case it is the date those quantities are current as of. See [bitemporality.md](bitemporality.md#share-count-basis).
 
-# Corporate event CSV format
+## Price CSV
 
-A separate CSV is used to import stock splits and cash dividends via the `ImportCorporateEvents` API. Splits and dividends share one file; the `event` column distinguishes them.
+A CSV of EOD prices imported via the `ImportPrices` API, and the format `ExportPrices` writes.
 
-## Columns
+### Columns
+
+Header names are case-insensitive. Column order is not significant.
 
 | Column | Required | Description |
 | ------ | -------- | ----------- |
-| `event` | Yes | `split` or `dividend`. Determines which event-specific columns are read. |
+| `identifier_type` | Yes | Identifier type used to resolve the instrument. Any IdentifierType enum value. |
+| `identifier_value` | Yes | Identifier value (e.g. `AAPL`, `NVDA250620P00110000`). |
+| `identifier_domain` | No | Domain for the identifier: MIC for `MIC_TICKER`, exchange code for `OPENFIGI_TICKER`, source for `BROKER_DESCRIPTION`, empty otherwise. |
+| `price_date` | Yes | `YYYY-MM-DD` trading date. |
+| `open` | No | Opening price. |
+| `high` | No | High price. |
+| `low` | No | Low price. |
+| `close` | Yes | Closing price, as the source supplied it. |
+| `adjusted_close` | No | The provider's own adjusted close. Never an input to valuation; it exists to cross-check the value PortfolioDB derives. See [prices.md](prices.md). |
+| `volume` | No | Integer trading volume. |
+| `asset_class` | No | Security type hint used to route identifier plugins when the instrument is unknown. |
+| `currency` | No | ISO 4217 currency code, used as a validation hint. |
+
+Prices are stored as supplied. `split_adjusted_close` is derived by PortfolioDB from `close` and the known splits, and is what performance math uses.
+
+### Comment lines
+
+Lines beginning with `#` are metadata or commentary and are not parsed as rows. Two keys are recognised:
+
+    # exported_at=2024-05-01T00:00:00.000Z
+    # coverage=2022-01-01,2025-07-07
+
+`exported_at` is knowledge time: when the supplied data was current. OCC symbols are split-adjusted to this point during instrument resolution, and imported rows record it as `last_fetched_at`. It does **not** say which share count the prices are denominated in. See [bitemporality.md](bitemporality.md#knowledge-time).
+
+`coverage` is described under [Coverage declarations](#coverage-declarations).
+
+### Example
+
+```csv
+# exported_at=2026-07-30T00:00:00.000Z
+# coverage=2022-01-01,2025-07-07
+# coverage=MIC_TICKER,ATVI,XNAS,2021-12-31,2023-10-14
+identifier_type,identifier_value,identifier_domain,price_date,open,high,low,close,adjusted_close,volume,asset_class,currency
+MIC_TICKER,AAPL,XNAS,2024-01-15,,,,185.9,,,STOCK,USD
+OCC,NVDA250620P00110000,,2024-06-11,,,,13.42,,,OPTION,USD
+```
+
+## Corporate event JSON
+
+Stock splits are imported via the `ImportCorporateEvents` API as JSON, and `ExportCorporateEvents` writes the same shape. Cash dividends are part of the API but are not yet carried by this file format.
+
+The canonical shape is an object with an `events` array and an optional `coverage` array. A bare array is accepted as events-only.
+
+### Event objects
+
+| Key | Required | Description |
+| --- | -------- | ----------- |
 | `identifier_type` | Yes | Identifier type used to resolve the instrument (`MIC_TICKER`, `OPENFIGI_TICKER`, `ISIN`, etc.). |
 | `identifier_value` | Yes | Identifier value (e.g. `AAPL`, `US0378331005`). |
 | `identifier_domain` | No | Domain for the identifier (MIC for `MIC_TICKER`, exchange code for `OPENFIGI_TICKER`). |
 | `asset_class` | No | `STOCK` or `ETF`. Used as the security type hint when the instrument is unknown and identifier plugins must resolve it. |
-| `ex_date` | Yes | `YYYY-MM-DD`. Effective/execution date for splits, ex-dividend date for dividends. This is valid time -- when the event took effect, not when it was announced or learned of (see [bitemporality.md](bitemporality.md)). |
-| `split_from` | Splits only | Decimal numerator of the pre-split ratio (e.g. `1` for a 2:1 split). |
-| `split_to` | Splits only | Decimal numerator of the post-split ratio (e.g. `2` for a 2:1 split). The factor is `split_to / split_from`. |
-| `amount` | Dividends only | Cash amount per share, denominated in `currency`. |
-| `currency` | Dividends only | ISO 4217 currency of the cash dividend. |
-| `pay_date` | No | `YYYY-MM-DD` payment date (dividends). |
-| `record_date` | No | `YYYY-MM-DD` record date (dividends). |
-| `declaration_date` | No | `YYYY-MM-DD` declaration date (dividends). |
-| `frequency` | No | `annual`, `semi-annual`, `quarterly`, `monthly`, or empty (dividends). |
-
-## Coverage rows
-
-The importer also accepts coverage declarations in a separate CSV (or section). Each row records that the caller has authoritative coverage for the half-open `[from, before)` interval; the server stores a `corporate_event_coverage` row tagged `data_provider = "import"` so the background fetcher does not refetch the same range from a plugin.
-
-| Column | Required | Description |
-| ------ | -------- | ----------- |
-| `identifier_type` | Yes | As above. |
-| `identifier_value` | Yes | As above. |
-| `identifier_domain` | No | As above. |
-| `from` | Yes | `YYYY-MM-DD` inclusive. |
-| `before` | Yes | `YYYY-MM-DD` exclusive; must be after `from`. To cover through 31 December 2024, send `2025-01-01`. |
-
-## Example
-
-```csv
-event,identifier_type,identifier_domain,identifier_value,asset_class,ex_date,split_from,split_to,amount,currency,pay_date,record_date,declaration_date,frequency
-split,MIC_TICKER,XNAS,AAPL,STOCK,2020-08-31,1,4,,,,,,
-split,MIC_TICKER,XNAS,AAPL,STOCK,2014-06-09,1,7,,,,,,
-dividend,MIC_TICKER,XNAS,AAPL,STOCK,2024-02-09,,,0.24,USD,2024-02-15,2024-02-12,2024-02-01,quarterly
-```
+| `ex_date` | Yes | `YYYY-MM-DD`. Effective/execution date. This is valid time -- when the split took effect, not when it was announced or learned of (see [bitemporality.md](bitemporality.md)). |
+| `split_from` | Yes | Decimal numerator of the pre-split ratio (e.g. `1` for a 2:1 split). |
+| `split_to` | Yes | Decimal numerator of the post-split ratio (e.g. `2` for a 2:1 split). The factor is `split_to / split_from`. |
+| `first_known_at` | No | ISO 8601 instant: when the exporting instance first learned of the split. Omit and the server falls back to the request's `exported_at`, then to storage time. A stored value only ever moves backwards. |
 
 When the importer sees an unknown `(identifier_type, identifier_domain, identifier_value)` triple, it routes through the same identifier plugin flow used by price imports: the supplied `asset_class` becomes the security-type hint and the resolved instrument is created with the supplied identifier as canonical.
+
+### Example
+
+```json
+{
+  "events": [
+    { "identifier_type": "MIC_TICKER", "identifier_domain": "XNAS", "identifier_value": "AAPL",
+      "asset_class": "STOCK", "ex_date": "2020-08-31", "split_from": "1", "split_to": "4" },
+    { "identifier_type": "MIC_TICKER", "identifier_domain": "XNAS", "identifier_value": "TSLA",
+      "asset_class": "STOCK", "ex_date": "2022-08-25", "split_from": "1", "split_to": "3" }
+  ],
+  "coverage": [
+    { "from": "2022-01-01", "before": "2026-07-30" }
+  ]
+}
+```
+
+## Coverage declarations
+
+A coverage declaration records that the caller has authoritative coverage of a date interval. Both the price CSV and the corporate event JSON accept them, with the same semantics and the same fields; only the syntax differs.
+
+What the server does with one depends on the import:
+
+- **Prices** -- non-trading days within the interval are filled with synthetic last-observation-carried-forward rows, so a file can carry only the days its source actually moved on. Without a declaration, rows are stored exactly as supplied and any gap stays a gap: valuation matches prices by exact date and has no read-time carry-forward.
+- **Corporate events** -- a `corporate_event_coverage` row is stored tagged `data_provider = "import"`, so the background fetcher does not re-query the same interval from a plugin and cannot overwrite hand-curated events with provider data.
+
+### Fields
+
+| Field | Required | Description |
+| ----- | -------- | ----------- |
+| `identifier_type` | No | Identifier type. Present together with `identifier_value` to name one instrument; absent to declare a file-wide default. |
+| `identifier_value` | No | Identifier value. See above. |
+| `identifier_domain` | No | Domain for the identifier. Only meaningful alongside the other two. |
+| `from` | Yes | `YYYY-MM-DD`, inclusive. |
+| `before` | Yes | `YYYY-MM-DD`, exclusive; must be after `from`. To cover through 31 December 2024, write `2025-01-01`. |
+
+The interval is half-open `[from, before)`, matching every other date interval on the wire (see [bitemporality.md](bitemporality.md) and adr/0018-half-open-date-intervals.md).
+
+### Global and specific declarations
+
+A declaration carrying no identifier at all is **global**: it applies to every instrument the file names. A declaration carrying one is **specific** to that instrument.
+
+- At most one global declaration per file.
+- A specific declaration **overrides** the global for its instrument rather than adding to it. An instrument with any specific declaration takes none of the global.
+- Several specific declarations for one instrument are all applied, so an instrument can carry more than one interval.
+- A partly-written identifier -- a type with no value, or a domain alone -- is an error rather than a global declaration.
+
+Most files need one global and a handful of exceptions: instruments that started or stopped trading partway through the period the file covers.
+
+### Syntax
+
+In the **price CSV**, a comment line in one of two forms, told apart by field count. The five-field form's order matches the data columns.
+
+    # coverage=<from>,<before>
+    # coverage=<identifier_type>,<identifier_value>,<identifier_domain>,<from>,<before>
+
+In the **corporate event JSON**, an entry in the top-level `coverage` array. Identifier keys are omitted or empty for a global declaration.
+
+```json
+"coverage": [
+  { "from": "2022-01-01", "before": "2026-07-30" },
+  { "identifier_type": "MIC_TICKER", "identifier_value": "ATVI",
+    "identifier_domain": "XNAS", "from": "2021-12-31", "before": "2023-10-14" }
+]
+```


### PR DESCRIPTION
The server has supported coverage on both imports for a while -- `upsertWithCoverage` routes an instrument to `UpsertPricesWithFill`, and `writeImportCoverage` records a `corporate_event_coverage` row tagged `"import"` -- but no client path ever sent any. Two consequences:

- A price file had to carry a row for every calendar day, since valuation matches prices by exact date (`gp.val_date = dh.val_date`) with no read-time carry-forward, so any gap is an unpriced day.
- A hand-curated splits file could be silently re-queried and overwritten by a plugin.

## One model, two syntaxes

`ImportCoverage` and `ImportCorporateEventCoverage` carry identical fields, so the semantics live in one place. `client/lib/coverage.ts` validates the half-open `[from, before)` convention and the all-or-nothing identifier rule, and expands declarations against the instruments a file actually names.

A declaration with **no identifier is global** and applies to every instrument in the file; one naming an instrument **overrides** the global for it outright. So a file needs one line plus its exceptions rather than a line per instrument. At most one global; several specific spans for one instrument are all kept, which the wire allows.

Syntax follows each format:

```
# coverage=2022-01-01,2025-07-07
# coverage=MIC_TICKER,ATVI,XNAS,2021-12-31,2023-10-14
```

```json
{ "events": [...], "coverage": [{ "from": "2022-01-01", "before": "2026-07-30" }] }
```

The JSON gains the object form alongside the bare array it already accepted, so existing files keep working.

## Docs

`docs/spec/csv-format.md` documented a corporate event **CSV** that has no parser anywhere in the client -- the real format is JSON (`parseSplitsJson`, a `.json` picker in the modal). That section is replaced with the format that exists, the previously undocumented price CSV is added, and the coverage semantics are stated once in a shared section both reference.

## Notes

- A bad comment line is now reported without discarding the rows; previously any error at all aborted the parse, which was only ever meant to catch a missing column.
- Both exporters still write no coverage -- neither export RPC returns it. That is the next PR.

## Testing

`make client-test` -- 189 pass, including 19 new shared cases in `lib/coverage.test.ts` and per-format syntax cases in `prices.test.ts` and `json/corporate-events.test.ts`. `tsc --noEmit` reports the same 5 pre-existing errors as `main` and no new ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)