### PR TITLE
Carry coverage on the price and corporate event exports

### DIFF
--- a/client/app/admin/corporate-events/splits-tab.tsx
+++ b/client/app/admin/corporate-events/splits-tab.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useState } from "react";
 import { ErrorAlert } from "@/app/components/error-alert";
 import { exportCorporateEvents } from "@/lib/portfolio-api";
 import { splitsToJson } from "@/lib/json/corporate-events";
-import type { ExportCorporateEventRow } from "@/gen/api/v1/api_pb";
+import type { ExportCorporateEventRow, ExportCoverage } from "@/gen/api/v1/api_pb";
 import { ImportSplitsModal } from "./import-splits-modal";
 
 interface SplitDisplay {
@@ -29,7 +29,9 @@ export function SplitsTab() {
     setError(null);
     try {
       const rows: SplitDisplay[] = [];
-      for await (const row of exportCorporateEvents()) {
+      for await (const item of exportCorporateEvents()) {
+        if (item.item.case !== "row") continue;
+        const row = item.item.value;
         if (row.event.case === "split") {
           rows.push({
             identifierType: row.identifierType,
@@ -60,10 +62,15 @@ export function SplitsTab() {
     setError(null);
     try {
       const rows: ExportCorporateEventRow[] = [];
-      for await (const row of exportCorporateEvents()) {
-        if (row.event.case === "split") rows.push(row);
+      const coverage: ExportCoverage[] = [];
+      for await (const item of exportCorporateEvents()) {
+        if (item.item.case === "coverage") {
+          coverage.push(item.item.value);
+        } else if (item.item.case === "row" && item.item.value.event.case === "split") {
+          rows.push(item.item.value);
+        }
       }
-      const json = splitsToJson(rows);
+      const json = splitsToJson(rows, coverage);
       const blob = new Blob([json], { type: "application/json" });
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");

--- a/client/app/admin/prices/page.tsx
+++ b/client/app/admin/prices/page.tsx
@@ -14,7 +14,7 @@ import { pricesToCsv } from "@/lib/csv/prices";
 import { dayAfter } from "@/lib/dates";
 import { useDebounce } from "@/hooks/use-debounce";
 import { ImportPricesModal } from "./import-modal";
-import type { EODPriceProto, ExportPriceRow, PriceFetchBlock } from "@/gen/api/v1/api_pb";
+import type { EODPriceProto, ExportCoverage, ExportPriceRow, PriceFetchBlock } from "@/gen/api/v1/api_pb";
 import { timestampDate } from "@bufbuild/protobuf/wkt";
 
 type Tab = "prices" | "blocks";
@@ -95,14 +95,21 @@ function PriceListTab() {
     setExportError(null);
     try {
       const rows: ExportPriceRow[] = [];
+      const coverage: ExportCoverage[] = [];
       let exportedAt: Date | undefined;
-      for await (const row of exportPrices()) {
+      for await (const item of exportPrices()) {
+        if (item.item.case === "coverage") {
+          coverage.push(item.item.value);
+          continue;
+        }
+        if (item.item.case !== "row") continue;
+        const row = item.item.value;
         if (!exportedAt && row.exportedAt) {
           exportedAt = timestampDate(row.exportedAt);
         }
         rows.push(row);
       }
-      const csv = pricesToCsv(rows, exportedAt);
+      const csv = pricesToCsv(rows, exportedAt, coverage);
       const blob = new Blob([csv], { type: "text/csv" });
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");

--- a/client/lib/csv/prices.test.ts
+++ b/client/lib/csv/prices.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { create } from "@bufbuild/protobuf";
-import { AssetClass, ExportPriceRowSchema } from "@/gen/api/v1/api_pb";
+import { AssetClass, ExportCoverageSchema, ExportPriceRowSchema } from "@/gen/api/v1/api_pb";
 import type { ExportPriceRow } from "@/gen/api/v1/api_pb";
 import { pricesToCsv, csvToPrices } from "./prices";
 
@@ -354,5 +354,36 @@ describe("csvToPrices coverage headers", () => {
     expect(result.errors[0].field).toBe("before");
     expect(result.prices).toHaveLength(2);
     expect(result.coverage).toEqual([]);
+  });
+});
+
+describe("price CSV coverage round trip", () => {
+  it("carries coverage spans through serialize and parse", () => {
+    const coverage = [
+      create(ExportCoverageSchema, {
+        identifierType: "ISIN",
+        identifierValue: "US0378331005",
+        identifierDomain: "",
+        from: "2024-01-15",
+        before: "2024-02-01",
+      }),
+    ];
+    const csv = pricesToCsv([makeRow()], new Date("2026-07-30T00:00:00.000Z"), coverage);
+    const result = csvToPrices(csv);
+    expect(result.errors).toEqual([]);
+    expect(result.exportedAt?.toISOString()).toBe("2026-07-30T00:00:00.000Z");
+    expect(result.coverage).toEqual([
+      expect.objectContaining({
+        identifierType: "ISIN",
+        identifierValue: "US0378331005",
+        identifierDomain: "",
+        from: "2024-01-15",
+        before: "2024-02-01",
+      }),
+    ]);
+  });
+
+  it("writes no coverage header when the export supplied none", () => {
+    expect(pricesToCsv([makeRow()])).not.toContain("# coverage=");
   });
 });

--- a/client/lib/csv/prices.ts
+++ b/client/lib/csv/prices.ts
@@ -5,7 +5,7 @@
 import Papa from "papaparse";
 import { create } from "@bufbuild/protobuf";
 import { ImportPriceRowSchema, ImportCoverageSchema } from "@/gen/api/v1/api_pb";
-import type { ExportPriceRow, ImportPriceRow, ImportCoverage } from "@/gen/api/v1/api_pb";
+import type { ExportCoverage, ExportPriceRow, ImportPriceRow, ImportCoverage } from "@/gen/api/v1/api_pb";
 import type { ParseError } from "./standard";
 import { assetClassToStr, assetClassFromStr } from "@/lib/asset-class";
 import { VALID_IDENTIFIER_TYPES } from "@/lib/identifiers";
@@ -40,8 +40,14 @@ function fmtOptBigint(v: bigint | undefined): string {
   return v === undefined ? "" : String(v);
 }
 
-/** Serialize ExportPriceRow[] to CSV text. */
-export function pricesToCsv(rows: ExportPriceRow[], exportedAt?: Date): string {
+/**
+ * Serialize ExportPriceRow[] to CSV text.
+ *
+ * Coverage spans are written as "# coverage=" headers in the specific form.
+ * They matter: the export omits synthetic rows, so the spans are what let a
+ * re-import regenerate the filled days rather than leaving them as gaps.
+ */
+export function pricesToCsv(rows: ExportPriceRow[], exportedAt?: Date, coverage?: ExportCoverage[]): string {
   const data = rows.map((r) => [
     r.identifierType,
     r.identifierValue,
@@ -57,10 +63,14 @@ export function pricesToCsv(rows: ExportPriceRow[], exportedAt?: Date): string {
     r.currency,
   ]);
   const csv = Papa.unparse({ fields: HEADER.split(","), data }, { newline: "\n" }) + "\n";
-  if (exportedAt) {
-    return `${EXPORTED_AT_PREFIX}${exportedAt.toISOString()}\n${csv}`;
+  const headers: string[] = [];
+  if (exportedAt) headers.push(`${EXPORTED_AT_PREFIX}${exportedAt.toISOString()}`);
+  for (const c of coverage ?? []) {
+    headers.push(
+      `${COVERAGE_PREFIX}${c.identifierType},${c.identifierValue},${c.identifierDomain},${c.from},${c.before}`,
+    );
   }
-  return csv;
+  return headers.length > 0 ? `${headers.join("\n")}\n${csv}` : csv;
 }
 
 export interface PriceParseResult {

--- a/client/lib/json/corporate-events.test.ts
+++ b/client/lib/json/corporate-events.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 import { create } from "@bufbuild/protobuf";
 import { timestampFromDate } from "@bufbuild/protobuf/wkt";
-import { AssetClass, ExportCorporateEventRowSchema, SplitRowSchema } from "@/gen/api/v1/api_pb";
+import { AssetClass, ExportCorporateEventRowSchema, ExportCoverageSchema, SplitRowSchema } from "@/gen/api/v1/api_pb";
 import type { ExportCorporateEventRow } from "@/gen/api/v1/api_pb";
 import { splitsToJson, parseSplitsJson } from "./corporate-events";
 
@@ -28,12 +28,12 @@ describe("splitsToJson", () => {
   it("serializes knowledge time as an ISO 8601 instant", () => {
     const knownAt = new Date("2015-03-04T09:30:00.000Z");
     const out = JSON.parse(splitsToJson([makeSplitRow(knownAt)]));
-    expect(out[0].first_known_at).toBe("2015-03-04T09:30:00.000Z");
+    expect(out.events[0].first_known_at).toBe("2015-03-04T09:30:00.000Z");
   });
 
   it("omits knowledge time when the row carries none", () => {
     const out = JSON.parse(splitsToJson([makeSplitRow()]));
-    expect(out[0]).not.toHaveProperty("first_known_at");
+    expect(out.events[0]).not.toHaveProperty("first_known_at");
   });
 });
 
@@ -130,5 +130,35 @@ describe("parseSplitsJson coverage", () => {
     const { errors } = parseSplitsJson(JSON.stringify({ coverage: [] }));
     expect(errors).toHaveLength(1);
     expect(errors[0].field).toBe("file");
+  });
+});
+
+describe("corporate event JSON coverage round trip", () => {
+  it("carries coverage spans through serialize and parse", () => {
+    const coverage = [
+      create(ExportCoverageSchema, {
+        identifierType: "MIC_TICKER",
+        identifierValue: "AAPL",
+        identifierDomain: "XNAS",
+        from: "2020-01-01",
+        before: "2025-01-01",
+      }),
+    ];
+    const json = splitsToJson([makeSplitRow()], coverage);
+    const result = parseSplitsJson(json);
+    expect(result.errors).toEqual([]);
+    expect(result.coverage).toEqual([
+      expect.objectContaining({
+        identifierType: "MIC_TICKER",
+        identifierValue: "AAPL",
+        identifierDomain: "XNAS",
+        from: "2020-01-01",
+        before: "2025-01-01",
+      }),
+    ]);
+  });
+
+  it("omits the coverage key when the export supplied none", () => {
+    expect(JSON.parse(splitsToJson([makeSplitRow()]))).not.toHaveProperty("coverage");
   });
 });

--- a/client/lib/json/corporate-events.ts
+++ b/client/lib/json/corporate-events.ts
@@ -10,7 +10,7 @@
 import { create } from "@bufbuild/protobuf";
 import { timestampDate } from "@bufbuild/protobuf/wkt";
 import { AssetClass, ImportCorporateEventCoverageSchema } from "@/gen/api/v1/api_pb";
-import type { ExportCorporateEventRow, ImportCorporateEventCoverage, SplitRow } from "@/gen/api/v1/api_pb";
+import type { ExportCorporateEventRow, ExportCoverage, ImportCorporateEventCoverage, SplitRow } from "@/gen/api/v1/api_pb";
 import type { CorporateSplitImportRow } from "@/lib/portfolio-api";
 import { assetClassToStr, assetClassFromStr } from "@/lib/asset-class";
 import type { ParseError } from "@/lib/csv/standard";
@@ -30,8 +30,19 @@ interface SerializedSplit {
   first_known_at?: string;
 }
 
-/** Serialize split export rows to JSON string. */
-export function splitsToJson(rows: ExportCorporateEventRow[]): string {
+interface SerializedCoverage {
+  identifier_type: string;
+  identifier_value: string;
+  identifier_domain?: string;
+  from: string;
+  before: string;
+}
+
+/**
+ * Serialize split export rows to a JSON string in the canonical object form.
+ * Coverage is written in the specific form, one entry per instrument.
+ */
+export function splitsToJson(rows: ExportCorporateEventRow[], coverage?: ExportCoverage[]): string {
   const serialized: SerializedSplit[] = rows
     .filter((r) => r.event.case === "split")
     .map((r) => {
@@ -49,7 +60,20 @@ export function splitsToJson(rows: ExportCorporateEventRow[]): string {
       if (split.firstKnownAt) obj.first_known_at = timestampDate(split.firstKnownAt).toISOString();
       return obj;
     });
-  return JSON.stringify(serialized, null, 2) + "\n";
+  const out: { events: SerializedSplit[]; coverage?: SerializedCoverage[] } = { events: serialized };
+  if (coverage && coverage.length > 0) {
+    out.coverage = coverage.map((c) => {
+      const obj: SerializedCoverage = {
+        identifier_type: c.identifierType,
+        identifier_value: c.identifierValue,
+        from: c.from,
+        before: c.before,
+      };
+      if (c.identifierDomain) obj.identifier_domain = c.identifierDomain;
+      return obj;
+    });
+  }
+  return JSON.stringify(out, null, 2) + "\n";
 }
 
 export interface SplitParseResult {

--- a/client/lib/portfolio-api.ts
+++ b/client/lib/portfolio-api.ts
@@ -7,10 +7,10 @@ import { timestampDate, timestampFromDate } from "@bufbuild/protobuf/wkt";
 import { DateSchema } from "@/gen/google/type/date_pb";
 import type { Date as ProtoDate } from "@/gen/google/type/date_pb";
 import {
-  ExportCorporateEventRowSchema,
+  ExportCorporateEventsResponseSchema,
   ExportCorporateEventsRequestSchema,
   ExportInstrumentsRequestSchema,
-  ExportPriceRowSchema,
+  ExportPricesResponseSchema,
   ExportPricesRequestSchema,
   GetPortfolioValuationRequestSchema,
   GetPortfolioValuationResponseSchema,
@@ -111,9 +111,12 @@ import type {
   DescriptionPluginConfig,
   EODPriceProto,
   ExportCorporateEventRow,
+  ExportCorporateEventsResponse,
+  ExportCoverage,
   InflationIndexProto,
   InflationPluginConfig,
   ExportPriceRow,
+  ExportPricesResponse,
   Holding,
   HoldingDeclaration,
   IdentificationError,
@@ -644,11 +647,11 @@ export async function importInstruments(instruments: Instrument[]): Promise<Impo
 }
 
 /** Stream all exported prices (admin only). */
-export async function* exportPrices(): AsyncGenerator<ExportPriceRow> {
+export async function* exportPrices(): AsyncGenerator<ExportPricesResponse> {
   const base = getBaseUrl();
   const req = create(ExportPricesRequestSchema, {});
   for await (const bytes of streamingFetch(base, ApiServicePrefix + "ExportPrices", toBinary(ExportPricesRequestSchema, req), { credentials: "include" })) {
-    yield fromBinary(ExportPriceRowSchema, bytes);
+    yield fromBinary(ExportPricesResponseSchema, bytes);
   }
 }
 
@@ -725,11 +728,11 @@ export async function importCorporateEventSplits(
 }
 
 /** Stream all exported corporate events (admin only). */
-export async function* exportCorporateEvents(): AsyncGenerator<ExportCorporateEventRow> {
+export async function* exportCorporateEvents(): AsyncGenerator<ExportCorporateEventsResponse> {
   const base = getBaseUrl();
   const req = create(ExportCorporateEventsRequestSchema, {});
   for await (const bytes of streamingFetch(base, ApiServicePrefix + "ExportCorporateEvents", toBinary(ExportCorporateEventsRequestSchema, req), { credentials: "include" })) {
-    yield fromBinary(ExportCorporateEventRowSchema, bytes);
+    yield fromBinary(ExportCorporateEventsResponseSchema, bytes);
   }
 }
 

--- a/docs/spec/csv-format.md
+++ b/docs/spec/csv-format.md
@@ -73,6 +73,8 @@ It declares the share count the file's quantities and unit prices are denominate
 
 A CSV of EOD prices imported via the `ImportPrices` API, and the format `ExportPrices` writes.
 
+The export omits synthetic forward-filled rows, so a file holds only the days its source actually reported. Its [coverage declarations](#coverage-declarations) are what let a re-import regenerate the days between, which is what makes the round trip reproduce the exported state.
+
 ### Columns
 
 Header names are case-insensitive. Column order is not significant.
@@ -119,6 +121,8 @@ OCC,NVDA250620P00110000,,2024-06-11,,,,13.42,,,OPTION,USD
 ## Corporate event JSON
 
 Stock splits are imported via the `ImportCorporateEvents` API as JSON, and `ExportCorporateEvents` writes the same shape. Cash dividends are part of the API but are not yet carried by this file format.
+
+Coverage is stored per (instrument, plugin), but an import records every span as `data_provider = "import"`, so the export merges spans across plugins rather than preserving a distinction that cannot survive the round trip.
 
 The canonical shape is an object with an `events` array and an optional `coverage` array. A bare array is accepted as events-only.
 

--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -224,7 +224,7 @@ service ApiService {
   rpc ListPrices(ListPricesRequest) returns (ListPricesResponse);
 
   // Price export/import (admin-only). Export streams all cached EOD prices with best identifier per instrument; import upserts with data_provider = "import".
-  rpc ExportPrices(ExportPricesRequest) returns (stream ExportPriceRow);
+  rpc ExportPrices(ExportPricesRequest) returns (stream ExportPricesResponse);
   rpc ImportPrices(ImportPricesRequest) returns (ImportPricesResponse);
 
   // Telemetry counters (admin-only). Returns counters discovered from Redis (portfoliodb:counters:*).
@@ -270,7 +270,7 @@ service ApiService {
   // Corporate event import / export. Mirrors the price import/export RPCs:
   // import is async via the job queue, export streams every event with the
   // best identifier per instrument.
-  rpc ExportCorporateEvents(ExportCorporateEventsRequest) returns (stream ExportCorporateEventRow);
+  rpc ExportCorporateEvents(ExportCorporateEventsRequest) returns (stream ExportCorporateEventsResponse);
   rpc ImportCorporateEvents(ImportCorporateEventsRequest) returns (ImportCorporateEventsResponse);
 
   // Unhandled corporate events (reverse splits, non-whole splits, mergers, etc.)
@@ -683,6 +683,27 @@ message ListPricesResponse {
 // ExportPrices streams all cached EOD prices. Each row carries the best identifier for the instrument.
 message ExportPricesRequest {}
 
+// ExportCoverage is one half-open [from, before) coverage span for an
+// instrument, streamed alongside the rows it covers. Re-importing rows without
+// their coverage does not reproduce the exported state: only real bars are
+// exported, so the synthetic days between them are regenerated from coverage.
+message ExportCoverage {
+  string identifier_type = 1;
+  string identifier_value = 2;
+  string identifier_domain = 3;
+  string from = 4;   // YYYY-MM-DD, inclusive
+  string before = 5; // YYYY-MM-DD, exclusive
+}
+
+// ExportPricesResponse is one element of the export stream. Coverage spans are
+// sent before the rows they cover.
+message ExportPricesResponse {
+  oneof item {
+    ExportPriceRow row = 1;
+    ExportCoverage coverage = 2;
+  }
+}
+
 // ExportPriceRow is one price row with instrument identifier context.
 message ExportPriceRow {
   string identifier_type = 1;    // IdentifierType name (e.g. "ISIN", "MIC_TICKER", "OPENFIGI_TICKER")
@@ -1058,6 +1079,17 @@ message ExportCorporateEventRow {
 }
 
 message ExportCorporateEventsRequest {}
+
+// ExportCorporateEventsResponse is one element of the export stream. Coverage
+// spans are sent before the rows they cover, merged across plugins: an import
+// records them all as data_provider = "import", so the per-plugin split does
+// not survive a round trip anyway.
+message ExportCorporateEventsResponse {
+  oneof item {
+    ExportCorporateEventRow row = 1;
+    ExportCoverage coverage = 2;
+  }
+}
 
 // ImportCorporateEventRow is one corporate event row to import. When the
 // instrument is unknown, asset_class is used as the security type hint for

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -372,6 +372,16 @@ type ExportPriceRow struct {
 	Volume           *int64
 }
 
+// ExportCoverageRow is one half-open [From, Before) coverage span with the best
+// instrument identifier for export.
+type ExportCoverageRow struct {
+	IdentifierType   string
+	IdentifierValue  string
+	IdentifierDomain string
+	From             time.Time
+	Before           time.Time
+}
+
 // EODPriceListDB provides paginated listing of EOD prices for admin UI.
 type EODPriceListDB interface {
 	// ListPrices returns EOD prices with optional search, half-open
@@ -382,6 +392,11 @@ type EODPriceListDB interface {
 	// ListPricesForExport returns all EOD prices with the best identifier per instrument.
 	// Instruments with no identifiers are excluded.
 	ListPricesForExport(ctx context.Context) ([]ExportPriceRow, error)
+	// ListPriceCoverageForExport returns the merged date spans covered by
+	// eod_prices per instrument, with the best identifier. Synthetic rows count
+	// towards a span: ListPricesForExport omits them, so the span is what lets
+	// an import regenerate them.
+	ListPriceCoverageForExport(ctx context.Context) ([]ExportCoverageRow, error)
 }
 
 // Valid asset class values (controlled vocabulary).
@@ -829,6 +844,11 @@ type CorporateEventDB interface {
 	// instruments. When instrumentIDs is empty all coverage rows are returned.
 	// Rows are sorted by (instrument_id, plugin_id, covered_from).
 	ListCorporateEventCoverage(ctx context.Context, instrumentIDs []string) ([]CorporateEventCoverage, error)
+	// ListCorporateEventCoverageForExport returns coverage spans per instrument
+	// with the best identifier, merged across plugins. An import records every
+	// span as data_provider = "import", so the per-plugin split does not
+	// survive a round trip.
+	ListCorporateEventCoverageForExport(ctx context.Context) ([]ExportCoverageRow, error)
 
 	// CreateCorporateEventFetchBlock blocks (instrument, plugin) for future
 	// corporate-event fetch attempts. Idempotent on (instrument_id, plugin_id).

--- a/server/db/postgres/corporate_events.go
+++ b/server/db/postgres/corporate_events.go
@@ -894,3 +894,25 @@ func (p *Postgres) ResolveUnhandledCorporateEvent(ctx context.Context, id string
 	return nil
 }
 
+
+// ListCorporateEventCoverageForExport implements db.CorporateEventDB.
+func (p *Postgres) ListCorporateEventCoverageForExport(ctx context.Context) ([]db.ExportCoverageRow, error) {
+	q := `
+		SELECT best_id.identifier_type, best_id.value, COALESCE(best_id.domain, '') AS domain,
+			lower(sub.r) AS covered_from, upper(sub.r) AS covered_before
+		FROM (
+			SELECT instrument_id,
+				unnest(range_agg(daterange(covered_from, covered_before))) AS r
+			FROM corporate_event_coverage
+			GROUP BY instrument_id
+		) sub
+		JOIN instruments i ON i.id = sub.instrument_id
+		` + bestIdentifierJoin + `
+		ORDER BY best_id.identifier_type, best_id.value, covered_from
+	`
+	var rows []exportCoverageRow
+	if err := p.q.SelectContext(ctx, &rows, q); err != nil {
+		return nil, fmt.Errorf("list corporate event coverage for export: %w", err)
+	}
+	return toExportCoverageRows(rows), nil
+}

--- a/server/db/postgres/corporate_events_test.go
+++ b/server/db/postgres/corporate_events_test.go
@@ -1617,3 +1617,44 @@ func TestApplyOptionSplit_ConvergesOnStaleOldOCC(t *testing.T) {
 }
 
 func timePtrCE(t time.Time) *time.Time { return &t }
+
+// Coverage is stored per (instrument, plugin), but an import records every span
+// as data_provider = "import", so the export merges across plugins.
+func TestListCorporateEventCoverageForExport_MergesAcrossPlugins(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+
+	instID := setupTickerInstrument(t, p, "AAPL")
+	if err := p.UpsertCorporateEventCoverage(ctx, instID, "massive", d(2020, 1, 1), d(2022, 1, 1), nil); err != nil {
+		t.Fatalf("upsert coverage massive: %v", err)
+	}
+	if err := p.UpsertCorporateEventCoverage(ctx, instID, "eodhd", d(2022, 1, 1), d(2024, 1, 1), nil); err != nil {
+		t.Fatalf("upsert coverage eodhd: %v", err)
+	}
+
+	cov, err := p.ListCorporateEventCoverageForExport(ctx)
+	if err != nil {
+		t.Fatalf("list corporate event coverage for export: %v", err)
+	}
+	if len(cov) != 1 {
+		t.Fatalf("expected the two adjacent spans merged into 1, got %d", len(cov))
+	}
+	if !cov[0].From.Equal(d(2020, 1, 1)) || !cov[0].Before.Equal(d(2024, 1, 1)) {
+		t.Errorf("expected [2020-01-01, 2024-01-01), got [%s, %s)",
+			cov[0].From.Format("2006-01-02"), cov[0].Before.Format("2006-01-02"))
+	}
+	if cov[0].IdentifierType != "MIC_TICKER" || cov[0].IdentifierValue != "AAPL" {
+		t.Errorf("got identifier %s %s", cov[0].IdentifierType, cov[0].IdentifierValue)
+	}
+}
+
+func TestListCorporateEventCoverageForExport_Empty(t *testing.T) {
+	p := testDBTx(t)
+	cov, err := p.ListCorporateEventCoverageForExport(context.Background())
+	if err != nil {
+		t.Fatalf("list corporate event coverage for export: %v", err)
+	}
+	if len(cov) != 0 {
+		t.Fatalf("expected no spans, got %d", len(cov))
+	}
+}

--- a/server/db/postgres/eod_prices.go
+++ b/server/db/postgres/eod_prices.go
@@ -163,3 +163,52 @@ func (p *Postgres) ListPricesForExport(ctx context.Context) ([]db.ExportPriceRow
 	}
 	return out, nil
 }
+
+// exportCoverageRow is a sqlx-scannable version of db.ExportCoverageRow.
+type exportCoverageRow struct {
+	IdentifierType   string    `db:"identifier_type"`
+	IdentifierValue  string    `db:"value"`
+	IdentifierDomain string    `db:"domain"`
+	From             time.Time `db:"covered_from"`
+	Before           time.Time `db:"covered_before"`
+}
+
+func toExportCoverageRows(rows []exportCoverageRow) []db.ExportCoverageRow {
+	out := make([]db.ExportCoverageRow, len(rows))
+	for i, r := range rows {
+		out[i] = db.ExportCoverageRow{
+			IdentifierType:   r.IdentifierType,
+			IdentifierValue:  r.IdentifierValue,
+			IdentifierDomain: r.IdentifierDomain,
+			From:             r.From,
+			Before:           r.Before,
+		}
+	}
+	return out
+}
+
+// ListPriceCoverageForExport implements db.EODPriceListDB.
+//
+// Synthetic rows are included in the aggregation even though
+// ListPricesForExport omits them: the span is exactly what tells an import
+// which days to regenerate.
+func (p *Postgres) ListPriceCoverageForExport(ctx context.Context) ([]db.ExportCoverageRow, error) {
+	q := `
+		SELECT best_id.identifier_type, best_id.value, COALESCE(best_id.domain, '') AS domain,
+			lower(sub.r) AS covered_from, upper(sub.r) AS covered_before
+		FROM (
+			SELECT instrument_id,
+				unnest(range_agg(daterange(price_date, price_date + 1))) AS r
+			FROM eod_prices
+			GROUP BY instrument_id
+		) sub
+		JOIN instruments i ON i.id = sub.instrument_id
+		` + bestIdentifierJoin + `
+		ORDER BY best_id.identifier_type, best_id.value, covered_from
+	`
+	var rows []exportCoverageRow
+	if err := p.q.SelectContext(ctx, &rows, q); err != nil {
+		return nil, fmt.Errorf("list price coverage for export: %w", err)
+	}
+	return toExportCoverageRows(rows), nil
+}

--- a/server/db/postgres/eod_prices_test.go
+++ b/server/db/postgres/eod_prices_test.go
@@ -331,3 +331,89 @@ func TestListPrices_Pagination(t *testing.T) {
 		t.Fatalf("expected no next token on last page, got %q", nextToken3)
 	}
 }
+
+// setupTickerInstrument creates an instrument identified by MIC_TICKER, which
+// the export's identifier precedence prefers.
+func setupTickerInstrument(t *testing.T, p *Postgres, ticker string) string {
+	t.Helper()
+	id, err := p.EnsureInstrument(context.Background(), "STOCK", "XNAS", "USD", ticker, "", "", []db.IdentifierInput{
+		{Type: "MIC_TICKER", Domain: "XNAS", Value: ticker, Canonical: true},
+	}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument %s: %v", ticker, err)
+	}
+	return id
+}
+
+// The export omits synthetic rows, so the coverage span is the only thing that
+// tells an import which days to regenerate. It must therefore span them.
+func TestListPriceCoverageForExport_SpansSyntheticRows(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+
+	instID := setupTickerInstrument(t, p, "AAPL")
+	if err := p.UpsertPricesWithFill(ctx, instID, "test", []db.EODPrice{
+		{InstrumentID: instID, PriceDate: d(2024, 1, 15), Close: 100},
+		{InstrumentID: instID, PriceDate: d(2024, 1, 18), Close: 110},
+	}, d(2024, 1, 15), d(2024, 1, 19), nil); err != nil {
+		t.Fatalf("upsert prices with fill: %v", err)
+	}
+
+	rows, err := p.ListPricesForExport(ctx)
+	if err != nil {
+		t.Fatalf("list prices for export: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected the 2 real rows, got %d", len(rows))
+	}
+
+	cov, err := p.ListPriceCoverageForExport(ctx)
+	if err != nil {
+		t.Fatalf("list price coverage for export: %v", err)
+	}
+	if len(cov) != 1 {
+		t.Fatalf("expected 1 merged span, got %d", len(cov))
+	}
+	if !cov[0].From.Equal(d(2024, 1, 15)) || !cov[0].Before.Equal(d(2024, 1, 19)) {
+		t.Errorf("expected [2024-01-15, 2024-01-19), got [%s, %s)",
+			cov[0].From.Format("2006-01-02"), cov[0].Before.Format("2006-01-02"))
+	}
+	if cov[0].IdentifierType != "MIC_TICKER" || cov[0].IdentifierValue != "AAPL" {
+		t.Errorf("got identifier %s %s", cov[0].IdentifierType, cov[0].IdentifierValue)
+	}
+}
+
+func TestListPriceCoverageForExport_SplitsOnGaps(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+
+	instID := setupTickerInstrument(t, p, "AAPL")
+	insertPriceWithProvider(t, p, instID, d(2024, 1, 15), 100, "test")
+	insertPriceWithProvider(t, p, instID, d(2024, 1, 16), 101, "test")
+	insertPriceWithProvider(t, p, instID, d(2024, 2, 1), 110, "test")
+
+	cov, err := p.ListPriceCoverageForExport(ctx)
+	if err != nil {
+		t.Fatalf("list price coverage for export: %v", err)
+	}
+	if len(cov) != 2 {
+		t.Fatalf("expected 2 spans either side of the gap, got %d", len(cov))
+	}
+	if !cov[0].From.Equal(d(2024, 1, 15)) || !cov[0].Before.Equal(d(2024, 1, 17)) {
+		t.Errorf("first span [%s, %s)", cov[0].From.Format("2006-01-02"), cov[0].Before.Format("2006-01-02"))
+	}
+	if !cov[1].From.Equal(d(2024, 2, 1)) || !cov[1].Before.Equal(d(2024, 2, 2)) {
+		t.Errorf("second span [%s, %s)", cov[1].From.Format("2006-01-02"), cov[1].Before.Format("2006-01-02"))
+	}
+}
+
+func TestListPriceCoverageForExport_Empty(t *testing.T) {
+	p := testDBTx(t)
+	cov, err := p.ListPriceCoverageForExport(context.Background())
+	if err != nil {
+		t.Fatalf("list price coverage for export: %v", err)
+	}
+	if len(cov) != 0 {
+		t.Fatalf("expected no spans, got %d", len(cov))
+	}
+}

--- a/server/service/api/corporate_events.go
+++ b/server/service/api/corporate_events.go
@@ -14,13 +14,25 @@ import (
 )
 
 // ExportCorporateEvents streams every stored stock split and cash dividend
-// with the best identifier per instrument. Splits stream first, then
-// dividends; within each block rows are ordered by (identifier_type,
-// identifier_value, ex_date). Admin only.
+// with the best identifier per instrument. Coverage spans come first, then
+// splits, then dividends; within each block rows are ordered by
+// (identifier_type, identifier_value, ex_date). Admin only.
 func (s *Server) ExportCorporateEvents(req *apiv1.ExportCorporateEventsRequest, stream apiv1.ApiService_ExportCorporateEventsServer) error {
 	ctx := stream.Context()
 	if _, authErr := auth.RequireAdmin(ctx); authErr != nil {
 		return authErr
+	}
+
+	coverage, err := s.db.ListCorporateEventCoverageForExport(ctx)
+	if err != nil {
+		return status.Error(codes.Internal, err.Error())
+	}
+	for _, c := range coverage {
+		if err := stream.Send(&apiv1.ExportCorporateEventsResponse{
+			Item: &apiv1.ExportCorporateEventsResponse_Coverage{Coverage: exportCoverage(c)},
+		}); err != nil {
+			return err
+		}
 	}
 
 	splits, err := s.db.ListStockSplitsForExport(ctx)
@@ -43,7 +55,9 @@ func (s *Server) ExportCorporateEvents(req *apiv1.ExportCorporateEventsRequest, 
 				},
 			},
 		}
-		if err := stream.Send(row); err != nil {
+		if err := stream.Send(&apiv1.ExportCorporateEventsResponse{
+			Item: &apiv1.ExportCorporateEventsResponse_Row{Row: row},
+		}); err != nil {
 			return err
 		}
 	}
@@ -78,7 +92,9 @@ func (s *Server) ExportCorporateEvents(req *apiv1.ExportCorporateEventsRequest, 
 			DataProvider:     r.DataProvider,
 			Event:            &apiv1.ExportCorporateEventRow_Dividend{Dividend: div},
 		}
-		if err := stream.Send(row); err != nil {
+		if err := stream.Send(&apiv1.ExportCorporateEventsResponse{
+			Item: &apiv1.ExportCorporateEventsResponse_Row{Row: row},
+		}); err != nil {
 			return err
 		}
 	}

--- a/server/service/api/export_corporate_events_test.go
+++ b/server/service/api/export_corporate_events_test.go
@@ -26,6 +26,13 @@ func TestExportCorporateEvents_CarriesKnowledgeTimeAndDividendType(t *testing.T)
 	splitKnownAt := time.Date(2015, 3, 4, 9, 30, 0, 0, time.UTC)
 	divKnownAt := time.Date(2024, 2, 2, 8, 0, 0, 0, time.UTC)
 
+	db.EXPECT().ListCorporateEventCoverageForExport(gomock.Any()).Return([]dbpkg.ExportCoverageRow{{
+		IdentifierType:   "MIC_TICKER",
+		IdentifierValue:  "AAPL",
+		IdentifierDomain: "XNAS",
+		From:             time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+		Before:           time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+	}}, nil)
 	db.EXPECT().ListStockSplitsForExport(gomock.Any()).Return([]dbpkg.ExportStockSplit{
 		{
 			IdentifierType:   "MIC_TICKER",
@@ -58,21 +65,30 @@ func TestExportCorporateEvents_CarriesKnowledgeTimeAndDividendType(t *testing.T)
 	if err := srv.ExportCorporateEvents(&apiv1.ExportCorporateEventsRequest{}, stream); err != nil {
 		t.Fatalf("ExportCorporateEvents: %v", err)
 	}
-	if len(stream.sent) != 2 {
-		t.Fatalf("expected 2 rows streamed, got %d", len(stream.sent))
+	if len(stream.coverage()) != 1 {
+		t.Fatalf("expected 1 coverage span streamed, got %d", len(stream.coverage()))
+	}
+	if cov := stream.coverage()[0]; cov.GetFrom() != "2020-01-01" || cov.GetBefore() != "2025-01-01" {
+		t.Fatalf("got span [%s, %s)", cov.GetFrom(), cov.GetBefore())
+	}
+	if stream.sent[0].GetCoverage() == nil {
+		t.Fatalf("expected coverage before the rows, got %+v", stream.sent[0])
+	}
+	if len(stream.rows()) != 2 {
+		t.Fatalf("expected 2 rows streamed, got %d", len(stream.rows()))
 	}
 
-	split := stream.sent[0].GetSplit()
+	split := stream.rows()[0].GetSplit()
 	if split == nil {
-		t.Fatalf("first row is not a split: %+v", stream.sent[0])
+		t.Fatalf("first row is not a split: %+v", stream.rows()[0])
 	}
 	if got := split.GetFirstKnownAt().AsTime(); !got.Equal(splitKnownAt) {
 		t.Errorf("split first_known_at: want %s, got %s", splitKnownAt, got)
 	}
 
-	div := stream.sent[1].GetDividend()
+	div := stream.rows()[1].GetDividend()
 	if div == nil {
-		t.Fatalf("second row is not a dividend: %+v", stream.sent[1])
+		t.Fatalf("second row is not a dividend: %+v", stream.rows()[1])
 	}
 	if div.GetType() != "SC" {
 		t.Errorf("dividend type: want SC, got %q", div.GetType())

--- a/server/service/api/export_import_prices_test.go
+++ b/server/service/api/export_import_prices_test.go
@@ -37,6 +37,15 @@ func TestExportPrices_Success(t *testing.T) {
 		},
 	}
 	db.EXPECT().
+		ListPriceCoverageForExport(gomock.Any()).
+		Return([]dbpkg.ExportCoverageRow{{
+			IdentifierType:   "MIC_TICKER",
+			IdentifierValue:  "AAPL",
+			IdentifierDomain: "US",
+			From:             time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
+			Before:           time.Date(2024, 1, 16, 0, 0, 0, 0, time.UTC),
+		}}, nil)
+	db.EXPECT().
 		ListPricesForExport(gomock.Any()).
 		Return(rows, nil)
 	stream := &exportPriceStreamMock{ctx: adminCtx("user-1", "sub|1")}
@@ -44,10 +53,10 @@ func TestExportPrices_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ExportPrices: %v", err)
 	}
-	if len(stream.sent) != 1 {
-		t.Fatalf("expected 1 row streamed, got %d", len(stream.sent))
+	if len(stream.rows()) != 1 {
+		t.Fatalf("expected 1 row streamed, got %d", len(stream.rows()))
 	}
-	row := stream.sent[0]
+	row := stream.rows()[0]
 	if row.GetIdentifierType() != "MIC_TICKER" || row.GetIdentifierValue() != "AAPL" {
 		t.Fatalf("got identifier %s %s", row.GetIdentifierType(), row.GetIdentifierValue())
 	}
@@ -74,6 +83,9 @@ func TestExportPrices_Success(t *testing.T) {
 func TestExportPrices_Empty(t *testing.T) {
 	srv, db := newAPIServerWithMock(t)
 	db.EXPECT().
+		ListPriceCoverageForExport(gomock.Any()).
+		Return(nil, nil)
+	db.EXPECT().
 		ListPricesForExport(gomock.Any()).
 		Return(nil, nil)
 	stream := &exportPriceStreamMock{ctx: adminCtx("user-1", "sub|1")}
@@ -81,8 +93,54 @@ func TestExportPrices_Empty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ExportPrices: %v", err)
 	}
-	if len(stream.sent) != 0 {
-		t.Fatalf("expected 0 rows, got %d", len(stream.sent))
+	if len(stream.rows()) != 0 {
+		t.Fatalf("expected 0 rows, got %d", len(stream.rows()))
+	}
+	if len(stream.coverage()) != 0 {
+		t.Fatalf("expected 0 coverage spans, got %d", len(stream.coverage()))
+	}
+}
+
+// Only real bars are exported, so the coverage spans are what let an import
+// regenerate the synthetic days between them. They precede the rows.
+func TestExportPrices_SendsCoverageBeforeRows(t *testing.T) {
+	srv, db := newAPIServerWithMock(t)
+	db.EXPECT().
+		ListPriceCoverageForExport(gomock.Any()).
+		Return([]dbpkg.ExportCoverageRow{{
+			IdentifierType:   "MIC_TICKER",
+			IdentifierValue:  "AAPL",
+			IdentifierDomain: "US",
+			From:             time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
+			Before:           time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC),
+		}}, nil)
+	db.EXPECT().
+		ListPricesForExport(gomock.Any()).
+		Return([]dbpkg.ExportPriceRow{{
+			IdentifierType:  "MIC_TICKER",
+			IdentifierValue: "AAPL",
+			PriceDate:       time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
+			Close:           185.90,
+		}}, nil)
+	stream := &exportPriceStreamMock{ctx: adminCtx("user-1", "sub|1")}
+	if err := srv.ExportPrices(&apiv1.ExportPricesRequest{}, stream); err != nil {
+		t.Fatalf("ExportPrices: %v", err)
+	}
+	if len(stream.sent) != 2 {
+		t.Fatalf("expected 2 stream items, got %d", len(stream.sent))
+	}
+	cov := stream.sent[0].GetCoverage()
+	if cov == nil {
+		t.Fatalf("expected coverage first, got %+v", stream.sent[0])
+	}
+	if cov.GetFrom() != "2024-01-15" || cov.GetBefore() != "2024-02-01" {
+		t.Fatalf("got span [%s, %s)", cov.GetFrom(), cov.GetBefore())
+	}
+	if cov.GetIdentifierValue() != "AAPL" || cov.GetIdentifierDomain() != "US" {
+		t.Fatalf("got identifier %s %s", cov.GetIdentifierValue(), cov.GetIdentifierDomain())
+	}
+	if stream.sent[1].GetRow() == nil {
+		t.Fatalf("expected a row second, got %+v", stream.sent[1])
 	}
 }
 

--- a/server/service/api/prices.go
+++ b/server/service/api/prices.go
@@ -72,11 +72,25 @@ func (s *Server) ListPrices(ctx context.Context, req *apiv1.ListPricesRequest) (
 	}, nil
 }
 
-// ExportPrices streams all cached EOD prices with the best identifier per instrument. Admin only.
+// ExportPrices streams all cached EOD prices with the best identifier per
+// instrument. Coverage spans come first, then the rows: only real bars are
+// exported, so the spans are what let an import regenerate the synthetic days
+// between them. Admin only.
 func (s *Server) ExportPrices(req *apiv1.ExportPricesRequest, stream apiv1.ApiService_ExportPricesServer) error {
 	ctx := stream.Context()
 	if _, authErr := auth.RequireAdmin(ctx); authErr != nil {
 		return authErr
+	}
+	coverage, err := s.db.ListPriceCoverageForExport(ctx)
+	if err != nil {
+		return status.Error(codes.Internal, err.Error())
+	}
+	for _, c := range coverage {
+		if err := stream.Send(&apiv1.ExportPricesResponse{
+			Item: &apiv1.ExportPricesResponse_Coverage{Coverage: exportCoverage(c)},
+		}); err != nil {
+			return err
+		}
 	}
 	rows, err := s.db.ListPricesForExport(ctx)
 	if err != nil {
@@ -109,11 +123,24 @@ func (s *Server) ExportPrices(req *apiv1.ExportPricesRequest, stream apiv1.ApiSe
 		if r.Volume != nil {
 			row.Volume = r.Volume
 		}
-		if err := stream.Send(row); err != nil {
+		if err := stream.Send(&apiv1.ExportPricesResponse{
+			Item: &apiv1.ExportPricesResponse_Row{Row: row},
+		}); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// exportCoverage converts a db coverage span to its wire form.
+func exportCoverage(c db.ExportCoverageRow) *apiv1.ExportCoverage {
+	return &apiv1.ExportCoverage{
+		IdentifierType:   c.IdentifierType,
+		IdentifierValue:  c.IdentifierValue,
+		IdentifierDomain: c.IdentifierDomain,
+		From:             c.From.Format("2006-01-02"),
+		Before:           c.Before.Format("2006-01-02"),
+	}
 }
 
 // ImportPrices creates an async job to upsert EOD prices. Admin only.

--- a/server/service/api/server_test.go
+++ b/server/service/api/server_test.go
@@ -65,12 +65,12 @@ func (e *exportStreamMock) SendMsg(m interface{}) error {
 // exportPriceStreamMock provides a stream with configurable context for ExportPrices tests.
 type exportPriceStreamMock struct {
 	ctx  context.Context
-	sent []*apiv1.ExportPriceRow
+	sent []*apiv1.ExportPricesResponse
 }
 
 func (e *exportPriceStreamMock) Context() context.Context    { return e.ctx }
 func (e *exportPriceStreamMock) RecvMsg(m interface{}) error { return nil }
-func (e *exportPriceStreamMock) Send(m *apiv1.ExportPriceRow) error {
+func (e *exportPriceStreamMock) Send(m *apiv1.ExportPricesResponse) error {
 	e.sent = append(e.sent, m)
 	return nil
 }
@@ -78,22 +78,44 @@ func (e *exportPriceStreamMock) SendHeader(m metadata.MD) error { return nil }
 func (e *exportPriceStreamMock) SetHeader(m metadata.MD) error  { return nil }
 func (e *exportPriceStreamMock) SetTrailer(m metadata.MD)       {}
 func (e *exportPriceStreamMock) SendMsg(m interface{}) error {
-	if row, ok := m.(*apiv1.ExportPriceRow); ok {
+	if row, ok := m.(*apiv1.ExportPricesResponse); ok {
 		e.sent = append(e.sent, row)
 	}
 	return nil
+}
+
+// rows returns the price rows in send order, dropping coverage envelopes.
+func (e *exportPriceStreamMock) rows() []*apiv1.ExportPriceRow {
+	var out []*apiv1.ExportPriceRow
+	for _, m := range e.sent {
+		if r := m.GetRow(); r != nil {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// coverage returns the coverage spans in send order.
+func (e *exportPriceStreamMock) coverage() []*apiv1.ExportCoverage {
+	var out []*apiv1.ExportCoverage
+	for _, m := range e.sent {
+		if c := m.GetCoverage(); c != nil {
+			out = append(out, c)
+		}
+	}
+	return out
 }
 
 // exportCorporateEventStreamMock provides a stream with configurable context
 // for ExportCorporateEvents tests.
 type exportCorporateEventStreamMock struct {
 	ctx  context.Context
-	sent []*apiv1.ExportCorporateEventRow
+	sent []*apiv1.ExportCorporateEventsResponse
 }
 
 func (e *exportCorporateEventStreamMock) Context() context.Context    { return e.ctx }
 func (e *exportCorporateEventStreamMock) RecvMsg(m interface{}) error { return nil }
-func (e *exportCorporateEventStreamMock) Send(m *apiv1.ExportCorporateEventRow) error {
+func (e *exportCorporateEventStreamMock) Send(m *apiv1.ExportCorporateEventsResponse) error {
 	e.sent = append(e.sent, m)
 	return nil
 }
@@ -101,10 +123,32 @@ func (e *exportCorporateEventStreamMock) SendHeader(m metadata.MD) error { retur
 func (e *exportCorporateEventStreamMock) SetHeader(m metadata.MD) error  { return nil }
 func (e *exportCorporateEventStreamMock) SetTrailer(m metadata.MD)       {}
 func (e *exportCorporateEventStreamMock) SendMsg(m interface{}) error {
-	if row, ok := m.(*apiv1.ExportCorporateEventRow); ok {
+	if row, ok := m.(*apiv1.ExportCorporateEventsResponse); ok {
 		e.sent = append(e.sent, row)
 	}
 	return nil
+}
+
+// rows returns the event rows in send order, dropping coverage envelopes.
+func (e *exportCorporateEventStreamMock) rows() []*apiv1.ExportCorporateEventRow {
+	var out []*apiv1.ExportCorporateEventRow
+	for _, m := range e.sent {
+		if r := m.GetRow(); r != nil {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+// coverage returns the coverage spans in send order.
+func (e *exportCorporateEventStreamMock) coverage() []*apiv1.ExportCoverage {
+	var out []*apiv1.ExportCoverage
+	for _, m := range e.sent {
+		if c := m.GetCoverage(); c != nil {
+			out = append(out, c)
+		}
+	}
+	return out
 }
 
 func TestAPI_Unauthenticated(t *testing.T) {


### PR DESCRIPTION
Stacked on #279.

Neither export RPC returned coverage, so a round trip could not reproduce what it exported. For prices that is not cosmetic: `ListPricesForExport` filters out synthetic rows (`WHERE NOT ep.synthetic`), so an export holds only the days its source actually reported. Re-importing it left every forward-filled day as a gap -- and valuation matches prices by exact date with no read-time carry-forward, so a gap is an unpriced day.

## Wire

Both export streams gain a oneof envelope, with coverage sent ahead of the rows it covers:

```proto
message ExportPricesResponse {
  oneof item { ExportPriceRow row = 1; ExportCoverage coverage = 2; }
}
```

One consistent read produces both, mirroring the import requests which already carry rows and coverage in one message. Pre-release, so changing the stream element type is free.

## Spans

Both new queries use `range_agg` over stored rows, so they merge across whatever produced them:

- **Prices** -- the aggregation includes the synthetic rows the export omits. That is deliberate: the span is precisely what tells an import which days to regenerate.
- **Corporate events** -- merged across plugins. An import records every span as `data_provider = "import"`, so the per-plugin split cannot survive a round trip and preserving it in the export would be misleading.

`splitsToJson` moves to the canonical `{events, coverage}` object form now that it has coverage to write. `parseSplitsJson` already accepted both shapes from #279.

## Testing

- `make db-test` -- new cases covering a span across synthetic rows, splitting on a real gap, merging across plugins, and the empty case.
- `make server-test` -- handler tests assert coverage precedes the rows; the stream mocks gained `rows()`/`coverage()` accessors.
- `make client-test` -- 193 pass, including round-trip tests both ways for the CSV and the JSON.
- `tsc --noEmit` reports the same 5 pre-existing errors as `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)