### PR TITLE
Open issues for Go formatting and for linting both trees

### DIFF
--- a/docs/issues/0059-gofmt-the-server-tree.md
+++ b/docs/issues/0059-gofmt-the-server-tree.md
@@ -1,0 +1,35 @@
+---
+status: open
+title: Format the Go tree with gofmt and keep it formatted
+---
+
+`gofmt -l ./server` lists 51 files. Nothing enforces it, so the count only
+grows.
+
+## Motivation
+
+The drift is entirely mechanical -- misaligned struct field comments, stray
+trailing blank lines -- so every one of those files produces spurious diff
+noise the moment anything near the affected lines is touched, and reviewers
+cannot tell reformatting from intent.
+
+It is also invisible: `make test` runs the four test targets and nothing else,
+and CI runs exactly those targets, so an unformatted file is never reported.
+
+## Design
+
+Run `gofmt -w ./server` once, in a commit that does nothing else so it can be
+skipped when reading history.
+
+`server/plugins/eodhd/exchangemap/codes_generated.go` is generated; either
+format it at generation time or exclude it, rather than letting a regeneration
+undo the fix.
+
+Then add the check to CI so it cannot drift again. It belongs alongside the
+existing matrix in `.github/workflows/ci.yml` and as a make target, so the same
+command is available locally. `gofmt -l` exits 0 with output rather than
+failing, so the target needs to fail on non-empty output itself.
+
+Consider `go vet` at the same time -- it is in the standard toolchain, needs no
+new dependency, and catches a different class of problem to the linting in
+0060.

--- a/docs/issues/0060-lint-go-and-typescript.md
+++ b/docs/issues/0060-lint-go-and-typescript.md
@@ -1,0 +1,45 @@
+---
+status: open
+title: Lint and typecheck Go and TypeScript in CI
+dependencies: [0059]
+---
+
+There is no working linter for either language, and the client does not
+typecheck.
+
+## Motivation
+
+Nothing currently reports a lint or type problem in either tree:
+
+- **Go** -- no `.golangci.yml` and no linter in the toolchain.
+- **Client** -- `npm run lint` is `next lint`, which newer Next.js removed. It
+  fails with `Invalid project directory provided, no such directory:
+  /app/client/lint`, so it has been silently doing nothing. There is no eslint
+  config either.
+- **Extension** -- has `typecheck` but no lint and no eslint config.
+- **Client typecheck** -- there is no `typecheck` script at all, and
+  `npx tsc --noEmit` currently reports 5 errors, all in
+  `client/lib/csv/prices.test.ts`: a `create()` argument mismatch and four
+  BigInt literals under an ES2019 target. Tests still run because vitest
+  transpiles without typechecking, so the errors are invisible in normal use.
+
+The style conventions the `go` and `typescript` skills describe are enforced by
+review alone. A linter would carry the mechanical part of that.
+
+## Design
+
+Three separate pieces of work, in rough order of value:
+
+1. **Fix the client typecheck.** Add a `typecheck` script, resolve the 5
+   errors (the BigInt literals need the target raised or `BigInt(...)` calls),
+   and gate it in CI. The extension already has the script and only needs the
+   gate.
+2. **Replace `next lint`.** Adopt eslint directly with a flat config, shared
+   between `client/` and `extension/` since the extension imports client
+   modules across two npm workspaces.
+3. **Add golangci-lint** with a conservative starting set, once 0059 has
+   formatted the tree -- otherwise the first run buries real findings under
+   formatting noise.
+
+Each gets a make target and a CI matrix entry, matching how the test targets
+already work.


### PR DESCRIPTION
Two issues for work found while building the coverage PRs.

**0059 -- gofmt.** `gofmt -l ./server` lists 51 files. The drift is purely mechanical (misaligned struct comments, trailing blank lines) but it means every one of those files carries reformatting noise into the next diff that touches it. Nothing enforces it: `make test` and CI run the four test targets and nothing else.

**0060 -- linting and typechecking.** No linter works in either tree:

- No `.golangci.yml`, no Go linter at all.
- `npm run lint` in the client is `next lint`, removed in newer Next.js. It fails with `Invalid project directory provided, no such directory: /app/client/lint`, so it has been silently doing nothing. No eslint config anywhere, in client or extension.
- The client has no `typecheck` script, and `npx tsc --noEmit` reports 5 errors today -- a `create()` argument mismatch and four BigInt literals under an ES2019 target, all in `prices.test.ts`. Vitest transpiles without typechecking, so they never surface.

0060 depends on 0059: running golangci-lint before the tree is formatted buries real findings under formatting noise.

Docs only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)