### PR TITLE
Typecheck the client and the extension in CI (0060, 1/3)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [fmt-check, vet, server-test, client-test, db-test, extension-test]
+        target:
+          [
+            fmt-check,
+            vet,
+            client-typecheck,
+            extension-typecheck,
+            server-test,
+            client-test,
+            db-test,
+            extension-test,
+          ]
     steps:
       - uses: actions/checkout@v4
       - run: make ${{ matrix.target }}

--- a/Makefile
+++ b/Makefile
@@ -92,6 +92,17 @@ fmt-check: $(STAMP_DIR)/generate
 vet: $(STAMP_DIR)/generate
 	$(COMPOSE_TOOLS) go vet ./server/...
 
+client-typecheck: $(STAMP_DIR)/generate
+	HOST_UID=$$(id -u) HOST_GID=$$(id -g) $(COMPOSE_DEV) run --rm client npm run typecheck
+
+# The extension imports client modules across two npm projects via a path alias,
+# and a broken alias only shows up in the type checker.
+extension-typecheck: $(STAMP_DIR)/generate
+	$(COMPOSE_TOOLS_EXT) sh -c 'npm ci && npm run typecheck'
+
+# Everything CI gates that is not a test.
+check: fmt-check vet client-typecheck extension-typecheck
+
 server-test: $(STAMP_DIR)/generate
 	$(COMPOSE_TOOLS) go test ./server/...
 
@@ -104,10 +115,8 @@ db-test: $(STAMP_DIR)/generate
 integration-test: $(STAMP_DIR)/generate
 	$(COMPOSE_TOOLS) go test -tags integration -v ./server/plugins/...
 
-# Typecheck as well as test: the extension imports client modules across two npm
-# projects via a path alias, and a broken alias only shows up in the type checker.
 extension-test: $(STAMP_DIR)/generate
-	$(COMPOSE_TOOLS_EXT) sh -c 'npm ci && npm run typecheck && npm run test:run'
+	$(COMPOSE_TOOLS_EXT) sh -c 'npm ci && npm run test:run'
 
 integration-test-list:
 	@find server/plugins -name 'integration_test.go' | xargs -I{} dirname {} | sed 's|^server/plugins/||' | sort
@@ -196,9 +205,12 @@ help:
 	@echo "  make google-finance-cli   Build Google Finance CLI (bin/google-finance-cli)"
 	@echo ""
 	@echo "Checks:"
+	@echo "  make check              Run every non-test check"
 	@echo "  make fmt                Format the Go tree with gofmt"
 	@echo "  make fmt-check          Fail if the Go tree is not gofmt-clean"
 	@echo "  make vet                Run go vet over the server tree"
+	@echo "  make client-typecheck   Typecheck the Next.js client"
+	@echo "  make extension-typecheck Typecheck the browser extension"
 	@echo ""
 	@echo "Testing:"
 	@echo "  make test               Run all tests (server, client, db, integration)"
@@ -220,4 +232,4 @@ help:
 	@echo ""
 	@echo "Dependencies are tracked automatically -- stale steps re-run as needed."
 
-.PHONY: generate build google-finance-cli fmt fmt-check vet server-test db-test client-test integration-test integration-test-list integration-test-record extension extension-dev extension-test e2e-test e2e-test-list e2e-test-record run init-db logs stop clean clean-generated clean-docker clean-next clean-stamps test help
+.PHONY: generate build google-finance-cli fmt fmt-check vet client-typecheck extension-typecheck check server-test db-test client-test integration-test integration-test-list integration-test-record extension extension-dev extension-test e2e-test e2e-test-list e2e-test-record run init-db logs stop clean clean-generated clean-docker clean-next clean-stamps test help

--- a/client/lib/csv/prices.test.ts
+++ b/client/lib/csv/prices.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from "vitest";
 import { create } from "@bufbuild/protobuf";
+import type { MessageInitShape } from "@bufbuild/protobuf";
 import { AssetClass, ExportCoverageSchema, ExportPriceRowSchema } from "@/gen/api/v1/api_pb";
 import type { ExportPriceRow } from "@/gen/api/v1/api_pb";
 import { pricesToCsv, csvToPrices } from "./prices";
 
-function makeRow(overrides: Partial<ExportPriceRow> = {}): ExportPriceRow {
+// Overrides are typed against the init shape, not Partial<ExportPriceRow>: the
+// latter makes $typeName optional, which create() will not accept.
+function makeRow(
+  overrides: MessageInitShape<typeof ExportPriceRowSchema> = {},
+): ExportPriceRow {
   return create(ExportPriceRowSchema, {
     identifierType: "ISIN",
     identifierValue: "US0378331005",

--- a/client/package.json
+++ b/client/package.json
@@ -7,6 +7,7 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
+    "typecheck": "tsc --noEmit",
     "test": "vitest",
     "test:run": "vitest run"
   },

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -26,7 +26,7 @@
         "./*"
       ]
     },
-    "target": "ES2017"
+    "target": "ES2020"
   },
   "include": [
     "next-env.d.ts",


### PR DESCRIPTION
First of three for 0060. Stacked on #283 (0059) -- base is
`gofmt-server-tree`.

The client had no `typecheck` script at all, and `npx tsc --noEmit`
reported five errors. They were invisible because vitest transpiles
without typechecking, so the tests passed regardless.

## The five errors

- `makeRow`'s overrides in [prices.test.ts](client/lib/csv/prices.test.ts)
  were typed `Partial<ExportPriceRow>`, which makes `$typeName` optional
  and so is not a valid `create()` init. Typed against `MessageInitShape`
  instead, matching how [api.ts](extension/src/lib/api.ts) already types
  protobuf inits.
- Four BigInt literals under an `ES2017` target. Raised the target to
  `ES2020` rather than rewriting them as `BigInt(...)` calls: int64 fields
  come back from protobuf-es as `bigint`, so the problem would keep
  recurring. `tsconfig` sets `noEmit` and pins `lib` to `esnext`, so the
  target only governs which syntax typechecks -- no build output changes.

## Gating

`client-typecheck` and `extension-typecheck` get a make target and a CI
matrix entry each. The extension already had the script, so its typecheck
moves out of `extension-test` into its own target rather than being run
twice. `make check` now aggregates every non-test check.

Verified: `make client-typecheck`, `make extension-typecheck` and
`make client-test` (193 tests) all pass.

Remaining for 0060: replace `next lint` with eslint, then add
golangci-lint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)