### PR TITLE
Close 0060: add golangci-lint (0060, 3/3)

### DIFF
--- a/.claude/skills/go/SKILL.md
+++ b/.claude/skills/go/SKILL.md
@@ -89,6 +89,15 @@ canonical gRPC assertion is `testutil.RequireGRPCCode(t, err, codes.X)`. See the
 
 ## Linting
 
-gofmt and `go vet` are the enforced baseline today. (golangci-lint is the intended
-linter but is not yet configured in the repo -- there is no `.golangci.yml` and no
-`make lint` target. Do not assume it runs in CI.)
+`make fmt-check`, `make vet` and `make lint-go` all gate CI. Run `make fmt` to
+format and `make lint-go` before pushing.
+
+golangci-lint is configured in `.golangci.yml` with its standard linter group
+(errcheck, ineffassign, staticcheck, unused), minus govet since `make vet`
+already covers the same tree. Two exclusions: the `std-error-handling` preset,
+and errcheck on `Encode`/`Write` in `_test.go`, where the stub HTTP handlers
+have no way to report a failed write.
+
+Do not silence a finding with `//nolint` without saying why on the same line.
+Prefer fixing it, or -- if the pattern will recur -- adding a scoped rule to
+`.golangci.yml` so the reason lives in one place.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,7 @@ jobs:
           [
             fmt-check,
             vet,
+            lint-go,
             lint-ts,
             client-typecheck,
             extension-typecheck,

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,27 @@
+version: "2"
+
+# Conservative starting set: golangci-lint's own standard group, minus govet,
+# which `make vet` already runs against the same tree.
+linters:
+  default: standard
+  disable:
+    - govet
+  exclusions:
+    presets:
+      # errcheck on deferred Close, Flush and the print family. Handling those
+      # errors is not what the code would do differently.
+      - std-error-handling
+    rules:
+      # Test HTTP handlers write a canned response body. There is nothing the
+      # test would do with a write error that the assertions do not already
+      # cover, and the stub handlers have no way to report one.
+      - path: _test\.go
+        linters:
+          - errcheck
+        text: "Error return value of `.*\\.(Encode|Write)` is not checked"
+
+# Defaults cap output at 50 per linter and 3 per repeated issue, which reads as
+# a clean-ish run when it is a truncated one.
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0

--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,9 @@ client-typecheck: $(STAMP_DIR)/generate
 extension-typecheck: $(STAMP_DIR)/generate
 	$(COMPOSE_TOOLS_EXT) sh -c 'npm ci && npm run typecheck'
 
+lint-go: $(STAMP_DIR)/generate
+	$(COMPOSE_TOOLS) golangci-lint run ./server/...
+
 # ESLint over both TypeScript trees. It lives in its own npm project at the repo
 # root rather than in client/ or extension/, so one config covers both; the
 # recipe runs npm ci itself, as the client entrypoint only bootstraps
@@ -110,8 +113,10 @@ lint-ts: $(STAMP_DIR)/generate
 lint-ts-fix: $(STAMP_DIR)/generate
 	$(COMPOSE_TOOLS_CLIENT) sh -c 'npm ci && npm run lint:fix'
 
+lint: lint-go lint-ts
+
 # Everything CI gates that is not a test.
-check: fmt-check vet lint-ts client-typecheck extension-typecheck
+check: fmt-check vet lint client-typecheck extension-typecheck
 
 server-test: $(STAMP_DIR)/generate
 	$(COMPOSE_TOOLS) go test ./server/...
@@ -219,6 +224,8 @@ help:
 	@echo "  make fmt                Format the Go tree with gofmt"
 	@echo "  make fmt-check          Fail if the Go tree is not gofmt-clean"
 	@echo "  make vet                Run go vet over the server tree"
+	@echo "  make lint               Lint both trees (lint-go + lint-ts)"
+	@echo "  make lint-go            golangci-lint over the server tree"
 	@echo "  make lint-ts            ESLint the client and extension trees"
 	@echo "  make lint-ts-fix        ESLint with --fix"
 	@echo "  make client-typecheck   Typecheck the Next.js client"
@@ -244,4 +251,4 @@ help:
 	@echo ""
 	@echo "Dependencies are tracked automatically -- stale steps re-run as needed."
 
-.PHONY: generate build google-finance-cli fmt fmt-check vet lint-ts lint-ts-fix client-typecheck extension-typecheck check server-test db-test client-test integration-test integration-test-list integration-test-record extension extension-dev extension-test e2e-test e2e-test-list e2e-test-record run init-db logs stop clean clean-generated clean-docker clean-next clean-stamps test help
+.PHONY: generate build google-finance-cli fmt fmt-check vet lint lint-go lint-ts lint-ts-fix client-typecheck extension-typecheck check server-test db-test client-test integration-test integration-test-list integration-test-record extension extension-dev extension-test e2e-test e2e-test-list e2e-test-record run init-db logs stop clean clean-generated clean-docker clean-next clean-stamps test help

--- a/docker/server/Dockerfile.dev
+++ b/docker/server/Dockerfile.dev
@@ -1,7 +1,11 @@
-# Dev image: Go + buf + protoc Go plugins + Air for live-reload. Source is mounted at /app at run time.
+# Dev image: Go + buf + protoc Go plugins + golangci-lint + Air for live-reload.
+# Source is mounted at /app at run time.
 FROM golang:1.25-alpine
 RUN apk add --no-cache git
 RUN go install github.com/bufbuild/buf/cmd/buf@latest
+# Pinned: golangci-lint bakes in the Go version it was built with, so an
+# unpinned upgrade can start reporting findings that did not move with the code.
+RUN go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.6.2
 RUN go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
 RUN go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
 RUN go install github.com/grpc-ecosystem/grpc-health-probe@latest

--- a/docs/issues/0060-lint-go-and-typescript.md
+++ b/docs/issues/0060-lint-go-and-typescript.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Lint and typecheck Go and TypeScript in CI
 dependencies: [0059]
 ---

--- a/server/db/migrate/migrate.go
+++ b/server/db/migrate/migrate.go
@@ -111,7 +111,7 @@ func applyMigration(ctx context.Context, db *sql.DB, migrations fs.FS, name, ver
 	if err != nil {
 		return err
 	}
-	defer tx.Rollback()
+	defer func() { _ = tx.Rollback() }()
 	if _, err := tx.ExecContext(ctx, string(body)); err != nil {
 		return err
 	}
@@ -141,5 +141,5 @@ func tryAdvisoryLock(ctx context.Context, db *sql.DB, timeout time.Duration, loc
 }
 
 func releaseAdvisoryLock(ctx context.Context, db *sql.DB, lockID int64) {
-	db.ExecContext(ctx, `SELECT pg_advisory_unlock($1)`, lockID)
+	_, _ = db.ExecContext(ctx, `SELECT pg_advisory_unlock($1)`, lockID)
 }

--- a/server/db/postgres/declarations_test.go
+++ b/server/db/postgres/declarations_test.go
@@ -105,8 +105,12 @@ func TestListHoldingDeclarations(t *testing.T) {
 	inst2, _ := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "A2", Canonical: false}}, "", nil, nil, nil)
 
 	asOf := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
-	p.CreateHoldingDeclaration(ctx, userID, "IBKR", "acct1", inst1, "100", asOf)
-	p.CreateHoldingDeclaration(ctx, userID, "IBKR", "acct1", inst2, "200", asOf)
+	if _, err := p.CreateHoldingDeclaration(ctx, userID, "IBKR", "acct1", inst1, "100", asOf); err != nil {
+		t.Fatalf("create decl 1: %v", err)
+	}
+	if _, err := p.CreateHoldingDeclaration(ctx, userID, "IBKR", "acct1", inst2, "200", asOf); err != nil {
+		t.Fatalf("create decl 2: %v", err)
+	}
 
 	rows, err := p.ListHoldingDeclarations(ctx, userID)
 	if err != nil {
@@ -135,7 +139,9 @@ func TestGetPortfolioStartDate(t *testing.T) {
 	instID, _ := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "SD1", Canonical: false}}, "", nil, nil, nil)
 	ts := time.Date(2025, 3, 15, 10, 0, 0, 0, time.UTC)
 	tx := &apiv1.Tx{Timestamp: timestamppb.New(ts), InstrumentDescription: "SD1", Type: apiv1.TxType_BUYSTOCK, Quantity: 10, Account: "acct1"}
-	p.CreateTx(ctx, userID, "IBKR", "acct1", tx, instID, nil)
+	if err := p.CreateTx(ctx, userID, "IBKR", "acct1", tx, instID, nil); err != nil {
+		t.Fatalf("create tx: %v", err)
+	}
 
 	startDate, err = p.GetPortfolioStartDate(ctx, userID)
 	if err != nil {
@@ -157,8 +163,12 @@ func TestComputeRunningBalance(t *testing.T) {
 
 	ts1 := time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC)
 	ts2 := time.Date(2025, 3, 15, 10, 0, 0, 0, time.UTC)
-	p.CreateTx(ctx, userID, "IBKR", "acct1", &apiv1.Tx{Timestamp: timestamppb.New(ts1), InstrumentDescription: "RB1", Type: apiv1.TxType_BUYSTOCK, Quantity: 100, Account: "acct1"}, instID, nil)
-	p.CreateTx(ctx, userID, "IBKR", "acct1", &apiv1.Tx{Timestamp: timestamppb.New(ts2), InstrumentDescription: "RB1", Type: apiv1.TxType_SELLSTOCK, Quantity: -30, Account: "acct1"}, instID, nil)
+	if err := p.CreateTx(ctx, userID, "IBKR", "acct1", &apiv1.Tx{Timestamp: timestamppb.New(ts1), InstrumentDescription: "RB1", Type: apiv1.TxType_BUYSTOCK, Quantity: 100, Account: "acct1"}, instID, nil); err != nil {
+		t.Fatalf("create buy: %v", err)
+	}
+	if err := p.CreateTx(ctx, userID, "IBKR", "acct1", &apiv1.Tx{Timestamp: timestamppb.New(ts2), InstrumentDescription: "RB1", Type: apiv1.TxType_SELLSTOCK, Quantity: -30, Account: "acct1"}, instID, nil); err != nil {
+		t.Fatalf("create sell: %v", err)
+	}
 
 	from := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2025, 12, 31, 23, 59, 59, 0, time.UTC)

--- a/server/db/postgres/inflation_test.go
+++ b/server/db/postgres/inflation_test.go
@@ -140,8 +140,8 @@ func TestListInflationIndices_Filters(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list GBP: %v", err)
 	}
-	if total != 2 {
-		t.Fatalf("expected 2, got %d", total)
+	if total != 2 || len(rows) != 2 {
+		t.Fatalf("expected 2, got total=%d rows=%d", total, len(rows))
 	}
 
 	// Filter by date range.
@@ -169,10 +169,9 @@ func TestListInflationIndices_Filters(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list all: %v", err)
 	}
-	if total != 3 {
-		t.Fatalf("expected 3, got %d", total)
+	if total != 3 || len(rows) != 3 {
+		t.Fatalf("expected 3, got total=%d rows=%d", total, len(rows))
 	}
-	_ = rows
 }
 
 func TestListInflationIndices_Pagination(t *testing.T) {

--- a/server/db/postgres/instruments_test.go
+++ b/server/db/postgres/instruments_test.go
@@ -10,8 +10,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-func strPtr(s string) *string { return &s }
-
 // TestEnsureInstrument_mergeWhenMultipleInstrumentsMatch verifies that when multiple identifiers
 // resolve to different instruments (e.g. A has ISIN 1, B has CUSIP 1), EnsureInstrument merges
 // them and returns the survivor; both identifiers end up on the survivor and txs are updated.

--- a/server/db/postgres/postgres.go
+++ b/server/db/postgres/postgres.go
@@ -143,7 +143,7 @@ func (p *Postgres) runInTx(ctx context.Context, f func(exec queryable) error) er
 		if err != nil {
 			return err
 		}
-		defer tx.Rollback()
+		defer func() { _ = tx.Rollback() }()
 		if err := f(tx); err != nil {
 			return err
 		}
@@ -179,13 +179,6 @@ func nullFloat(f float64) interface{} {
 		return nil
 	}
 	return f
-}
-
-func ptrStr(s *string) string {
-	if s == nil {
-		return ""
-	}
-	return *s
 }
 
 func decodePageToken(token string) int64 {

--- a/server/db/postgres/postgres_test.go
+++ b/server/db/postgres/postgres_test.go
@@ -38,22 +38,6 @@ func TestMain(m *testing.M) {
 	os.Exit(m.Run())
 }
 
-func testDB(t *testing.T) *Postgres {
-	url := os.Getenv("TEST_DATABASE_URL")
-	if url == "" {
-		t.Skip("TEST_DATABASE_URL not set (run via make test-db)")
-	}
-	conn, err := sqlx.Open("postgres", url)
-	if err != nil {
-		t.Fatalf("open: %v", err)
-	}
-	t.Cleanup(func() { conn.Close() })
-	if err := conn.Ping(); err != nil {
-		t.Fatalf("ping: %v", err)
-	}
-	return New(conn)
-}
-
 // testDBTx returns a Postgres backed by a transaction that is rolled back when the test ends, so each test gets an isolated clean state without maintaining a table list.
 func testDBTx(t *testing.T) *Postgres {
 	url := os.Getenv("TEST_DATABASE_URL")

--- a/server/db/postgres/price_cache_test.go
+++ b/server/db/postgres/price_cache_test.go
@@ -832,21 +832,27 @@ func TestUpsertPricesWithFill_NoSeedAtStart(t *testing.T) {
 
 	// Day 3 real, day 4 synthetic. Days 1-2 absent.
 	var count int
-	p.q.QueryRowContext(ctx, `SELECT COUNT(*) FROM eod_prices WHERE instrument_id = $1::uuid`, instID).Scan(&count)
+	if err := p.q.QueryRowContext(ctx, `SELECT COUNT(*) FROM eod_prices WHERE instrument_id = $1::uuid`, instID).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
 	if count != 2 {
 		t.Fatalf("expected 2 rows, got %d", count)
 	}
 
 	var synthetic bool
-	p.q.QueryRowContext(ctx,
+	if err := p.q.QueryRowContext(ctx,
 		`SELECT synthetic FROM eod_prices WHERE instrument_id = $1::uuid AND price_date = $2`,
-		instID, d(2024, 1, 3)).Scan(&synthetic)
+		instID, d(2024, 1, 3)).Scan(&synthetic); err != nil {
+		t.Fatalf("day 3: %v", err)
+	}
 	if synthetic {
 		t.Error("day 3: expected real")
 	}
-	p.q.QueryRowContext(ctx,
+	if err := p.q.QueryRowContext(ctx,
 		`SELECT synthetic FROM eod_prices WHERE instrument_id = $1::uuid AND price_date = $2`,
-		instID, d(2024, 1, 4)).Scan(&synthetic)
+		instID, d(2024, 1, 4)).Scan(&synthetic); err != nil {
+		t.Fatalf("day 4: %v", err)
+	}
 	if !synthetic {
 		t.Error("day 4: expected synthetic")
 	}
@@ -871,9 +877,11 @@ func TestUpsertPricesWithFill_DuplicateDates(t *testing.T) {
 	}
 
 	var close float64
-	p.q.QueryRowContext(ctx,
+	if err := p.q.QueryRowContext(ctx,
 		`SELECT close FROM eod_prices WHERE instrument_id = $1::uuid AND price_date = $2`,
-		instID, mon).Scan(&close)
+		instID, mon).Scan(&close); err != nil {
+		t.Fatalf("scan close: %v", err)
+	}
 	if close != 101.0 {
 		t.Errorf("duplicate date: close = %v, want 101.0 (last occurrence)", close)
 	}

--- a/server/inflationfetcher/worker_test.go
+++ b/server/inflationfetcher/worker_test.go
@@ -1,7 +1,6 @@
 package inflationfetcher
 
 import (
-	"context"
 	"testing"
 	"time"
 )
@@ -92,22 +91,6 @@ func TestTrigger(t *testing.T) {
 
 func TestTrigger_Nil(t *testing.T) {
 	Trigger(nil) // should not panic
-}
-
-// fetchPlugin records calls for testing.
-type fetchPlugin struct {
-	stubPlugin
-	calls    int
-	indices  []MonthlyIndex
-	fetchErr error
-}
-
-func (f *fetchPlugin) FetchInflation(_ context.Context, _ []byte, _ string, _, _ time.Time) (*FetchResult, error) {
-	f.calls++
-	if f.fetchErr != nil {
-		return nil, f.fetchErr
-	}
-	return &FetchResult{Indices: f.indices}, nil
 }
 
 func TestToDBIndices(t *testing.T) {

--- a/server/plugins/cash/description/plugin_test.go
+++ b/server/plugins/cash/description/plugin_test.go
@@ -55,7 +55,7 @@ func TestPlugin_ExtractBatch_EmptyCurrency_ReturnsNothing(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ExtractBatch: %v", err)
 	}
-	if out != nil && len(out) > 0 {
+	if len(out) > 0 {
 		t.Errorf("expected nil or empty map when Currency empty, got %+v", out)
 	}
 }

--- a/server/plugins/eodhd/corporateevents/plugin.go
+++ b/server/plugins/eodhd/corporateevents/plugin.go
@@ -296,16 +296,14 @@ func (p *Plugin) reportOutcome(ctx context.Context, err error) {
 	if p.counter == nil {
 		return
 	}
+	var rl *client.ErrRateLimit
 	switch {
 	case err == nil:
 		p.counter.Incr(ctx, counterSucceeded)
+	case errors.As(err, &rl):
+		p.counter.Incr(ctx, counterRateLimit)
 	default:
-		var rl *client.ErrRateLimit
-		if errors.As(err, &rl) {
-			p.counter.Incr(ctx, counterRateLimit)
-		} else {
-			p.counter.Incr(ctx, counterFailed)
-		}
+		p.counter.Incr(ctx, counterFailed)
 	}
 }
 

--- a/server/plugins/eodhd/price/plugin.go
+++ b/server/plugins/eodhd/price/plugin.go
@@ -213,16 +213,14 @@ func (p *Plugin) reportOutcome(ctx context.Context, err error) {
 	if p.counter == nil {
 		return
 	}
+	var rl *client.ErrRateLimit
 	switch {
 	case err == nil:
 		p.counter.Incr(ctx, counterSucceeded)
+	case errors.As(err, &rl):
+		p.counter.Incr(ctx, counterRateLimit)
 	default:
-		var rl *client.ErrRateLimit
-		if errors.As(err, &rl) {
-			p.counter.Incr(ctx, counterRateLimit)
-		} else {
-			p.counter.Incr(ctx, counterFailed)
-		}
+		p.counter.Incr(ctx, counterFailed)
 	}
 }
 

--- a/server/plugins/massive/corporateevents/plugin.go
+++ b/server/plugins/massive/corporateevents/plugin.go
@@ -252,16 +252,14 @@ func (p *Plugin) reportOutcome(ctx context.Context, err error) {
 	if p.counter == nil {
 		return
 	}
+	var rl *client.ErrRateLimit
 	switch {
 	case err == nil:
 		p.counter.Incr(ctx, counterSucceeded)
+	case errors.As(err, &rl):
+		p.counter.Incr(ctx, counterRateLimit)
 	default:
-		var rl *client.ErrRateLimit
-		if errors.As(err, &rl) {
-			p.counter.Incr(ctx, counterRateLimit)
-		} else {
-			p.counter.Incr(ctx, counterFailed)
-		}
+		p.counter.Incr(ctx, counterFailed)
 	}
 }
 

--- a/server/plugins/massive/price/plugin.go
+++ b/server/plugins/massive/price/plugin.go
@@ -211,16 +211,14 @@ func (p *Plugin) reportOutcome(ctx context.Context, err error) {
 	if p.counter == nil {
 		return
 	}
+	var rl *client.ErrRateLimit
 	switch {
 	case err == nil:
 		p.counter.Incr(ctx, counterSucceeded)
+	case errors.As(err, &rl):
+		p.counter.Incr(ctx, counterRateLimit)
 	default:
-		var rl *client.ErrRateLimit
-		if errors.As(err, &rl) {
-			p.counter.Incr(ctx, counterRateLimit)
-		} else {
-			p.counter.Incr(ctx, counterFailed)
-		}
+		p.counter.Incr(ctx, counterFailed)
 	}
 }
 

--- a/server/service/api/holdings.go
+++ b/server/service/api/holdings.go
@@ -21,7 +21,10 @@ func (s *Server) GetHoldings(ctx context.Context, req *apiv1.GetHoldingsRequest)
 	var asOf *timestamppb.Timestamp
 	var err error
 	if req.GetPortfolioId() != "" {
-		ok, err := s.db.PortfolioBelongsToUser(ctx, req.GetPortfolioId(), u.ID)
+		// Not `:=`: that would shadow err, and the ComputeHoldingsForPortfolio
+		// error below would never reach the check after the block.
+		var ok bool
+		ok, err = s.db.PortfolioBelongsToUser(ctx, req.GetPortfolioId(), u.ID)
 		if err != nil {
 			return nil, status.Error(codes.Internal, err.Error())
 		}

--- a/server/service/api/server_test.go
+++ b/server/service/api/server_test.go
@@ -22,10 +22,6 @@ func authCtx(userID, authSub string) context.Context {
 	return auth.WithUser(context.Background(), &auth.User{ID: userID, AuthSub: authSub})
 }
 
-func authCtxWithProfile(userID, authSub, name, email string) context.Context {
-	return auth.WithUser(context.Background(), &auth.User{ID: userID, AuthSub: authSub, Name: name, Email: email})
-}
-
 // adminCtx returns a context with an admin user (for Export/Import RPCs).
 func adminCtx(userID, authSub string) context.Context {
 	return auth.WithUser(context.Background(), &auth.User{ID: userID, AuthSub: authSub, Role: "admin"})

--- a/server/service/auth/server.go
+++ b/server/service/auth/server.go
@@ -2,6 +2,7 @@ package auth
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -88,9 +89,9 @@ func (s *Server) AuthUser(ctx context.Context, req *authv1.AuthUserRequest) (*au
 	result, err := s.verifier.Verify(ctx, token)
 	if err != nil {
 		switch {
-		case err == google.ErrInvalidArgument:
+		case errors.Is(err, google.ErrInvalidArgument):
 			return nil, status.Error(codes.InvalidArgument, err.Error())
-		case err == google.ErrPermissionDenied:
+		case errors.Is(err, google.ErrPermissionDenied):
 			return nil, status.Error(codes.PermissionDenied, err.Error())
 		default:
 			return nil, status.Error(codes.Unauthenticated, err.Error())

--- a/server/service/auth/server_test.go
+++ b/server/service/auth/server_test.go
@@ -174,13 +174,9 @@ func newTestServer(t *testing.T, clientID string, svcAcctDB db.ServiceAccountDB,
 	srv := makeJWKSServer(t, &testRSAKey.PublicKey, "test-kid")
 	t.Cleanup(srv.Close)
 
-	verifier := google.NewVerifier(clientID,
-		google.WithHTTPClient(srv.Client()),
-		google.WithJWKSCacheTTL(time.Minute),
-	)
 	// Point the verifier at our stub JWKS server by overriding the URL via a custom HTTP transport.
 	// We need to redirect the JWKS URL fetch to our test server.
-	verifier = google.NewVerifier(clientID,
+	verifier := google.NewVerifier(clientID,
 		google.WithHTTPClient(newRedirectClient(srv.URL)),
 		google.WithJWKSCacheTTL(time.Minute),
 		google.WithClockSkew(time.Minute),


### PR DESCRIPTION
Last of three for 0060, and closes it. Stacked on #285 -- base is
`eslint-flat-config`.

golangci-lint is pinned in the dev image and configured with its own
standard group -- errcheck, ineffassign, staticcheck, unused -- minus
`govet`, which `make vet` already runs over the same tree.

## Config decisions

- **Two exclusions.** The `std-error-handling` preset (deferred `Close`,
  `Flush`, the print family), and errcheck on `Encode`/`Write` in
  `_test.go`. The second covers 44 of the findings: stub HTTP handlers
  writing a canned response, which have no way to report a write error and
  nothing a test would do with one. A per-site `_ =` across 44 lines would
  be a rule every new stub handler has to rediscover.
- **Issue caps lifted.** The defaults truncate at 50 per linter and 3 per
  repeated issue. The first run looked like 31 findings; it was 48. A
  truncated run reads as a clean-ish one, so `max-issues-per-linter` and
  `max-same-issues` are both 0.

## The findings

Everything not covered by an exclusion is fixed rather than silenced.

The substantive one is `SA4006` in
[holdings.go:24](server/service/api/holdings.go#L24). The portfolio
ownership check used `:=`, which declared a second `err` scoped to the
`if` block. `ComputeHoldingsForPortfolio` then assigned to *that* one, so
its error never reached the `if err != nil` after the block -- a failed
holdings computation returned empty holdings and no error.

The rest:

- Deferred `tx.Rollback` and the best-effort advisory unlock now discard
  their errors explicitly.
- DB test setup (`CreateTx`, `CreateHoldingDeclaration`, `Row.Scan`) checks
  and fails instead of dropping the error.
- Six unused test helpers, one unused production helper, one unused import.
- Two ineffectual assignments: a verifier built and immediately replaced,
  and a `ListInflationIndices` page fetched and dropped -- the latter is
  now asserted on, which is what the trailing `_ = rows` stood in for.
- Four `QF1002` `reportOutcome` switches flattened so the rate-limit branch
  is a case rather than a nested if; the auth sentinel comparisons move to
  `errors.Is`, which also survives wrapping.
- One redundant nil check before `len()` on a map.

## Gating

`make lint-go`, with `make lint` now running both linters, `lint-go` in the
CI matrix, and `lint` in `make check`. The `go` skill's linting section is
updated -- it said golangci-lint was intended but not configured.

Verified: `make lint-go` (0 issues), `make lint-ts`, `make fmt-check`,
`make vet`, `make server-test`, `make db-test` and `make integration-test`
all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)