### PR TITLE
Close 0061: load client data with TanStack Query

### DIFF
--- a/.claude/skills/typescript/SKILL.md
+++ b/.claude/skills/typescript/SKILL.md
@@ -61,6 +61,11 @@ which prefix-matches. Poll with `refetchInterval`, not `setInterval`. Use
 so give the paginated child a `key` built from the filter values and let the
 remount clear the page.
 
+The same `key` trick is how to reset any state when an input changes -- both
+`react-hooks/set-state-in-effect` and `set-state-in-render` are on at error, so
+neither an effect nor a guarded render-time `setState` is available. Derive
+during render where you can, remount where you cannot.
+
 ## Strictness and idioms
 
 - `tsconfig.json` sets `strict: true`, `moduleResolution: "bundler"`, and the `@/*`
@@ -78,10 +83,6 @@ through a path alias, so the rules applying to shared source cannot be allowed
 to drift. Rules are typescript-eslint's non-type-aware `recommended` for both
 trees, plus react, react-hooks and `@next/next` core-web-vitals for the client
 only.
-
-`react-hooks/set-state-in-effect` and `react-hooks/refs` are off pending 0061.
-Do not write new fetch-in-effect data loading on the strength of that -- the
-issue is to remove the pattern, not to keep adding to it.
 
 There is no Prettier config -- follow the observed style: 2-space indent, double
 quotes, semicolons, and trailing commas.

--- a/.claude/skills/typescript/SKILL.md
+++ b/.claude/skills/typescript/SKILL.md
@@ -32,7 +32,7 @@ Backend types come from generated protobuf-es v2 code (`@bufbuild/protobuf`) und
   metadata/layout only.
 - Shared state uses React hooks plus Context (`client/contexts/*`); each context
   exposes a `useX()` hook that throws when used outside its provider. There is no
-  Redux/Zustand and no React Query/SWR.
+  Redux/Zustand. Server state is TanStack Query, not context -- see Data fetching.
 - Styling is Tailwind (`^3.4`) with CSS-variable semantic tokens (`text-text-muted`,
   `bg-accent-soft/50`); `darkMode: 'media'`.
 - Component filenames are kebab-case (`app-shell.tsx`). Add `data-testid`
@@ -43,9 +43,23 @@ Backend types come from generated protobuf-es v2 code (`@bufbuild/protobuf`) und
 Call the backend through the `client/lib/*-api.ts` wrapper modules, which build
 requests with `create/toBinary`, send them via the hand-written gRPC-Web transport
 in `client/lib/grpc-web.ts` (`unaryFetch` / `streamingFetch`), and decode with
-`fromBinary`. Handle `GrpcError` / `SessionLostError`; a lost session triggers
-`notifySessionLost()`. Fetch in `useEffect` with manual loading/error state; use
-`client/hooks/use-pagination.ts` for token pagination.
+`fromBinary`. Those throw `GrpcError` / `SessionLostError`; a lost session
+triggers `notifySessionLost()` from inside the transport, so no call site handles
+it.
+
+Reads go through TanStack Query -- **never fetch in a `useEffect`** (see
+docs/adr/0019). Use `useAuthedQuery` from `client/hooks/use-authed-query.ts`,
+which gates on the session being resolved, and take keys from the `qk` factories
+in `client/lib/query-keys.ts`. Keys hold primitives only: they are compared
+structurally, so an object rebuilt with equal contents is a new key and silently
+refetches -- pass `portfolio.id`, not `portfolio`. Render errors with
+`errorMessage()` from `client/lib/errors.ts`.
+
+Refresh after a mutation with `queryClient.invalidateQueries({ queryKey })`,
+which prefix-matches. Poll with `refetchInterval`, not `setInterval`. Use
+`client/hooks/use-pagination.ts` for token pagination; it does not reset itself,
+so give the paginated child a `key` built from the filter values and let the
+remount clear the page.
 
 ## Strictness and idioms
 

--- a/client/app/admin/corporate-events/page.tsx
+++ b/client/app/admin/corporate-events/page.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useAuthedQuery } from "@/hooks/use-authed-query";
+import { errorMessage } from "@/lib/errors";
+import { qk } from "@/lib/query-keys";
 import { ErrorAlert } from "@/app/components/error-alert";
 import {
   listUnhandledCorporateEvents,
@@ -51,40 +55,36 @@ function TabButton({
 
 export default function AdminCorporateEventsPage() {
   const [tab, setTab] = useState<Tab>("unhandled");
-  const [events, setEvents] = useState<UnhandledCorporateEvent[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+  const [resolveError, setResolveError] = useState<string | null>(null);
   const [resolving, setResolving] = useState<string | null>(null);
 
-  const load = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const result = await listUnhandledCorporateEvents();
-      setEvents(result.events);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to load corporate events");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  const {
+    data: events = [],
+    isPending: loading,
+    error: loadError,
+  } = useAuthedQuery<UnhandledCorporateEvent[]>({
+    queryKey: qk.unhandledCorporateEvents(),
+    queryFn: async () => (await listUnhandledCorporateEvents()).events,
+  });
+
+  const error =
+    resolveError ?? (loadError ? errorMessage(loadError, "Failed to load corporate events") : null);
 
   async function handleResolve(id: string) {
     setResolving(id);
-    setError(null);
+    setResolveError(null);
     try {
       await resolveUnhandledCorporateEvent(id);
-      await load();
+      await queryClient.invalidateQueries({ queryKey: qk.unhandledCorporateEvents() });
+      // The dashboard shows the same count.
+      await queryClient.invalidateQueries({ queryKey: qk.unhandledCorporateEventCount() });
     } catch (e) {
-      setError(e instanceof Error ? e.message : `Failed to resolve event ${id}`);
+      setResolveError(errorMessage(e, `Failed to resolve event ${id}`));
     } finally {
       setResolving(null);
     }
   }
-
-  useEffect(() => {
-    load();
-  }, [load]);
 
   return (
     <div data-testid="page-corporate-events">

--- a/client/app/admin/corporate-events/splits-tab.tsx
+++ b/client/app/admin/corporate-events/splits-tab.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useAuthedQuery } from "@/hooks/use-authed-query";
+import { errorMessage } from "@/lib/errors";
+import { qk } from "@/lib/query-keys";
 import { ErrorAlert } from "@/app/components/error-alert";
 import { exportCorporateEvents } from "@/lib/portfolio-api";
 import { splitsToJson } from "@/lib/json/corporate-events";
@@ -18,16 +22,20 @@ interface SplitDisplay {
 }
 
 export function SplitsTab() {
-  const [splits, setSplits] = useState<SplitDisplay[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
   const [exportLoading, setExportLoading] = useState(false);
+  const [exportError, setExportError] = useState<string | null>(null);
   const [importOpen, setImportOpen] = useState(false);
 
-  const loadSplits = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
+  // The export is a streaming generator, so the queryFn drains it and returns
+  // the accumulated rows. The generator itself is unchanged.
+  const {
+    data: splits = [],
+    isPending: loading,
+    error: loadError,
+  } = useAuthedQuery<SplitDisplay[]>({
+    queryKey: qk.corporateEventSplits(),
+    queryFn: async () => {
       const rows: SplitDisplay[] = [];
       for await (const item of exportCorporateEvents()) {
         if (item.item.case !== "row") continue;
@@ -45,21 +53,17 @@ export function SplitsTab() {
         }
       }
       rows.sort((a, b) => b.exDate.localeCompare(a.exDate));
-      setSplits(rows);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to load splits");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+      return rows;
+    },
+  });
 
-  useEffect(() => {
-    loadSplits();
-  }, [loadSplits]);
+  const loadSplits = () => queryClient.invalidateQueries({ queryKey: qk.corporateEventSplits() });
+
+  const error = exportError ?? (loadError ? errorMessage(loadError, "Failed to load splits") : null);
 
   async function handleExport() {
     setExportLoading(true);
-    setError(null);
+    setExportError(null);
     try {
       const rows: ExportCorporateEventRow[] = [];
       const coverage: ExportCoverage[] = [];
@@ -79,7 +83,7 @@ export function SplitsTab() {
       a.click();
       URL.revokeObjectURL(url);
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Export failed");
+      setExportError(errorMessage(e, "Export failed"));
     } finally {
       setExportLoading(false);
     }

--- a/client/app/admin/inflation/page.tsx
+++ b/client/app/admin/inflation/page.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useCallback, useState } from "react";
+import { useState } from "react";
 import { ErrorAlert } from "@/app/components/error-alert";
 import { PaginationControls } from "@/app/components/pagination-controls";
 import { usePagination } from "@/hooks/use-pagination";
 import { useDebounce } from "@/hooks/use-debounce";
+import { errorMessage } from "@/lib/errors";
+import { qk } from "@/lib/query-keys";
 import { listInflationIndices } from "@/lib/portfolio-api";
 import { dayAfter } from "@/lib/dates";
 import type { InflationIndexProto } from "@/gen/api/v1/api_pb";
@@ -14,36 +16,6 @@ export default function AdminInflationPage() {
   const debouncedSearch = useDebounce(search);
   const [dateFrom, setDateFrom] = useState("");
   const [dateTo, setDateTo] = useState("");
-
-  const fetchIndices = useCallback(
-    async (pageToken: string | null) => {
-      const result = await listInflationIndices({
-        currency: debouncedSearch || undefined,
-        dateFrom: dateFrom || undefined,
-        // The picker is inclusive; the API bound is exclusive.
-        dateBefore: dayAfter(dateTo),
-        pageToken,
-      });
-      return {
-        items: result.indices,
-        totalCount: result.totalCount,
-        nextPageToken: result.nextPageToken,
-      };
-    },
-    [debouncedSearch, dateFrom, dateTo]
-  );
-
-  const {
-    items: indices,
-    totalCount,
-    loading,
-    error,
-    pageIndex,
-    hasPrev,
-    hasNext,
-    goNext,
-    goPrev,
-  } = usePagination(fetchIndices);
 
   return (
     <div className="space-y-5">
@@ -78,73 +50,123 @@ export default function AdminInflationPage() {
               className="rounded-md border border-border bg-surface px-2 py-1.5 text-sm text-text-primary focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary/30"
             />
           </label>
-          {!loading && (
-            <span className="font-mono text-xs text-text-muted">
-              {totalCount} total
-            </span>
-          )}
         </div>
 
-        {loading && <p className="text-text-muted">Loading inflation data...</p>}
-        {!loading && error && <ErrorAlert>{error}</ErrorAlert>}
-        {!loading && !error && (
-          <>
-            <div className="overflow-x-auto rounded-md border border-border bg-surface shadow-sm">
-              <table className="w-full min-w-[500px] border-collapse text-sm">
-                <thead>
-                  <tr className="border-b-2 border-primary-dark/10 bg-primary-dark/[0.03]">
-                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-text-muted">
-                      Currency
-                    </th>
-                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-text-muted">
-                      Month
-                    </th>
-                    <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wider text-text-muted">
-                      Index Value
-                    </th>
-                    <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wider text-text-muted">
-                      Base Year
-                    </th>
-                    <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-text-muted">
-                      Provider
-                    </th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {indices.length === 0 ? (
-                    <tr>
-                      <td
-                        colSpan={5}
-                        className="px-4 py-8 text-center text-text-muted"
-                      >
-                        {debouncedSearch || dateFrom || dateTo
-                          ? "No inflation data matches your filters."
-                          : "No inflation data yet."}
-                      </td>
-                    </tr>
-                  ) : (
-                    indices.map((idx) => (
-                      <InflationRow
-                        key={`${idx.currency}-${idx.month}`}
-                        index={idx}
-                      />
-                    ))
-                  )}
-                </tbody>
-              </table>
-            </div>
-
-            <PaginationControls
-              pageIndex={pageIndex}
-              hasPrev={hasPrev}
-              hasNext={hasNext}
-              onPrev={goPrev}
-              onNext={goNext}
-            />
-          </>
-        )}
+        {/* Keyed on the filters: a filter change remounts the list, which is
+            what returns it to page 1. */}
+        <InflationList
+          key={`${debouncedSearch}|${dateFrom}|${dateTo}`}
+          currency={debouncedSearch}
+          dateFrom={dateFrom}
+          dateTo={dateTo}
+        />
       </div>
     </div>
+  );
+}
+
+function InflationList({
+  currency,
+  dateFrom,
+  dateTo,
+}: {
+  currency: string;
+  dateFrom: string;
+  dateTo: string;
+}) {
+  const {
+    items: indices,
+    totalCount,
+    loading,
+    error,
+    pageIndex,
+    hasPrev,
+    hasNext,
+    goNext,
+    goPrev,
+  } = usePagination<InflationIndexProto>({
+    queryKey: qk.inflationIndices(currency, dateFrom, dateTo),
+    queryFn: async (pageToken) => {
+      const result = await listInflationIndices({
+        currency: currency || undefined,
+        dateFrom: dateFrom || undefined,
+        // The picker is inclusive; the API bound is exclusive.
+        dateBefore: dayAfter(dateTo),
+        pageToken,
+      });
+      return {
+        items: result.indices,
+        totalCount: result.totalCount,
+        nextPageToken: result.nextPageToken,
+      };
+    },
+  });
+
+  return (
+    <>
+      {!loading && (
+        <span className="block font-mono text-xs text-text-muted">{totalCount} total</span>
+      )}
+
+      {loading && <p className="text-text-muted">Loading inflation data...</p>}
+      {!loading && error && <ErrorAlert>{errorMessage(error)}</ErrorAlert>}
+      {!loading && !error && (
+        <>
+          <div className="overflow-x-auto rounded-md border border-border bg-surface shadow-sm">
+            <table className="w-full min-w-[500px] border-collapse text-sm">
+              <thead>
+                <tr className="border-b-2 border-primary-dark/10 bg-primary-dark/[0.03]">
+                  <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-text-muted">
+                    Currency
+                  </th>
+                  <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-text-muted">
+                    Month
+                  </th>
+                  <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wider text-text-muted">
+                    Index Value
+                  </th>
+                  <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wider text-text-muted">
+                    Base Year
+                  </th>
+                  <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-text-muted">
+                    Provider
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {indices.length === 0 ? (
+                  <tr>
+                    <td
+                      colSpan={5}
+                      className="px-4 py-8 text-center text-text-muted"
+                    >
+                      {currency || dateFrom || dateTo
+                        ? "No inflation data matches your filters."
+                        : "No inflation data yet."}
+                    </td>
+                  </tr>
+                ) : (
+                  indices.map((idx) => (
+                    <InflationRow
+                      key={`${idx.currency}-${idx.month}`}
+                      index={idx}
+                    />
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+
+          <PaginationControls
+            pageIndex={pageIndex}
+            hasPrev={hasPrev}
+            hasNext={hasNext}
+            onPrev={goPrev}
+            onNext={goNext}
+          />
+        </>
+      )}
+    </>
   );
 }
 

--- a/client/app/admin/instruments/page.tsx
+++ b/client/app/admin/instruments/page.tsx
@@ -1,9 +1,12 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { ErrorAlert } from "@/app/components/error-alert";
 import { PaginationControls } from "@/app/components/pagination-controls";
 import { usePagination } from "@/hooks/use-pagination";
+import { errorMessage } from "@/lib/errors";
+import { qk } from "@/lib/query-keys";
 import { exportInstruments, listInstruments } from "@/lib/portfolio-api";
 import { instrumentsToJson } from "@/lib/json/instruments";
 import { useDebounce } from "@/hooks/use-debounce";
@@ -45,16 +48,10 @@ export default function AdminInstrumentsPage() {
   const [activeClasses, setActiveClasses] = useState<Set<AssetClass>>(
     () => new Set(DEFAULT_ASSET_CLASSES)
   );
-  const [expandedId, setExpandedId] = useState<string | null>(null);
   const [exportLoading, setExportLoading] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
   const [importOpen, setImportOpen] = useState(false);
-  const [refreshKey, setRefreshKey] = useState(0);
-
-  // Collapse expanded row when search changes.
-  useEffect(() => {
-    setExpandedId(null);
-  }, [debouncedSearch]);
+  const queryClient = useQueryClient();
 
   const toggleClass = (cls: AssetClass) => {
     setActiveClasses((prev) => {
@@ -63,10 +60,9 @@ export default function AdminInstrumentsPage() {
       else next.add(cls);
       return next;
     });
-    setExpandedId(null);
   };
 
-  // Memoize the sorted array so the effect dep is stable when the set contents haven't changed.
+  // Sorted join so the key is stable when the set's contents have not changed.
   const assetClassesKey = useMemo(
     () => [...activeClasses].sort().join(","),
     [activeClasses]
@@ -98,35 +94,6 @@ export default function AdminInstrumentsPage() {
     }
   }
 
-  const fetchInstruments = useCallback(
-    async (pageToken: string | null) => {
-      const classes = assetClassesKey ? assetClassesKey.split(",").map(Number) as AssetClass[] : [];
-      const result = await listInstruments({
-        search: debouncedSearch,
-        assetClasses: classes.length < ALL_ASSET_CLASSES.length ? classes : [],
-        pageToken,
-      });
-      return {
-        items: result.instruments,
-        totalCount: result.totalCount,
-        nextPageToken: result.nextPageToken,
-      };
-    },
-    [debouncedSearch, assetClassesKey, refreshKey] // eslint-disable-line react-hooks/exhaustive-deps
-  );
-
-  const {
-    items: instruments,
-    totalCount,
-    loading,
-    error,
-    pageIndex,
-    hasPrev,
-    hasNext,
-    goNext,
-    goPrev,
-  } = usePagination(fetchInstruments);
-
   return (
     <div className="space-y-5">
       <h2 className="font-display text-2xl font-bold tracking-tight text-text-primary">
@@ -142,11 +109,6 @@ export default function AdminInstrumentsPage() {
           placeholder="Search by name or ticker..."
           className="w-full max-w-sm rounded-md border border-border bg-surface px-3 py-2 text-sm text-text-primary placeholder:text-text-muted focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary/30"
         />
-        {!loading && (
-          <span className="font-mono text-xs text-text-muted">
-            {totalCount} total
-          </span>
-        )}
         <div className="ml-auto flex gap-2">
           <button
             type="button"
@@ -190,10 +152,70 @@ export default function AdminInstrumentsPage() {
         </div>
       </div>
 
+      {/* Keyed on the filters: a change remounts the list, which returns it to
+          page 1 and collapses any expanded row. */}
+      <InstrumentList
+        key={`${debouncedSearch}|${assetClassesKey}`}
+        search={debouncedSearch}
+        assetClassesKey={assetClassesKey}
+      />
+
+      <ImportInstrumentsModal
+        open={importOpen}
+        onClose={() => setImportOpen(false)}
+        onComplete={() => queryClient.invalidateQueries({ queryKey: qk.instruments() })}
+      />
+    </div>
+  );
+}
+
+function InstrumentList({
+  search,
+  assetClassesKey,
+}: {
+  search: string;
+  assetClassesKey: string;
+}) {
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+
+  const {
+    items: instruments,
+    totalCount,
+    loading,
+    error,
+    pageIndex,
+    hasPrev,
+    hasNext,
+    goNext,
+    goPrev,
+  } = usePagination<Instrument>({
+    queryKey: qk.instruments(search, assetClassesKey),
+    queryFn: async (pageToken) => {
+      const classes = assetClassesKey
+        ? (assetClassesKey.split(",").map(Number) as AssetClass[])
+        : [];
+      const result = await listInstruments({
+        search,
+        assetClasses: classes.length < ALL_ASSET_CLASSES.length ? classes : [],
+        pageToken,
+      });
+      return {
+        items: result.instruments,
+        totalCount: result.totalCount,
+        nextPageToken: result.nextPageToken,
+      };
+    },
+  });
+
+  return (
+    <>
+      {!loading && (
+        <span className="block font-mono text-xs text-text-muted">{totalCount} total</span>
+      )}
       {loading && (
         <p className="text-text-muted">Loading instruments...</p>
       )}
-      {!loading && error && <ErrorAlert>{error}</ErrorAlert>}
+      {!loading && error && <ErrorAlert>{errorMessage(error)}</ErrorAlert>}
       {!loading && !error && (
         <>
           <div className="overflow-x-auto rounded-md border border-border bg-surface shadow-sm">
@@ -224,7 +246,7 @@ export default function AdminInstrumentsPage() {
                       colSpan={5}
                       className="px-4 py-8 text-center text-text-muted"
                     >
-                      {debouncedSearch
+                      {search
                         ? "No instruments match your search."
                         : "No instruments in the system yet."}
                     </td>
@@ -301,12 +323,7 @@ export default function AdminInstrumentsPage() {
         </>
       )}
 
-      <ImportInstrumentsModal
-        open={importOpen}
-        onClose={() => setImportOpen(false)}
-        onComplete={() => setRefreshKey((k) => k + 1)}
-      />
-    </div>
+    </>
   );
 }
 

--- a/client/app/admin/page.tsx
+++ b/client/app/admin/page.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useAuthedQuery } from "@/hooks/use-authed-query";
+import { qk } from "@/lib/query-keys";
 import Link from "next/link";
 import {
   listIdentifierPlugins,
@@ -89,40 +90,36 @@ const dashboardCards: {
 ];
 
 export default function AdminOverviewPage() {
-  const [identifierPlugins, setIdentifierPlugins] = useState<
-    { displayName: string }[]
-  >([]);
-  const [descriptionPlugins, setDescriptionPlugins] = useState<
-    { displayName: string }[]
-  >([]);
-  const [pricePlugins, setPricePlugins] = useState<
-    { displayName: string }[]
-  >([]);
-  const [workers, setWorkers] = useState<WorkerRow[]>([]);
-  const [unhandledEventCount, setUnhandledEventCount] = useState<number>(0);
+  // Five separate queries rather than one Promise.all whose catch swallowed
+  // everything: a card whose summary fails now blanks on its own instead of
+  // taking the other four with it. The plugin lists share their keys with the
+  // plugin pages, so navigating there is a cache hit.
+  const names = (list: { displayName: string; pluginId: string }[]) =>
+    list.map((p) => ({ displayName: p.displayName || p.pluginId }));
 
-  const load = useCallback(async () => {
-    try {
-      const [idList, descList, priceList, workerList, eventCount] = await Promise.all([
-        listIdentifierPlugins(),
-        listDescriptionPlugins(),
-        listPricePlugins(),
-        listWorkers(),
-        countUnhandledCorporateEvents(),
-      ]);
-      setIdentifierPlugins(idList.map((p) => ({ displayName: p.displayName || p.pluginId })));
-      setDescriptionPlugins(descList.map((p) => ({ displayName: p.displayName || p.pluginId })));
-      setPricePlugins(priceList.map((p) => ({ displayName: p.displayName || p.pluginId })));
-      setWorkers(workerList);
-      setUnhandledEventCount(eventCount);
-    } catch {
-      // Non-blocking: cards still work without the summary
-    }
-  }, []);
-
-  useEffect(() => {
-    load();
-  }, [load]);
+  const { data: identifierPlugins = [] } = useAuthedQuery({
+    queryKey: qk.plugins("identifier"),
+    queryFn: listIdentifierPlugins,
+    select: names,
+  });
+  const { data: descriptionPlugins = [] } = useAuthedQuery({
+    queryKey: qk.plugins("description"),
+    queryFn: listDescriptionPlugins,
+    select: names,
+  });
+  const { data: pricePlugins = [] } = useAuthedQuery({
+    queryKey: qk.plugins("price"),
+    queryFn: listPricePlugins,
+    select: names,
+  });
+  const { data: workers = [] } = useAuthedQuery<WorkerRow[]>({
+    queryKey: qk.workers(),
+    queryFn: listWorkers,
+  });
+  const { data: unhandledEventCount = 0 } = useAuthedQuery<number>({
+    queryKey: qk.unhandledCorporateEventCount(),
+    queryFn: countUnhandledCorporateEvents,
+  });
 
   function pluginSummary(
     id: string

--- a/client/app/admin/plugins/description/page.tsx
+++ b/client/app/admin/plugins/description/page.tsx
@@ -12,6 +12,7 @@ export default function AdminDescriptionPluginsPage() {
     <PluginConfigEditor
       title="Description plugins"
       description="Enable or disable plugins that extract identifier hints from broker instrument descriptions. They run in series by precedence (higher runs first); the first that returns hints is used. Config JSON can include API keys; only admins can view or edit."
+      category="description"
       listFn={listDescriptionPlugins}
       updateFn={updateDescriptionPlugin}
       reorderFn={(ids) => reorderPlugins("description", ids)}

--- a/client/app/admin/plugins/identifier/page.tsx
+++ b/client/app/admin/plugins/identifier/page.tsx
@@ -12,6 +12,7 @@ export default function AdminIdentifierPluginsPage() {
     <PluginConfigEditor
       title="Identifier plugins"
       description="Enable or disable plugins and set precedence (higher runs first). Config JSON can include API keys (e.g. openfigi_api_key, openai_api_key); only admins can view or edit."
+      category="identifier"
       listFn={listIdentifierPlugins}
       updateFn={updateIdentifierPlugin}
       reorderFn={(ids) => reorderPlugins("identifier", ids)}

--- a/client/app/admin/plugins/inflation/page.tsx
+++ b/client/app/admin/plugins/inflation/page.tsx
@@ -12,6 +12,7 @@ export default function AdminInflationPluginsPage() {
     <PluginConfigEditor
       title="Inflation plugins"
       description="Enable or disable plugins that fetch monthly inflation index data. Config JSON can include API endpoints and rate limits; only admins can view or edit."
+      category="inflation"
       listFn={listInflationPlugins}
       updateFn={updateInflationPlugin}
       reorderFn={(ids) => reorderPlugins("inflation", ids)}

--- a/client/app/admin/plugins/plugin-config-editor.tsx
+++ b/client/app/admin/plugins/plugin-config-editor.tsx
@@ -1,6 +1,10 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useAuthedQuery } from "@/hooks/use-authed-query";
+import { errorMessage } from "@/lib/errors";
+import { qk } from "@/lib/query-keys";
 import {
   DndContext,
   closestCenter,
@@ -201,6 +205,7 @@ function SortablePluginCard<T extends PluginConfig>({
 export function PluginConfigEditor<T extends PluginConfig>({
   title,
   description,
+  category,
   listFn,
   updateFn,
   reorderFn,
@@ -208,6 +213,8 @@ export function PluginConfigEditor<T extends PluginConfig>({
 }: {
   title: string;
   description: string;
+  /** Query key discriminator: listFn is a stable module reference but cannot be a key. */
+  category: "identifier" | "description" | "price" | "inflation";
   listFn: () => Promise<T[]>;
   updateFn: (
     pluginId: string,
@@ -216,8 +223,7 @@ export function PluginConfigEditor<T extends PluginConfig>({
   reorderFn?: (pluginIds: string[]) => Promise<void>;
   renderExtra?: (plugin: T, opts: { saving: boolean; onUpdate: (updated: T) => void }) => React.ReactNode;
 }) {
-  const [plugins, setPlugins] = useState<T[]>([]);
-  const [loading, setLoading] = useState(true);
+  const queryClient = useQueryClient();
   const [error, setError] = useState<string | null>(null);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editConfig, setEditConfig] = useState("");
@@ -228,22 +234,19 @@ export function PluginConfigEditor<T extends PluginConfig>({
     useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
   );
 
-  const load = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const list = await listFn();
-      setPlugins(list);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to load plugins");
-    } finally {
-      setLoading(false);
-    }
-  }, [listFn]);
+  const queryKey = qk.plugins(category);
+  const {
+    data: plugins = [],
+    isPending: loading,
+    error: loadError,
+  } = useAuthedQuery<T[]>({ queryKey, queryFn: listFn });
 
-  useEffect(() => {
-    load();
-  }, [load]);
+  // Writes the list straight into the cache. The handlers below already knew the
+  // updated plugin, so refetching to learn what they were just told would be a
+  // round trip for nothing -- and the drag reorder needs to roll back to a
+  // previous value, which only works if it owns the write.
+  const setPlugins = (update: (prev: T[]) => T[]) =>
+    queryClient.setQueryData<T[]>(queryKey, (prev) => update(prev ?? []));
 
   async function handleToggleEnabled(plugin: T) {
     setSaving(true);
@@ -256,7 +259,7 @@ export function PluginConfigEditor<T extends PluginConfig>({
         prev.map((p) => (p.pluginId === updated.pluginId ? updated : p))
       );
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to update");
+      setError(errorMessage(e, "Failed to update"));
     } finally {
       setSaving(false);
     }
@@ -285,7 +288,7 @@ export function PluginConfigEditor<T extends PluginConfig>({
       );
       cancelEdit();
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to save config");
+      setError(errorMessage(e, "Failed to save config"));
     } finally {
       setSaving(false);
     }
@@ -297,14 +300,15 @@ export function PluginConfigEditor<T extends PluginConfig>({
     const oldIdx = plugins.findIndex((p) => p.pluginId === active.id);
     const newIdx = plugins.findIndex((p) => p.pluginId === over.id);
     const reordered = arrayMove(plugins, oldIdx, newIdx);
-    const prev = plugins;
-    setPlugins(reordered);
+    const previous = plugins;
+    setPlugins(() => reordered);
     setError(null);
     try {
       await reorderFn(reordered.map((p) => p.pluginId));
     } catch (e) {
-      setPlugins(prev);
-      setError(e instanceof Error ? e.message : "Failed to reorder");
+      // Roll the optimistic reorder back.
+      setPlugins(() => previous);
+      setError(errorMessage(e, "Failed to reorder"));
     }
   }
 
@@ -312,6 +316,10 @@ export function PluginConfigEditor<T extends PluginConfig>({
     return (
       <div className="text-text-muted">Loading plugin configs...</div>
     );
+  }
+
+  if (loadError && plugins.length === 0) {
+    return <ErrorAlert>{errorMessage(loadError, "Failed to load plugins")}</ErrorAlert>;
   }
 
   const pluginIds = plugins.map((p) => p.pluginId);

--- a/client/app/admin/plugins/price/page.tsx
+++ b/client/app/admin/plugins/price/page.tsx
@@ -14,6 +14,7 @@ export default function AdminPricePluginsPage() {
     <PluginConfigEditor
       title="Price plugins"
       description="Enable or disable plugins that fetch end-of-day prices for identified instruments. Config JSON can include API keys and rate limits; only admins can view or edit."
+      category="price"
       listFn={listPricePlugins}
       updateFn={updatePricePlugin}
       reorderFn={(ids) => reorderPlugins("price", ids)}

--- a/client/app/admin/prices/page.tsx
+++ b/client/app/admin/prices/page.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { ErrorAlert } from "@/app/components/error-alert";
 import { PaginationControls } from "@/app/components/pagination-controls";
 import { usePagination } from "@/hooks/use-pagination";
+import { useAuthedQuery } from "@/hooks/use-authed-query";
 import { errorMessage } from "@/lib/errors";
 import { qk } from "@/lib/query-keys";
 import {
@@ -351,42 +352,37 @@ function PriceRow({ price: p }: { price: EODPriceProto }) {
 // --- Price Fetch Blocks Tab ---
 
 function PriceFetchBlocksTab() {
-  const [blocks, setBlocks] = useState<PriceFetchBlock[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+  const [clearError, setClearError] = useState<string | null>(null);
   const [clearing, setClearing] = useState<string | null>(null);
 
-  const load = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      setBlocks(await listPriceFetchBlocks());
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to load blocks");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  const {
+    data: blocks = [],
+    isPending: loading,
+    error: loadError,
+  } = useAuthedQuery<PriceFetchBlock[]>({
+    queryKey: qk.priceFetchBlocks(),
+    queryFn: listPriceFetchBlocks,
+  });
 
-  useEffect(() => {
-    load();
-  }, [load]);
+  const error =
+    clearError ?? (loadError ? errorMessage(loadError, "Failed to load blocks") : null);
 
   async function handleClear(block: PriceFetchBlock) {
     const key = `${block.instrumentId}:${block.pluginId}`;
     setClearing(key);
-    setError(null);
+    setClearError(null);
     try {
       await deletePriceFetchBlock(block.instrumentId, block.pluginId);
-      setBlocks((prev) =>
-        prev.filter(
-          (b) =>
-            b.instrumentId !== block.instrumentId ||
-            b.pluginId !== block.pluginId
+      // Drop the row from the cache rather than refetching: the delete already
+      // tells us it is gone.
+      queryClient.setQueryData<PriceFetchBlock[]>(qk.priceFetchBlocks(), (prev) =>
+        (prev ?? []).filter(
+          (b) => b.instrumentId !== block.instrumentId || b.pluginId !== block.pluginId
         )
       );
     } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to clear block");
+      setClearError(errorMessage(e, "Failed to clear block"));
     } finally {
       setClearing(null);
     }

--- a/client/app/admin/prices/page.tsx
+++ b/client/app/admin/prices/page.tsx
@@ -1,9 +1,12 @@
 "use client";
 
 import { useCallback, useEffect, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { ErrorAlert } from "@/app/components/error-alert";
 import { PaginationControls } from "@/app/components/pagination-controls";
 import { usePagination } from "@/hooks/use-pagination";
+import { errorMessage } from "@/lib/errors";
+import { qk } from "@/lib/query-keys";
 import {
   listPrices,
   listPriceFetchBlocks,
@@ -88,7 +91,7 @@ function PriceListTab() {
   const [exportLoading, setExportLoading] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
   const [importOpen, setImportOpen] = useState(false);
-  const [refreshKey, setRefreshKey] = useState(0);
+  const queryClient = useQueryClient();
 
   async function handleExport() {
     setExportLoading(true);
@@ -124,37 +127,6 @@ function PriceListTab() {
     }
   }
 
-  const fetchPrices = useCallback(
-    async (pageToken: string | null) => {
-      const result = await listPrices({
-        search: debouncedSearch,
-        dateFrom: dateFrom || undefined,
-        // The picker is inclusive; the API bound is exclusive.
-        dateBefore: dayAfter(dateTo),
-        pageToken,
-      });
-      return {
-        items: result.prices,
-        totalCount: result.totalCount,
-        nextPageToken: result.nextPageToken,
-      };
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [debouncedSearch, dateFrom, dateTo, refreshKey]
-  );
-
-  const {
-    items: prices,
-    totalCount,
-    loading,
-    error,
-    pageIndex,
-    hasPrev,
-    hasNext,
-    goNext,
-    goPrev,
-  } = usePagination(fetchPrices);
-
   return (
     <div className="space-y-4">
       {/* Header with export/import buttons */}
@@ -184,11 +156,6 @@ function PriceListTab() {
             className="rounded-md border border-border bg-surface px-2 py-1.5 text-sm text-text-primary focus:border-primary focus:outline-none focus:ring-1 focus:ring-primary/30"
           />
         </label>
-        {!loading && (
-          <span className="font-mono text-xs text-text-muted">
-            {totalCount} total
-          </span>
-        )}
         <div className="ml-auto flex gap-2">
           <button
             type="button"
@@ -209,8 +176,68 @@ function PriceListTab() {
       </div>
       {exportError && <ErrorAlert>{exportError}</ErrorAlert>}
 
+      {/* Keyed on the filters: a change remounts the list, which returns it to
+          page 1. */}
+      <PriceList
+        key={`${debouncedSearch}|${dateFrom}|${dateTo}`}
+        search={debouncedSearch}
+        dateFrom={dateFrom}
+        dateTo={dateTo}
+      />
+
+      <ImportPricesModal
+        open={importOpen}
+        onClose={() => setImportOpen(false)}
+        onComplete={() => queryClient.invalidateQueries({ queryKey: qk.prices() })}
+      />
+    </div>
+  );
+}
+
+function PriceList({
+  search,
+  dateFrom,
+  dateTo,
+}: {
+  search: string;
+  dateFrom: string;
+  dateTo: string;
+}) {
+  const {
+    items: prices,
+    totalCount,
+    loading,
+    error,
+    pageIndex,
+    hasPrev,
+    hasNext,
+    goNext,
+    goPrev,
+  } = usePagination<EODPriceProto>({
+    queryKey: qk.prices(search, dateFrom, dateTo),
+    queryFn: async (pageToken) => {
+      const result = await listPrices({
+        search,
+        dateFrom: dateFrom || undefined,
+        // The picker is inclusive; the API bound is exclusive.
+        dateBefore: dayAfter(dateTo),
+        pageToken,
+      });
+      return {
+        items: result.prices,
+        totalCount: result.totalCount,
+        nextPageToken: result.nextPageToken,
+      };
+    },
+  });
+
+  return (
+    <>
+      {!loading && (
+        <span className="block font-mono text-xs text-text-muted">{totalCount} total</span>
+      )}
       {loading && <p className="text-text-muted">Loading prices...</p>}
-      {!loading && error && <ErrorAlert>{error}</ErrorAlert>}
+      {!loading && error && <ErrorAlert>{errorMessage(error)}</ErrorAlert>}
       {!loading && !error && (
         <>
           <div className="overflow-x-auto rounded-md border border-border bg-surface shadow-sm">
@@ -253,7 +280,7 @@ function PriceListTab() {
                       colSpan={9}
                       className="px-4 py-8 text-center text-text-muted"
                     >
-                      {debouncedSearch || dateFrom || dateTo
+                      {search || dateFrom || dateTo
                         ? "No prices match your filters."
                         : "No price data yet."}
                     </td>
@@ -277,12 +304,7 @@ function PriceListTab() {
         </>
       )}
 
-      <ImportPricesModal
-        open={importOpen}
-        onClose={() => setImportOpen(false)}
-        onComplete={() => setRefreshKey((k) => k + 1)}
-      />
-    </div>
+    </>
   );
 }
 

--- a/client/app/admin/telemetry/page.tsx
+++ b/client/app/admin/telemetry/page.tsx
@@ -1,7 +1,10 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { ErrorAlert } from "@/app/components/error-alert";
+import { useAuthedQuery } from "@/hooks/use-authed-query";
+import { errorMessage } from "@/lib/errors";
+import { qk } from "@/lib/query-keys";
 import { listTelemetryCounters, type TelemetryCounterRow } from "@/lib/portfolio-api";
 
 type CounterEntry = { label: string; value: number };
@@ -125,26 +128,17 @@ function titleCase(name: string): string {
 }
 
 export default function AdminTelemetryPage() {
-  const [counters, setCounters] = useState<TelemetryCounterRow[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+  const {
+    data: counters = [],
+    isFetching: loading,
+    error,
+  } = useAuthedQuery<TelemetryCounterRow[]>({
+    queryKey: qk.telemetryCounters(),
+    queryFn: listTelemetryCounters,
+  });
 
-  const load = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const list = await listTelemetryCounters();
-      setCounters(list);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to load counters");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    load();
-  }, [load]);
+  const load = () => queryClient.invalidateQueries({ queryKey: qk.telemetryCounters() });
 
   if (loading && counters.length === 0) {
     return (
@@ -172,7 +166,7 @@ export default function AdminTelemetryPage() {
       </div>
       {error && (
         <div className="mt-2">
-          <ErrorAlert>{error}</ErrorAlert>
+          <ErrorAlert>{errorMessage(error, "Failed to load counters")}</ErrorAlert>
         </div>
       )}
       <p className="mt-1 text-sm text-text-muted">

--- a/client/app/admin/tools/page.tsx
+++ b/client/app/admin/tools/page.tsx
@@ -1,25 +1,24 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { GoogleLogin } from "@react-oauth/google";
 import { useAuth } from "@/contexts/auth-context";
+import { useAuthedQuery } from "@/hooks/use-authed-query";
+import { qk } from "@/lib/query-keys";
 import { getSession } from "@/lib/auth-api";
 
 export default function ToolsPage() {
   const { signIn, state } = useAuth();
   const [idToken, setIdToken] = useState<string | null>(null);
-  const [sessionToken, setSessionToken] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (state.status !== "authenticated") {
-      setSessionToken(null);
-      return;
-    }
-    getSession()
-      .then((res) => setSessionToken(res.sessionId || null))
-      .catch(() => setSessionToken(null));
-  }, [state.status]);
+  // Same key as the session query behind useAuth, so this is deduped rather
+  // than a second GetSession call. Signing out disables it and the token clears.
+  const { data: sessionToken = null } = useAuthedQuery({
+    queryKey: qk.session(),
+    queryFn: getSession,
+    select: (res) => res.sessionId || null,
+  });
 
   return (
     <div className="space-y-4">

--- a/client/app/admin/workers/page.tsx
+++ b/client/app/admin/workers/page.tsx
@@ -1,6 +1,9 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
+import { useAuthedQuery } from "@/hooks/use-authed-query";
+import { errorMessage } from "@/lib/errors";
+import { qk } from "@/lib/query-keys";
 import { ErrorAlert } from "@/app/components/error-alert";
 import { listWorkers, triggerPriceFetch, triggerInflationFetch, WorkerState, type WorkerRow } from "@/lib/portfolio-api";
 
@@ -27,22 +30,26 @@ function stateBadge(state: WorkerState): string {
 }
 
 export default function AdminWorkersPage() {
-  const [workers, setWorkers] = useState<WorkerRow[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [triggerError, setTriggerError] = useState<string | null>(null);
   const [triggering, setTriggering] = useState<string | null>(null);
 
-  const load = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      setWorkers(await listWorkers());
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to load workers");
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  // refetchInterval rather than a setInterval the effect has to tear down. The
+  // old version had no cancel flag either, so a response arriving after unmount
+  // called setState on a dead component.
+  const {
+    data: workers = [],
+    isPending: loading,
+    isFetching,
+    refetch,
+    error: loadError,
+  } = useAuthedQuery<WorkerRow[]>({
+    queryKey: qk.workers(),
+    queryFn: listWorkers,
+    refetchInterval: 2000,
+  });
+
+  const error =
+    triggerError ?? (loadError ? errorMessage(loadError, "Failed to load workers") : null);
 
   const triggerFns: Record<string, () => Promise<void>> = {
     price_fetcher: triggerPriceFetch,
@@ -51,21 +58,15 @@ export default function AdminWorkersPage() {
 
   async function handleTrigger(name: string, fn: () => Promise<void>) {
     setTriggering(name);
-    setError(null);
+    setTriggerError(null);
     try {
       await fn();
     } catch (e) {
-      setError(e instanceof Error ? e.message : `Failed to trigger ${name}`);
+      setTriggerError(errorMessage(e, `Failed to trigger ${name}`));
     } finally {
       setTriggering(null);
     }
   }
-
-  useEffect(() => {
-    load();
-    const interval = setInterval(load, 2000);
-    return () => clearInterval(interval);
-  }, [load]);
 
   if (loading && workers.length === 0) {
     return (
@@ -82,11 +83,11 @@ export default function AdminWorkersPage() {
         <h1 className="font-display text-xl font-bold text-text-primary">Workers</h1>
         <button
           type="button"
-          onClick={load}
-          disabled={loading}
+          onClick={() => void refetch()}
+          disabled={isFetching}
           className="rounded bg-primary px-3 py-1.5 text-sm font-medium text-white hover:bg-primary-dark disabled:opacity-50"
         >
-          {loading ? "Refreshing..." : "Refresh"}
+          {isFetching ? "Refreshing..." : "Refresh"}
         </button>
       </div>
       {error && (

--- a/client/app/components/ignored-asset-class-editor.tsx
+++ b/client/app/components/ignored-asset-class-editor.tsx
@@ -1,7 +1,11 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { ErrorAlert } from "@/app/components/error-alert";
+import { useAuthedQuery } from "@/hooks/use-authed-query";
+import { errorMessage } from "@/lib/errors";
+import { qk } from "@/lib/query-keys";
 import {
   getIgnoredAssetClasses,
   setIgnoredAssetClasses,
@@ -33,16 +37,61 @@ function keySetToRules(keys: Set<string>): IgnoredAssetClassRule[] {
   });
 }
 
-interface Props {
-  authStatus: string;
+/**
+ * Loads the data, then hands it to the form. The split exists so the form's
+ * draft state can initialise from the saved rules as ordinary initial state: it
+ * is keyed on them, so a save or a refetch remounts it with a fresh draft
+ * instead of an effect copying fetched data into state.
+ */
+export function IgnoredAssetClassEditor() {
+  const {
+    data,
+    isPending: loading,
+    error,
+  } = useAuthedQuery<{ brokerAccounts: BrokerAccounts[]; savedKeys: Set<string> }>({
+    queryKey: qk.ignoredAssetClasses(),
+    queryFn: async () => {
+      const [ba, rules] = await Promise.all([listBrokersAndAccounts(), getIgnoredAssetClasses()]);
+      return { brokerAccounts: ba, savedKeys: rulesToKeySet(rules) };
+    },
+  });
+
+  if (loading) {
+    return (
+      <div className="rounded-lg border border-border bg-surface p-5">
+        <p className="text-sm text-text-muted">Loading...</p>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-border bg-surface p-5">
+        <ErrorAlert>{errorMessage(error)}</ErrorAlert>
+      </div>
+    );
+  }
+
+  const savedKeys = data?.savedKeys ?? new Set<string>();
+  return (
+    <IgnoredAssetClassForm
+      key={[...savedKeys].sort().join("|")}
+      brokerAccounts={data?.brokerAccounts ?? []}
+      savedKeys={savedKeys}
+    />
+  );
 }
 
-export function IgnoredAssetClassEditor({ authStatus }: Props) {
-  const [brokerAccounts, setBrokerAccounts] = useState<BrokerAccounts[]>([]);
-  const [loading, setLoading] = useState(true);
+function IgnoredAssetClassForm({
+  brokerAccounts,
+  savedKeys,
+}: {
+  brokerAccounts: BrokerAccounts[];
+  savedKeys: Set<string>;
+}) {
+  const queryClient = useQueryClient();
   const [error, setError] = useState<string | null>(null);
-  const [savedKeys, setSavedKeys] = useState<Set<string>>(new Set());
-  const [editKeys, setEditKeys] = useState<Set<string>>(new Set());
+  const [editKeys, setEditKeys] = useState<Set<string>>(() => new Set(savedKeys));
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
   const [confirmDialog, setConfirmDialog] = useState<{
@@ -52,30 +101,6 @@ export function IgnoredAssetClassEditor({ authStatus }: Props) {
   } | null>(null);
 
   const hasChanges = !setsEqual(savedKeys, editKeys);
-
-  const loadData = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const [ba, rules] = await Promise.all([
-        listBrokersAndAccounts(),
-        getIgnoredAssetClasses(),
-      ]);
-      setBrokerAccounts(ba);
-      const keys = rulesToKeySet(rules);
-      setSavedKeys(keys);
-      setEditKeys(new Set(keys));
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (authStatus !== "authenticated") return;
-    loadData();
-  }, [authStatus, loadData]);
 
   // Check if a broker-level ignore is active for the given asset class.
   function isBrokerIgnored(broker: string, assetClass: AssetClass): boolean {
@@ -178,7 +203,7 @@ export function IgnoredAssetClassEditor({ authStatus }: Props) {
       }
       await doSave(rules);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(errorMessage(e));
       setSaving(false);
     }
   }
@@ -188,13 +213,13 @@ export function IgnoredAssetClassEditor({ authStatus }: Props) {
     setError(null);
     try {
       await setIgnoredAssetClasses(rules);
-      const keys = rulesToKeySet(rules);
-      setSavedKeys(keys);
-      setEditKeys(new Set(keys));
+      // Refetching remounts this form under a new key, so the draft resets to
+      // what was just saved.
+      await queryClient.invalidateQueries({ queryKey: qk.ignoredAssetClasses() });
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setError(errorMessage(e));
     } finally {
       setSaving(false);
       setConfirmDialog(null);
@@ -203,14 +228,6 @@ export function IgnoredAssetClassEditor({ authStatus }: Props) {
 
   function handleCancel() {
     setEditKeys(new Set(savedKeys));
-  }
-
-  if (loading) {
-    return (
-      <div className="rounded-lg border border-border bg-surface p-5">
-        <p className="text-sm text-text-muted">Loading...</p>
-      </div>
-    );
   }
 
   return (

--- a/client/app/components/portfolio-filter-editor.tsx
+++ b/client/app/components/portfolio-filter-editor.tsx
@@ -1,10 +1,12 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { ErrorAlert } from "@/app/components/error-alert";
 import { PaginationControls } from "@/app/components/pagination-controls";
 import { usePagination } from "@/hooks/use-pagination";
 import { useDebounce } from "@/hooks/use-debounce";
+import { errorMessage } from "@/lib/errors";
+import { qk } from "@/lib/query-keys";
 import {
   getPortfolioFilters,
   setPortfolioFilters,
@@ -174,36 +176,6 @@ export function PortfolioFilterEditor({
     [activeClasses]
   );
 
-  const fetchInstruments = useCallback(
-    async (pageToken: string | null) => {
-      const classes = assetClassesKey ? assetClassesKey.split(",").map(Number) as AssetClass[] : [];
-      const result = await listInstruments({
-        search: debouncedSearch,
-        assetClasses:
-          classes.length < ALL_ASSET_CLASSES.length ? classes : [],
-        pageToken,
-      });
-      return {
-        items: result.instruments,
-        totalCount: result.totalCount,
-        nextPageToken: result.nextPageToken,
-      };
-    },
-    [debouncedSearch, assetClassesKey]
-  );
-
-  const {
-    items: instruments,
-    totalCount: instTotal,
-    loading: instLoading,
-    error: instError,
-    pageIndex,
-    hasPrev,
-    hasNext,
-    goNext,
-    goPrev,
-  } = usePagination(fetchInstruments);
-
   const handleSave = async () => {
     setSaving(true);
     setSaveError(null);
@@ -300,16 +272,8 @@ export function PortfolioFilterEditor({
             onSearchChange={setInstSearch}
             activeClasses={activeClasses}
             onToggleClass={toggleClass}
-            instruments={instruments}
-            instTotal={instTotal}
-            instLoading={instLoading}
-            instError={instError}
             debouncedSearch={debouncedSearch}
-            pageIndex={pageIndex}
-            hasPrev={hasPrev}
-            hasNext={hasNext}
-            goNext={goNext}
-            goPrev={goPrev}
+            assetClassesKey={assetClassesKey}
             onToggleInstrument={toggleInstrument}
             onRemoveInstrument={removeInstrument}
           />
@@ -411,16 +375,8 @@ function InstrumentsTab({
   onSearchChange,
   activeClasses,
   onToggleClass,
-  instruments,
-  instTotal,
-  instLoading,
-  instError,
   debouncedSearch,
-  pageIndex,
-  hasPrev,
-  hasNext,
-  goNext,
-  goPrev,
+  assetClassesKey,
   onToggleInstrument,
   onRemoveInstrument,
 }: {
@@ -429,16 +385,8 @@ function InstrumentsTab({
   onSearchChange: (v: string) => void;
   activeClasses: Set<AssetClass>;
   onToggleClass: (cls: AssetClass) => void;
-  instruments: Instrument[];
-  instTotal: number;
-  instLoading: boolean;
-  instError: string | null;
   debouncedSearch: string;
-  pageIndex: number;
-  hasPrev: boolean;
-  hasNext: boolean;
-  goNext: () => void;
-  goPrev: () => void;
+  assetClassesKey: string;
   onToggleInstrument: (inst: Instrument) => void;
   onRemoveInstrument: (id: string) => void;
 }) {
@@ -508,11 +456,66 @@ function InstrumentsTab({
         </div>
       </div>
 
+      {/* Keyed on the filters: a change remounts the results, returning them to
+          page 1. The search input above stays mounted so typing keeps focus. */}
+      <InstrumentResults
+        key={`${debouncedSearch}|${assetClassesKey}`}
+        debouncedSearch={debouncedSearch}
+        assetClassesKey={assetClassesKey}
+        selInstruments={selInstruments}
+        onToggleInstrument={onToggleInstrument}
+      />
+    </div>
+  );
+}
+
+function InstrumentResults({
+  debouncedSearch,
+  assetClassesKey,
+  selInstruments,
+  onToggleInstrument,
+}: {
+  debouncedSearch: string;
+  assetClassesKey: string;
+  selInstruments: Map<string, string>;
+  onToggleInstrument: (inst: Instrument) => void;
+}) {
+  const {
+    items: instruments,
+    totalCount: instTotal,
+    loading: instLoading,
+    error: instError,
+    pageIndex,
+    hasPrev,
+    hasNext,
+    goNext,
+    goPrev,
+  } = usePagination<Instrument>({
+    queryKey: qk.instruments(debouncedSearch, assetClassesKey),
+    queryFn: async (pageToken) => {
+      const classes = assetClassesKey
+        ? (assetClassesKey.split(",").map(Number) as AssetClass[])
+        : [];
+      const result = await listInstruments({
+        search: debouncedSearch,
+        assetClasses: classes.length < ALL_ASSET_CLASSES.length ? classes : [],
+        pageToken,
+      });
+      return {
+        items: result.instruments,
+        totalCount: result.totalCount,
+        nextPageToken: result.nextPageToken,
+      };
+    },
+  });
+
+  return (
+    <>
       {/* Instrument results */}
       {instLoading && (
         <p className="py-2 text-xs text-text-muted">Loading instruments...</p>
       )}
-      {!instLoading && instError && <ErrorAlert>{instError}</ErrorAlert>}
+      {!instLoading && instError && <ErrorAlert>{errorMessage(instError)}</ErrorAlert>}
       {!instLoading && !instError && (
         <div>
           {instruments.length === 0 ? (
@@ -562,6 +565,6 @@ function InstrumentsTab({
           )}
         </div>
       )}
-    </div>
+    </>
   );
 }

--- a/client/app/components/portfolio-selector-modal.tsx
+++ b/client/app/components/portfolio-selector-modal.tsx
@@ -1,7 +1,11 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { ErrorAlert } from "@/app/components/error-alert";
+import { useAuthedQuery } from "@/hooks/use-authed-query";
+import { errorMessage } from "@/lib/errors";
+import { qk } from "@/lib/query-keys";
 import { Modal } from "@/app/components/modal";
 import { PortfolioFilterEditor } from "@/app/components/portfolio-filter-editor";
 import { usePortfolio } from "@/contexts/portfolio-context";
@@ -13,11 +17,20 @@ import {
   deletePortfolio,
 } from "@/lib/portfolio-api";
 
+/**
+ * Shell. The body mounts only while the modal is open, so the filter box and the
+ * create/rename/delete affordances all start clean on each open -- which is what
+ * the reset half of the old open-effect did.
+ */
 export function PortfolioSelectorModal() {
+  const { modalOpen } = usePortfolio();
+  return modalOpen ? <PortfolioSelectorBody /> : null;
+}
+
+function PortfolioSelectorBody() {
   const { selected, setSelected, modalOpen, closeModal } = usePortfolio();
-  const [portfolios, setPortfolios] = useState<Portfolio[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+  const [mutationError, setMutationError] = useState<string | null>(null);
   const [filter, setFilter] = useState("");
   const [creating, setCreating] = useState(false);
   const [newName, setNewName] = useState("");
@@ -26,10 +39,14 @@ export function PortfolioSelectorModal() {
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [editingFiltersId, setEditingFiltersId] = useState<string | null>(null);
 
-  const fetchAll = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
+  // The list is not paginated in the UI, so the queryFn drains every page.
+  const {
+    data: portfolios = [],
+    isPending: loading,
+    error: loadError,
+  } = useAuthedQuery<Portfolio[]>({
+    queryKey: qk.portfolios(),
+    queryFn: async () => {
       const all: Portfolio[] = [];
       let token: string | null = null;
       for (;;) {
@@ -38,25 +55,12 @@ export function PortfolioSelectorModal() {
         if (!result.nextPageToken) break;
         token = result.nextPageToken;
       }
-      setPortfolios(all);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+      return all;
+    },
+  });
 
-  useEffect(() => {
-    if (modalOpen) {
-      fetchAll();
-      setFilter("");
-      setCreating(false);
-      setNewName("");
-      setRenamingId(null);
-      setDeletingId(null);
-      setEditingFiltersId(null);
-    }
-  }, [modalOpen, fetchAll]);
+  const error = mutationError ?? (loadError ? errorMessage(loadError) : null);
+  const fetchAll = () => queryClient.invalidateQueries({ queryKey: qk.portfolios() });
 
   const handleSelect = (p: Portfolio | null) => {
     setSelected(p);
@@ -67,7 +71,7 @@ export function PortfolioSelectorModal() {
     e.preventDefault();
     const name = newName.trim();
     if (!name) return;
-    setError(null);
+    setMutationError(null);
     try {
       const created = await createPortfolio(name);
       setNewName("");
@@ -75,7 +79,7 @@ export function PortfolioSelectorModal() {
       await fetchAll();
       setEditingFiltersId(created.id);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setMutationError(errorMessage(e));
     }
   };
 
@@ -83,7 +87,7 @@ export function PortfolioSelectorModal() {
     e.preventDefault();
     const name = renameValue.trim();
     if (!name) return;
-    setError(null);
+    setMutationError(null);
     try {
       await updatePortfolio(id, name);
       setRenamingId(null);
@@ -93,12 +97,12 @@ export function PortfolioSelectorModal() {
       }
       await fetchAll();
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setMutationError(errorMessage(e));
     }
   };
 
   const handleDelete = async (id: string) => {
-    setError(null);
+    setMutationError(null);
     try {
       await deletePortfolio(id);
       setDeletingId(null);
@@ -106,7 +110,7 @@ export function PortfolioSelectorModal() {
       if (selected?.id === id) setSelected(null);
       await fetchAll();
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setMutationError(errorMessage(e));
     }
   };
 

--- a/client/app/components/upload-modal.tsx
+++ b/client/app/components/upload-modal.tsx
@@ -4,7 +4,9 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { ErrorAlert } from "@/app/components/error-alert";
 import { Modal } from "@/app/components/modal";
 import { useUploadModal } from "@/contexts/upload-modal-context";
-import { useAuth } from "@/contexts/auth-context";
+import { useAuthedQuery } from "@/hooks/use-authed-query";
+import { errorMessage } from "@/lib/errors";
+import { qk } from "@/lib/query-keys";
 import { getJob } from "@/lib/portfolio-api";
 import { upsertTxs } from "@/lib/ingestion-api";
 import { parseStandardCSV } from "@/lib/csv/standard";
@@ -20,18 +22,44 @@ import {
 const BROKER_OPTIONS = getBrokerOptionsForUpload();
 const DEFAULT_BROKER = BROKER_OPTIONS[0]?.value ?? Broker.FIDELITY;
 
+/**
+ * Shell. The body is mounted only while the modal is open, so every field it
+ * owns starts fresh on each open -- which is what the reset-on-open effect used
+ * to do. jobId stays here because the shell needs it to decide whether the
+ * modal can be dismissed.
+ */
 export function UploadModal() {
-  const { isOpen, closeUploadModal, onComplete } = useUploadModal();
-  const { state } = useAuth();
+  const { isOpen, closeUploadModal } = useUploadModal();
+  const [jobId, setJobId] = useState<string | null>(null);
+
+  return (
+    <Modal
+      open={isOpen}
+      onClose={closeUploadModal}
+      title="Upload transactions"
+      closable={!jobId}
+      data-testid="upload-modal"
+    >
+      {isOpen && <UploadModalBody jobId={jobId} onJobStarted={setJobId} />}
+    </Modal>
+  );
+}
+
+function UploadModalBody({
+  jobId,
+  onJobStarted,
+}: {
+  jobId: string | null;
+  onJobStarted: (id: string | null) => void;
+}) {
+  const { closeUploadModal, onComplete } = useUploadModal();
   const [step, setStep] = useState<1 | 2>(1);
   const [broker, setBroker] = useState<Broker>(DEFAULT_BROKER);
   const [formatId, setFormatId] = useState<string>("standard");
   const [converterOptions, setConverterOptions] = useState<Record<string, unknown>>({});
   const [file, setFile] = useState<File | null>(null);
-  const [parseResult, setParseResult] = useState<ReturnType<typeof parseStandardCSV> | null>(null);
+  const [fileText, setFileText] = useState<string | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
-  const [jobId, setJobId] = useState<string | null>(null);
-  const [jobStatus, setJobStatus] = useState<Awaited<ReturnType<typeof getJob>> | null>(null);
   const [fileInputActive, setFileInputActive] = useState(false);
   const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -41,41 +69,28 @@ export function UploadModal() {
     selectedFormat?.OptionsComponent == null ||
     (converterOptions?.currency != null && converterOptions?.currency !== "");
 
-  // Reset state when modal opens.
-  useEffect(() => {
-    if (isOpen) {
-      setStep(1);
-      setBroker(DEFAULT_BROKER);
-      setFormatId("standard");
-      setConverterOptions({});
-      setFile(null);
-      setParseResult(null);
-      setSubmitError(null);
-      setJobId(null);
-      setJobStatus(null);
-    }
-  }, [isOpen]);
+  // Reading the file is the event; parsing it is derivation. Holding the text
+  // rather than the parsed rows means a format or option change re-parses
+  // without re-reading, and without an effect to clear the stale result.
+  const parseResult = useMemo(() => {
+    if (fileText == null || !optionsValid) return null;
+    return selectedFormat?.convert
+      ? selectedFormat.convert(fileText, converterOptions)
+      : parseStandardCSV(fileText);
+  }, [fileText, selectedFormat, converterOptions, optionsValid]);
 
-  const handleFileChange = useCallback(
-    (e: React.ChangeEvent<HTMLInputElement>) => {
-      const f = e.target.files?.[0];
-      setFile(f ?? null);
-      setParseResult(null);
-      setSubmitError(null);
-      if (!f) return;
-      const reader = new FileReader();
-      reader.onload = () => {
-        const text = typeof reader.result === "string" ? reader.result : "";
-        if (selectedFormat?.convert) {
-          setParseResult(selectedFormat.convert(text, converterOptions));
-        } else {
-          setParseResult(parseStandardCSV(text));
-        }
-      };
-      reader.readAsText(f);
-    },
-    [selectedFormat, converterOptions]
-  );
+  const handleFileChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const f = e.target.files?.[0];
+    setFile(f ?? null);
+    setFileText(null);
+    setSubmitError(null);
+    if (!f) return;
+    const reader = new FileReader();
+    reader.onload = () => {
+      setFileText(typeof reader.result === "string" ? reader.result : "");
+    };
+    reader.readAsText(f);
+  }, []);
 
   const handleUpload = useCallback(async () => {
     if (!parseResult || parseResult.errors.length > 0 || parseResult.txs.length === 0) return;
@@ -92,62 +107,31 @@ export function UploadModal() {
         filename: file?.name,
         shareCountBasis: parseResult.shareCountBasis,
       });
-      setJobId(res.jobId);
+      onJobStarted(res.jobId);
     } catch (e) {
-      setSubmitError(e instanceof Error ? e.message : String(e));
+      setSubmitError(errorMessage(e));
     }
-  }, [broker, formatId, parseResult, file]);
+  }, [broker, formatId, parseResult, file, onJobStarted]);
 
-  // Clear parse result when broker/format/options change.
-  useEffect(() => {
-    setParseResult(null);
-  }, [broker, formatId, converterOptions]);
+  // Poll until the job reaches a terminal status, then stop.
+  const { data: jobStatus } = useAuthedQuery<Awaited<ReturnType<typeof getJob>>>({
+    queryKey: qk.job(jobId ?? ""),
+    queryFn: () => getJob(jobId!),
+    enabled: !!jobId,
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      return status === JobStatus.SUCCESS || status === JobStatus.FAILED ? false : 2000;
+    },
+  });
 
-  // Re-parse when format or converter options change and we already have a file.
+  // Closing on success is a genuine side effect -- telling the caller to refresh
+  // and dismissing the modal -- so it belongs in an effect, not in render.
+  const succeeded = jobStatus?.status === JobStatus.SUCCESS;
   useEffect(() => {
-    if (!file || !selectedFormat || !optionsValid) return;
-    const reader = new FileReader();
-    reader.onload = () => {
-      const text = typeof reader.result === "string" ? reader.result : "";
-      if (selectedFormat.convert) {
-        setParseResult(selectedFormat.convert(text, converterOptions));
-      } else {
-        setParseResult(parseStandardCSV(text));
-      }
-    };
-    reader.readAsText(file);
-  }, [file, formatId, selectedFormat, converterOptions, optionsValid]);
-
-  // Poll job status; auto-close on success.
-  useEffect(() => {
-    if (!jobId || state.status !== "authenticated") return;
-    let cancelled = false;
-    const poll = async () => {
-      try {
-        const result = await getJob(jobId);
-        if (cancelled) return false;
-        setJobStatus(result);
-        if (result.status === JobStatus.SUCCESS) {
-          onComplete?.();
-          closeUploadModal();
-          return true;
-        }
-        return result.status === JobStatus.FAILED;
-      } catch {
-        return false;
-      }
-    };
-    poll();
-    const t = setInterval(() => {
-      poll().then((done) => {
-        if (done) clearInterval(t);
-      });
-    }, 2000);
-    return () => {
-      cancelled = true;
-      clearInterval(t);
-    };
-  }, [jobId, state.status, onComplete, closeUploadModal]);
+    if (!succeeded) return;
+    onComplete?.();
+    closeUploadModal();
+  }, [succeeded, onComplete, closeUploadModal]);
 
   const canUpload =
     parseResult &&
@@ -157,13 +141,7 @@ export function UploadModal() {
     !jobId;
 
   return (
-    <Modal
-      open={isOpen}
-      onClose={closeUploadModal}
-      title="Upload transactions"
-      closable={!jobId}
-      data-testid="upload-modal"
-    >
+    <>
       {/* Content */}
       <div className="flex-1 overflow-y-auto px-5 py-4">
         {jobId && jobStatus?.status === JobStatus.FAILED ? (
@@ -384,6 +362,6 @@ export function UploadModal() {
           </div>
         )}
       </div>
-    </Modal>
+    </>
   );
 }

--- a/client/app/components/user-menu.tsx
+++ b/client/app/components/user-menu.tsx
@@ -7,16 +7,21 @@ import { useAuth } from "@/contexts/auth-context";
 
 export function UserMenu({ inverted }: { inverted?: boolean }) {
   const { state, signOut } = useAuth();
-  const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   const pathname = usePathname();
+
+  // The route the menu was opened on, rather than a boolean: navigating away
+  // closes it by derivation, so no effect has to reset anything.
+  const [openedAt, setOpenedAt] = useState<string | null>(null);
+  const open = openedAt === pathname;
+  const setOpen = (next: boolean) => setOpenedAt(next ? pathname : null);
 
   // Close on click outside.
   useEffect(() => {
     if (!open) return;
     const handler = (e: MouseEvent) => {
       if (ref.current && !ref.current.contains(e.target as Node)) {
-        setOpen(false);
+        setOpenedAt(null);
       }
     };
     document.addEventListener("mousedown", handler);
@@ -27,16 +32,11 @@ export function UserMenu({ inverted }: { inverted?: boolean }) {
   useEffect(() => {
     if (!open) return;
     const handler = (e: KeyboardEvent) => {
-      if (e.key === "Escape") setOpen(false);
+      if (e.key === "Escape") setOpenedAt(null);
     };
     document.addEventListener("keydown", handler);
     return () => document.removeEventListener("keydown", handler);
   }, [open]);
-
-  // Close when navigating.
-  useEffect(() => {
-    setOpen(false);
-  }, [pathname]);
 
   if (state.status !== "authenticated") return null;
 
@@ -46,7 +46,7 @@ export function UserMenu({ inverted }: { inverted?: boolean }) {
     <div ref={ref} className="relative">
       <button
         type="button"
-        onClick={() => setOpen((v) => !v)}
+        onClick={() => setOpen(!open)}
         className={
           "flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-sm font-medium transition-colors " +
           (inverted

--- a/client/app/holdings/declaration-form.tsx
+++ b/client/app/holdings/declaration-form.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { useDebounce } from "@/hooks/use-debounce";
+import { useAuthedQuery } from "@/hooks/use-authed-query";
+import { qk } from "@/lib/query-keys";
 import { ErrorAlert } from "@/app/components/error-alert";
 import {
   listBrokersAndAccounts,
@@ -18,6 +20,14 @@ function todayStr(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
+/** Ticker if the instrument has one, else its name, else the bare id. */
+function instrumentDisplayLabel(decl: HoldingDeclaration): string {
+  const ticker = decl.instrument?.identifiers?.find(
+    (id) => id.type === IdentifierType.MIC_TICKER || id.type === IdentifierType.OPENFIGI_TICKER
+  )?.value;
+  return ticker || decl.instrument?.name || decl.instrumentId;
+}
+
 export function DeclarationForm({
   editing,
   onDone,
@@ -27,11 +37,12 @@ export function DeclarationForm({
   onDone: () => void;
   onCancel: () => void;
 }) {
-  const [brokerAccounts, setBrokerAccounts] = useState<BrokerAccounts[]>([]);
   const [broker, setBroker] = useState(editing?.broker ?? "");
   const [account, setAccount] = useState(editing?.account ?? "");
-  const [instrumentId, setInstrumentId] = useState(editing?.instrumentId ?? "");
-  const [instrumentLabel, setInstrumentLabel] = useState("");
+  // The instrument the user picked, if any. Everything about the instrument is
+  // derived from this or from the `editing` prop, so no effect copies the prop
+  // into state.
+  const [picked, setPicked] = useState<{ id: string; label: string } | null>(null);
   const [declaredQty, setDeclaredQty] = useState(editing?.declaredQty ?? "");
   const [asOfDate, setAsOfDate] = useState(editing?.asOfDate ? protoDateToStr(editing.asOfDate) : todayStr());
   const [error, setError] = useState<string | null>(null);
@@ -40,39 +51,24 @@ export function DeclarationForm({
   // Instrument search
   const [instrumentSearch, setInstrumentSearch] = useState("");
   const debouncedInstrumentSearch = useDebounce(instrumentSearch);
-  const [searchResults, setSearchResults] = useState<Instrument[]>([]);
-  const [searchLoading, setSearchLoading] = useState(false);
 
-  useEffect(() => {
-    listBrokersAndAccounts()
-      .then(setBrokerAccounts)
-      .catch(() => {});
-  }, []);
+  const { data: brokerAccounts = [] } = useAuthedQuery<BrokerAccounts[]>({
+    queryKey: qk.brokersAndAccounts(),
+    queryFn: listBrokersAndAccounts,
+  });
 
-  // Set initial instrument label for editing
-  useEffect(() => {
-    if (editing?.instrument) {
-      const ticker = editing.instrument.identifiers?.find(
-        (id) => id.type === IdentifierType.MIC_TICKER || id.type === IdentifierType.OPENFIGI_TICKER
-      )?.value;
-      setInstrumentLabel(ticker || editing.instrument.name || editing.instrumentId);
-    }
-  }, [editing]);
+  // Each search term is its own cache entry, so a late reply cannot overwrite
+  // the results for a newer term -- which is what the cancelled flag was for.
+  const { data: searchResults = [], isFetching: searchLoading } = useAuthedQuery({
+    queryKey: qk.instruments(debouncedInstrumentSearch, ""),
+    queryFn: () => listInstruments({ search: debouncedInstrumentSearch }),
+    select: (res) => res.instruments,
+    enabled: debouncedInstrumentSearch.length >= 2,
+  });
 
-  // Instrument search
-  useEffect(() => {
-    if (debouncedInstrumentSearch.length < 2) {
-      setSearchResults([]);
-      return;
-    }
-    let cancelled = false;
-    setSearchLoading(true);
-    listInstruments({ search: debouncedInstrumentSearch })
-      .then((res) => { if (!cancelled) setSearchResults(res.instruments); })
-      .catch(() => { if (!cancelled) setSearchResults([]); })
-      .finally(() => { if (!cancelled) setSearchLoading(false); });
-    return () => { cancelled = true; };
-  }, [debouncedInstrumentSearch]);
+  const instrumentId = picked?.id ?? editing?.instrumentId ?? "";
+  const instrumentLabel =
+    picked?.label ?? (editing?.instrument ? instrumentDisplayLabel(editing) : "");
 
   const accounts = brokerAccounts.find((b) => b.broker === broker)?.accounts ?? [];
 
@@ -109,13 +105,12 @@ export function DeclarationForm({
   };
 
   const selectInstrument = (inst: Instrument) => {
-    setInstrumentId(inst.id);
     const ticker = inst.identifiers?.find(
       (id) => id.type === IdentifierType.MIC_TICKER || id.type === IdentifierType.OPENFIGI_TICKER
     )?.value;
-    setInstrumentLabel(ticker || inst.name || inst.id);
+    setPicked({ id: inst.id, label: ticker || inst.name || inst.id });
+    // Clearing the term disables the search query, so the results go with it.
     setInstrumentSearch("");
-    setSearchResults([]);
   };
 
   const inputClass =
@@ -183,7 +178,7 @@ export function DeclarationForm({
                 <span className="text-sm font-medium text-text-primary">{instrumentLabel}</span>
                 <button
                   type="button"
-                  onClick={() => { setInstrumentId(""); setInstrumentLabel(""); }}
+                  onClick={() => setPicked({ id: "", label: "" })}
                   className="text-xs text-accent-dark hover:underline"
                 >
                   Change

--- a/client/app/holdings/opening-balances.tsx
+++ b/client/app/holdings/opening-balances.tsx
@@ -1,7 +1,11 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { ErrorAlert } from "@/app/components/error-alert";
+import { useAuthedQuery } from "@/hooks/use-authed-query";
+import { errorMessage } from "@/lib/errors";
+import { qk } from "@/lib/query-keys";
 import {
   listHoldingDeclarations,
   deleteHoldingDeclaration,
@@ -13,47 +17,53 @@ import type { HoldingDeclaration } from "@/gen/api/v1/api_pb";
 import { DeclarationForm } from "./declaration-form";
 
 export function OpeningBalances() {
-  const [declarations, setDeclarations] = useState<HoldingDeclaration[]>([]);
-  const [hasBrokers, setHasBrokers] = useState(true);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const queryClient = useQueryClient();
+  const [deleteError, setDeleteError] = useState<string | null>(null);
   const [showForm, setShowForm] = useState(false);
   const [editingDecl, setEditingDecl] = useState<HoldingDeclaration | null>(null);
 
-  const fetchDeclarations = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const [decls, brokers] = await Promise.all([
-        listHoldingDeclarations(),
-        listBrokersAndAccounts(),
-      ]);
-      setDeclarations(decls);
-      setHasBrokers(brokers.length > 0);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  // Two independent lists rather than the Promise.all they used to share: the
+  // broker list is also read by the declaration form, so keeping it separate
+  // means the two share a cache entry.
+  const {
+    data: declarations = [],
+    isPending: declLoading,
+    error: declError,
+  } = useAuthedQuery<HoldingDeclaration[]>({
+    queryKey: qk.holdingDeclarations(),
+    queryFn: listHoldingDeclarations,
+  });
+  const {
+    data: brokers = [],
+    isPending: brokersLoading,
+    error: brokersError,
+  } = useAuthedQuery<Awaited<ReturnType<typeof listBrokersAndAccounts>>>({
+    queryKey: qk.brokersAndAccounts(),
+    queryFn: listBrokersAndAccounts,
+  });
 
-  useEffect(() => {
-    fetchDeclarations();
-  }, [fetchDeclarations]);
+  const hasBrokers = brokers.length > 0;
+  const loading = declLoading || brokersLoading;
+  const loadError = declError ?? brokersError;
+  const error = deleteError ?? (loadError ? errorMessage(loadError) : null);
+
+  const refreshDeclarations = () =>
+    queryClient.invalidateQueries({ queryKey: qk.holdingDeclarations() });
 
   const handleDelete = async (id: string) => {
+    setDeleteError(null);
     try {
       await deleteHoldingDeclaration(id);
-      fetchDeclarations();
+      await refreshDeclarations();
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setDeleteError(errorMessage(e));
     }
   };
 
   const handleFormDone = () => {
     setShowForm(false);
     setEditingDecl(null);
-    fetchDeclarations();
+    void refreshDeclarations();
   };
 
   if (showForm || editingDecl) {

--- a/client/app/holdings/page.tsx
+++ b/client/app/holdings/page.tsx
@@ -1,10 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 import { AppShell } from "@/app/components/app-shell";
 import { useAuth } from "@/contexts/auth-context";
 import { usePortfolio } from "@/contexts/portfolio-context";
 import { ErrorAlert } from "@/app/components/error-alert";
+import { useAuthedQuery } from "@/hooks/use-authed-query";
+import { errorMessage } from "@/lib/errors";
+import { qk } from "@/lib/query-keys";
 import { getHoldings } from "@/lib/portfolio-api";
 import { getBrokerLabel } from "@/lib/csv/converters";
 import { IdentifierType } from "@/gen/api/v1/api_pb";
@@ -15,29 +18,19 @@ type Tab = "holdings" | "opening-balances";
 export default function UserHoldingsPage() {
   const { state, authError } = useAuth();
   const { selected: selectedPortfolio } = usePortfolio();
-  const [holdings, setHoldings] = useState<Awaited<ReturnType<typeof getHoldings>> | null>(null);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const [activeTab, setActiveTab] = useState<Tab>("holdings");
+  const portfolioId = selectedPortfolio?.id;
 
-  const fetchData = useCallback(async (portfolioId?: string) => {
-    setLoading(true);
-    setError(null);
-    try {
-      const h = await getHoldings({ portfolioId });
-      setHoldings(h);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-      setHoldings(null);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (state.status !== "authenticated") return;
-    fetchData(selectedPortfolio?.id);
-  }, [state.status, selectedPortfolio, fetchData]);
+  // Keyed on the id, not the portfolio object: renaming a portfolio replaces the
+  // object and would otherwise refetch holdings that have not changed.
+  const {
+    data: holdings,
+    isPending: loading,
+    error,
+  } = useAuthedQuery<Awaited<ReturnType<typeof getHoldings>>>({
+    queryKey: qk.holdings(portfolioId),
+    queryFn: () => getHoldings({ portfolioId }),
+  });
 
   return (
     <AppShell>
@@ -103,7 +96,7 @@ export default function UserHoldingsPage() {
                 {loading && (
                   <p className="text-text-muted">Loading holdings...</p>
                 )}
-                {!loading && error && <ErrorAlert>{error}</ErrorAlert>}
+                {!loading && error && <ErrorAlert>{errorMessage(error)}</ErrorAlert>}
                 {!loading && !error && holdings && (
                   <div className="overflow-x-auto rounded-md border border-border bg-surface shadow-sm">
                     <table data-testid="holdings-table" className="w-full min-w-[320px] border-collapse text-sm">

--- a/client/app/performance/page.tsx
+++ b/client/app/performance/page.tsx
@@ -1,10 +1,13 @@
 "use client";
 
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useMemo, useState } from "react";
 import { AppShell } from "@/app/components/app-shell";
 import { PerformanceChart } from "@/app/components/performance-chart";
 import { ErrorAlert } from "@/app/components/error-alert";
 import { useAuth } from "@/contexts/auth-context";
+import { useAuthedQuery } from "@/hooks/use-authed-query";
+import { errorMessage } from "@/lib/errors";
+import { qk } from "@/lib/query-keys";
 import { usePortfolio } from "@/contexts/portfolio-context";
 import {
   getPortfolioValuation,
@@ -54,44 +57,39 @@ export default function PerformancePage() {
   const { state, authError } = useAuth();
   const { selected: selectedPortfolio } = usePortfolio();
   const [period, setPeriod] = useState<Period>("1y");
-  const [points, setPoints] = useState<ValuationPointUI[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [displayCurrency, setDisplayCurrency] = useState<string>("USD");
+  const portfolioId = selectedPortfolio?.id;
+  const dateFrom = dateFromPeriod(period);
+  const dateBefore = todayStr();
 
-  const dateRange = useMemo(
-    () => ({ dateFrom: dateFromPeriod(period), dateBefore: todayStr() }),
-    [period]
-  );
+  // Shared with the settings page rather than fetched again here.
+  const { data: displayCurrency = "USD", error: currencyError } = useAuthedQuery<string>({
+    queryKey: qk.displayCurrency(),
+    queryFn: getDisplayCurrency,
+  });
 
-  const fetchData = useCallback(
-    async (portfolioId: string | undefined, from: string, before: string) => {
-      setLoading(true);
-      setError(null);
-      try {
-        const dc = await getDisplayCurrency();
-        setDisplayCurrency(dc);
-        const res = await getPortfolioValuation({
-          portfolioId,
-          dateFrom: from,
-          dateBefore: before,
-          displayCurrency: dc,
-        });
-        setPoints(res.points);
-      } catch (e) {
-        setError(e instanceof Error ? e.message : String(e));
-        setPoints([]);
-      } finally {
-        setLoading(false);
-      }
+  // Dependent: the valuation is denominated in the display currency, so it waits
+  // for it rather than the two being sequenced inside one loader.
+  const {
+    data: points = [],
+    isPending: valuationPending,
+    error: valuationError,
+  } = useAuthedQuery<ValuationPointUI[]>({
+    queryKey: qk.valuation(portfolioId, dateFrom, dateBefore, displayCurrency),
+    queryFn: async () => {
+      const res = await getPortfolioValuation({
+        portfolioId,
+        dateFrom,
+        dateBefore,
+        displayCurrency,
+      });
+      return res.points;
     },
-    []
-  );
+    enabled: !!displayCurrency,
+  });
 
-  useEffect(() => {
-    if (state.status !== "authenticated") return;
-    fetchData(selectedPortfolio?.id, dateRange.dateFrom, dateRange.dateBefore);
-  }, [state.status, selectedPortfolio, dateRange, fetchData]);
+  const loading = valuationPending;
+  const loadError = currencyError ?? valuationError;
+  const error = loadError ? errorMessage(loadError) : null;
 
   // Compute percentage change.
   const pctChange = useMemo(() => {

--- a/client/app/providers.tsx
+++ b/client/app/providers.tsx
@@ -1,25 +1,34 @@
 "use client";
 
+import { useState } from "react";
+import { QueryClientProvider } from "@tanstack/react-query";
 import { GoogleOAuthProvider } from "@react-oauth/google";
 import { AuthProvider } from "@/contexts/auth-context";
 import { PortfolioProvider } from "@/contexts/portfolio-context";
 import { UploadModalProvider } from "@/contexts/upload-modal-context";
 import { SessionLostHandler } from "@/app/components/session-lost-handler";
+import { createQueryClient } from "@/lib/query-client";
 
 const googleClientId =
   process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID ?? "";
 
 export function Providers({ children }: { children: React.ReactNode }) {
+  // useState, not module scope: one client per mount, never rebuilt on re-render.
+  const [queryClient] = useState(createQueryClient);
+
   return (
-    <GoogleOAuthProvider clientId={googleClientId}>
-      <AuthProvider>
-        <PortfolioProvider>
-          <UploadModalProvider>
-            <SessionLostHandler />
-            {children}
-          </UploadModalProvider>
-        </PortfolioProvider>
-      </AuthProvider>
-    </GoogleOAuthProvider>
+    // Outermost, because AuthProvider reads the session through a query.
+    <QueryClientProvider client={queryClient}>
+      <GoogleOAuthProvider clientId={googleClientId}>
+        <AuthProvider>
+          <PortfolioProvider>
+            <UploadModalProvider>
+              <SessionLostHandler />
+              {children}
+            </UploadModalProvider>
+          </PortfolioProvider>
+        </AuthProvider>
+      </GoogleOAuthProvider>
+    </QueryClientProvider>
   );
 }

--- a/client/app/settings/page.tsx
+++ b/client/app/settings/page.tsx
@@ -1,10 +1,14 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 import { AppShell } from "@/app/components/app-shell";
 import { ErrorAlert } from "@/app/components/error-alert";
 import { IgnoredAssetClassEditor } from "@/app/components/ignored-asset-class-editor";
 import { useAuth } from "@/contexts/auth-context";
+import { useQueryClient } from "@tanstack/react-query";
+import { useAuthedQuery } from "@/hooks/use-authed-query";
+import { errorMessage } from "@/lib/errors";
+import { qk } from "@/lib/query-keys";
 import { getDisplayCurrency, setDisplayCurrency } from "@/lib/portfolio-api";
 
 const CURRENCIES = [
@@ -15,36 +19,30 @@ const CURRENCIES = [
 
 export default function SettingsPage() {
   const { state } = useAuth();
-  const [currency, setCurrency] = useState<string>("");
+  const queryClient = useQueryClient();
   const [saving, setSaving] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
   const [saved, setSaved] = useState(false);
 
-  const fetchCurrency = useCallback(async () => {
-    try {
-      const dc = await getDisplayCurrency();
-      setCurrency(dc);
-    } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
-    }
-  }, []);
-
-  useEffect(() => {
-    if (state.status !== "authenticated") return;
-    fetchCurrency();
-  }, [state.status, fetchCurrency]);
+  // Shared with the performance page, which needs the same value to label its
+  // chart -- one request between them rather than two.
+  const { data: currency = "", error: loadError } = useAuthedQuery<string>({
+    queryKey: qk.displayCurrency(),
+    queryFn: getDisplayCurrency,
+  });
+  const error = saveError ?? (loadError ? errorMessage(loadError) : null);
 
   const handleChange = async (newCurrency: string) => {
     setSaving(true);
-    setError(null);
+    setSaveError(null);
     setSaved(false);
     try {
       const result = await setDisplayCurrency(newCurrency);
-      setCurrency(result);
+      queryClient.setQueryData(qk.displayCurrency(), result);
       setSaved(true);
       setTimeout(() => setSaved(false), 2000);
     } catch (e) {
-      setError(e instanceof Error ? e.message : String(e));
+      setSaveError(errorMessage(e));
     } finally {
       setSaving(false);
     }
@@ -108,7 +106,7 @@ export default function SettingsPage() {
               </div>
             </div>
 
-            <IgnoredAssetClassEditor authStatus={state.status} />
+            <IgnoredAssetClassEditor />
           </div>
         )}
       </div>

--- a/client/app/transactions/page.tsx
+++ b/client/app/transactions/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCallback } from "react";
+import { useQueryClient } from "@tanstack/react-query";
 import { AppShell } from "@/app/components/app-shell";
 import { ErrorAlert } from "@/app/components/error-alert";
 import { PaginationControls } from "@/app/components/pagination-controls";
@@ -8,6 +8,8 @@ import { useAuth } from "@/contexts/auth-context";
 import { usePortfolio } from "@/contexts/portfolio-context";
 import { useUploadModal } from "@/contexts/upload-modal-context";
 import { usePagination } from "@/hooks/use-pagination";
+import { errorMessage } from "@/lib/errors";
+import { qk } from "@/lib/query-keys";
 import { listTxs } from "@/lib/portfolio-api";
 import { getBrokerLabel } from "@/lib/csv/converters";
 import { TxType, IdentifierType } from "@/gen/api/v1/api_pb";
@@ -42,33 +44,8 @@ export default function TxsPage() {
   const { state, authError } = useAuth();
   const { selected: selectedPortfolio } = usePortfolio();
   const { openUploadModal } = useUploadModal();
-
-  const fetchTxs = useCallback(
-    async (pageToken: string | null) => {
-      const result = await listTxs({
-        portfolioId: selectedPortfolio?.id,
-        pageToken,
-      });
-      return {
-        items: result.txs,
-        totalCount: 0,
-        nextPageToken: result.nextPageToken,
-      };
-    },
-    [selectedPortfolio?.id]
-  );
-
-  const {
-    items: txs,
-    loading,
-    error,
-    pageIndex,
-    hasPrev,
-    hasNext,
-    goNext,
-    goPrev,
-    refresh,
-  } = usePagination(fetchTxs);
+  const queryClient = useQueryClient();
+  const portfolioId = selectedPortfolio?.id;
 
   if (state.status === "loading") {
     return (
@@ -108,17 +85,55 @@ export default function TxsPage() {
             </h2>
             <button
               type="button"
-              onClick={() => openUploadModal(() => refresh())}
+              onClick={() =>
+                openUploadModal(() =>
+                  queryClient.invalidateQueries({ queryKey: qk.txs(portfolioId) })
+                )
+              }
               className="ml-auto rounded-md bg-accent px-3.5 py-1.5 text-sm font-semibold text-white transition-colors hover:bg-accent-dark"
             >
               Upload transactions
             </button>
           </div>
 
-          {loading && <p className="text-text-muted">Loading transactions...</p>}
-          {!loading && error && <ErrorAlert>{error}</ErrorAlert>}
-          {!loading && !error && (
-            <>
+          {/* Keyed on the portfolio: switching it remounts the list, which
+              returns it to page 1. */}
+          <TxList key={portfolioId ?? "all"} portfolioId={portfolioId} />
+        </div>
+      </div>
+    </AppShell>
+  );
+}
+
+function TxList({ portfolioId }: { portfolioId: string | undefined }) {
+  const {
+    items: txs,
+    loading,
+    error,
+    pageIndex,
+    hasPrev,
+    hasNext,
+    goNext,
+    goPrev,
+  } = usePagination<PortfolioTx>({
+    queryKey: qk.txs(portfolioId),
+    queryFn: async (pageToken) => {
+      const result = await listTxs({ portfolioId, pageToken });
+      return {
+        items: result.txs,
+        // ListTxs returns no count.
+        totalCount: 0,
+        nextPageToken: result.nextPageToken,
+      };
+    },
+  });
+
+  return (
+    <>
+      {loading && <p className="text-text-muted">Loading transactions...</p>}
+      {!loading && error && <ErrorAlert>{errorMessage(error)}</ErrorAlert>}
+      {!loading && !error && (
+        <>
               <div className="overflow-x-auto rounded-md border border-border bg-surface shadow-sm">
                 <table data-testid="transactions-table" className="w-full min-w-[720px] border-collapse text-sm">
                   <thead>
@@ -181,11 +196,9 @@ export default function TxsPage() {
                 onPrev={goPrev}
                 onNext={goNext}
               />
-            </>
-          )}
-        </div>
-      </div>
-    </AppShell>
+        </>
+      )}
+    </>
   );
 }
 

--- a/client/app/uploads/page.tsx
+++ b/client/app/uploads/page.tsx
@@ -1,12 +1,15 @@
 "use client";
 
-import { useCallback, useEffect, useState } from "react";
+import { useState } from "react";
 import { AppShell } from "@/app/components/app-shell";
 import { ErrorAlert } from "@/app/components/error-alert";
 import { PaginationControls } from "@/app/components/pagination-controls";
 import { useAuth } from "@/contexts/auth-context";
 import { useUploadModal } from "@/contexts/upload-modal-context";
 import { usePagination } from "@/hooks/use-pagination";
+import { useAuthedQuery } from "@/hooks/use-authed-query";
+import { errorMessage } from "@/lib/errors";
+import { qk } from "@/lib/query-keys";
 import { listJobs, getJob } from "@/lib/portfolio-api";
 import type { JobSummary, GetJobResult } from "@/lib/portfolio-api";
 import { JobStatus } from "@/gen/api/v1/api_pb";
@@ -29,21 +32,9 @@ export default function UploadsPage() {
   const { state, authError } = useAuth();
   const { openUploadModal } = useUploadModal();
   const [expandedId, setExpandedId] = useState<string | null>(null);
-  const [expandedDetail, setExpandedDetail] = useState<GetJobResult | null>(null);
-  const [detailLoading, setDetailLoading] = useState(false);
 
-  const fetchJobs = useCallback(
-    async (pageToken: string | null) => {
-      const result = await listJobs(pageToken);
-      return {
-        items: result.jobs,
-        totalCount: result.totalCount,
-        nextPageToken: result.nextPageToken,
-      };
-    },
-    []
-  );
-
+  // No filters here, so nothing ever changes the key and the list needs no
+  // key-prop reset -- unlike the other paginated pages.
   const {
     items: jobs,
     totalCount,
@@ -55,30 +46,26 @@ export default function UploadsPage() {
     goNext,
     goPrev,
     refresh,
-  } = usePagination(fetchJobs);
+  } = usePagination<JobSummary>({
+    queryKey: qk.jobs(),
+    queryFn: async (pageToken) => {
+      const result = await listJobs(pageToken);
+      return {
+        items: result.jobs,
+        totalCount: result.totalCount,
+        nextPageToken: result.nextPageToken,
+      };
+    },
+    enabled: state.status === "authenticated",
+  });
 
-  // Fetch error details when a row is expanded.
-  useEffect(() => {
-    if (!expandedId) {
-      setExpandedDetail(null);
-      return;
-    }
-    let cancelled = false;
-    setDetailLoading(true);
-    getJob(expandedId)
-      .then((result) => {
-        if (!cancelled) setExpandedDetail(result);
-      })
-      .catch(() => {
-        if (!cancelled) setExpandedDetail(null);
-      })
-      .finally(() => {
-        if (!cancelled) setDetailLoading(false);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [expandedId]);
+  // Error details for the expanded row. Collapsing disables the query, so the
+  // detail falls back to null without anything having to clear it.
+  const { data: expandedDetail, isFetching: detailLoading } = useAuthedQuery<GetJobResult>({
+    queryKey: qk.job(expandedId ?? ""),
+    queryFn: () => getJob(expandedId!),
+    enabled: !!expandedId,
+  });
 
   if (state.status === "loading") {
     return (
@@ -134,7 +121,7 @@ export default function UploadsPage() {
           </div>
 
           {loading && <p className="text-text-muted">Loading uploads...</p>}
-          {!loading && error && <ErrorAlert>{error}</ErrorAlert>}
+          {!loading && error && <ErrorAlert>{errorMessage(error)}</ErrorAlert>}
           {!loading && !error && (
             <>
               <div className="overflow-x-auto rounded-md border border-border bg-surface shadow-sm">
@@ -180,7 +167,7 @@ export default function UploadsPage() {
                             job={job}
                             errorCount={errorCount}
                             expanded={expanded}
-                            detail={expanded ? expandedDetail : null}
+                            detail={expanded ? (expandedDetail ?? null) : null}
                             detailLoading={expanded && detailLoading}
                             onToggle={() =>
                               setExpandedId(expanded ? null : job.id)

--- a/client/hooks/use-authed-query.ts
+++ b/client/hooks/use-authed-query.ts
@@ -16,8 +16,8 @@ import { useAuth } from "@/contexts/auth-context";
  * queries instead (see AuthProvider), so keys stay readable and a signed-out
  * cache holds nothing to leak.
  */
-export function useAuthedQuery<TData, TError = Error>(
-  options: UseQueryOptions<TData, TError> & { queryKey: readonly unknown[] }
+export function useAuthedQuery<TQueryFnData = unknown, TError = Error, TData = TQueryFnData>(
+  options: UseQueryOptions<TQueryFnData, TError, TData> & { queryKey: readonly unknown[] }
 ): UseQueryResult<TData, TError> {
   const { state } = useAuth();
   return useQuery({

--- a/client/hooks/use-authed-query.ts
+++ b/client/hooks/use-authed-query.ts
@@ -1,0 +1,27 @@
+"use client";
+
+import { useQuery, type UseQueryOptions, type UseQueryResult } from "@tanstack/react-query";
+import { useAuth } from "@/contexts/auth-context";
+
+/**
+ * A query that does not run until the session is known to be good.
+ *
+ * The session starts as `{ status: "loading" }` while getSession() is in flight,
+ * and firing a request in that window gets a 401 -- which the transport turns
+ * into a session-lost redirect. Every call site used to open with
+ * `if (state.status !== "authenticated") return;` inside its effect; this is that
+ * gate, once.
+ *
+ * The user is deliberately not part of the query key. Sign-out drops the cached
+ * queries instead (see AuthProvider), so keys stay readable and a signed-out
+ * cache holds nothing to leak.
+ */
+export function useAuthedQuery<TData, TError = Error>(
+  options: UseQueryOptions<TData, TError> & { queryKey: readonly unknown[] }
+): UseQueryResult<TData, TError> {
+  const { state } = useAuth();
+  return useQuery({
+    ...options,
+    enabled: state.status === "authenticated" && (options.enabled ?? true),
+  });
+}

--- a/client/hooks/use-pagination.test.tsx
+++ b/client/hooks/use-pagination.test.tsx
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { usePagination, type PaginatedResult } from "./use-pagination";
+import { queryWrapper } from "@/test-utils";
+
+type Row = { id: string };
+
+/**
+ * A fetcher over fixed pages, keyed by the token that reaches it. Records every
+ * call so tests can assert on how many requests a navigation actually made --
+ * which is the point of most of these cases.
+ */
+function pagedFetcher(pages: PaginatedResult<Row>[]) {
+  const calls: (string | null)[] = [];
+  const byToken = new Map<string | null, PaginatedResult<Row>>();
+  let token: string | null = null;
+  for (const page of pages) {
+    byToken.set(token, page);
+    token = page.nextPageToken;
+  }
+  const fn = vi.fn(async (pageToken: string | null) => {
+    calls.push(pageToken);
+    const page = byToken.get(pageToken);
+    if (!page) throw new Error(`no page for token ${String(pageToken)}`);
+    return page;
+  });
+  return { fn, calls };
+}
+
+const THREE_PAGES: PaginatedResult<Row>[] = [
+  { items: [{ id: "a" }], totalCount: 3, nextPageToken: "t1" },
+  { items: [{ id: "b" }], totalCount: 3, nextPageToken: "t2" },
+  { items: [{ id: "c" }], totalCount: 3, nextPageToken: null },
+];
+
+function render(fetchFn: (t: string | null) => Promise<PaginatedResult<Row>>, queryKey: readonly unknown[] = ["rows"]) {
+  return renderHook(() => usePagination<Row>({ queryKey, queryFn: fetchFn }), {
+    wrapper: queryWrapper(),
+  });
+}
+
+describe("usePagination", () => {
+  it("loads the first page with a null token", async () => {
+    const { fn, calls } = pagedFetcher(THREE_PAGES);
+    const { result } = render(fn);
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.items).toEqual([{ id: "a" }]);
+    expect(result.current.totalCount).toBe(3);
+    expect(result.current.pageIndex).toBe(0);
+    expect(result.current.hasPrev).toBe(false);
+    expect(result.current.hasNext).toBe(true);
+    expect(calls).toEqual([null]);
+  });
+
+  it("goNext fetches with the token the previous page returned", async () => {
+    const { fn, calls } = pagedFetcher(THREE_PAGES);
+    const { result } = render(fn);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => result.current.goNext());
+    await waitFor(() => expect(result.current.items).toEqual([{ id: "b" }]));
+
+    expect(result.current.pageIndex).toBe(1);
+    expect(result.current.hasPrev).toBe(true);
+    expect(calls).toEqual([null, "t1"]);
+  });
+
+  it("hasNext is false on the last page", async () => {
+    const { fn } = pagedFetcher(THREE_PAGES);
+    const { result } = render(fn);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // Wait for each page to settle: goNext needs the current page's
+    // nextPageToken, so it is a no-op while a fetch is still in flight.
+    act(() => result.current.goNext());
+    await waitFor(() => expect(result.current.items).toEqual([{ id: "b" }]));
+    act(() => result.current.goNext());
+    await waitFor(() => expect(result.current.items).toEqual([{ id: "c" }]));
+
+    expect(result.current.pageIndex).toBe(2);
+    expect(result.current.hasNext).toBe(false);
+  });
+
+  it("goPrev returns to a page already fetched without refetching it", async () => {
+    const { fn, calls } = pagedFetcher(THREE_PAGES);
+    const { result } = render(fn);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    act(() => result.current.goNext());
+    await waitFor(() => expect(result.current.items).toEqual([{ id: "b" }]));
+
+    act(() => result.current.goPrev());
+    await waitFor(() => expect(result.current.items).toEqual([{ id: "a" }]));
+
+    // Page 0 is served from cache: still just the two requests.
+    expect(calls).toEqual([null, "t1"]);
+    expect(result.current.pageIndex).toBe(0);
+  });
+
+  it("starts at page 0 with a single request when remounted under a new key", async () => {
+    // The key-prop reset path: a filter change remounts the component that owns
+    // this hook. Regression test for the old hook, which fired two requests --
+    // one for the stale pageIndex, then another after resetting to page 0.
+    const { fn, calls } = pagedFetcher(THREE_PAGES);
+    const first = render(fn, ["rows", "search-a"]);
+    await waitFor(() => expect(first.result.current.loading).toBe(false));
+
+    act(() => first.result.current.goNext());
+    await waitFor(() => expect(first.result.current.pageIndex).toBe(1));
+    first.unmount();
+    calls.length = 0;
+
+    const second = render(fn, ["rows", "search-b"]);
+    await waitFor(() => expect(second.result.current.loading).toBe(false));
+
+    expect(second.result.current.pageIndex).toBe(0);
+    expect(second.result.current.items).toEqual([{ id: "a" }]);
+    expect(calls).toEqual([null]);
+  });
+
+  it("refresh refetches with no other render trigger", async () => {
+    // Regression test for the old hook, where refresh() bumped a ref. Mutating a
+    // ref does not re-render, so it only ever worked when something else
+    // happened to re-render the component.
+    const { fn, calls } = pagedFetcher(THREE_PAGES);
+    const { result } = render(fn);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(calls).toEqual([null]);
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    await waitFor(() => expect(calls).toEqual([null, null]));
+  });
+
+  it("surfaces a rejection and leaves items empty", async () => {
+    const fn = vi.fn(async () => {
+      throw new Error("boom");
+    });
+    const { result } = render(fn);
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+
+    expect(result.current.error?.message).toBe("boom");
+    expect(result.current.items).toEqual([]);
+    expect(result.current.totalCount).toBe(0);
+  });
+
+  it("does not fetch while disabled", async () => {
+    const { fn, calls } = pagedFetcher(THREE_PAGES);
+    const { result } = renderHook(
+      () => usePagination<Row>({ queryKey: ["rows"], queryFn: fn, enabled: false }),
+      { wrapper: queryWrapper() }
+    );
+
+    expect(calls).toEqual([]);
+    expect(result.current.items).toEqual([]);
+  });
+});

--- a/client/hooks/use-pagination.ts
+++ b/client/hooks/use-pagination.ts
@@ -1,6 +1,7 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useState } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 
 export type PaginatedResult<T> = {
   items: T[];
@@ -8,95 +9,75 @@ export type PaginatedResult<T> = {
   nextPageToken: string | null;
 };
 
+export type UsePaginationOptions<T> = {
+  /**
+   * Identifies the filter set. The page token is appended internally, so each
+   * page is its own cache entry and paging backwards is a cache hit.
+   */
+  queryKey: readonly unknown[];
+  queryFn: (pageToken: string | null) => Promise<PaginatedResult<T>>;
+  enabled?: boolean;
+};
+
 /**
- * Manages token-based pagination state. The caller provides a fetch function
- * that accepts a page token and returns a page of results. The hook tracks
- * page tokens, loading/error state, and exposes navigation helpers.
+ * Token-based (cursor) pagination over a TanStack Query cache.
  *
- * `fetchFn` should be wrapped in useCallback by the caller so that changes
- * to filter/search params naturally trigger a re-fetch via the dependency
- * array. When fetchFn identity changes the hook resets to page 0.
+ * `pageTokens[i]` holds the token that fetches page `i`; index 0 is null, and
+ * each fetched page writes the token for the page after it. That is what lets
+ * "Previous" work by index without re-deriving a token.
+ *
+ * The hook does not reset itself when the filters change, on purpose. Give the
+ * component that calls it a `key` built from the filter values so a change
+ * remounts it -- state resets by construction, which is both the idiomatic React
+ * answer and the one that avoids resetting state from an effect. Remounting
+ * costs no requests: the query cache outlives the unmount.
  */
-export function usePagination<T>(fetchFn: (pageToken: string | null) => Promise<PaginatedResult<T>>) {
-  const [items, setItems] = useState<T[]>([]);
-  const [totalCount, setTotalCount] = useState(0);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-  const [nextPageToken, setNextPageToken] = useState<string | null>(null);
-  const [pageTokens, setPageTokens] = useState<(string | null)[]>([null]);
+export function usePagination<T>({ queryKey, queryFn, enabled = true }: UsePaginationOptions<T>) {
+  const queryClient = useQueryClient();
   const [pageIndex, setPageIndex] = useState(0);
-  const refreshRef = useRef(0);
+  const [pageTokens, setPageTokens] = useState<(string | null)[]>([null]);
 
-  // Reset to page 0 when fetchFn identity changes (e.g. filters changed).
-  const fetchFnRef = useRef(fetchFn);
-  useEffect(() => {
-    if (fetchFnRef.current !== fetchFn) {
-      fetchFnRef.current = fetchFn;
-      setPageIndex(0);
-      setPageTokens([null]);
-    }
-  }, [fetchFn]);
+  const pageToken = pageTokens[pageIndex] ?? null;
 
-  const fetchPage = useCallback(
-    async (pageToken: string | null, forPageIndex: number) => {
-      setLoading(true);
-      setError(null);
-      try {
-        const result = await fetchFn(pageToken);
-        setItems(result.items);
-        setTotalCount(result.totalCount);
-        setNextPageToken(result.nextPageToken);
-        if (result.nextPageToken) {
-          setPageTokens((prev) => {
-            const next = [...prev];
-            next[forPageIndex + 1] = result.nextPageToken!;
-            return next;
-          });
-        }
-      } catch (e) {
-        setError(e instanceof Error ? e.message : String(e));
-        setItems([]);
-        setTotalCount(0);
-      } finally {
-        setLoading(false);
-      }
-    },
-    [fetchFn]
-  );
-
-  useEffect(() => {
-    const token = pageTokens[pageIndex] ?? null;
-    fetchPage(token, pageIndex);
-  }, [pageIndex, fetchPage, refreshRef.current]); // eslint-disable-line react-hooks/exhaustive-deps
+  const { data, isPending, isFetching, error } = useQuery({
+    queryKey: [...queryKey, pageToken],
+    queryFn: () => queryFn(pageToken),
+    enabled,
+  });
 
   const goNext = useCallback(() => {
-    if (nextPageToken) setPageIndex((i) => i + 1);
-  }, [nextPageToken]);
+    const token = data?.nextPageToken;
+    if (!token) return;
+    setPageTokens((prev) => {
+      const next = [...prev];
+      next[pageIndex + 1] = token;
+      return next;
+    });
+    setPageIndex(pageIndex + 1);
+  }, [data?.nextPageToken, pageIndex]);
 
   const goPrev = useCallback(() => {
-    if (pageIndex > 0) setPageIndex((i) => i - 1);
-  }, [pageIndex]);
-
-  const reset = useCallback(() => {
-    setPageIndex(0);
-    setPageTokens([null]);
+    setPageIndex((i) => (i > 0 ? i - 1 : i));
   }, []);
 
-  const refresh = useCallback(() => {
-    refreshRef.current += 1;
-  }, []);
+  // Prefix match, so every cached page of this filter set is refetched. Not
+  // memoised: queryKey is a fresh array literal at every call site, so a
+  // useCallback over it would need either a stringified dep or a disable
+  // comment, and no caller memoises on refresh's identity.
+  const refresh = () => queryClient.invalidateQueries({ queryKey });
 
   return {
-    items,
-    totalCount,
-    loading,
-    error,
+    items: data?.items ?? [],
+    totalCount: data?.totalCount ?? 0,
+    // isPending covers the first load; isFetching keeps the indicator up while a
+    // refresh replaces an already-rendered page.
+    loading: isPending || isFetching,
+    error: error ?? null,
     pageIndex,
     hasPrev: pageIndex > 0,
-    hasNext: !!nextPageToken,
+    hasNext: !!data?.nextPageToken,
     goNext,
     goPrev,
-    reset,
     refresh,
   };
 }

--- a/client/lib/errors.ts
+++ b/client/lib/errors.ts
@@ -1,0 +1,12 @@
+/**
+ * Turns a thrown value into something renderable.
+ *
+ * The API layer throws rather than returning a result union, and every call site
+ * used to repeat `e instanceof Error ? e.message : String(e)`. `fallback` covers
+ * an Error with an empty message and the callers that want their own wording
+ * ("Failed to load counters") in place of whatever the transport produced.
+ */
+export function errorMessage(e: unknown, fallback = "Something went wrong"): string {
+  if (e instanceof Error) return e.message || fallback;
+  return e == null ? fallback : String(e);
+}

--- a/client/lib/query-client.ts
+++ b/client/lib/query-client.ts
@@ -12,8 +12,13 @@ import { QueryClient } from "@tanstack/react-query";
  *     cassettes have no entry for.
  *   - refetchOnWindowFocus / refetchOnReconnect: both default to true and would
  *     be background refetches this app has never done.
- *   - staleTime: reactStrictMode double-mounts components in dev, so a non-zero
- *     staleTime makes the second mount a cache hit instead of a second request.
+ *   - staleTime 0: price fetching, corporate event discovery and split
+ *     adjustment all change data behind the client's back, so treating a cached
+ *     read as fresh for any window risks showing a stale table right after a
+ *     worker has run. Mounting still paints the cached value immediately and
+ *     revalidates behind it, so this is not a return to a blank loading state.
+ *
+ * gcTime is left at the library default and stated only for the record.
  */
 export function createQueryClient(): QueryClient {
   return new QueryClient({
@@ -22,7 +27,7 @@ export function createQueryClient(): QueryClient {
         retry: 0,
         refetchOnWindowFocus: false,
         refetchOnReconnect: false,
-        staleTime: 30_000,
+        staleTime: 0,
         gcTime: 5 * 60_000,
       },
     },

--- a/client/lib/query-client.ts
+++ b/client/lib/query-client.ts
@@ -1,0 +1,30 @@
+import { QueryClient } from "@tanstack/react-query";
+
+/**
+ * The app's QueryClient defaults.
+ *
+ * These deliberately reproduce how the client behaved when every page hand-rolled
+ * its own fetch-in-effect, rather than taking the library defaults:
+ *
+ *   - retry: nothing retried before. Retrying is also wrong for most of what this
+ *     backend returns -- INVALID_ARGUMENT and UNAUTHENTICATED will not succeed on
+ *     a second attempt -- and it would make the e2e suites issue requests the VCR
+ *     cassettes have no entry for.
+ *   - refetchOnWindowFocus / refetchOnReconnect: both default to true and would
+ *     be background refetches this app has never done.
+ *   - staleTime: reactStrictMode double-mounts components in dev, so a non-zero
+ *     staleTime makes the second mount a cache hit instead of a second request.
+ */
+export function createQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: 0,
+        refetchOnWindowFocus: false,
+        refetchOnReconnect: false,
+        staleTime: 30_000,
+        gcTime: 5 * 60_000,
+      },
+    },
+  });
+}

--- a/client/lib/query-keys.ts
+++ b/client/lib/query-keys.ts
@@ -15,4 +15,17 @@
  */
 export const qk = {
   telemetryCounters: () => ["telemetry-counters"] as const,
+  // Called with no arguments to invalidate every search/filter variant.
+  instruments: (search?: string, assetClasses?: string) =>
+    search === undefined ? (["instruments"] as const) : (["instruments", search, assetClasses ?? ""] as const),
+  // Called with no arguments to invalidate every filter variant.
+  prices: (search?: string, dateFrom?: string, dateTo?: string) =>
+    search === undefined
+      ? (["prices"] as const)
+      : (["prices", search, dateFrom ?? "", dateTo ?? ""] as const),
+  txs: (portfolioId?: string) => ["txs", portfolioId ?? null] as const,
+  jobs: () => ["jobs"] as const,
+  job: (jobId: string) => ["job", jobId] as const,
+  inflationIndices: (currency: string, dateFrom: string, dateTo: string) =>
+    ["inflation-indices", currency, dateFrom, dateTo] as const,
 };

--- a/client/lib/query-keys.ts
+++ b/client/lib/query-keys.ts
@@ -14,6 +14,14 @@
  * Grows as call sites are converted; there are no keys here without a consumer.
  */
 export const qk = {
+  session: () => ["session"] as const,
+  plugins: (category: "identifier" | "description" | "price" | "inflation") =>
+    ["plugins", category] as const,
+  workers: () => ["workers"] as const,
+  unhandledCorporateEvents: () => ["unhandled-corporate-events"] as const,
+  unhandledCorporateEventCount: () => ["unhandled-corporate-event-count"] as const,
+  corporateEventSplits: () => ["corporate-event-splits"] as const,
+  priceFetchBlocks: () => ["price-fetch-blocks"] as const,
   telemetryCounters: () => ["telemetry-counters"] as const,
   holdings: (portfolioId?: string) => ["holdings", portfolioId ?? null] as const,
   displayCurrency: () => ["display-currency"] as const,

--- a/client/lib/query-keys.ts
+++ b/client/lib/query-keys.ts
@@ -1,0 +1,18 @@
+/**
+ * Query keys, in one place so that invalidation and the queries it targets cannot
+ * drift apart.
+ *
+ * Two conventions:
+ *
+ *   - The first element is the resource name and the rest are its parameters, so
+ *     `invalidateQueries({ queryKey: qk.prices() })` prefix-matches every filter
+ *     and page variant of it.
+ *   - Parameters are primitives, never objects. Keys are compared structurally,
+ *     so an object that is rebuilt with the same contents is a different key and
+ *     silently refetches. Pass `portfolio.id`, not `portfolio`.
+ *
+ * Grows as call sites are converted; there are no keys here without a consumer.
+ */
+export const qk = {
+  telemetryCounters: () => ["telemetry-counters"] as const,
+};

--- a/client/lib/query-keys.ts
+++ b/client/lib/query-keys.ts
@@ -15,6 +15,13 @@
  */
 export const qk = {
   telemetryCounters: () => ["telemetry-counters"] as const,
+  holdings: (portfolioId?: string) => ["holdings", portfolioId ?? null] as const,
+  displayCurrency: () => ["display-currency"] as const,
+  valuation: (portfolioId: string | undefined, dateFrom: string, dateBefore: string, currency: string) =>
+    ["valuation", portfolioId ?? null, dateFrom, dateBefore, currency] as const,
+  ignoredAssetClasses: () => ["ignored-asset-classes"] as const,
+  holdingDeclarations: () => ["holding-declarations"] as const,
+  brokersAndAccounts: () => ["brokers-and-accounts"] as const,
   // Called with no arguments to invalidate every search/filter variant.
   instruments: (search?: string, assetClasses?: string) =>
     search === undefined ? (["instruments"] as const) : (["instruments", search, assetClasses ?? ""] as const),

--- a/client/lib/query-keys.ts
+++ b/client/lib/query-keys.ts
@@ -15,6 +15,7 @@
  */
 export const qk = {
   session: () => ["session"] as const,
+  portfolios: () => ["portfolios"] as const,
   plugins: (category: "identifier" | "description" | "price" | "inflation") =>
     ["plugins", category] as const,
   workers: () => ["workers"] as const,

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -14,6 +14,7 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@radix-ui/react-dialog": "^1.1.15",
         "@react-oauth/google": "^0.13.4",
+        "@tanstack/react-query": "^5.101.4",
         "@types/papaparse": "^5.5.2",
         "next": "^16.1.6",
         "papaparse": "^5.5.3",
@@ -2307,6 +2308,32 @@
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.101.4.tgz",
+      "integrity": "sha512-gNwcvOJcRbLWPOLG/2OBm+zM+Yv+MKsXKEOWC57USuZDEsI71hEErQsiEGx5wX9rzWWkfwM0fVSPoiIFSsxfiw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.101.4",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.101.4.tgz",
+      "integrity": "sha512-yRg2pfOCxIs4ZJW3XYYHU/WgtD04FHSnfHlpRT7h7pR77hwkdRG4wxbKe4aq6P0RvXUTBSQpQeadS1SUYUe+KA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.101.4"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/client/package.json
+++ b/client/package.json
@@ -17,6 +17,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-dialog": "^1.1.15",
     "@react-oauth/google": "^0.13.4",
+    "@tanstack/react-query": "^5.101.4",
     "@types/papaparse": "^5.5.2",
     "next": "^16.1.6",
     "papaparse": "^5.5.3",

--- a/client/test-utils.tsx
+++ b/client/test-utils.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+/**
+ * A QueryClient for tests: no retries, so a rejecting queryFn surfaces as an
+ * error immediately rather than after backoff, and nothing goes stale on its
+ * own, so the only refetches are the ones a test asks for. `invalidateQueries`
+ * still refetches regardless of staleTime.
+ */
+export function createTestQueryClient(): QueryClient {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, staleTime: Infinity, gcTime: Infinity },
+    },
+  });
+}
+
+/**
+ * Wrapper for renderHook/render. Each call gets its own client so cache state
+ * cannot leak between tests.
+ */
+export function queryWrapper(client: QueryClient = createTestQueryClient()) {
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  };
+}

--- a/docs/adr/0019-tanstack-query-data-fetching.md
+++ b/docs/adr/0019-tanstack-query-data-fetching.md
@@ -23,7 +23,11 @@ before, because this backend's `INVALID_ARGUMENT` and `UNAUTHENTICATED` will not
 succeed on a second attempt, and because retries would make the e2e suites issue
 requests their VCR cassettes have no entry for; `refetchOnWindowFocus` and
 `refetchOnReconnect` off because background refetching is new behaviour nobody
-asked for.
+asked for; and `staleTime` 0, because price fetching, corporate event discovery
+and split adjustment all change data behind the client's back, so treating a
+cached read as fresh for any window risks showing a stale table just after a
+worker has run. Mounting still paints the cached value and revalidates behind
+it, so nothing returns to a blank loading state.
 
 We did not add request cancellation. The old `cancelled` flags did not abort the
 HTTP request either -- they suppressed the `setState` -- which is what the query

--- a/docs/adr/0019-tanstack-query-data-fetching.md
+++ b/docs/adr/0019-tanstack-query-data-fetching.md
@@ -1,0 +1,38 @@
+# Client data fetching: TanStack Query
+
+Every page and most components used to load data the same way: a `useEffect`
+calling a loader that set `loading`, `error` and the data itself. Repeated across
+twenty-odd sites it drifted -- some cancelled with a `let cancelled` closure and
+some did not, three different refresh mechanisms grew up alongside each other,
+and two of them did not work (a `useRef` bumped to force a refetch does not
+re-render, and a filter change while off page one fired two requests). It also
+cannot satisfy `react-hooks/set-state-in-effect`, which the React team's
+recommended lint config now enables.
+
+We use TanStack Query for all client reads. Queries are keyed on the resource and
+its parameters, so a filter or portfolio change refetches by changing the key
+rather than by an effect, mutations refresh by invalidating a key prefix instead
+of calling a loader back, and polling is `refetchInterval` rather than a
+`setInterval` the component has to tear down. Keys hold primitives only: they are
+compared structurally, so passing an object that is rebuilt with equal contents
+silently refetches.
+
+The defaults in `client/lib/query-client.ts` deliberately reproduce the old
+behaviour rather than taking the library's: `retry: 0` because nothing retried
+before, because this backend's `INVALID_ARGUMENT` and `UNAUTHENTICATED` will not
+succeed on a second attempt, and because retries would make the e2e suites issue
+requests their VCR cassettes have no entry for; `refetchOnWindowFocus` and
+`refetchOnReconnect` off because background refetching is new behaviour nobody
+asked for.
+
+We did not add request cancellation. The old `cancelled` flags did not abort the
+HTTP request either -- they suppressed the `setState` -- which is what the query
+cache does structurally for every query, so dropping them changes nothing.
+Out-of-order responses, the bug the flags guarded against, are prevented by the
+key instead: two searches are two cache entries and a late reply cannot overwrite
+the current one. That leaves the gRPC-Web transport and the `client/lib/*-api.ts`
+wrappers untouched, which is worth more than a cancellation nothing needs yet.
+
+The session itself is a query, so `enabled` can gate on it; sign-out drops every
+non-session query, because a cache that outlives the session would otherwise show
+one user's data to the next.

--- a/docs/issues/0061-client-fetch-in-effect.md
+++ b/docs/issues/0061-client-fetch-in-effect.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Stop loading client data with setState inside an effect
 dependencies: [0060]
 ---

--- a/docs/issues/0062-two-failing-e2e-specs.md
+++ b/docs/issues/0062-two-failing-e2e-specs.md
@@ -1,0 +1,36 @@
+---
+status: open
+title: Two e2e specs fail on main
+---
+
+`make e2e-test` is red on main: 27 pass, 2 fail.
+
+- `e2e/tests/stock-split.spec.ts:43` -- "upload txs, discover split, verify
+  adjustments". Fails at the option-row assertion (`toHaveCount(1)` for the row
+  with quantity 1 and adjusted quantity 4); the locator resolves to 0 elements.
+  The two stock-row assertions immediately above it pass, so the split is being
+  discovered and stock adjustments are being applied -- it is the option leg
+  that does not show an adjusted quantity.
+- `e2e/tests/corporate-event-roundtrip.spec.ts:44` -- "knowledge time survives
+  export and re-import". Fails in well under a second, so it is not a timeout.
+
+## Motivation
+
+Both were confirmed against `44d0891` (the commit that closed 0060), so they
+predate the 0061 client conversion and are not caused by it. The suite being
+red by default means a genuine regression in an e2e-covered path would not
+stand out, and e2e is the only automated cover several client paths have.
+
+## Design
+
+Diagnose each on its own. For the split one, start from whether the option leg's
+adjustment is missing in the database or only missing from the ListTxs response
+-- the second stock assertion passing narrows it to the option path. The
+knowledge-time one failing that fast suggests the import or the export is
+erroring rather than returning wrong data; check the response before the
+assertion.
+
+Neither is covered by CI today: the workflow runs the four test targets plus the
+checks, and `e2e-test` is not among them. Adding it is a separate decision --
+the suite needs the full stack and VCR cassettes -- but the failures should be
+fixed either way.

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -55,13 +55,6 @@ export default defineConfig([
       // A Pages Router rule: the client is App Router only, so there is no
       // pages directory for it to check against.
       "@next/next/no-html-link-for-pages": "off",
-
-      // Off pending 0061. Both fire on the client's fetch-in-effect data
-      // loading, which every page and most components use; clearing them is a
-      // rework of how the client loads data, not a lint fix, and leaving them
-      // as errors would mean this config could not be turned on at all.
-      "react-hooks/set-state-in-effect": "off",
-      "react-hooks/refs": "off",
     },
   },
   {


### PR DESCRIPTION
Closes 0061. Six commits, meant to be read one at a time.

Every page loaded its data with a `useEffect` calling a loader that called
`setState`. Repeated across ~24 sites it had drifted: some cancelled with a
`let cancelled` closure and some did not, three different refresh
mechanisms had grown up alongside each other, and two of them did not work.
`react-hooks/set-state-in-effect` and `react-hooks/refs` were switched off
because of it. Both are now on at error and the config carries no
exception.

## Bugs this fixes

- **`usePagination.refresh()` never worked reliably.** It bumped a
  `useRef` and listed `refreshRef.current` in a dep array. Mutating a ref
  does not re-render, so it only had an effect when something *else*
  re-rendered the component -- on `/uploads`, closing the upload modal.
- **A filter change while off page 1 fired two requests**, the first for
  the stale page index against the new filters.
- **`admin/workers` set state after unmount.** Its 2s poll had no cancel
  flag at all.
- **Renaming a portfolio refetched holdings and the valuation chart.**
  Both had the whole `selectedPortfolio` object in a dep array, and rename
  does `setSelected({...selected, name})`.

## Approach

TanStack Query v5 for all reads (ADR 0019). Keys come from `qk` factories
in [query-keys.ts](client/lib/query-keys.ts) and hold primitives only;
`useAuthedQuery` gates on the session so no call site repeats the
`if (state.status !== "authenticated") return` guard.

Resetting state when an input changes is a **`key` prop**, not an effect --
`set-state-in-render` is on too, so neither an effect nor a guarded
render-time `setState` is available. Five paginated pages split into a
parent holding the filter inputs and a child keyed on their values;
`/uploads` needs no split because it has no filters. Remounting costs no
requests, since the cache outlives the unmount.

**No cancellation was added, and the API layer is untouched.** The old
`cancelled` flags did not abort the HTTP request either -- they suppressed
the `setState`, which is what the query cache does structurally. The
out-of-order-response case they guarded is handled by the key instead: two
searches are two cache entries. So `grpc-web.ts`, `portfolio-api.ts` and
`portfolio-api.test.ts` are unchanged.

## Behaviour changes worth knowing

- `admin/page.tsx` becomes five queries instead of one `Promise.all` with a
  bare `catch {}`. Today one failing RPC blanks every summary card; now a
  card fails alone.
- Paging backwards is served from cache, so it no longer flashes
  "Loading...". `placeholderData: keepPreviousData` was deliberately not
  added.
- Defaults reproduce the old behaviour rather than taking the library's:
  `retry: 0`, `refetchOnWindowFocus`/`refetchOnReconnect` off, and
  `staleTime: 0` -- background workers change data behind the client's
  back, so no cached read is treated as fresh.

## Verification

`make lint-ts`, `make client-typecheck` and `make client-test` (201, up
from 193) all pass with both rules at error.

Eight new `renderHook` tests cover the pagination hook, including the two
behaviours the old implementation got wrong: a remount under a new key
issues exactly one request, and `refresh()` refetches with no other render
trigger.

`make e2e-test` gives 27 passed / 2 failed -- **and the same 2 fail on
`44d0891`**, so they predate this work. Opened as 0062 rather than folded
in here.

## Size

+1386 / -940 across 40 files, excluding `package-lock.json`. Well over the
500-800 target. It was not split because the pagination hook's signature
change and its six callers cannot land separately, and the rules can only
be turned on once the last site is converted. The commits are the intended
review path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
