### PR TITLE
Close 0036: group transaction legs with tx_groups

### DIFF
--- a/docs/adr/0020-double-entry-postings.md
+++ b/docs/adr/0020-double-entry-postings.md
@@ -1,0 +1,37 @@
+# Transactions are double-entry postings grouped by economic event
+
+A `txs` row is a **posting**, and the postings of one economic event belong to a
+**tx group** whose amounts are required to sum to zero, in the manner of beancount
+and ledger. The table was already a posting table in all but name -- the commodity is
+`instrument_id` (currencies are instruments), the amount is a signed `quantity`, the
+account is `(broker, account)`, and holdings are `SUM(quantity)` with no type-based
+sign flip. What was missing was the parent record and the invariant.
+
+The reason is the portfolio cash-flow boundary. Money-weighted return needs to know
+which flows crossed it (deposits, withdrawals) and which were internal (a buy
+converts cash into shares inside the boundary), and time-weighted return needs the
+same boundary to sub-period correctly. With single-legged transactions that is a
+classification problem over the ~22 OFX transaction types, per broker, with no
+structural guarantee and nothing that fails loudly when a mapping is wrong. With
+grouped postings and a small non-asset account vocabulary it is structural: a flow is
+external iff it crosses out of the asset accounts.
+
+The invariant will be enforced by a deferred constraint trigger in the database
+rather than at load time as beancount does, because a database constraint has no
+equivalent of an unchecked writer: no code path, no bad import and no manual psql
+session can leave an unbalanced group behind.
+
+## Consequences
+
+An INITIALIZE row (see [0011](0011-synthetic-initialize-transactions.md)) is a pad
+with no counterparty, so it cannot satisfy the invariant until a reserved `Equity`
+account gives it one. The invariant is also not expressible while `quantity` and
+`unit_price` are `DOUBLE PRECISION`: summing float buys and sells does not land on
+exactly zero, which is why `qty_is_zero(q) := ABS(q) < 1e-9` already exists, and
+applying that epsilon to a balance check would let a genuine imbalance smaller than
+the tolerance pass silently. Both are prerequisites of turning the constraint on, so
+grouping lands first and the constraint follows.
+
+The read path is unaffected. Holdings, valuation, price coverage and holding
+declarations all aggregate `SUM(quantity)` grouped by instrument, and adding a
+grouping key changes none of them.

--- a/docs/adr/0021-converters-own-transaction-grouping.md
+++ b/docs/adr/0021-converters-own-transaction-grouping.md
@@ -1,0 +1,33 @@
+# Converters own transaction grouping; the server never derives a leg
+
+An upload is a list of postings, and the broker-specific converter decides which of
+them are legs of one economic event. The server persists what it is given: it does
+not infer a missing leg, does not pair rows, and does not fold a fee into a cash
+amount.
+
+The alternative was to derive the cash leg server-side as
+`-(quantity * unit_price)` from the security row. That double-counts for any broker
+that already reports its own cash leg, and Fidelity does: a `Sell` is accompanied by
+a `Cash In From Sell` row for the same money, and the two match exactly on
+`|Amount|` within an account and completion date across all 55 sells in the sample
+export. Deriving a second cash leg on top would post the proceeds twice. Pairing them
+after the fact is not possible either, because by the time the data reaches the
+standard format the broker's own reference numbers have been discarded -- only the
+converter still has them.
+
+Fees are therefore postings, not columns. A dealing fee, PTM levy or stamp duty is a
+cash posting with `type=INVEXPENSE`, which is already how the Fidelity converter
+emits them and is the only representation that works when a broker charges them
+separately from the trade and on a different date. Adding `fees` and `net_amount`
+columns to the standard CSV was considered and rejected: it would express a
+Fidelity-shaped fee twice, and a broker that nets commission into a single total
+(IBKR reports `Amount` and no commission column) can be split by its own converter,
+which is the one place that knows the broker's conventions.
+
+## Consequences
+
+Every broker oddity lands in one converter rather than being spread between a
+converter, a CSV column and a server-side rule. The cost is that a converter which
+supplies neither a cash row nor a unit price produces an unbalanced group; that
+residual is routed to an explicit imbalance account rather than rejected, so
+coverage tightens per broker over time instead of in a single cut-over.

--- a/docs/issues/0036-tx-groups-postings.md
+++ b/docs/issues/0036-tx-groups-postings.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Group transaction legs with tx_groups
 milestone: M12
 ---

--- a/docs/issues/0038-derive-cash-legs-imbalance.md
+++ b/docs/issues/0038-derive-cash-legs-imbalance.md
@@ -1,13 +1,18 @@
 ---
 status: open
-title: Derive cash legs at ingestion and route residuals to Imbalance
+title: Route posting residuals to Imbalance
 milestone: M12
-dependencies: [0036, 0037]
+dependencies: [0036, 0037, 0063]
 ---
 
-Ingestion produces a group of postings per source row rather than a single tx.
-Derive the cash leg from the security leg and route any residual to
-`Imbalance:<currency>`. Still no balance constraint.
+Route the residual of an unbalanced group to `Imbalance:<currency>`, and unmatched
+transfer sides to `Transfers.InFlight`. Still no balance constraint.
+
+**Amended.** This issue originally had the server derive the cash leg as
+`-(quantity * unit_price)` from the security row. It does not: deriving a leg
+double-counts for any broker that already reports its own cash row, and Fidelity
+does. Grouping and leg production are the converter's job (0063, 0064; see
+adr/0021-converters-own-transaction-grouping.md). What remains here is routing.
 
 ## Motivation
 
@@ -18,20 +23,14 @@ unreliable.
 
 ## The problem
 
-The standard CSV (docs/spec/csv-format.md) cannot express a balanced
-transaction:
-
-- there is no `fees` or `commission` column, so `quantity * unit_price` is the
-  gross consideration, not the cash movement -- the derived leg is wrong by the
-  fee;
-- `unit_price` is optional, so sometimes the cash leg cannot be derived at all.
-
-Requiring every broker converter to be correct before double-entry can be
-turned on would make this change unshippable.
+Not every converter will supply a complete group. A broker may report no cash row
+and no unit price, or report a price that does not account for a charge. Requiring
+every broker converter to be correct before double-entry can be turned on would make
+this change unshippable.
 
 ## The solution
 
-Never reject. Derive what can be derived and post the residual to an explicit
+Never reject. Post the group as supplied and send the residual to an explicit
 `Imbalance:<currency>` account. This is ledger's behaviour, and it is what
 makes double-entry adoptable before the source data is perfect:
 
@@ -42,11 +41,9 @@ makes double-entry adoptable before the source data is perfect:
 
 ## Design
 
-- Cash leg: `-(quantity * unit_price)` denominated in `settlement_currency`,
-  falling back to `trading_currency` when settlement is absent.
-- Where `unit_price` is absent, emit only the security leg and let the whole
-  consideration fall to `Imbalance`.
-- Amount elision follows beancount: state one side, infer the other.
+- Any group whose postings do not sum to zero gets an `Imbalance:<currency>`
+  posting for the residual, denominated in `settlement_currency` and falling back
+  to `trading_currency` when settlement is absent.
 - **Transfers** (JRNLFUND, JRNLSEC, TRANSFER): do not attempt to pair the two
   sides at ingest. Brokers report them in separate statements and matching is
   unreliable. Post each side against `Transfers:InFlight`; a later matching

--- a/docs/issues/0040-csv-fees-net-amount.md
+++ b/docs/issues/0040-csv-fees-net-amount.md
@@ -1,40 +1,36 @@
 ---
 status: open
-title: Extend standard CSV with fees and net amount
+title: Emit fee and cash postings from brokers that net commission
 milestone: M12
-dependencies: [0039]
+dependencies: [0039, 0063]
 ---
 
-Add `fees` and `net_amount` columns to the standard CSV format and update the
-broker converters to populate them.
+Update the broker converters that report only a net total to split out the
+commission and emit it as its own posting.
+
+**Amended.** This issue originally added `fees` and `net_amount` columns to the
+standard CSV. It no longer does. A fee is a posting with `type=INVEXPENSE`, not a
+column: that is already how Fidelity's separately-reported charges arrive, and
+columns would express the same money twice. See
+adr/0021-converters-own-transaction-grouping.md. What remains is the converter-side
+work for brokers that do not report charges separately.
 
 ## Motivation
 
-The standard CSV cannot currently express a balanced transaction. It carries
-`quantity`, an optional `unit_price`, `trading_currency` and
-`settlement_currency`, but no fee and no cash total. `quantity * unit_price` is
-the gross consideration; the actual cash movement is gross plus commissions and
-charges. Without those, every derived cash leg is wrong by the fee and the
-difference lands in `Imbalance` (0038).
-
-This is a breaking change to the format, which is acceptable: the project is
-pre-release and CLAUDE.md states that data models and APIs are not stable and
-should not carry migrations or back-compat.
+Where a broker nets commission into a single cash total and reports no separate
+charge row, the fee is invisible: the cash posting is correct but the consideration
+and the expense are conflated, which matters for cost basis. The residual also lands
+in `Imbalance` (0038) whenever the price and the cash total disagree.
 
 ## Design
 
-- `net_amount` -- signed cash movement in `settlement_currency`. Authoritative
-  when present: use it directly for the cash leg rather than deriving.
-- `fees` -- total commissions and charges for the row, in
-  `settlement_currency`.
-- Precedence: `net_amount` when supplied; otherwise
-  `-(quantity * unit_price) - fees`; otherwise security leg only with the
-  balance falling to `Imbalance`.
-- Post `fees` to an expense account rather than folding it into the cash leg,
-  so that cost basis and expenses stay separable. This matters for the lot and
-  cost-basis work if that is taken up later.
-- Both columns optional, so existing hand-written CSVs keep working and only
-  contribute imbalance.
+- The converter derives the fee as `|Amount| - quantity * price` and emits it as an
+  `INVEXPENSE` posting in the same group as the trade.
+- Where a broker reports charges as their own rows on their own dates (Fidelity),
+  they stay separate single-posting groups. Do not fold them into the trade group;
+  they are separate cash events and grouping them would misdate them.
+- The currency qualifier matters. Derive the fee only after the price and the cash
+  total are in the same currency.
 
 ## Sequencing
 
@@ -44,11 +40,10 @@ existing worked example.
 
 ## Manual test data
 
-The broker CSVs under `local/standard-format` predate these columns, so they
-carry no fee or cash total and every one of their derived cash legs will land in
-`Imbalance` until they are regenerated. Doing that is part of this work: the
-scripts that produce them live in `local/scripts` and have to populate the new
-columns alongside the client converters.
+The broker CSVs under `local/standard-format` carry no fee postings, so every
+conflated fee shows up as `Imbalance` until they are regenerated. Doing that is part
+of this work: the scripts that produce them live in `local/scripts` and have to emit
+the fee postings alongside the client converters.
 
 Whether the source data supports it varies by broker, so check before assuming a
 regeneration is mechanical. The IBKR master (`local/masters/Lee-IBKR-CWSY.csv`)

--- a/docs/issues/0063-group-ref-upload-format.md
+++ b/docs/issues/0063-group-ref-upload-format.md
@@ -1,0 +1,32 @@
+---
+status: open
+title: Group reference in the standard upload format
+milestone: M12
+dependencies: [0036]
+---
+
+Add an optional `group_ref` to the standard CSV and the `Tx` proto so that an upload
+can say which postings are legs of one economic event, and group them on ingestion.
+
+## Motivation
+
+0036 added the group table, but nothing can currently say which rows belong
+together. The standard CSV has no grouping column, so every posting arrives as its
+own single-posting group no matter what the broker reported.
+
+## Design
+
+- `group_ref` is an opaque string scoped to a single upload. Rows sharing a non-empty
+  value are legs of one event; an empty value means the row is its own group. It is
+  not a durable identifier and is not stored (see adr/0002-transaction-ingestion-model.md,
+  which states transactions have no natural key).
+- `ReplaceTxsInPeriod` takes group keys parallel to the txs, resolves each distinct
+  non-empty key to one group per upload, and stamps the group with the first leg's
+  timestamp.
+- `filterStoredTxs` drops non-stored types (e.g. SPLIT) and must carry group keys
+  through the surviving indices, so a partially-dropped group still groups correctly.
+- `CreateTx` ignores it: one tx, one group.
+- No validation rule. A group that does not balance is 0038 and 0041's problem.
+
+Fees are not a column. A fee is a posting with `type=INVEXPENSE`; see
+adr/0021-converters-own-transaction-grouping.md.

--- a/docs/issues/0064-fidelity-converter-groups.md
+++ b/docs/issues/0064-fidelity-converter-groups.md
@@ -1,0 +1,49 @@
+---
+status: open
+title: Fidelity converter emits transaction groups
+milestone: M12
+dependencies: [0063]
+---
+
+Pair Fidelity's security rows with the cash rows it already supplies, and emit them
+as one group. This is the tracer bullet for the upload format: the rules are measured
+against the 689-row master export rather than assumed.
+
+## Motivation
+
+Fidelity reports the cash leg of a trade as a separate row, so deriving one from the
+security row would post the money twice. The information needed to pair them exists
+in the raw export and is discarded by the converters, which keep neither
+`Reference Number` nor `Amount`.
+
+## Pairing rules
+
+Measured against `local/masters/Lee-Fidelity-CWSY.csv`:
+
+- `Sell` -> `Cash In From Sell`: exact `|Amount|` match within (Account Number,
+  Completion date). 55/55, no residual.
+- `Buy` -> `Cash Out For Buy`: nearest `Reference Number` within (Account Number,
+  Completion date). 36/36.
+- `group_ref` is the security row's `Reference Number`.
+- An unpaired cash row keeps no `group_ref`. Never drop a posting and never fail an
+  upload over an unpaired leg.
+
+## What is deliberately not grouped
+
+- Dealing fees, PTM levies, stamp duty and FX charges stay single-posting groups.
+  They are dated on the **order** date while the trade settles on the completion
+  date, so folding them into the trade group would misdate them. The gap between a
+  `Buy` row's `Amount` and its `Cash Out For Buy` is exactly the sum of at most three
+  of those charge rows for all 36 buys, so leaving them independent accounts for
+  every penny once.
+- `Transfer To Cash Management Account For Fees` and `Cash In Ring-fenced For Fees`
+  are the two sides of a cross-account transfer and never share an account or date.
+  They are 0038's Transfers.InFlight case and are not paired at ingest.
+
+## Scope
+
+`client/lib/csv/converters/fidelity-csv.ts`, `local/scripts/convert-fidelity.py` with
+regenerated `local/standard-format` files, and `extension/src/brokers/fidelity-json.ts`,
+whose JSON payload carries the same value as `referenceId`. The captured HAR sample
+has no Buy/Sell rows, so the extension path can only be unit-tested against synthetic
+rows; the CSV path carries the real-data validation.

--- a/docs/spec/portfoliodb-spec.md
+++ b/docs/spec/portfoliodb-spec.md
@@ -36,6 +36,8 @@ Transactions do not have a reliable natural key and the system does not enforce 
 
 Each transaction has a **broker** (required) and an **account** (may be empty); an empty account string is valid and represents the default/only account for that broker. See adr/0002-transaction-ingestion-model.md.
 
+A transaction is a **posting**: a signed amount of one commodity in one account. The postings of a single economic event belong to a **transaction group** and are required to sum to zero. See [postings.md](postings.md) and adr/0020-double-entry-postings.md.
+
 ## Upload Formats
 
 The client supports uploading transactions in several formats:

--- a/docs/spec/postings.md
+++ b/docs/spec/postings.md
@@ -1,0 +1,60 @@
+# Transaction Groups and Postings
+
+A **tx group** is one economic event. The `txs` rows that reference it are its
+**postings**. See adr/0020-double-entry-postings.md.
+
+## Postings
+
+A posting is a signed amount of one commodity in one account at one point in time:
+
+| Concept   | Column                        |
+| --------- | ----------------------------- |
+| Account   | `broker` + `account`          |
+| Commodity | `instrument_id`               |
+| Amount    | `quantity` (signed)           |
+| Date      | `timestamp`                   |
+
+Currencies are instruments, so a cash movement is an ordinary posting and needs no
+separate representation. Nothing in the read path distinguishes a cash posting from a
+security posting: holdings, valuation, price coverage and holding declarations all
+aggregate `SUM(quantity)` grouped by instrument, and a cash balance is that sum over
+a currency instrument.
+
+## Groups
+
+| Column      | Notes                                                              |
+| ----------- | ------------------------------------------------------------------ |
+| `id`        | uuid, PK                                                            |
+| `user_id`   | uuid, FK -> users                                                   |
+| `timestamp` | The date of the event. The postings carry their own timestamps.     |
+| `job_id`    | The ingestion job that created the group. NULL when system-derived. |
+| `created_at`| timestamptz                                                         |
+
+`job_id` is **not** a foreign key. A group must outlive its job, and if job rows are
+ever pruned by age the id still distinguishes one creation from another and still
+groups everything written by the same upload.
+
+Every posting belongs to exactly one group. `txs.group_id` is nullable only so that
+raw fixtures can write a posting without one; no production write path leaves it
+unset.
+
+Groups currently hold a single posting each: what is stored is unchanged from before
+grouping existed, and no balance is enforced. Once ingestion emits multiple legs per
+group, the postings of a group are required to sum to zero.
+
+## Deletion
+
+The group is the unit of deletion. Deleting a group deletes its postings, so no code
+path can leave half an economic event behind.
+
+Bulk upload replaces a period by deleting the groups whose postings fall inside it
+(see adr/0002-transaction-ingestion-model.md). Synthetic INITIALIZE postings are
+managed by the declaration machinery rather than by ingestion, so their groups are
+excluded from that delete and survive a replace (see fixed-point.md).
+
+## Where grouping is decided
+
+The broker-specific converter decides which postings are legs of one event; the
+server persists what it is given and never infers a missing leg, pairs rows, or folds
+a fee into a cash amount. Fees are expressed as postings with `type=INVEXPENSE`, not
+as a column on the upload. See adr/0021-converters-own-transaction-grouping.md.

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -208,10 +208,12 @@ type PortfolioDB interface {
 
 // TxDB provides transaction write and list.
 type TxDB interface {
+	// Each tx is written as a posting of its own single-posting tx group, stamped
+	// with the ingestion job that created it.
 	// shareCountBasis is the date the uploaded quantities and unit prices are
 	// denominated in. nil means as-traded: each row uses its own timestamp.
-	ReplaceTxsInPeriod(ctx context.Context, userID, broker string, periodFrom, periodBefore *timestamppb.Timestamp, txs []*apiv1.Tx, instrumentIDs []string, shareCountBasis *time.Time) error
-	CreateTx(ctx context.Context, userID, broker, account string, tx *apiv1.Tx, instrumentID string, shareCountBasis *time.Time) error
+	ReplaceTxsInPeriod(ctx context.Context, userID, broker, jobID string, periodFrom, periodBefore *timestamppb.Timestamp, txs []*apiv1.Tx, instrumentIDs []string, shareCountBasis *time.Time) error
+	CreateTx(ctx context.Context, userID, broker, account, jobID string, tx *apiv1.Tx, instrumentID string, shareCountBasis *time.Time) error
 	ListTxs(ctx context.Context, userID string, broker *apiv1.Broker, account string, periodFrom, periodBefore *timestamppb.Timestamp, descending bool, pageSize int32, pageToken string) ([]*apiv1.PortfolioTx, string, error)
 	ListTxsByPortfolio(ctx context.Context, portfolioID string, broker *apiv1.Broker, periodFrom, periodBefore *timestamppb.Timestamp, descending bool, pageSize int32, pageToken string) ([]*apiv1.PortfolioTx, string, error)
 }

--- a/server/db/postgres/declarations.go
+++ b/server/db/postgres/declarations.go
@@ -182,16 +182,53 @@ func (p *Postgres) UpsertInitializeTx(ctx context.Context, userID, broker, accou
 	if err != nil {
 		return fmt.Errorf("invalid instrument id: %w", err)
 	}
-	_, err = p.q.ExecContext(ctx, `
-		INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type, quantity, instrument_id, synthetic_purpose)
-		VALUES ($1, $2, $3, $4, 'INITIALIZE', $7, $5, $6, 'INITIALIZE')
-		ON CONFLICT (user_id, broker, account, instrument_id) WHERE synthetic_purpose = 'INITIALIZE'
-		DO UPDATE SET timestamp = EXCLUDED.timestamp, quantity = EXCLUDED.quantity, tx_type = EXCLUDED.tx_type
-	`, userUUID, broker, account, timestamp, quantity, instUUID, txType)
-	if err != nil {
-		return fmt.Errorf("upsert initialize tx: %w", err)
-	}
-	return nil
+	// The INITIALIZE posting and its group are updated in place rather than
+	// re-inserted, so that recalculating a declaration does not orphan a group.
+	// The group has no job: it is derived from the declaration, not ingested.
+	return p.runInTx(ctx, func(exec queryable) error {
+		var groupID uuid.NullUUID
+		err := exec.QueryRowContext(ctx, `
+			SELECT group_id FROM txs
+			WHERE user_id = $1 AND broker = $2 AND account = $3 AND instrument_id = $4
+			  AND synthetic_purpose = 'INITIALIZE'
+		`, userUUID, broker, account, instUUID).Scan(&groupID)
+		switch {
+		case err == sql.ErrNoRows:
+			var newGroupID uuid.UUID
+			if err := exec.QueryRowContext(ctx, `
+				INSERT INTO tx_groups (user_id, timestamp) VALUES ($1, $2) RETURNING id
+			`, userUUID, timestamp).Scan(&newGroupID); err != nil {
+				return fmt.Errorf("insert initialize tx group: %w", err)
+			}
+			_, err := exec.ExecContext(ctx, `
+				INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type, quantity, instrument_id, synthetic_purpose, group_id)
+				VALUES ($1, $2, $3, $4, 'INITIALIZE', $7, $5, $6, 'INITIALIZE', $8)
+			`, userUUID, broker, account, timestamp, quantity, instUUID, txType, newGroupID)
+			if err != nil {
+				return fmt.Errorf("insert initialize tx: %w", err)
+			}
+			return nil
+		case err != nil:
+			return fmt.Errorf("find initialize tx: %w", err)
+		}
+		_, err = exec.ExecContext(ctx, `
+			UPDATE txs SET timestamp = $5, quantity = $6, tx_type = $7
+			WHERE user_id = $1 AND broker = $2 AND account = $3 AND instrument_id = $4
+			  AND synthetic_purpose = 'INITIALIZE'
+		`, userUUID, broker, account, instUUID, timestamp, quantity, txType)
+		if err != nil {
+			return fmt.Errorf("update initialize tx: %w", err)
+		}
+		if !groupID.Valid {
+			return nil
+		}
+		if _, err := exec.ExecContext(ctx, `
+			UPDATE tx_groups SET timestamp = $2 WHERE id = $1
+		`, groupID.UUID, timestamp); err != nil {
+			return fmt.Errorf("update initialize tx group: %w", err)
+		}
+		return nil
+	})
 }
 
 // DeleteInitializeTx implements db.HoldingDeclarationDB.
@@ -204,15 +241,33 @@ func (p *Postgres) DeleteInitializeTx(ctx context.Context, userID, broker, accou
 	if err != nil {
 		return fmt.Errorf("invalid instrument id: %w", err)
 	}
-	_, err = p.q.ExecContext(ctx, `
-		DELETE FROM txs
-		WHERE user_id = $1 AND broker = $2 AND account = $3 AND instrument_id = $4
-		  AND synthetic_purpose = 'INITIALIZE'
-	`, userUUID, broker, account, instUUID)
-	if err != nil {
-		return fmt.Errorf("delete initialize tx: %w", err)
-	}
-	return nil
+	// Delete the group and let the FK cascade take the posting, so no empty group
+	// is left behind. Postings written without a group are cleared directly.
+	return p.runInTx(ctx, func(exec queryable) error {
+		_, err := exec.ExecContext(ctx, `
+			DELETE FROM tx_groups g
+			WHERE g.user_id = $1
+			  AND EXISTS (
+			    SELECT 1 FROM txs t
+			    WHERE t.group_id = g.id
+			      AND t.broker = $2 AND t.account = $3 AND t.instrument_id = $4
+			      AND t.synthetic_purpose = 'INITIALIZE'
+			  )
+		`, userUUID, broker, account, instUUID)
+		if err != nil {
+			return fmt.Errorf("delete initialize tx group: %w", err)
+		}
+		_, err = exec.ExecContext(ctx, `
+			DELETE FROM txs
+			WHERE user_id = $1 AND broker = $2 AND account = $3 AND instrument_id = $4
+			  AND synthetic_purpose = 'INITIALIZE'
+			  AND group_id IS NULL
+		`, userUUID, broker, account, instUUID)
+		if err != nil {
+			return fmt.Errorf("delete initialize tx: %w", err)
+		}
+		return nil
+	})
 }
 
 // CreateDeclarationWithInitializeTx implements db.HoldingDeclarationDB.

--- a/server/db/postgres/declarations_test.go
+++ b/server/db/postgres/declarations_test.go
@@ -139,7 +139,7 @@ func TestGetPortfolioStartDate(t *testing.T) {
 	instID, _ := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "SD1", Canonical: false}}, "", nil, nil, nil)
 	ts := time.Date(2025, 3, 15, 10, 0, 0, 0, time.UTC)
 	tx := &apiv1.Tx{Timestamp: timestamppb.New(ts), InstrumentDescription: "SD1", Type: apiv1.TxType_BUYSTOCK, Quantity: 10, Account: "acct1"}
-	if err := p.CreateTx(ctx, userID, "IBKR", "acct1", tx, instID, nil); err != nil {
+	if err := p.CreateTx(ctx, userID, "IBKR", "acct1", "", tx, instID, nil); err != nil {
 		t.Fatalf("create tx: %v", err)
 	}
 
@@ -163,10 +163,10 @@ func TestComputeRunningBalance(t *testing.T) {
 
 	ts1 := time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC)
 	ts2 := time.Date(2025, 3, 15, 10, 0, 0, 0, time.UTC)
-	if err := p.CreateTx(ctx, userID, "IBKR", "acct1", &apiv1.Tx{Timestamp: timestamppb.New(ts1), InstrumentDescription: "RB1", Type: apiv1.TxType_BUYSTOCK, Quantity: 100, Account: "acct1"}, instID, nil); err != nil {
+	if err := p.CreateTx(ctx, userID, "IBKR", "acct1", "", &apiv1.Tx{Timestamp: timestamppb.New(ts1), InstrumentDescription: "RB1", Type: apiv1.TxType_BUYSTOCK, Quantity: 100, Account: "acct1"}, instID, nil); err != nil {
 		t.Fatalf("create buy: %v", err)
 	}
-	if err := p.CreateTx(ctx, userID, "IBKR", "acct1", &apiv1.Tx{Timestamp: timestamppb.New(ts2), InstrumentDescription: "RB1", Type: apiv1.TxType_SELLSTOCK, Quantity: -30, Account: "acct1"}, instID, nil); err != nil {
+	if err := p.CreateTx(ctx, userID, "IBKR", "acct1", "", &apiv1.Tx{Timestamp: timestamppb.New(ts2), InstrumentDescription: "RB1", Type: apiv1.TxType_SELLSTOCK, Quantity: -30, Account: "acct1"}, instID, nil); err != nil {
 		t.Fatalf("create sell: %v", err)
 	}
 
@@ -240,5 +240,67 @@ func TestUpsertAndDeleteInitializeTx(t *testing.T) {
 		if pt.GetTx().GetSyntheticPurpose() == "INITIALIZE" {
 			t.Fatal("INITIALIZE tx should have been deleted")
 		}
+	}
+}
+
+func TestUpsertInitializeTx_GroupsThePosting(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|init-grp", "U", "u@init.com")
+	instID, _ := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "IG1", Canonical: false}}, "", nil, nil, nil)
+
+	at := time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)
+	if err := p.UpsertInitializeTx(ctx, userID, "IBKR", "acct1", instID, "BUYSTOCK", at, 50); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	// A derived posting has no ingestion job, so its group carries a NULL job_id.
+	var groupID string
+	var jobID *string
+	var groupTs time.Time
+	err := p.q.QueryRowContext(ctx, `
+		SELECT g.id, g.job_id, g.timestamp FROM txs t JOIN tx_groups g ON g.id = t.group_id
+		WHERE t.user_id = $1 AND t.synthetic_purpose = 'INITIALIZE'
+	`, userID).Scan(&groupID, &jobID, &groupTs)
+	if err != nil {
+		t.Fatalf("read group: %v", err)
+	}
+	if jobID != nil {
+		t.Errorf("job_id: want NULL, got %v", *jobID)
+	}
+	if !groupTs.Equal(at) {
+		t.Errorf("group timestamp: want %v, got %v", at, groupTs)
+	}
+
+	// Recalculating a declaration must move the existing group rather than
+	// replacing it, or every recalc would orphan one.
+	moved := at.Add(48 * time.Hour)
+	if err := p.UpsertInitializeTx(ctx, userID, "IBKR", "acct1", instID, "BUYSTOCK", moved, 75); err != nil {
+		t.Fatalf("re-upsert: %v", err)
+	}
+	var groupID2 string
+	var groupTs2 time.Time
+	err = p.q.QueryRowContext(ctx, `
+		SELECT g.id, g.timestamp FROM txs t JOIN tx_groups g ON g.id = t.group_id
+		WHERE t.user_id = $1 AND t.synthetic_purpose = 'INITIALIZE'
+	`, userID).Scan(&groupID2, &groupTs2)
+	if err != nil {
+		t.Fatalf("read group after update: %v", err)
+	}
+	if groupID2 != groupID {
+		t.Errorf("group id changed on update: %s -> %s", groupID, groupID2)
+	}
+	if !groupTs2.Equal(moved) {
+		t.Errorf("group timestamp after update: want %v, got %v", moved, groupTs2)
+	}
+	if got := countGroups(t, p, userID); got != 1 {
+		t.Errorf("tx_groups after re-upsert: want 1, got %d", got)
+	}
+
+	if err := p.DeleteInitializeTx(ctx, userID, "IBKR", "acct1", instID); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+	if got := countGroups(t, p, userID); got != 0 {
+		t.Errorf("tx_groups after delete: want 0, got %d", got)
 	}
 }

--- a/server/db/postgres/holdings_test.go
+++ b/server/db/postgres/holdings_test.go
@@ -39,7 +39,7 @@ func TestComputeHoldings_instrumentNameOverTxDescription(t *testing.T) {
 	txs := []*apiv1.Tx{
 		{Timestamp: ts, InstrumentDescription: "MSFT MICROSOFT CORP", Type: apiv1.TxType_INCOME, Quantity: 137.08, Account: ""},
 	}
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{cashID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{cashID}, nil); err != nil {
 		t.Fatalf("replace: %v", err)
 	}
 
@@ -75,7 +75,7 @@ func TestComputeHoldings_signedQuantity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ensure instrument: %v", err)
 	}
-	err = p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{instID}, nil)
+	err = p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID}, nil)
 	if err != nil {
 		t.Fatalf("replace: %v", err)
 	}

--- a/server/db/postgres/instruments_test.go
+++ b/server/db/postgres/instruments_test.go
@@ -40,7 +40,7 @@ func TestEnsureInstrument_mergeWhenMultipleInstrumentsMatch(t *testing.T) {
 		{Timestamp: ts1, InstrumentDescription: "StockA", Type: apiv1.TxType_BUYSTOCK, Quantity: 10, Account: ""},
 		{Timestamp: ts2, InstrumentDescription: "StockB", Type: apiv1.TxType_BUYSTOCK, Quantity: 5, Account: ""},
 	}
-	err = p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{idA, idB}, nil)
+	err = p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{idA, idB}, nil)
 	if err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}

--- a/server/db/postgres/postgres.go
+++ b/server/db/postgres/postgres.go
@@ -167,6 +167,19 @@ func nullUUID(u *uuid.UUID) interface{} {
 	return *u
 }
 
+// parseNullUUID parses an optional UUID column value, treating the empty string as
+// NULL rather than as a parse error.
+func parseNullUUID(s string) (interface{}, error) {
+	if s == "" {
+		return nil, nil
+	}
+	u, err := uuid.Parse(s)
+	if err != nil {
+		return nil, err
+	}
+	return u, nil
+}
+
 func nullTime(t *time.Time) interface{} {
 	if t == nil {
 		return nil

--- a/server/db/postgres/price_cache_test.go
+++ b/server/db/postgres/price_cache_test.go
@@ -53,7 +53,7 @@ func insertTxs(t *testing.T, p *Postgres, userID, instID string, txs []*apiv1.Tx
 	}
 	from := timestamppb.New(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))
 	to := timestamppb.New(time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "TEST", from, to, txs, ids, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "TEST", "", from, to, txs, ids, nil); err != nil {
 		t.Fatalf("insert txs: %v", err)
 	}
 }
@@ -237,12 +237,12 @@ func TestHeldRanges_MultipleInstruments(t *testing.T) {
 	})
 
 	// Insert txs for inst2 using CreateTx to avoid ReplaceTxsInPeriod conflict with same broker/period.
-	if err := p.CreateTx(ctx, userID, "TEST2", "A", &apiv1.Tx{
+	if err := p.CreateTx(ctx, userID, "TEST2", "A", "", &apiv1.Tx{
 		Timestamp: ts(2024, 3, 1), InstrumentDescription: "INST2", Type: apiv1.TxType_BUYSTOCK, Quantity: 20, Account: "A",
 	}, inst2, nil); err != nil {
 		t.Fatalf("create tx: %v", err)
 	}
-	if err := p.CreateTx(ctx, userID, "TEST2", "A", &apiv1.Tx{
+	if err := p.CreateTx(ctx, userID, "TEST2", "A", "", &apiv1.Tx{
 		Timestamp: ts(2024, 4, 1), InstrumentDescription: "INST2", Type: apiv1.TxType_SELLSTOCK, Quantity: -20, Account: "A",
 	}, inst2, nil); err != nil {
 		t.Fatalf("create tx: %v", err)
@@ -277,12 +277,12 @@ func TestHeldRanges_MultipleUsers(t *testing.T) {
 	})
 
 	// User 2 holds Mar-Apr (separate broker to avoid replace conflict).
-	if err := p.CreateTx(ctx, user2, "TEST2", "B", &apiv1.Tx{
+	if err := p.CreateTx(ctx, user2, "TEST2", "B", "", &apiv1.Tx{
 		Timestamp: ts(2024, 3, 1), InstrumentDescription: "SHARED", Type: apiv1.TxType_BUYSTOCK, Quantity: 5, Account: "B",
 	}, instID, nil); err != nil {
 		t.Fatalf("create tx: %v", err)
 	}
-	if err := p.CreateTx(ctx, user2, "TEST2", "B", &apiv1.Tx{
+	if err := p.CreateTx(ctx, user2, "TEST2", "B", "", &apiv1.Tx{
 		Timestamp: ts(2024, 4, 1), InstrumentDescription: "SHARED", Type: apiv1.TxType_SELLSTOCK, Quantity: -5, Account: "B",
 	}, instID, nil); err != nil {
 		t.Fatalf("create tx: %v", err)
@@ -931,22 +931,22 @@ func TestFXGaps_MixedCurrencies(t *testing.T) {
 		{Timestamp: ts(2024, 1, 10), InstrumentDescription: "SAP", Type: apiv1.TxType_BUYSTOCK, Quantity: 10, Account: "A"},
 		{Timestamp: ts(2024, 2, 10), InstrumentDescription: "SAP", Type: apiv1.TxType_SELLSTOCK, Quantity: -10, Account: "A"},
 	})
-	if err := p.CreateTx(ctx, userID, "TEST2", "A", &apiv1.Tx{
+	if err := p.CreateTx(ctx, userID, "TEST2", "A", "", &apiv1.Tx{
 		Timestamp: ts(2024, 1, 10), InstrumentDescription: "HSBC", Type: apiv1.TxType_BUYSTOCK, Quantity: 5, Account: "A",
 	}, gbpInst, nil); err != nil {
 		t.Fatalf("create tx: %v", err)
 	}
-	if err := p.CreateTx(ctx, userID, "TEST2", "A", &apiv1.Tx{
+	if err := p.CreateTx(ctx, userID, "TEST2", "A", "", &apiv1.Tx{
 		Timestamp: ts(2024, 2, 10), InstrumentDescription: "HSBC", Type: apiv1.TxType_SELLSTOCK, Quantity: -5, Account: "A",
 	}, gbpInst, nil); err != nil {
 		t.Fatalf("create tx: %v", err)
 	}
-	if err := p.CreateTx(ctx, userID, "TEST3", "A", &apiv1.Tx{
+	if err := p.CreateTx(ctx, userID, "TEST3", "A", "", &apiv1.Tx{
 		Timestamp: ts(2024, 1, 10), InstrumentDescription: "AAPL-FX", Type: apiv1.TxType_BUYSTOCK, Quantity: 20, Account: "A",
 	}, usdInst, nil); err != nil {
 		t.Fatalf("create tx: %v", err)
 	}
-	if err := p.CreateTx(ctx, userID, "TEST3", "A", &apiv1.Tx{
+	if err := p.CreateTx(ctx, userID, "TEST3", "A", "", &apiv1.Tx{
 		Timestamp: ts(2024, 2, 10), InstrumentDescription: "AAPL-FX", Type: apiv1.TxType_SELLSTOCK, Quantity: -20, Account: "A",
 	}, usdInst, nil); err != nil {
 		t.Fatalf("create tx: %v", err)
@@ -1034,12 +1034,12 @@ func TestFXGaps_MultipleInstrumentsSameCurrency(t *testing.T) {
 		{Timestamp: ts(2024, 1, 5), InstrumentDescription: "SAP-M1", Type: apiv1.TxType_BUYSTOCK, Quantity: 10, Account: "A"},
 		{Timestamp: ts(2024, 1, 20), InstrumentDescription: "SAP-M1", Type: apiv1.TxType_SELLSTOCK, Quantity: -10, Account: "A"},
 	})
-	if err := p.CreateTx(ctx, userID, "TEST2", "A", &apiv1.Tx{
+	if err := p.CreateTx(ctx, userID, "TEST2", "A", "", &apiv1.Tx{
 		Timestamp: ts(2024, 1, 15), InstrumentDescription: "BMW-M1", Type: apiv1.TxType_BUYSTOCK, Quantity: 5, Account: "A",
 	}, eurInst2, nil); err != nil {
 		t.Fatalf("create tx: %v", err)
 	}
-	if err := p.CreateTx(ctx, userID, "TEST2", "A", &apiv1.Tx{
+	if err := p.CreateTx(ctx, userID, "TEST2", "A", "", &apiv1.Tx{
 		Timestamp: ts(2024, 1, 30), InstrumentDescription: "BMW-M1", Type: apiv1.TxType_SELLSTOCK, Quantity: -5, Account: "A",
 	}, eurInst2, nil); err != nil {
 		t.Fatalf("create tx: %v", err)
@@ -1136,12 +1136,12 @@ func TestFXGaps_DisplayCurrency_MixedHoldings(t *testing.T) {
 		{Timestamp: ts(2024, 1, 10), InstrumentDescription: "HSBC-DC", Type: apiv1.TxType_BUYSTOCK, Quantity: 5, Account: "A"},
 		{Timestamp: ts(2024, 1, 20), InstrumentDescription: "HSBC-DC", Type: apiv1.TxType_SELLSTOCK, Quantity: -5, Account: "A"},
 	})
-	if err := p.CreateTx(ctx, userID, "TEST2", "A", &apiv1.Tx{
+	if err := p.CreateTx(ctx, userID, "TEST2", "A", "", &apiv1.Tx{
 		Timestamp: ts(2024, 2, 1), InstrumentDescription: "AAPL-DC2", Type: apiv1.TxType_BUYSTOCK, Quantity: 10, Account: "A",
 	}, usdInst, nil); err != nil {
 		t.Fatalf("create tx: %v", err)
 	}
-	if err := p.CreateTx(ctx, userID, "TEST2", "A", &apiv1.Tx{
+	if err := p.CreateTx(ctx, userID, "TEST2", "A", "", &apiv1.Tx{
 		Timestamp: ts(2024, 2, 10), InstrumentDescription: "AAPL-DC2", Type: apiv1.TxType_SELLSTOCK, Quantity: -10, Account: "A",
 	}, usdInst, nil); err != nil {
 		t.Fatalf("create tx: %v", err)

--- a/server/db/postgres/txs.go
+++ b/server/db/postgres/txs.go
@@ -13,11 +13,31 @@ import (
 
 var psql = sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
 
+// insertPostingSQL inserts a tx as the single posting of a new tx group. The group
+// is created in the same statement so that grouping costs no extra round trip.
+// split_adjusted_quantity / split_adjusted_unit_price are omitted deliberately:
+// default_split_adjusted_tx() seeds them from the raw columns.
+const insertPostingSQL = `
+	WITH g AS (
+		INSERT INTO tx_groups (user_id, timestamp, job_id)
+		VALUES ($1, $4, $13)
+		RETURNING id
+	)
+	INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type,
+	                 quantity, trading_currency, settlement_currency, unit_price,
+	                 instrument_id, share_count_basis, group_id)
+	SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::date, g.id FROM g
+`
+
 // ReplaceTxsInPeriod implements db.TxDB.
-func (p *Postgres) ReplaceTxsInPeriod(ctx context.Context, userID, broker string, periodFrom, periodBefore *timestamppb.Timestamp, txs []*apiv1.Tx, instrumentIDs []string, shareCountBasis *time.Time) error {
+func (p *Postgres) ReplaceTxsInPeriod(ctx context.Context, userID, broker, jobID string, periodFrom, periodBefore *timestamppb.Timestamp, txs []*apiv1.Tx, instrumentIDs []string, shareCountBasis *time.Time) error {
 	userUUID, err := uuid.Parse(userID)
 	if err != nil {
 		return fmt.Errorf("invalid user id: %w", err)
+	}
+	jobUUID, err := parseNullUUID(jobID)
+	if err != nil {
+		return fmt.Errorf("invalid job id: %w", err)
 	}
 	if len(instrumentIDs) != len(txs) {
 		return fmt.Errorf("instrumentIDs length %d != txs length %d", len(instrumentIDs), len(txs))
@@ -31,17 +51,36 @@ func (p *Postgres) ReplaceTxsInPeriod(ctx context.Context, userID, broker string
 		if err != nil {
 			return fmt.Errorf("period_before: %w", err)
 		}
+		// Delete whole groups and let the FK cascade take their postings, so that a
+		// replace can never leave half an economic event behind.
 		// Synthetic txs (e.g. INITIALIZE rows backing holding declarations) are
-		// managed by the declaration / recalc machinery, not by ingestion. Skip
-		// them here so a bulk replace cannot collaterally delete them.
+		// managed by the declaration / recalc machinery, not by ingestion. Their
+		// groups never match here, so a bulk replace cannot collaterally delete them.
+		_, err = exec.ExecContext(ctx, `
+			DELETE FROM tx_groups g
+			WHERE g.user_id = $1
+			  AND EXISTS (
+			    SELECT 1 FROM txs t
+			    WHERE t.group_id = g.id
+			      AND t.broker = $2
+			      AND t.timestamp >= $3 AND t.timestamp < $4
+			      AND t.synthetic_purpose IS NULL
+			  )
+		`, userUUID, broker, fromT, beforeT)
+		if err != nil {
+			return fmt.Errorf("delete tx groups in period: %w", err)
+		}
+		// Postings written without a group (raw-SQL test fixtures) have no group to
+		// cascade from and are cleared directly.
 		_, err = exec.ExecContext(ctx, `
 			DELETE FROM txs
 			WHERE user_id = $1 AND broker = $2
 			  AND timestamp >= $3 AND timestamp < $4
 			  AND synthetic_purpose IS NULL
+			  AND group_id IS NULL
 		`, userUUID, broker, fromT, beforeT)
 		if err != nil {
-			return fmt.Errorf("delete txs in period: %w", err)
+			return fmt.Errorf("delete ungrouped txs in period: %w", err)
 		}
 		for i, t := range txs {
 			instUUID, err := uuid.Parse(instrumentIDs[i])
@@ -57,10 +96,10 @@ func (p *Postgres) ReplaceTxsInPeriod(ctx context.Context, userID, broker string
 				return err
 			}
 			acc := t.GetAccount()
-			_, err = exec.ExecContext(ctx, `
-				INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type, quantity, trading_currency, settlement_currency, unit_price, instrument_id, share_count_basis)
-				VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::date)
-			`, userUUID, broker, acc, ts, t.InstrumentDescription, txTypeStr, t.Quantity, nullStr(t.TradingCurrency), nullStr(t.SettlementCurrency), nullFloat(t.UnitPrice), instUUID, shareCountBasis)
+			_, err = exec.ExecContext(ctx, insertPostingSQL,
+				userUUID, broker, acc, ts, t.InstrumentDescription, txTypeStr, t.Quantity,
+				nullStr(t.TradingCurrency), nullStr(t.SettlementCurrency), nullFloat(t.UnitPrice),
+				instUUID, shareCountBasis, jobUUID)
 			if err != nil {
 				return fmt.Errorf("insert tx: %w", err)
 			}
@@ -70,7 +109,7 @@ func (p *Postgres) ReplaceTxsInPeriod(ctx context.Context, userID, broker string
 }
 
 // CreateTx implements db.TxDB.
-func (p *Postgres) CreateTx(ctx context.Context, userID, broker, account string, tx *apiv1.Tx, instrumentID string, shareCountBasis *time.Time) error {
+func (p *Postgres) CreateTx(ctx context.Context, userID, broker, account, jobID string, tx *apiv1.Tx, instrumentID string, shareCountBasis *time.Time) error {
 	userUUID, err := uuid.Parse(userID)
 	if err != nil {
 		return fmt.Errorf("invalid user id: %w", err)
@@ -78,6 +117,10 @@ func (p *Postgres) CreateTx(ctx context.Context, userID, broker, account string,
 	instUUID, err := uuid.Parse(instrumentID)
 	if err != nil {
 		return fmt.Errorf("invalid instrument id: %w", err)
+	}
+	jobUUID, err := parseNullUUID(jobID)
+	if err != nil {
+		return fmt.Errorf("invalid job id: %w", err)
 	}
 	ts, err := tsToTime(tx.Timestamp)
 	if err != nil {
@@ -87,10 +130,10 @@ func (p *Postgres) CreateTx(ctx context.Context, userID, broker, account string,
 	if err != nil {
 		return err
 	}
-	_, err = p.q.ExecContext(ctx, `
-		INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type, quantity, trading_currency, settlement_currency, unit_price, instrument_id, share_count_basis)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::date)
-	`, userUUID, broker, account, ts, tx.InstrumentDescription, txTypeStr, tx.Quantity, nullStr(tx.TradingCurrency), nullStr(tx.SettlementCurrency), nullFloat(tx.UnitPrice), instUUID, shareCountBasis)
+	_, err = p.q.ExecContext(ctx, insertPostingSQL,
+		userUUID, broker, account, ts, tx.InstrumentDescription, txTypeStr, tx.Quantity,
+		nullStr(tx.TradingCurrency), nullStr(tx.SettlementCurrency), nullFloat(tx.UnitPrice),
+		instUUID, shareCountBasis, jobUUID)
 	if err != nil {
 		return fmt.Errorf("create tx: %w", err)
 	}

--- a/server/db/postgres/txs_test.go
+++ b/server/db/postgres/txs_test.go
@@ -29,7 +29,7 @@ func TestReplaceTxsInPeriod_and_ComputeHoldings(t *testing.T) {
 		t.Fatalf("ensure instrument: %v", err)
 	}
 	instrumentIDs := []string{instID, instID}
-	err = p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, instrumentIDs, nil)
+	err = p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, instrumentIDs, nil)
 	if err != nil {
 		t.Fatalf("replace: %v", err)
 	}
@@ -71,14 +71,14 @@ func TestReplaceTxsInPeriod_PeriodBeforeIsExclusive(t *testing.T) {
 		{boundary, 2},
 	} {
 		tx := &apiv1.Tx{Timestamp: timestamppb.New(seed.at), InstrumentDescription: "BND", Type: apiv1.TxType_BUYSTOCK, Quantity: seed.qty, Account: ""}
-		if err := p.CreateTx(ctx, userID, "IBKR", "", tx, instID, nil); err != nil {
+		if err := p.CreateTx(ctx, userID, "IBKR", "", "", tx, instID, nil); err != nil {
 			t.Fatalf("create tx: %v", err)
 		}
 	}
 
 	// Replacing [March 1, April 1) with nothing must delete only the earlier row:
 	// a window abutting the next one must not reach into it.
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR",
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "",
 		timestamppb.New(time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)), timestamppb.New(boundary),
 		nil, nil, nil); err != nil {
 		t.Fatalf("replace: %v", err)
@@ -117,7 +117,7 @@ func TestReplaceTxsInPeriod_PreservesSyntheticInitializeTx(t *testing.T) {
 	oldTx := []*apiv1.Tx{
 		{Timestamp: timestamppb.New(now.Add(-80 * time.Minute)), InstrumentDescription: "MSFT", Type: apiv1.TxType_BUYSTOCK, Quantity: 5, Account: ""},
 	}
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, oldTx, []string{instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, oldTx, []string{instID}, nil); err != nil {
 		t.Fatalf("seed real tx: %v", err)
 	}
 
@@ -126,7 +126,7 @@ func TestReplaceTxsInPeriod_PreservesSyntheticInitializeTx(t *testing.T) {
 		{Timestamp: timestamppb.New(now.Add(-60 * time.Minute)), InstrumentDescription: "MSFT", Type: apiv1.TxType_BUYSTOCK, Quantity: 7, Account: ""},
 		{Timestamp: timestamppb.New(now.Add(-20 * time.Minute)), InstrumentDescription: "MSFT", Type: apiv1.TxType_SELLSTOCK, Quantity: -2, Account: ""},
 	}
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, newTxs, []string{instID, instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, newTxs, []string{instID, instID}, nil); err != nil {
 		t.Fatalf("replace: %v", err)
 	}
 
@@ -161,6 +161,140 @@ func TestReplaceTxsInPeriod_PreservesSyntheticInitializeTx(t *testing.T) {
 	if sawOldBuy {
 		t.Error("old real tx survived ReplaceTxsInPeriod")
 	}
+	// The synthetic posting's group must survive with it. Deleting by group is
+	// what makes replace-by-period safe, so a group that outlives its posting or
+	// a posting that outlives its group both break the invariant.
+	if got := countGroups(t, p, userID); got != 3 {
+		t.Errorf("tx_groups after replace: want 3 (2 new + 1 synthetic), got %d", got)
+	}
+	if got := countOrphanGroups(t, p, userID); got != 0 {
+		t.Errorf("orphan tx_groups after replace: want 0, got %d", got)
+	}
+}
+
+// countGroups returns the number of tx_groups rows for a user.
+func countGroups(t *testing.T, p *Postgres, userID string) int {
+	t.Helper()
+	var n int
+	if err := p.q.QueryRowContext(context.Background(),
+		`SELECT count(*) FROM tx_groups WHERE user_id = $1`, userID).Scan(&n); err != nil {
+		t.Fatalf("count groups: %v", err)
+	}
+	return n
+}
+
+// countOrphanGroups returns the number of a user's tx_groups with no postings.
+func countOrphanGroups(t *testing.T, p *Postgres, userID string) int {
+	t.Helper()
+	var n int
+	if err := p.q.QueryRowContext(context.Background(), `
+		SELECT count(*) FROM tx_groups g
+		WHERE g.user_id = $1 AND NOT EXISTS (SELECT 1 FROM txs t WHERE t.group_id = g.id)
+	`, userID).Scan(&n); err != nil {
+		t.Fatalf("count orphan groups: %v", err)
+	}
+	return n
+}
+
+func TestCreateTx_CreatesGroup(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|grp-create", "U", "u@grp.com")
+	instID, err := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "NVDA", Canonical: false}}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+	jobID, err := p.CreateJob(ctx, db.CreateJobParams{UserID: userID, JobType: "tx", Broker: "IBKR", Source: "IBKR:test:csv"})
+	if err != nil {
+		t.Fatalf("create job: %v", err)
+	}
+	at := time.Date(2025, 6, 2, 14, 30, 0, 0, time.UTC)
+	tx := &apiv1.Tx{Timestamp: timestamppb.New(at), InstrumentDescription: "NVDA", Type: apiv1.TxType_BUYSTOCK, Quantity: 4, Account: "A"}
+	if err := p.CreateTx(ctx, userID, "IBKR", "A", jobID, tx, instID, nil); err != nil {
+		t.Fatalf("create tx: %v", err)
+	}
+
+	var groupTs time.Time
+	var groupJob string
+	err = p.q.QueryRowContext(ctx, `
+		SELECT g.timestamp, g.job_id FROM txs t JOIN tx_groups g ON g.id = t.group_id
+		WHERE t.user_id = $1
+	`, userID).Scan(&groupTs, &groupJob)
+	if err != nil {
+		t.Fatalf("read group: %v", err)
+	}
+	if !groupTs.Equal(at) {
+		t.Errorf("group timestamp: want %v, got %v", at, groupTs)
+	}
+	if groupJob != jobID {
+		t.Errorf("group job_id: want %q, got %q", jobID, groupJob)
+	}
+}
+
+func TestReplaceTxsInPeriod_CreatesGroupPerTx(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|grp-per-tx", "U", "u@grp2.com")
+	instID, err := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "TSLA", Canonical: false}}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+	base := time.Date(2025, 5, 1, 0, 0, 0, 0, time.UTC)
+	txs := []*apiv1.Tx{
+		{Timestamp: timestamppb.New(base.Add(time.Hour)), InstrumentDescription: "TSLA", Type: apiv1.TxType_BUYSTOCK, Quantity: 1, Account: ""},
+		{Timestamp: timestamppb.New(base.Add(2 * time.Hour)), InstrumentDescription: "TSLA", Type: apiv1.TxType_BUYSTOCK, Quantity: 2, Account: ""},
+		{Timestamp: timestamppb.New(base.Add(3 * time.Hour)), InstrumentDescription: "TSLA", Type: apiv1.TxType_SELLSTOCK, Quantity: -1, Account: ""},
+	}
+	from, to := timestamppb.New(base), timestamppb.New(base.Add(24*time.Hour))
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID, instID, instID}, nil); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+
+	var distinct, withGroup int
+	if err := p.q.QueryRowContext(ctx,
+		`SELECT count(DISTINCT group_id), count(group_id) FROM txs WHERE user_id = $1`, userID).
+		Scan(&distinct, &withGroup); err != nil {
+		t.Fatalf("count groups: %v", err)
+	}
+	if withGroup != 3 {
+		t.Errorf("postings with a group: want 3, got %d", withGroup)
+	}
+	if distinct != 3 {
+		t.Errorf("distinct groups: want 3 (one per posting), got %d", distinct)
+	}
+}
+
+func TestReplaceTxsInPeriod_DeletesGroupsInPeriod(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|grp-replace", "U", "u@grp3.com")
+	instID, err := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "AMD", Canonical: false}}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+	base := time.Date(2025, 7, 1, 0, 0, 0, 0, time.UTC)
+	from, to := timestamppb.New(base), timestamppb.New(base.Add(24*time.Hour))
+	seed := []*apiv1.Tx{
+		{Timestamp: timestamppb.New(base.Add(time.Hour)), InstrumentDescription: "AMD", Type: apiv1.TxType_BUYSTOCK, Quantity: 1, Account: ""},
+		{Timestamp: timestamppb.New(base.Add(2 * time.Hour)), InstrumentDescription: "AMD", Type: apiv1.TxType_BUYSTOCK, Quantity: 2, Account: ""},
+	}
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, seed, []string{instID, instID}, nil); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	replacement := []*apiv1.Tx{
+		{Timestamp: timestamppb.New(base.Add(3 * time.Hour)), InstrumentDescription: "AMD", Type: apiv1.TxType_BUYSTOCK, Quantity: 9, Account: ""},
+	}
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, replacement, []string{instID}, nil); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+
+	// The replaced groups must go with their postings rather than accumulating.
+	if got := countGroups(t, p, userID); got != 1 {
+		t.Errorf("tx_groups after replace: want 1, got %d", got)
+	}
+	if got := countOrphanGroups(t, p, userID); got != 0 {
+		t.Errorf("orphan tx_groups after replace: want 0, got %d", got)
+	}
 }
 
 func TestCreateTx_AppendOnly(t *testing.T) {
@@ -175,10 +309,10 @@ func TestCreateTx_AppendOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ensure instrument: %v", err)
 	}
-	if err := p.CreateTx(ctx, userID, "IBKR", "", tx1, instID, nil); err != nil {
+	if err := p.CreateTx(ctx, userID, "IBKR", "", "", tx1, instID, nil); err != nil {
 		t.Fatalf("first create: %v", err)
 	}
-	if err := p.CreateTx(ctx, userID, "IBKR", "", tx2, instID, nil); err != nil {
+	if err := p.CreateTx(ctx, userID, "IBKR", "", "", tx2, instID, nil); err != nil {
 		t.Fatalf("second create: %v", err)
 	}
 	holdings, _, _ := p.ComputeHoldings(ctx, userID, nil, "", nil)
@@ -216,7 +350,7 @@ func TestListTxs_BrokerFilterAndOrder(t *testing.T) {
 			t.Fatalf("broker to str: %v", err)
 		}
 		tx := &apiv1.Tx{Timestamp: timestamppb.New(now.Add(s.offset)), InstrumentDescription: "ORD", Type: apiv1.TxType_BUYSTOCK, Quantity: s.qty}
-		if err := p.CreateTx(ctx, userID, brokerStr, "", tx, instID, nil); err != nil {
+		if err := p.CreateTx(ctx, userID, brokerStr, "", "", tx, instID, nil); err != nil {
 			t.Fatalf("create tx: %v", err)
 		}
 	}
@@ -291,7 +425,7 @@ func TestListTxs_PeriodBeforeIsExclusive(t *testing.T) {
 		{boundary, 2},
 	} {
 		tx := &apiv1.Tx{Timestamp: timestamppb.New(seed.at), InstrumentDescription: "PER", Type: apiv1.TxType_BUYSTOCK, Quantity: seed.qty}
-		if err := p.CreateTx(ctx, userID, brokerStr, "", tx, instID, nil); err != nil {
+		if err := p.CreateTx(ctx, userID, brokerStr, "", "", tx, instID, nil); err != nil {
 			t.Fatalf("create tx: %v", err)
 		}
 	}
@@ -323,7 +457,7 @@ func TestListTxs_TiedTimestampsPageBoundary(t *testing.T) {
 	const total = 6
 	for i := 0; i < total; i++ {
 		tx := &apiv1.Tx{Timestamp: ts, InstrumentDescription: "TIE", Type: apiv1.TxType_BUYSTOCK, Quantity: float64(i + 1)}
-		if err := p.CreateTx(ctx, userID, "IBKR", "", tx, instID, nil); err != nil {
+		if err := p.CreateTx(ctx, userID, "IBKR", "", "", tx, instID, nil); err != nil {
 			t.Fatalf("create tx %d: %v", i, err)
 		}
 	}
@@ -404,7 +538,7 @@ func TestListTxsByPortfolio_ComputeHoldingsForPortfolio(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ensure instrument: %v", err)
 	}
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txList, []string{instID, instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txList, []string{instID, instID}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 	txs, tok, err = p.ListTxsByPortfolio(ctx, port.GetId(), nil, nil, nil, false, 50, "")
@@ -456,15 +590,15 @@ func TestListTxsByPortfolio_ANDBetweenCategories(t *testing.T) {
 		t.Fatalf("ensure instrument: %v", err)
 	}
 	// Tx1: IBKR, account "B" -> matches broker but NOT account -> excluded
-	if err := p.CreateTx(ctx, userID, "IBKR", "B", &apiv1.Tx{Timestamp: ts, InstrumentDescription: "X", Type: apiv1.TxType_BUYSTOCK, Quantity: 1, Account: "B"}, instID, nil); err != nil {
+	if err := p.CreateTx(ctx, userID, "IBKR", "B", "", &apiv1.Tx{Timestamp: ts, InstrumentDescription: "X", Type: apiv1.TxType_BUYSTOCK, Quantity: 1, Account: "B"}, instID, nil); err != nil {
 		t.Fatalf("create tx1: %v", err)
 	}
 	// Tx2: SCHB, account "A" -> matches account but NOT broker -> excluded
-	if err := p.CreateTx(ctx, userID, "SCHB", "A", &apiv1.Tx{Timestamp: ts, InstrumentDescription: "X", Type: apiv1.TxType_BUYSTOCK, Quantity: 2, Account: "A"}, instID, nil); err != nil {
+	if err := p.CreateTx(ctx, userID, "SCHB", "A", "", &apiv1.Tx{Timestamp: ts, InstrumentDescription: "X", Type: apiv1.TxType_BUYSTOCK, Quantity: 2, Account: "A"}, instID, nil); err != nil {
 		t.Fatalf("create tx2: %v", err)
 	}
 	// Tx3: IBKR, account "A" -> matches both -> included
-	if err := p.CreateTx(ctx, userID, "IBKR", "A", &apiv1.Tx{Timestamp: ts, InstrumentDescription: "X", Type: apiv1.TxType_BUYSTOCK, Quantity: 3, Account: "A"}, instID, nil); err != nil {
+	if err := p.CreateTx(ctx, userID, "IBKR", "A", "", &apiv1.Tx{Timestamp: ts, InstrumentDescription: "X", Type: apiv1.TxType_BUYSTOCK, Quantity: 3, Account: "A"}, instID, nil); err != nil {
 		t.Fatalf("create tx3: %v", err)
 	}
 	txs, _, err := p.ListTxsByPortfolio(ctx, port.GetId(), nil, nil, nil, false, 50, "")

--- a/server/db/postgres/valuation_test.go
+++ b/server/db/postgres/valuation_test.go
@@ -34,7 +34,7 @@ func TestGetPortfolioValuation_Basic(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -139,7 +139,7 @@ func TestGetPortfolioValuation_DifferentDescriptionsNetToZero(t *testing.T) {
 	}
 	from := timestamppb.New(transferDate.Add(-1 * time.Hour))
 	to := timestamppb.New(sellDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{instID, instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID, instID}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -208,7 +208,7 @@ func TestGetPortfolioValuation_UnpricedDeduplication(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{instID, instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID, instID}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -255,7 +255,7 @@ func TestGetPortfolioValuation_MultipleInstruments(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{instA, instB}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instA, instB}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -303,7 +303,7 @@ func TestGetUserValuation_Basic(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -380,7 +380,7 @@ func TestGetPortfolioValuation_ExcludesDateBefore(t *testing.T) {
 	txs := []*apiv1.Tx{
 		{Timestamp: timestamppb.New(buyDate), InstrumentDescription: "AAPL Corp", Type: apiv1.TxType_BUYSTOCK, Quantity: 10, Account: "main"},
 	}
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", timestamppb.New(buyDate.Add(-time.Hour)), timestamppb.New(buyDate.Add(time.Hour)), txs, []string{instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", timestamppb.New(buyDate.Add(-time.Hour)), timestamppb.New(buyDate.Add(time.Hour)), txs, []string{instID}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 	prices := []db.EODPrice{
@@ -424,7 +424,7 @@ func TestGetPortfolioValuation_FromEqualsBeforeReturnsNothing(t *testing.T) {
 	txs := []*apiv1.Tx{
 		{Timestamp: timestamppb.New(buyDate), InstrumentDescription: "AAPL Corp", Type: apiv1.TxType_BUYSTOCK, Quantity: 10, Account: "main"},
 	}
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", timestamppb.New(buyDate.Add(-time.Hour)), timestamppb.New(buyDate.Add(time.Hour)), txs, []string{instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", timestamppb.New(buyDate.Add(-time.Hour)), timestamppb.New(buyDate.Add(time.Hour)), txs, []string{instID}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 	if err := p.UpsertPrices(ctx, []db.EODPrice{
@@ -474,7 +474,7 @@ func TestGetUserValuation_FXConversion_DisplayUSD(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -529,7 +529,7 @@ func TestGetUserValuation_FXConversion_CrossRate(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -583,7 +583,7 @@ func TestGetUserValuation_FXConversion_MissingRate(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -635,7 +635,7 @@ func TestGetUserValuation_FXConversion_USDDisplayNonUSD(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -688,7 +688,7 @@ func TestGetUserValuation_FXConversion_MissingBaseRate(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -752,7 +752,7 @@ func TestGetUserValuation_CashInDisplayCurrency(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{usdInstID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{usdInstID}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -804,7 +804,7 @@ func TestGetUserValuation_CashInForeignCurrency(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{gbpInstID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{gbpInstID}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -845,7 +845,7 @@ func TestGetUserValuation_CashForeignMissingFXRate(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{gbpInstID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{gbpInstID}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -906,7 +906,7 @@ func TestGetUserValuation_CashForeignCurrency_NonUSDDisplay(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", from, to, txs, []string{eurInstID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{eurInstID}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -957,7 +957,7 @@ func TestGetUserValuation_ContinuousAcrossSplit(t *testing.T) {
 		{Timestamp: timestamppb.New(buyDate), InstrumentDescription: "AAPL Split", Type: apiv1.TxType_BUYSTOCK, Quantity: 100, Account: "main"},
 	}
 	if err := p.ReplaceTxsInPeriod(ctx, userID,
-		"IBKR", timestamppb.New(buyDate.Add(-time.Hour)), timestamppb.New(buyDate.Add(time.Hour)),
+		"IBKR", "", timestamppb.New(buyDate.Add(-time.Hour)), timestamppb.New(buyDate.Add(time.Hour)),
 		txs, []string{instID}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
@@ -1019,7 +1019,7 @@ func TestGetUserValuation_FXUnaffectedByASplit(t *testing.T) {
 	txs := []*apiv1.Tx{
 		{Timestamp: timestamppb.New(buyDate), InstrumentDescription: "SAP FXSplit", Type: apiv1.TxType_BUYSTOCK, Quantity: 100, Account: "main"},
 	}
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR",
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "",
 		timestamppb.New(buyDate.Add(-time.Hour)), timestamppb.New(buyDate.Add(time.Hour)),
 		txs, []string{instID}, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -37,8 +37,31 @@ CREATE TABLE portfolio_filters (
 
 CREATE INDEX idx_portfolio_filters_portfolio ON portfolio_filters (portfolio_id);
 
+-- A tx_group is one economic event; the txs referencing it are its postings.
+-- timestamp is the event date; the postings carry the amounts and accounts.
+-- job_id is the ingestion job that created the group, and is NULL for
+-- system-generated groups such as the one backing an INITIALIZE posting.
+-- It is deliberately not a foreign key: a group must outlive its job, and if job
+-- rows are ever pruned by age the id still distinguishes one creation from another
+-- and still groups everything written by the same upload.
+-- Groups hold a single posting until ingestion emits grouped legs, at which point
+-- the postings of a group are required to sum to zero.
+-- See docs/spec/postings.md.
+CREATE TABLE tx_groups (
+  id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id    UUID NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+  timestamp  TIMESTAMPTZ NOT NULL,
+  job_id     UUID,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX idx_tx_groups_user_time ON tx_groups (user_id, timestamp);
+CREATE INDEX idx_tx_groups_job_id ON tx_groups (job_id);
+
 -- Transactions. No natural key (broker statements often supply date only). Bulk idempotency
 -- by replace-by-period (user_id, broker, period). Single-tx ingestion is append-only.
+-- group_id is the economic event this row is a posting of. Deleting a group deletes
+-- its postings, which makes the group the unit of deletion for replace-by-period.
 -- share_count_basis is the date at which the share count the raw quantity and
 -- unit_price are denominated in was current. It defaults to timestamp::date --
 -- the as-traded assumption, that a broker log line accounts only for events
@@ -66,10 +89,12 @@ CREATE TABLE txs (
   split_adjusted_unit_price DOUBLE PRECISION,
   share_count_basis         DATE NOT NULL,
   synthetic_purpose         TEXT CHECK (synthetic_purpose IS NULL OR synthetic_purpose = 'INITIALIZE'),
+  group_id                  UUID REFERENCES tx_groups (id) ON DELETE CASCADE,
   created_at                TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
 CREATE INDEX idx_txs_user_broker_time ON txs (user_id, broker, timestamp);
+CREATE INDEX idx_txs_group_id ON txs (group_id);
 
 -- Async ingestion jobs. status and validation_errors surfaced via front-end API.
 -- job_type distinguishes tx uploads from price imports; broker/source are tx-specific.

--- a/server/service/ingestion/worker.go
+++ b/server/service/ingestion/worker.go
@@ -237,9 +237,9 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 	// Store transactions.
 	var storeErr error
 	if bulk {
-		storeErr = database.ReplaceTxsInPeriod(ctx, userID, broker, req.PeriodFrom, req.PeriodBefore, txsToProcess, instrumentIDs, shareCountBasis)
+		storeErr = database.ReplaceTxsInPeriod(ctx, userID, broker, j.JobID, req.PeriodFrom, req.PeriodBefore, txsToProcess, instrumentIDs, shareCountBasis)
 	} else {
-		storeErr = database.CreateTx(ctx, userID, broker, txsToProcess[0].GetAccount(), txsToProcess[0], instrumentIDs[0], shareCountBasis)
+		storeErr = database.CreateTx(ctx, userID, broker, txsToProcess[0].GetAccount(), j.JobID, txsToProcess[0], instrumentIDs[0], shareCountBasis)
 	}
 	if storeErr != nil {
 		log.Printf("ingestion job %s: %v", j.JobID, storeErr)

--- a/server/service/ingestion/worker_test.go
+++ b/server/service/ingestion/worker_test.go
@@ -94,7 +94,7 @@ func TestProcessBulk_AppendsIdentificationErrorsWhenBrokerDescriptionOnly(t *tes
 		ListInstrumentsByIDs(gomock.Any(), []string{"broker-only-id"}).
 		Return([]*db.InstrumentRow{{ID: "broker-only-id"}}, nil)
 	database.EXPECT().
-		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", gomock.Any(), gomock.Any(), gomock.Any(), []string{"broker-only-id"}, gomock.Any()).
+		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", "job-1", gomock.Any(), gomock.Any(), gomock.Any(), []string{"broker-only-id"}, gomock.Any()).
 		Return(nil)
 	database.EXPECT().
 		InstrumentsWithSplits(gomock.Any(), gomock.Any()).
@@ -156,7 +156,7 @@ func TestProcessBulk_BatchCache_ResolvesSameDescriptionOnce(t *testing.T) {
 		ListInstrumentsByIDs(gomock.Any(), []string{"cached-inst-id"}).
 		Return([]*db.InstrumentRow{{ID: "cached-inst-id"}}, nil)
 	database.EXPECT().
-		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", gomock.Any(), gomock.Any(), gomock.Any(), []string{"cached-inst-id", "cached-inst-id"}, gomock.Any()).
+		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", "job-2", gomock.Any(), gomock.Any(), gomock.Any(), []string{"cached-inst-id", "cached-inst-id"}, gomock.Any()).
 		Return(nil)
 	database.EXPECT().
 		InstrumentsWithSplits(gomock.Any(), gomock.Any()).
@@ -218,8 +218,8 @@ func TestProcessBulk_DropsTxTypeSplitTransactions(t *testing.T) {
 		ListInstrumentsByIDs(gomock.Any(), []string{"aapl-id"}).
 		Return([]*db.InstrumentRow{{ID: "aapl-id"}}, nil)
 	database.EXPECT().
-		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", gomock.Any(), gomock.Any(), gomock.Len(1), []string{"aapl-id"}, gomock.Any()).
-		DoAndReturn(func(_ context.Context, _, _ string, _, _ *timestamppb.Timestamp, storedTxs []*apiv1.Tx, ids []string, _ *time.Time) error {
+		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", "job-split", gomock.Any(), gomock.Any(), gomock.Len(1), []string{"aapl-id"}, gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _ string, _, _ *timestamppb.Timestamp, storedTxs []*apiv1.Tx, ids []string, _ *time.Time) error {
 			if len(storedTxs) != 1 || storedTxs[0].InstrumentDescription != "AAPL" || storedTxs[0].Type != apiv1.TxType_BUYSTOCK {
 				t.Errorf("ReplaceTxsInPeriod called with %d txs, expected 1 (AAPL BUYSTOCK)", len(storedTxs))
 			}
@@ -358,7 +358,7 @@ func TestProcessBulk_StockEtfEquivalence(t *testing.T) {
 		ListInstrumentsByIDs(gomock.Any(), []string{"spy-etf-id"}).
 		Return([]*db.InstrumentRow{{ID: "spy-etf-id", AssetClass: strPtr(db.AssetClassETF)}}, nil)
 	database.EXPECT().
-		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", gomock.Any(), gomock.Any(), gomock.Any(), []string{"spy-etf-id"}, gomock.Any()).
+		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", "job-etf", gomock.Any(), gomock.Any(), gomock.Any(), []string{"spy-etf-id"}, gomock.Any()).
 		Return(nil)
 	database.EXPECT().
 		InstrumentsWithSplits(gomock.Any(), gomock.Any()).
@@ -532,7 +532,7 @@ func TestProcessBulk_TransferToStockAllowed(t *testing.T) {
 		ListInstrumentsByIDs(gomock.Any(), []string{"msft-id"}).
 		Return([]*db.InstrumentRow{{ID: "msft-id", AssetClass: strPtr(db.AssetClassStock)}}, nil)
 	database.EXPECT().
-		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", gomock.Any(), gomock.Any(), gomock.Any(), []string{"msft-id"}, gomock.Any()).
+		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", "job-transfer-stock", gomock.Any(), gomock.Any(), gomock.Any(), []string{"msft-id"}, gomock.Any()).
 		Return(nil)
 	database.EXPECT().
 		InstrumentsWithSplits(gomock.Any(), gomock.Any()).


### PR DESCRIPTION
Adds the `tx_groups` parent table and a nullable `txs.group_id`, so the legs of one economic event can be grouped. Closes 0036.

Each tx becomes the single posting of its own group -- what is stored is unchanged, and holdings, valuation, price coverage and declarations all still aggregate `SUM(quantity)` by instrument. All three write paths populate `group_id`, so there is no window where the column is dead.

## Notable choices

**The group is the unit of deletion.** Replace-by-period deletes the groups whose postings fall in the period and lets the FK cascade take the postings, so a replace can never leave half an event behind. Synthetic INITIALIZE postings carry `synthetic_purpose`, so their groups never match and still survive a bulk replace. `UpsertInitializeTx` moved off `ON CONFLICT DO UPDATE` and updates its posting and group in place -- the CTE form would have inserted an orphan group on every declaration recalc.

**`job_id` is not a foreign key.** It records the ingestion job that created the group. Nothing prunes `ingestion_jobs` today, but if age-based pruning is added later, `ON DELETE SET NULL` would destroy information at exactly the moment it became scarce. Once the job row is gone the id still distinguishes one creation from another and still groups everything written by the same upload.

**`group_id` stays nullable** per the issue. Several db tests insert into `txs` with raw SQL and no group; `NOT NULL` would force churn there for a guarantee 0041 delivers properly.

Schema goes into `001_initial.sql` per the no-new-migrations policy -- **a dev DB must be recreated**.

## Two ADRs

**0020** records the decision to adopt double-entry, which 0036 asked for before this lands.

**0021** records that converters own grouping and the server never derives a leg. This came out of checking the plan against the real Fidelity export: 0038 proposed deriving the cash leg as `-(quantity * unit_price)`, which double-counts, because Fidelity already reports its own cash rows. Measured on the 689-row master, `Sell` pairs with `Cash In From Sell` on exact `|Amount|` 55/55, and `Buy` pairs with `Cash Out For Buy` by nearest reference number 36/36 -- and for all 36 buys the gap is exactly the sum of Fidelity's separately-reported dealing fee, PTM levy and stamp duty rows, which is why fees are postings rather than a CSV column.

That makes 0038 and 0040 stale, so both are amended here rather than left contradicting an ADR in the same tree. 0063 (a `group_ref` on the upload format) and 0064 (Fidelity as the tracer bullet) open the follow-on work.

## Testing

`make test` and `make check` pass. New db-layer tests cover: a group per `CreateTx` with the right timestamp and job id, one group per tx on bulk replace, no orphan groups after a re-replace, the synthetic group surviving a replace, and an INITIALIZE recalc reusing its group rather than orphaning one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)