### PR TITLE
Close 0063: group_ref in the standard upload format

### DIFF
--- a/client/lib/csv/standard.test.ts
+++ b/client/lib/csv/standard.test.ts
@@ -362,3 +362,31 @@ describe("share count basis", () => {
   });
 });
 });
+
+describe("group_ref", () => {
+  it("carries the grouping key onto each posting", () => {
+    const csv = `date,instrument_description,type,quantity,unit_price,account,group_ref
+2024-03-01,VOD - Vodafone,SELLSTOCK,-100,1.25,ACC1,563466569
+2024-03-01,Cash,CASHFLOW,125,1,ACC1,563466569
+2024-03-01,Dealing Fee,INVEXPENSE,-7.5,1,ACC1,`;
+
+    const result = parseStandardCSV(csv);
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.txs).toHaveLength(3);
+    expect(result.txs[0].groupRef).toBe("563466569");
+    expect(result.txs[1].groupRef).toBe("563466569");
+    // A separately-reported charge is its own event, so it names no group.
+    expect(result.txs[2].groupRef).toBe("");
+  });
+
+  it("defaults to empty when the column is absent", () => {
+    const csv = `date,instrument_description,type,quantity
+2024-03-01,AAPL,BUYSTOCK,10`;
+
+    const result = parseStandardCSV(csv);
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.txs[0].groupRef).toBe("");
+  });
+});

--- a/client/lib/csv/standard.ts
+++ b/client/lib/csv/standard.ts
@@ -90,7 +90,8 @@ export function parseCSVLine(line: string): string[] {
 /**
  * Parse standard-format CSV text into Tx array and period.
  * Header names are case-insensitive. Required: date (or timestamp), instrument_description, type, quantity.
- * Optional: trading_currency, settlement_currency, unit_price, account, symbol_type, symbol, exchange_type, exchange.
+ * Optional: trading_currency, settlement_currency, unit_price, account, symbol_type, symbol, exchange_type,
+ * exchange, group_ref.
  */
 export function parseStandardCSV(csvText: string): StandardParseResult {
   const errors: ParseError[] = [];
@@ -138,6 +139,7 @@ export function parseStandardCSV(csvText: string): StandardParseResult {
   const symbolCol = col("symbol");
   const exchangeTypeCol = col("exchange_type");
   const exchangeCol = col("exchange");
+  const groupRefCol = col("group_ref");
 
   if (dateCol < 0) errors.push({ rowIndex: 0, field: "header", message: "Missing required column: date or timestamp" });
   if (descCol < 0) errors.push({ rowIndex: 0, field: "header", message: "Missing required column: instrument_description" });
@@ -191,6 +193,7 @@ export function parseStandardCSV(csvText: string): StandardParseResult {
     }
 
     const account = accountCol >= 0 ? get(accountCol) : "";
+    const groupRef = groupRefCol >= 0 ? get(groupRefCol) : "";
 
     // Parse exchange_type + exchange into a domain for the identifier hint.
     let domain: string | undefined;
@@ -237,6 +240,7 @@ export function parseStandardCSV(csvText: string): StandardParseResult {
         type: txType,
         quantity,
         account,
+        ...(groupRef ? { groupRef } : {}),
         ...(tradingCurrency ? { tradingCurrency } : {}),
         ...(settlementCurrency ? { settlementCurrency } : {}),
         ...(unitPrice !== undefined && !Number.isNaN(unitPrice) ? { unitPrice } : {}),

--- a/docs/issues/0063-group-ref-upload-format.md
+++ b/docs/issues/0063-group-ref-upload-format.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Group reference in the standard upload format
 milestone: M12
 dependencies: [0036]

--- a/docs/spec/csv-format.md
+++ b/docs/spec/csv-format.md
@@ -24,6 +24,19 @@ Header names are case-insensitive. Supported column names:
 | `symbol`                 | No       | Identifier value (e.g. "AAPL", "US0378331005", "AAPL  240119C00185000"). Required when `symbol_type` is present. |
 | `exchange_type`          | No       | Exchange code system: `MIC` (ISO 10383) or `OPENFIGI` (Bloomberg exchange code). Required when `exchange` is present. |
 | `exchange`               | No       | Exchange code value (e.g. "XNAS" for MIC, "US" for OPENFIGI). Populates the domain field on the identifier hint. Required when `exchange_type` is present. |
+| `group_ref`              | No       | Opaque grouping key. Rows sharing a non-empty value are postings of one economic event. See [Transaction groups](#transaction-groups). |
+
+### Transaction groups
+
+Each row is a **posting**: a signed amount of one commodity in one account (see [postings.md](postings.md)). The postings of a single economic event -- a trade and the cash that paid for it -- are grouped by giving them the same `group_ref`. A row with no `group_ref` is its own single-posting group.
+
+`group_ref` is opaque and scoped to one upload. Any value works as long as it is distinct per event within the file; a broker's own order or reference number is the natural choice. It is not stored and carries no meaning across uploads, so re-uploading a period produces new groups.
+
+Grouping is the converter's job. The server persists what it is given: it does not infer a missing leg, pair rows, or fold a fee into a cash amount (see adr/0021-converters-own-transaction-grouping.md).
+
+**Fees are postings, not a column.** A commission, levy or duty is a row with `type=INVEXPENSE` and a negative `quantity` in the settlement currency. Put it in the trade's group when the broker charges it as part of the trade; leave it ungrouped when the broker reports it as a separate cash event on its own date. Where a broker nets commission into a single total and reports no separate charge, the converter derives the fee and emits the row itself.
+
+A group whose postings do not sum to zero is accepted, not rejected. The residual is made visible rather than silently absorbed.
 
 ### Transaction types (type column)
 

--- a/docs/spec/postings.md
+++ b/docs/spec/postings.md
@@ -38,9 +38,22 @@ Every posting belongs to exactly one group. `txs.group_id` is nullable only so t
 raw fixtures can write a posting without one; no production write path leaves it
 unset.
 
-Groups currently hold a single posting each: what is stored is unchanged from before
-grouping existed, and no balance is enforced. Once ingestion emits multiple legs per
-group, the postings of a group are required to sum to zero.
+No balance is enforced yet. Once every converter groups its legs, the postings of a
+group are required to sum to zero.
+
+## Naming a group on upload
+
+An uploaded tx carries an optional `group_ref`: an opaque key, scoped to that
+upload, naming the event the posting belongs to. Txs sharing a non-empty `group_ref`
+are stored in one group; an empty one means the tx is its own single-posting group.
+The group takes the timestamp of the first leg that names it.
+
+`group_ref` is not stored and carries no meaning across uploads, so re-uploading a
+period produces new groups. This follows from transactions having no natural key
+(see adr/0002-transaction-ingestion-model.md): there is nothing stable to key a
+durable group identity on.
+
+Single-transaction uploads ignore `group_ref`. One tx has nothing to group with.
 
 ## Deletion
 

--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -161,6 +161,13 @@ message Tx {
   double split_adjusted_quantity = 12;
   // Split-adjusted unit price (unit_price / cumulative split factor).
   double split_adjusted_unit_price = 13;
+  // Opaque grouping key, scoped to a single upload. Txs sharing a non-empty
+  // group_ref are postings of one economic event and are stored in one tx group.
+  // Empty means the tx is its own single-posting group. Set by the broker
+  // converter, which is the only thing that knows how a broker reports the legs
+  // of a trade. Not a durable identifier: it is not stored and carries no
+  // meaning across uploads.
+  string group_ref = 14;
 }
 
 // ApiService provides gRPC endpoints for the web front end: portfolio CRUD,

--- a/server/db/postgres/txs.go
+++ b/server/db/postgres/txs.go
@@ -27,7 +27,46 @@ const insertPostingSQL = `
 	                 quantity, trading_currency, settlement_currency, unit_price,
 	                 instrument_id, share_count_basis, group_id)
 	SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::date, g.id FROM g
+	RETURNING group_id
 `
+
+// insertPostingInGroupSQL inserts a tx as a posting of an existing tx group, for
+// the second and subsequent legs of one economic event.
+const insertPostingInGroupSQL = `
+	INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type,
+	                 quantity, trading_currency, settlement_currency, unit_price,
+	                 instrument_id, share_count_basis, group_id)
+	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::date, $13)
+`
+
+// groupResolver hands out the tx group for a tx's group_ref. An empty group_ref
+// means the tx is its own single-posting group; a repeated one returns the group
+// created for the first leg that used it. Refs are scoped to a single upload, so
+// the resolver lives no longer than one call.
+type groupResolver struct {
+	byRef map[string]uuid.UUID
+}
+
+func newGroupResolver() *groupResolver {
+	return &groupResolver{byRef: map[string]uuid.UUID{}}
+}
+
+// group returns the group id an already-created group should be reused for, and
+// false when the caller must create one (an empty ref, or the first leg of a ref).
+func (r *groupResolver) group(ref string) (uuid.UUID, bool) {
+	if ref == "" {
+		return uuid.UUID{}, false
+	}
+	id, ok := r.byRef[ref]
+	return id, ok
+}
+
+// record remembers the group created for a non-empty ref so later legs join it.
+func (r *groupResolver) record(ref string, id uuid.UUID) {
+	if ref != "" {
+		r.byRef[ref] = id
+	}
+}
 
 // ReplaceTxsInPeriod implements db.TxDB.
 func (p *Postgres) ReplaceTxsInPeriod(ctx context.Context, userID, broker, jobID string, periodFrom, periodBefore *timestamppb.Timestamp, txs []*apiv1.Tx, instrumentIDs []string, shareCountBasis *time.Time) error {
@@ -82,6 +121,7 @@ func (p *Postgres) ReplaceTxsInPeriod(ctx context.Context, userID, broker, jobID
 		if err != nil {
 			return fmt.Errorf("delete ungrouped txs in period: %w", err)
 		}
+		resolver := newGroupResolver()
 		for i, t := range txs {
 			instUUID, err := uuid.Parse(instrumentIDs[i])
 			if err != nil {
@@ -96,19 +136,31 @@ func (p *Postgres) ReplaceTxsInPeriod(ctx context.Context, userID, broker, jobID
 				return err
 			}
 			acc := t.GetAccount()
-			_, err = exec.ExecContext(ctx, insertPostingSQL,
+			args := []interface{}{
 				userUUID, broker, acc, ts, t.InstrumentDescription, txTypeStr, t.Quantity,
 				nullStr(t.TradingCurrency), nullStr(t.SettlementCurrency), nullFloat(t.UnitPrice),
-				instUUID, shareCountBasis, jobUUID)
-			if err != nil {
+				instUUID, shareCountBasis,
+			}
+			ref := t.GetGroupRef()
+			if groupID, ok := resolver.group(ref); ok {
+				if _, err := exec.ExecContext(ctx, insertPostingInGroupSQL, append(args, groupID)...); err != nil {
+					return fmt.Errorf("insert tx: %w", err)
+				}
+				continue
+			}
+			// The group takes the timestamp of the first leg that names it.
+			var groupID uuid.UUID
+			if err := exec.QueryRowContext(ctx, insertPostingSQL, append(args, jobUUID)...).Scan(&groupID); err != nil {
 				return fmt.Errorf("insert tx: %w", err)
 			}
+			resolver.record(ref, groupID)
 		}
 		return nil
 	})
 }
 
-// CreateTx implements db.TxDB.
+// CreateTx implements db.TxDB. group_ref is ignored: a single-tx upload has nothing
+// to group with.
 func (p *Postgres) CreateTx(ctx context.Context, userID, broker, account, jobID string, tx *apiv1.Tx, instrumentID string, shareCountBasis *time.Time) error {
 	userUUID, err := uuid.Parse(userID)
 	if err != nil {

--- a/server/db/postgres/txs_test.go
+++ b/server/db/postgres/txs_test.go
@@ -264,6 +264,123 @@ func TestReplaceTxsInPeriod_CreatesGroupPerTx(t *testing.T) {
 	}
 }
 
+func TestReplaceTxsInPeriod_GroupsByGroupRef(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|grp-ref", "U", "u@ref.com")
+	instID, err := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "VOD", Canonical: false}}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+	base := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
+	// A trade and its cash leg share a ref; a separately-reported fee names none.
+	txs := []*apiv1.Tx{
+		{Timestamp: timestamppb.New(base.Add(time.Hour)), InstrumentDescription: "VOD", Type: apiv1.TxType_SELLSTOCK, Quantity: -100, Account: "", GroupRef: "ref-1"},
+		{Timestamp: timestamppb.New(base.Add(2 * time.Hour)), InstrumentDescription: "VOD", Type: apiv1.TxType_CASHFLOW, Quantity: 125, Account: "", GroupRef: "ref-1"},
+		{Timestamp: timestamppb.New(base.Add(3 * time.Hour)), InstrumentDescription: "VOD", Type: apiv1.TxType_INVEXPENSE, Quantity: -7.5, Account: ""},
+	}
+	from, to := timestamppb.New(base), timestamppb.New(base.Add(24*time.Hour))
+	ids := []string{instID, instID, instID}
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, ids, nil); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+
+	if got := countGroups(t, p, userID); got != 2 {
+		t.Fatalf("tx_groups: want 2 (one shared, one ungrouped fee), got %d", got)
+	}
+	// The group takes the timestamp of the first leg that named it, not the last.
+	var legs int
+	var groupTs time.Time
+	err = p.q.QueryRowContext(ctx, `
+		SELECT count(*), max(g.timestamp) FROM txs t JOIN tx_groups g ON g.id = t.group_id
+		WHERE t.user_id = $1
+		  AND t.group_id = (SELECT group_id FROM txs WHERE user_id = $1 AND quantity = -100)
+		GROUP BY t.group_id
+	`, userID).Scan(&legs, &groupTs)
+	if err != nil {
+		t.Fatalf("read shared group: %v", err)
+	}
+	if legs != 2 {
+		t.Errorf("postings in the shared group: want 2, got %d", legs)
+	}
+	if want := base.Add(time.Hour); !groupTs.Equal(want) {
+		t.Errorf("group timestamp: want the first leg's %v, got %v", want, groupTs)
+	}
+}
+
+func TestReplaceTxsInPeriod_GroupRefScopedToUpload(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|grp-scope", "U", "u@scope.com")
+	instID, err := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "BP", Canonical: false}}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+	base := time.Date(2025, 4, 1, 0, 0, 0, 0, time.UTC)
+	upload := func(period time.Time) {
+		t.Helper()
+		txs := []*apiv1.Tx{
+			{Timestamp: timestamppb.New(period.Add(time.Hour)), InstrumentDescription: "BP", Type: apiv1.TxType_BUYSTOCK, Quantity: 10, Account: "", GroupRef: "same-ref"},
+			{Timestamp: timestamppb.New(period.Add(time.Hour)), InstrumentDescription: "BP", Type: apiv1.TxType_CASHFLOW, Quantity: -50, Account: "", GroupRef: "same-ref"},
+		}
+		from, to := timestamppb.New(period), timestamppb.New(period.Add(24*time.Hour))
+		if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID, instID}, nil); err != nil {
+			t.Fatalf("replace: %v", err)
+		}
+	}
+	// The same ref in a second upload must not join the first upload's group: refs
+	// are scoped to one request and carry no meaning across them.
+	upload(base)
+	upload(base.Add(48 * time.Hour))
+
+	if got := countGroups(t, p, userID); got != 2 {
+		t.Errorf("tx_groups across two uploads: want 2, got %d", got)
+	}
+	var distinct int
+	if err := p.q.QueryRowContext(ctx,
+		`SELECT count(DISTINCT group_id) FROM txs WHERE user_id = $1`, userID).Scan(&distinct); err != nil {
+		t.Fatalf("count distinct groups: %v", err)
+	}
+	if distinct != 2 {
+		t.Errorf("distinct groups referenced by postings: want 2, got %d", distinct)
+	}
+}
+
+func TestReplaceTxsInPeriod_DeletesWholeGroups(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|grp-whole", "U", "u@whole.com")
+	instID, err := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "GSK", Canonical: false}}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+	base := time.Date(2025, 8, 1, 0, 0, 0, 0, time.UTC)
+	from, to := timestamppb.New(base), timestamppb.New(base.Add(24*time.Hour))
+	seed := []*apiv1.Tx{
+		{Timestamp: timestamppb.New(base.Add(time.Hour)), InstrumentDescription: "GSK", Type: apiv1.TxType_BUYSTOCK, Quantity: 10, Account: "", GroupRef: "r"},
+		{Timestamp: timestamppb.New(base.Add(time.Hour)), InstrumentDescription: "GSK", Type: apiv1.TxType_CASHFLOW, Quantity: -50, Account: "", GroupRef: "r"},
+	}
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, seed, []string{instID, instID}, nil); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, nil, nil, nil); err != nil {
+		t.Fatalf("replace with nothing: %v", err)
+	}
+
+	// Deleting by group must take every leg: a surviving orphan leg would be half
+	// an economic event.
+	rows, _, err := p.ListTxs(ctx, userID, nil, "", nil, nil, false, 50, "")
+	if err != nil {
+		t.Fatalf("list txs: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("postings after replacing the group with nothing: want 0, got %d", len(rows))
+	}
+	if got := countGroups(t, p, userID); got != 0 {
+		t.Errorf("tx_groups after replace: want 0, got %d", got)
+	}
+}
+
 func TestReplaceTxsInPeriod_DeletesGroupsInPeriod(t *testing.T) {
 	p := testDBTx(t)
 	ctx := context.Background()

--- a/server/service/ingestion/worker_test.go
+++ b/server/service/ingestion/worker_test.go
@@ -183,8 +183,8 @@ func TestProcessBulk_DropsTxTypeSplitTransactions(t *testing.T) {
 	from := timestamppb.Now()
 	before := timestamppb.Now()
 	txs := []*apiv1.Tx{
-		{Timestamp: from, InstrumentDescription: "AAPL", Type: apiv1.TxType_BUYSTOCK, Quantity: 10, Account: ""},
-		{Timestamp: from, InstrumentDescription: "SPLIT", Type: apiv1.TxType_SPLIT, Quantity: 1, Account: ""},
+		{Timestamp: from, InstrumentDescription: "AAPL", Type: apiv1.TxType_BUYSTOCK, Quantity: 10, Account: "", GroupRef: "ref-1"},
+		{Timestamp: from, InstrumentDescription: "SPLIT", Type: apiv1.TxType_SPLIT, Quantity: 1, Account: "", GroupRef: "ref-1"},
 	}
 	payload := marshalPayload(t, &ingestionv1.UpsertTxsRequest{
 		Broker:       apiv1.Broker_IBKR,
@@ -222,6 +222,10 @@ func TestProcessBulk_DropsTxTypeSplitTransactions(t *testing.T) {
 		DoAndReturn(func(_ context.Context, _, _, _ string, _, _ *timestamppb.Timestamp, storedTxs []*apiv1.Tx, ids []string, _ *time.Time) error {
 			if len(storedTxs) != 1 || storedTxs[0].InstrumentDescription != "AAPL" || storedTxs[0].Type != apiv1.TxType_BUYSTOCK {
 				t.Errorf("ReplaceTxsInPeriod called with %d txs, expected 1 (AAPL BUYSTOCK)", len(storedTxs))
+			}
+			// Dropping a leg must not lose the surviving legs' grouping.
+			if got := storedTxs[0].GetGroupRef(); got != "ref-1" {
+				t.Errorf("group_ref after dropping a leg: want ref-1, got %q", got)
 			}
 			return nil
 		})


### PR DESCRIPTION
**Stacked on #291** (`0036-tx-groups-postings`). Merge that first; this retargets to `main`.

Adds an optional `group_ref` to the `Tx` proto and the standard CSV, so an upload can say which postings are legs of one economic event. Closes 0063.

Rows sharing a non-empty ref are stored in one tx group; an empty ref means the row is its own single-posting group. Every current converter emits nothing, so behaviour is unchanged until 0064 makes Fidelity group its legs.

## One deviation from the plan

The ref rides on the `Tx` rather than arriving as a `groupKeys []string` slice parallel to it, so `TxDB` needs no signature change and no mock regeneration.

It also removes a class of bug outright. `filterStoredTxs` drops non-stored rows (e.g. `SPLIT`) part-way through an upload; a parallel slice would have had to be resliced in step with it or the surviving legs would silently regroup against the wrong refs. Carrying the ref on the message it belongs to makes that impossible — the existing test now asserts it, by giving the dropped `SPLIT` row the same ref as the `BUYSTOCK` that survives.

## Notes

- Refs are scoped to one request and are not stored. Transactions have no natural key (adr/0002), so there is nothing stable to key a durable group identity on, and re-uploading a period produces new groups. A db test covers that.
- The group takes the timestamp of the first leg that names it.
- `CreateTx` ignores the ref: one tx has nothing to group with.
- [csv-format.md](docs/spec/csv-format.md) gains a "Transaction groups" section stating the format's choice: fees are postings with `type=INVEXPENSE`, not a column, and a group that does not balance is accepted rather than rejected.

## Testing

`make test` and `make check` pass. New coverage: `group_ref` parsed from the CSV and defaulting to empty when the column is absent; a trade and its cash leg grouped while a separately-reported fee stays ungrouped; the same ref in two uploads producing two groups; and replacing a multi-leg group with nothing removing every leg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)