### PR TITLE
Add ADR 0022 superseding 0020: typed, per-account cash flow boundary

### DIFF
--- a/docs/adr/0020-double-entry-postings.md
+++ b/docs/adr/0020-double-entry-postings.md
@@ -1,4 +1,12 @@
+---
+status: superseded by ADR-0022
+---
+
 # Transactions are double-entry postings grouped by economic event
+
+Superseded by [0022](0022-typed-per-account-cash-flow-boundary.md), which keeps
+the posting and group model below but replaces the non-asset account vocabulary
+with a typed `account_type`, and corrects the boundary rule stated here.
 
 A `txs` row is a **posting**, and the postings of one economic event belong to a
 **tx group** whose amounts are required to sum to zero, in the manner of beancount

--- a/docs/adr/0022-typed-per-account-cash-flow-boundary.md
+++ b/docs/adr/0022-typed-per-account-cash-flow-boundary.md
@@ -1,0 +1,86 @@
+# The cash-flow boundary is typed and classified per account
+
+Supersedes [0020](0020-double-entry-postings.md). The posting and group model it
+established is unchanged and carried forward: a `txs` row is a **posting**, the
+postings of one economic event belong to a **tx group** required to sum to zero,
+and the invariant is enforced by a deferred constraint trigger rather than at load
+time as beancount does, because a database constraint has no equivalent of an
+unchecked writer. What changes is how the non-asset side of an event is
+identified and how the portfolio cash-flow boundary is derived from it.
+
+## The non-asset side is a type, not an account name
+
+0020 called for "a small non-asset account vocabulary", first designed as reserved
+name prefixes on `txs.account` after beancount's account roots. Postings instead
+carry an `account_type` -- `USER`, `EQUITY`, `INCOME`, `EXPENSE`, `IMBALANCE`,
+`TRANSFER_CLEARING` -- while keeping the `broker` and `account` of the event they
+belong to.
+
+`account` is user-supplied free text, so a name convention is unenforceable: a
+broker account named `Imbalance.USD` collides with the machinery, and every read
+path has to exclude reserved names with a `LIKE` that no index helps. A name also
+has nowhere to record which broker account a residual came from, which is exactly
+the attribution the imbalance report exists to give. And the currency is already
+the posting's commodity, so encoding it in a name duplicates a typed,
+foreign-keyed column in a string the two can disagree with.
+
+## Leaving the asset accounts does not make a flow external
+
+0020 said a flow is external iff it crosses out of the asset accounts. That is
+wrong. A dividend crosses from `INCOME` into cash and a commission crosses from
+cash into `EXPENSE`; both leave the asset accounts and neither is an external
+flow. Classing them as external would strip dividends out of the return and
+report it gross of fees.
+
+Only `EQUITY` and a crossing to another account are external. `INCOME`, `EXPENSE`
+and `IMBALANCE` are internal, being return and cost rather than contribution.
+`IMBALANCE` is internal because a residual is usually a missing fee or a missing
+cash leg, both of which are internal, and because classing it external would
+launder bad data out of the return instead of leaving it visible.
+
+## Classification is per account and fixed at ingest
+
+A posting in account A is an external flow of A iff its group has a leg outside A.
+Netting between accounts is resolved per portfolio at query time and is not
+stored.
+
+Classifying flows relative to the portfolio being measured was rejected as both
+unimplementable and unstable. Unimplementable because when a transfer's first side
+is posted we may not know whether the other side is an account we hold, or whether
+it exists in our data at all -- that is the whole reason `TRANSFER_CLEARING`
+exists, and a rule needing an answer we do not have cannot be applied. Unstable
+because portfolios are views over editable `portfolio_filters`
+(see [0010](0010-portfolios-as-views.md)), so adding an account to a portfolio
+would silently reclassify historical flows and move every past return figure.
+
+For the same reason there is no per-portfolio user override of internal versus
+external. Membership already expresses the intent, and a toggle would be a second
+place to say the same thing that can disagree with the first.
+
+## Consequences
+
+Matching the two sides of a transfer becomes a correctness requirement rather than
+housekeeping. Until a pair is matched, a transfer between two accounts of one
+portfolio reads as a withdrawal and an unrelated deposit, so money-weighted return
+is wrong for any multi-account portfolio.
+
+Converters, not the server, emit income and expense legs
+(see [0021](0021-converters-own-transaction-grouping.md)). The server cannot
+distinguish an uncategorised dividend from a genuinely incomplete trade, so every
+unbalanced residual routes to `IMBALANCE` and early imbalance figures are
+dominated by uncategorised income rather than by the missing fees the mechanism
+is aimed at.
+
+0020 held that the read path was unaffected. Grouping alone left it unaffected;
+typing does not. Holdings and portfolio views must filter to `account_type =
+'USER'` so that no residual or in-flight balance appears as a position. Valuation
+is a separate question from holdings: excluding `TRANSFER_CLEARING` makes a
+holding vanish for the days between the two sides of a matched transfer, so
+in-flight value is included in valuation for matched pairs whose accounts are
+both portfolio members, and excluded otherwise.
+
+0020's remaining consequences stand. An INITIALIZE row (see
+[0011](0011-synthetic-initialize-transactions.md)) is a pad with no counterparty
+and needs an `EQUITY` posting to satisfy the invariant, and the invariant is not
+expressible while `quantity` and `unit_price` are `DOUBLE PRECISION`, because
+summing float buys and sells does not land on exactly zero.

--- a/docs/issues/0037-typed-account-classification.md
+++ b/docs/issues/0037-typed-account-classification.md
@@ -8,6 +8,7 @@ dependencies: [0036]
 Add an `account_type` to postings that classifies the account they land in, so
 that the non-asset side of a one-sided event has somewhere to go and the
 portfolio cash-flow boundary is a typed predicate rather than a string parse.
+See adr/0022-typed-per-account-cash-flow-boundary.md.
 
 ## Motivation
 

--- a/docs/spec/portfoliodb-spec.md
+++ b/docs/spec/portfoliodb-spec.md
@@ -36,7 +36,7 @@ Transactions do not have a reliable natural key and the system does not enforce 
 
 Each transaction has a **broker** (required) and an **account** (may be empty); an empty account string is valid and represents the default/only account for that broker. See adr/0002-transaction-ingestion-model.md.
 
-A transaction is a **posting**: a signed amount of one commodity in one account. The postings of a single economic event belong to a **transaction group** and are required to sum to zero. See [postings.md](postings.md) and adr/0020-double-entry-postings.md.
+A transaction is a **posting**: a signed amount of one commodity in one account. The postings of a single economic event belong to a **transaction group** and are required to sum to zero. See [postings.md](postings.md) and adr/0022-typed-per-account-cash-flow-boundary.md.
 
 ## Upload Formats
 

--- a/docs/spec/postings.md
+++ b/docs/spec/postings.md
@@ -1,7 +1,7 @@
 # Transaction Groups and Postings
 
 A **tx group** is one economic event. The `txs` rows that reference it are its
-**postings**. See adr/0020-double-entry-postings.md.
+**postings**. See adr/0022-typed-per-account-cash-flow-boundary.md.
 
 ## Postings
 


### PR DESCRIPTION
Follows #294, which reworked the M12 issues around a typed `account_type`. This
records the decision behind that change and supersedes the ADR it contradicts.

## Why a new ADR rather than an amendment

[0020](docs/adr/0020-double-entry-postings.md) established the posting and group
model, which is unchanged and carried forward: a `txs` row is a posting, the
postings of one economic event sum to zero, and the invariant is enforced by a
deferred constraint trigger rather than at load time, because a database
constraint has no equivalent of an unchecked writer.

Two things it said about the non-asset side of a posting no longer hold, and one
decision it did not cover has since been made.

## What changed

**The non-asset side is a type, not an account name.** 0020 called for "a small
non-asset account vocabulary", first designed as reserved name prefixes on
`txs.account`. `account` is user-supplied free text, so the convention is
unenforceable; a name has nowhere to record which broker account a residual came
from, which is the attribution the imbalance report exists to give; and the
currency is already the posting's commodity.

**Leaving the asset accounts does not make a flow external.** 0020 said a flow is
external iff it crosses out of the asset accounts. A dividend crosses from
`INCOME` into cash and a commission crosses from cash into `EXPENSE`; both leave
the asset accounts and neither is an external flow. As stated the rule would
strip dividends out of the return and report it gross of fees.

**Classification is per account and fixed at ingest**, with netting resolved per
portfolio at query time. This is the substantive new decision and the main reason
for a new ADR. The rejected alternative -- classifying relative to the portfolio
being measured -- is recorded along with both reasons it fails: unimplementable,
because when a transfer's first side is posted we may not know whether the other
side is an account we hold or whether it exists in our data at all; and unstable,
because portfolios are views over editable `portfolio_filters`, so adding an
account would silently reclassify historical flows and move every past return
figure.

## Consequences recorded

Transfer matching becomes a correctness requirement rather than housekeeping,
since an unmatched transfer between two accounts of one portfolio reads as a
withdrawal and an unrelated deposit.

Converters emit income and expense legs, not the server, so early `IMBALANCE`
figures are dominated by uncategorised income rather than the missing fees the
mechanism targets.

0020's claim that the read path is unaffected is corrected. True of grouping, not
of typing: holdings must filter to `account_type = 'USER'`, and valuation needs a
separate rule for in-flight balances, since excluding `TRANSFER_CLEARING` makes a
holding vanish for the days between the two sides of a matched transfer.

## Housekeeping

0020 gains `status: superseded by ADR-0022` frontmatter and a pointer. No ADR in
the repo used frontmatter before; the `adr` skill sanctions it for exactly this
case, so 0020 is the first. The two spec references in `postings.md` and
`portfoliodb-spec.md` now point at 0022, and 0037 gains a pointer to it.

Docs only -- no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)