### PR TITLE
Record price coverage as a stored fact

### DIFF
--- a/docs/adr/0020-double-entry-postings.md
+++ b/docs/adr/0020-double-entry-postings.md
@@ -1,4 +1,12 @@
+---
+status: superseded by ADR-0022
+---
+
 # Transactions are double-entry postings grouped by economic event
+
+Superseded by [0022](0022-typed-per-account-cash-flow-boundary.md), which keeps
+the posting and group model below but replaces the non-asset account vocabulary
+with a typed `account_type`, and corrects the boundary rule stated here.
 
 A `txs` row is a **posting**, and the postings of one economic event belong to a
 **tx group** whose amounts are required to sum to zero, in the manner of beancount

--- a/docs/adr/0022-typed-per-account-cash-flow-boundary.md
+++ b/docs/adr/0022-typed-per-account-cash-flow-boundary.md
@@ -1,0 +1,86 @@
+# The cash-flow boundary is typed and classified per account
+
+Supersedes [0020](0020-double-entry-postings.md). The posting and group model it
+established is unchanged and carried forward: a `txs` row is a **posting**, the
+postings of one economic event belong to a **tx group** required to sum to zero,
+and the invariant is enforced by a deferred constraint trigger rather than at load
+time as beancount does, because a database constraint has no equivalent of an
+unchecked writer. What changes is how the non-asset side of an event is
+identified and how the portfolio cash-flow boundary is derived from it.
+
+## The non-asset side is a type, not an account name
+
+0020 called for "a small non-asset account vocabulary", first designed as reserved
+name prefixes on `txs.account` after beancount's account roots. Postings instead
+carry an `account_type` -- `USER`, `EQUITY`, `INCOME`, `EXPENSE`, `IMBALANCE`,
+`TRANSFER_CLEARING` -- while keeping the `broker` and `account` of the event they
+belong to.
+
+`account` is user-supplied free text, so a name convention is unenforceable: a
+broker account named `Imbalance.USD` collides with the machinery, and every read
+path has to exclude reserved names with a `LIKE` that no index helps. A name also
+has nowhere to record which broker account a residual came from, which is exactly
+the attribution the imbalance report exists to give. And the currency is already
+the posting's commodity, so encoding it in a name duplicates a typed,
+foreign-keyed column in a string the two can disagree with.
+
+## Leaving the asset accounts does not make a flow external
+
+0020 said a flow is external iff it crosses out of the asset accounts. That is
+wrong. A dividend crosses from `INCOME` into cash and a commission crosses from
+cash into `EXPENSE`; both leave the asset accounts and neither is an external
+flow. Classing them as external would strip dividends out of the return and
+report it gross of fees.
+
+Only `EQUITY` and a crossing to another account are external. `INCOME`, `EXPENSE`
+and `IMBALANCE` are internal, being return and cost rather than contribution.
+`IMBALANCE` is internal because a residual is usually a missing fee or a missing
+cash leg, both of which are internal, and because classing it external would
+launder bad data out of the return instead of leaving it visible.
+
+## Classification is per account and fixed at ingest
+
+A posting in account A is an external flow of A iff its group has a leg outside A.
+Netting between accounts is resolved per portfolio at query time and is not
+stored.
+
+Classifying flows relative to the portfolio being measured was rejected as both
+unimplementable and unstable. Unimplementable because when a transfer's first side
+is posted we may not know whether the other side is an account we hold, or whether
+it exists in our data at all -- that is the whole reason `TRANSFER_CLEARING`
+exists, and a rule needing an answer we do not have cannot be applied. Unstable
+because portfolios are views over editable `portfolio_filters`
+(see [0010](0010-portfolios-as-views.md)), so adding an account to a portfolio
+would silently reclassify historical flows and move every past return figure.
+
+For the same reason there is no per-portfolio user override of internal versus
+external. Membership already expresses the intent, and a toggle would be a second
+place to say the same thing that can disagree with the first.
+
+## Consequences
+
+Matching the two sides of a transfer becomes a correctness requirement rather than
+housekeeping. Until a pair is matched, a transfer between two accounts of one
+portfolio reads as a withdrawal and an unrelated deposit, so money-weighted return
+is wrong for any multi-account portfolio.
+
+Converters, not the server, emit income and expense legs
+(see [0021](0021-converters-own-transaction-grouping.md)). The server cannot
+distinguish an uncategorised dividend from a genuinely incomplete trade, so every
+unbalanced residual routes to `IMBALANCE` and early imbalance figures are
+dominated by uncategorised income rather than by the missing fees the mechanism
+is aimed at.
+
+0020 held that the read path was unaffected. Grouping alone left it unaffected;
+typing does not. Holdings and portfolio views must filter to `account_type =
+'USER'` so that no residual or in-flight balance appears as a position. Valuation
+is a separate question from holdings: excluding `TRANSFER_CLEARING` makes a
+holding vanish for the days between the two sides of a matched transfer, so
+in-flight value is included in valuation for matched pairs whose accounts are
+both portfolio members, and excluded otherwise.
+
+0020's remaining consequences stand. An INITIALIZE row (see
+[0011](0011-synthetic-initialize-transactions.md)) is a pad with no counterparty
+and needs an `EQUITY` posting to satisfy the invariant, and the invariant is not
+expressible while `quantity` and `unit_price` are `DOUBLE PRECISION`, because
+summing float buys and sells does not land on exactly zero.

--- a/docs/issues/0037-typed-account-classification.md
+++ b/docs/issues/0037-typed-account-classification.md
@@ -8,6 +8,7 @@ dependencies: [0036]
 Add an `account_type` to postings that classifies the account they land in, so
 that the non-asset side of a one-sided event has somewhere to go and the
 portfolio cash-flow boundary is a typed predicate rather than a string parse.
+See adr/0022-typed-per-account-cash-flow-boundary.md.
 
 ## Motivation
 

--- a/docs/spec/portfoliodb-spec.md
+++ b/docs/spec/portfoliodb-spec.md
@@ -36,7 +36,7 @@ Transactions do not have a reliable natural key and the system does not enforce 
 
 Each transaction has a **broker** (required) and an **account** (may be empty); an empty account string is valid and represents the default/only account for that broker. See adr/0002-transaction-ingestion-model.md.
 
-A transaction is a **posting**: a signed amount of one commodity in one account. The postings of a single economic event belong to a **transaction group** and are required to sum to zero. See [postings.md](postings.md) and adr/0020-double-entry-postings.md.
+A transaction is a **posting**: a signed amount of one commodity in one account. The postings of a single economic event belong to a **transaction group** and are required to sum to zero. See [postings.md](postings.md) and adr/0022-typed-per-account-cash-flow-boundary.md.
 
 ## Upload Formats
 

--- a/docs/spec/postings.md
+++ b/docs/spec/postings.md
@@ -1,7 +1,7 @@
 # Transaction Groups and Postings
 
 A **tx group** is one economic event. The `txs` rows that reference it are its
-**postings**. See adr/0020-double-entry-postings.md.
+**postings**. See adr/0022-typed-per-account-cash-flow-boundary.md.
 
 ## Postings
 

--- a/server/db/postgres/corporate_events.go
+++ b/server/db/postgres/corporate_events.go
@@ -309,64 +309,12 @@ func (p *Postgres) DeleteCashDividend(ctx context.Context, instrumentID string, 
 	return nil
 }
 
-// UpsertCorporateEventCoverage implements db.CorporateEventDB. The merge step
-// finds every existing row for (instrument, plugin) whose interval touches
-// [from, before), deletes them, and inserts a single row spanning the union.
-// The whole operation runs in a single transaction so concurrent inserts cannot
-// leave partial state.
-//
-// The merged row keeps the oldest constituent last_fetched_at, since the union
-// is only as freshly confirmed as its stalest part. lastFetchedAt is when the
-// supplied span was confirmed; nil means now.
+// UpsertCorporateEventCoverage implements db.CorporateEventDB. The merge runs in
+// a single transaction so concurrent inserts cannot leave partial state. See
+// upsertCoverageSpan for the merge semantics, which price_coverage shares.
 func (p *Postgres) UpsertCorporateEventCoverage(ctx context.Context, instrumentID, pluginID string, from, before time.Time, lastFetchedAt *time.Time) error {
-	if !before.After(from) {
-		return fmt.Errorf("upsert corporate event coverage: covered_before %s not after covered_from %s", before, from)
-	}
-	id, err := uuid.Parse(instrumentID)
-	if err != nil {
-		return fmt.Errorf("upsert corporate event coverage: invalid instrument id %q: %w", instrumentID, err)
-	}
 	return p.runInTx(ctx, func(exec queryable) error {
-		// Half-open [a,b) and [c,d) touch or overlap iff a <= d AND c <= b, so
-		// abutting spans merge with no adjacency fudge. Find every existing row
-		// that touches [from, before), compute the union, delete them, and
-		// insert one merged row. CTE data-modifying statements share a snapshot
-		// in PostgreSQL so DELETE and INSERT cannot see one another -- run them
-		// as separate statements inside the transaction.
-		//
-		// LEAST ignores NULL, so with no touching rows the merged fetch time
-		// is just the supplied one (or now()).
-		var newFrom, newBefore, newFetched time.Time
-		err := exec.QueryRowContext(ctx, `
-			SELECT
-				LEAST($3::date,    COALESCE(MIN(covered_from),   $3::date)),
-				GREATEST($4::date, COALESCE(MAX(covered_before), $4::date)),
-				LEAST(COALESCE($5::timestamptz, now()), MIN(last_fetched_at))
-			FROM corporate_event_coverage
-			WHERE instrument_id = $1
-			  AND plugin_id     = $2
-			  AND covered_from   <= $4::date
-			  AND covered_before >= $3::date
-		`, id, pluginID, from, before, lastFetchedAt).Scan(&newFrom, &newBefore, &newFetched)
-		if err != nil {
-			return fmt.Errorf("upsert corporate event coverage: compute merge: %w", err)
-		}
-		if _, err := exec.ExecContext(ctx, `
-			DELETE FROM corporate_event_coverage
-			WHERE instrument_id = $1
-			  AND plugin_id     = $2
-			  AND covered_from   <= $4::date
-			  AND covered_before >= $3::date
-		`, id, pluginID, from, before); err != nil {
-			return fmt.Errorf("upsert corporate event coverage: delete overlapping: %w", err)
-		}
-		if _, err := exec.ExecContext(ctx, `
-			INSERT INTO corporate_event_coverage (instrument_id, plugin_id, covered_from, covered_before, last_fetched_at)
-			VALUES ($1, $2, $3, $4, $5)
-		`, id, pluginID, newFrom, newBefore, newFetched); err != nil {
-			return fmt.Errorf("upsert corporate event coverage: insert merged: %w", err)
-		}
-		return nil
+		return upsertCoverageSpan(ctx, exec, corporateEventCoverageTable, instrumentID, pluginID, from, before, lastFetchedAt)
 	})
 }
 

--- a/server/db/postgres/coverage.go
+++ b/server/db/postgres/coverage.go
@@ -1,0 +1,75 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// Coverage tables share a shape: (instrument_id, plugin_id, covered_from,
+// covered_before, last_fetched_at) with the half-open [covered_from,
+// covered_before) convention and non-overlapping spans per (instrument,
+// plugin). price_coverage and corporate_event_coverage both use it, so the
+// merge below is written once and named by table.
+const (
+	priceCoverageTable          = "price_coverage"
+	corporateEventCoverageTable = "corporate_event_coverage"
+)
+
+// upsertCoverageSpan merges [from, before) into the coverage spans already
+// recorded for (instrumentID, pluginID) in table. Every existing row whose
+// interval touches the new one is deleted and replaced by a single row spanning
+// the union, so the table never holds overlapping or abutting spans.
+//
+// The merged row keeps the oldest constituent last_fetched_at, since the union
+// is only as freshly confirmed as its stalest part. lastFetchedAt is when the
+// supplied span was confirmed; nil means now.
+//
+// exec must be a transaction: the compute, delete and insert are three
+// statements and are only safe together.
+func upsertCoverageSpan(ctx context.Context, exec queryable, table, instrumentID, pluginID string, from, before time.Time, lastFetchedAt *time.Time) error {
+	if !before.After(from) {
+		return fmt.Errorf("upsert %s: covered_before %s not after covered_from %s", table, before, from)
+	}
+	id, err := uuid.Parse(instrumentID)
+	if err != nil {
+		return fmt.Errorf("upsert %s: invalid instrument id %q: %w", table, instrumentID, err)
+	}
+
+	// Half-open [a,b) and [c,d) touch or overlap iff a <= d AND c <= b, so
+	// abutting spans merge with no adjacency fudge. CTE data-modifying
+	// statements share a snapshot in PostgreSQL so DELETE and INSERT cannot see
+	// one another -- run them as separate statements inside the transaction.
+	//
+	// LEAST ignores NULL, so with no touching rows the merged fetch time is just
+	// the supplied one (or now()).
+	touching := `
+		WHERE instrument_id = $1
+		  AND plugin_id     = $2
+		  AND covered_from   <= $4::date
+		  AND covered_before >= $3::date`
+
+	var newFrom, newBefore, newFetched time.Time
+	err = exec.QueryRowContext(ctx, `
+		SELECT
+			LEAST($3::date,    COALESCE(MIN(covered_from),   $3::date)),
+			GREATEST($4::date, COALESCE(MAX(covered_before), $4::date)),
+			LEAST(COALESCE($5::timestamptz, now()), MIN(last_fetched_at))
+		FROM `+table+touching,
+		id, pluginID, from, before, lastFetchedAt).Scan(&newFrom, &newBefore, &newFetched)
+	if err != nil {
+		return fmt.Errorf("upsert %s: compute merge: %w", table, err)
+	}
+	if _, err := exec.ExecContext(ctx, `DELETE FROM `+table+touching, id, pluginID, from, before); err != nil {
+		return fmt.Errorf("upsert %s: delete overlapping: %w", table, err)
+	}
+	if _, err := exec.ExecContext(ctx, `
+		INSERT INTO `+table+` (instrument_id, plugin_id, covered_from, covered_before, last_fetched_at)
+		VALUES ($1, $2, $3, $4, $5)
+	`, id, pluginID, newFrom, newBefore, newFetched); err != nil {
+		return fmt.Errorf("upsert %s: insert merged: %w", table, err)
+	}
+	return nil
+}

--- a/server/db/postgres/coverage_test.go
+++ b/server/db/postgres/coverage_test.go
@@ -1,0 +1,205 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/leedenison/portfoliodb/server/db"
+)
+
+// readPriceCoverage reads price_coverage directly. The DB-layer reader arrives
+// with the gap-analysis change; these tests assert the write path in isolation.
+func readPriceCoverage(t *testing.T, p *Postgres, instID string) []db.DateRange {
+	t.Helper()
+	rows, err := p.q.QueryContext(context.Background(), `
+		SELECT covered_from, covered_before FROM price_coverage
+		WHERE instrument_id = $1::uuid ORDER BY covered_from
+	`, instID)
+	if err != nil {
+		t.Fatalf("read price coverage: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+	var out []db.DateRange
+	for rows.Next() {
+		var r db.DateRange
+		if err := rows.Scan(&r.From, &r.Before); err != nil {
+			t.Fatalf("scan coverage: %v", err)
+		}
+		out = append(out, r)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate coverage: %v", err)
+	}
+	return out
+}
+
+func assertRanges(t *testing.T, got []db.DateRange, want []db.DateRange) {
+	t.Helper()
+	if len(got) != len(want) {
+		t.Fatalf("expected %d spans, got %d: %+v", len(want), len(got), got)
+	}
+	for i := range want {
+		if !got[i].From.Equal(want[i].From) || !got[i].Before.Equal(want[i].Before) {
+			t.Errorf("span %d: got [%s, %s), want [%s, %s)", i,
+				got[i].From.Format("2006-01-02"), got[i].Before.Format("2006-01-02"),
+				want[i].From.Format("2006-01-02"), want[i].Before.Format("2006-01-02"))
+		}
+	}
+}
+
+// assertCoverageContains is the containment invariant: every eod_prices row lies
+// within some price_coverage span for its instrument. The converse deliberately
+// does not hold -- a covered span with no rows is how "we asked and there is
+// nothing there" is recorded.
+func assertCoverageContains(t *testing.T, p *Postgres) {
+	t.Helper()
+	rows, err := p.q.QueryContext(context.Background(), `
+		SELECT p.instrument_id, p.price_date FROM eod_prices p
+		WHERE NOT EXISTS (
+			SELECT 1 FROM price_coverage c
+			WHERE c.instrument_id = p.instrument_id
+			  AND p.price_date >= c.covered_from AND p.price_date < c.covered_before)
+	`)
+	if err != nil {
+		t.Fatalf("check containment: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var instID string
+		var date time.Time
+		if err := rows.Scan(&instID, &date); err != nil {
+			t.Fatalf("scan uncovered: %v", err)
+		}
+		t.Errorf("price row outside coverage: instrument %s on %s", instID, date.Format("2006-01-02"))
+	}
+}
+
+// UpsertPricesWithFill records its declared range, not merely the days it wrote
+// rows for: the range is what the provider was asked about.
+func TestUpsertPricesWithFill_RecordsDeclaredRange(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	instID := setupInstrument(t, p, "AAPL")
+
+	bars := []db.EODPrice{
+		{InstrumentID: instID, PriceDate: d(2024, 1, 3), Close: 10},
+		{InstrumentID: instID, PriceDate: d(2024, 1, 5), Close: 12},
+	}
+	if err := p.UpsertPricesWithFill(ctx, instID, "massive", bars, d(2024, 1, 1), d(2024, 1, 11), nil); err != nil {
+		t.Fatalf("upsert with fill: %v", err)
+	}
+
+	assertRanges(t, readPriceCoverage(t, p, instID), []db.DateRange{
+		{From: d(2024, 1, 1), Before: d(2024, 1, 11)},
+	})
+	assertCoverageContains(t, p)
+}
+
+// A provider that returns nothing has still covered the range. This is the case
+// row presence alone cannot express, and the reason the table exists.
+func TestUpsertPricesWithFill_EmptyResultStillCovers(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	instID := setupInstrument(t, p, "DELISTED")
+
+	if err := p.UpsertPricesWithFill(ctx, instID, "massive", nil, d(2024, 1, 1), d(2024, 1, 11), nil); err != nil {
+		t.Fatalf("upsert with fill: %v", err)
+	}
+
+	assertRanges(t, readPriceCoverage(t, p, instID), []db.DateRange{
+		{From: d(2024, 1, 1), Before: d(2024, 1, 11)},
+	})
+}
+
+// A caller with no range to declare asserts the days it names and nothing more,
+// so a gap between supplied bars stays a gap rather than being spanned.
+func TestUpsertPrices_CoversSuppliedDatesOnly(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	instID := setupInstrument(t, p, "AAPL")
+
+	// Jan 3, 4, 5 are contiguous and merge; Feb 1 stands alone.
+	prices := []db.EODPrice{
+		{InstrumentID: instID, PriceDate: d(2024, 1, 3), Close: 10, DataProvider: "import"},
+		{InstrumentID: instID, PriceDate: d(2024, 1, 4), Close: 11, DataProvider: "import"},
+		{InstrumentID: instID, PriceDate: d(2024, 1, 5), Close: 12, DataProvider: "import"},
+		{InstrumentID: instID, PriceDate: d(2024, 2, 1), Close: 20, DataProvider: "import"},
+	}
+	if err := p.UpsertPrices(ctx, prices); err != nil {
+		t.Fatalf("upsert prices: %v", err)
+	}
+
+	assertRanges(t, readPriceCoverage(t, p, instID), []db.DateRange{
+		{From: d(2024, 1, 3), Before: d(2024, 1, 6)},
+		{From: d(2024, 2, 1), Before: d(2024, 2, 2)},
+	})
+	assertCoverageContains(t, p)
+}
+
+// Two disjoint held periods stay disjoint: the hole between them is a fact
+// about what was fetched, and merging would erase it.
+func TestUpsertPricesWithFill_DisjointPeriodsStayDisjoint(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	instID := setupInstrument(t, p, "AAPL")
+
+	first := []db.EODPrice{{InstrumentID: instID, PriceDate: d(2023, 1, 3), Close: 10}}
+	if err := p.UpsertPricesWithFill(ctx, instID, "massive", first, d(2023, 1, 1), d(2023, 7, 1), nil); err != nil {
+		t.Fatalf("upsert first period: %v", err)
+	}
+	second := []db.EODPrice{{InstrumentID: instID, PriceDate: d(2024, 1, 3), Close: 20}}
+	if err := p.UpsertPricesWithFill(ctx, instID, "massive", second, d(2024, 1, 1), d(2024, 7, 1), nil); err != nil {
+		t.Fatalf("upsert second period: %v", err)
+	}
+
+	assertRanges(t, readPriceCoverage(t, p, instID), []db.DateRange{
+		{From: d(2023, 1, 1), Before: d(2023, 7, 1)},
+		{From: d(2024, 1, 1), Before: d(2024, 7, 1)},
+	})
+	assertCoverageContains(t, p)
+}
+
+// Coverage is per plugin, so a range one plugin declined does not stop another
+// being asked. Both spans coexist for the same instrument.
+func TestUpsertPricesWithFill_CoverageIsPerPlugin(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	instID := setupInstrument(t, p, "AAPL")
+
+	if err := p.UpsertPricesWithFill(ctx, instID, "massive", nil, d(2024, 1, 1), d(2024, 1, 11), nil); err != nil {
+		t.Fatalf("upsert massive: %v", err)
+	}
+	if err := p.UpsertPricesWithFill(ctx, instID, "eodhd", nil, d(2024, 1, 1), d(2024, 1, 11), nil); err != nil {
+		t.Fatalf("upsert eodhd: %v", err)
+	}
+
+	var count int
+	if err := p.q.QueryRowContext(ctx, `
+		SELECT count(DISTINCT plugin_id) FROM price_coverage WHERE instrument_id = $1::uuid
+	`, instID).Scan(&count); err != nil {
+		t.Fatalf("count plugins: %v", err)
+	}
+	if count != 2 {
+		t.Errorf("expected coverage for 2 plugins, got %d", count)
+	}
+}
+
+// Coverage rides the instrument's cascade, so a merge cannot leave spans
+// pointing at an instrument that no longer exists.
+func TestPriceCoverage_CascadesOnInstrumentDelete(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	instID := setupInstrument(t, p, "AAPL")
+
+	if err := p.UpsertPricesWithFill(ctx, instID, "massive", nil, d(2024, 1, 1), d(2024, 1, 11), nil); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	if _, err := p.q.ExecContext(ctx, `DELETE FROM instruments WHERE id = $1::uuid`, instID); err != nil {
+		t.Fatalf("delete instrument: %v", err)
+	}
+
+	if got := readPriceCoverage(t, p, instID); len(got) != 0 {
+		t.Errorf("expected coverage to cascade away, got %+v", got)
+	}
+}

--- a/server/db/postgres/price_cache.go
+++ b/server/db/postgres/price_cache.go
@@ -400,10 +400,45 @@ func displayCurrencyFXValues(currencies []string) []string {
 // It bulk inserts EOD prices using unnest arrays, updating on conflict.
 // Real prices (synthetic=false) always overwrite existing rows. Synthetic
 // prices only overwrite when the existing row is also synthetic.
+//
+// Each supplied bar covers its own date and nothing more: a caller with no
+// range to declare is asserting the days it names, not the span between them.
+// Coverage is written in the same transaction as the rows, so no path exists
+// that stores a price without recording what it covers.
 func (p *Postgres) UpsertPrices(ctx context.Context, prices []db.EODPrice) error {
 	if len(prices) == 0 {
 		return nil
 	}
+	return p.runInTx(ctx, func(exec queryable) error {
+		if err := upsertPrices(ctx, exec, prices); err != nil {
+			return err
+		}
+		return coverSuppliedDates(ctx, exec, prices)
+	})
+}
+
+// coverSuppliedDates records one coverage span per contiguous run of supplied
+// dates, per (instrument, provider). Single days merge into runs, so a dense
+// series costs one span rather than one per bar.
+func coverSuppliedDates(ctx context.Context, exec queryable, prices []db.EODPrice) error {
+	type key struct{ instrumentID, provider string }
+	byKey := make(map[key][]db.DateRange)
+	for _, pr := range prices {
+		d := pr.PriceDate
+		k := key{pr.InstrumentID, pr.DataProvider}
+		byKey[k] = append(byKey[k], db.DateRange{From: d, Before: d.Add(db.Day)})
+	}
+	for k, ranges := range byKey {
+		for _, r := range db.MergeRanges(ranges) {
+			if err := upsertCoverageSpan(ctx, exec, priceCoverageTable, k.instrumentID, k.provider, r.From, r.Before, nil); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func upsertPrices(ctx context.Context, exec queryable, prices []db.EODPrice) error {
 
 	instIDs := make([]string, len(prices))
 	dates := make([]time.Time, len(prices))
@@ -444,7 +479,7 @@ func (p *Postgres) UpsertPrices(ctx context.Context, prices []db.EODPrice) error
 		}
 	}
 
-	_, err := p.q.ExecContext(ctx, `
+	_, err := exec.ExecContext(ctx, `
 		INSERT INTO eod_prices (instrument_id, price_date, open, high, low, close, volume, data_provider, synthetic, last_fetched_at, share_count_basis, adjusted_close)
 		SELECT unnest($1::uuid[]), unnest($2::date[]), unnest($3::double precision[]),
 			unnest($4::double precision[]), unnest($5::double precision[]),
@@ -481,7 +516,20 @@ func (p *Postgres) UpsertPrices(ctx context.Context, prices []db.EODPrice) error
 // [from, before) that has no real bar, all in a single SQL round-trip. The last
 // non-synthetic close price before `from` seeds the forward-fill for dates
 // preceding the first real bar.
+//
+// [from, before) is recorded as coverage in the same transaction, whether or not
+// any bars came back: a provider that answered "nothing here" has covered the
+// range just as authoritatively as one that returned a full series.
 func (p *Postgres) UpsertPricesWithFill(ctx context.Context, instrumentID, provider string, bars []db.EODPrice, from, before time.Time, fetchedAt *time.Time) error {
+	return p.runInTx(ctx, func(exec queryable) error {
+		if err := upsertPricesWithFill(ctx, exec, instrumentID, provider, bars, from, before, fetchedAt); err != nil {
+			return err
+		}
+		return upsertCoverageSpan(ctx, exec, priceCoverageTable, instrumentID, provider, from, before, fetchedAt)
+	})
+}
+
+func upsertPricesWithFill(ctx context.Context, exec queryable, instrumentID, provider string, bars []db.EODPrice, from, before time.Time, fetchedAt *time.Time) error {
 	id, err := uuid.Parse(instrumentID)
 	if err != nil {
 		return fmt.Errorf("upsert prices with fill: invalid id %q: %w", instrumentID, err)
@@ -530,7 +578,7 @@ func (p *Postgres) UpsertPricesWithFill(ctx context.Context, instrumentID, provi
 		}
 	}
 
-	_, err = p.q.ExecContext(ctx, `
+	_, err = exec.ExecContext(ctx, `
 		WITH
 		seed AS (
 			SELECT close, share_count_basis FROM eod_prices

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -412,6 +412,31 @@ CREATE TABLE eod_prices (
 
 SELECT create_hypertable('eod_prices', 'price_date');
 
+-- Coverage tracking for prices. A missing eod_prices row does not say whether
+-- the date was never fetched or was fetched and had no price (pre-IPO,
+-- delisted, suspended, or beyond a plugin's history limit). This table records,
+-- per (instrument, plugin), the date intervals the plugin has answered
+-- authoritatively -- including answers that returned no bars at all, which are
+-- coverage just as much as a full series is.
+-- The interval is half-open [covered_from, covered_before). Adjacent or
+-- overlapping intervals for the same (instrument, plugin) are merged on insert.
+-- Every eod_prices row lies within some span here for its instrument; the
+-- converse does not hold, and a span with no rows in it is exactly the "asked,
+-- nothing there" answer that row presence alone cannot express.
+CREATE TABLE price_coverage (
+  instrument_id  UUID        NOT NULL REFERENCES instruments (id) ON DELETE CASCADE,
+  plugin_id      TEXT        NOT NULL,
+  covered_from   DATE        NOT NULL,
+  covered_before DATE        NOT NULL CHECK (covered_before > covered_from),
+  -- Staleness only: when this span was last confirmed. A merged span keeps the
+  -- oldest constituent value, since a union is only as freshly confirmed as its
+  -- stalest part.
+  last_fetched_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (instrument_id, plugin_id, covered_from)
+);
+
+CREATE INDEX idx_price_coverage_instrument ON price_coverage (instrument_id);
+
 -- Stock splits per instrument. ex_date is the effective/execution date. The
 -- split factor is split_to / split_from (e.g. 2:1 split = split_from=1,
 -- split_to=2, factor=2; 1:2 reverse split = split_from=2, split_to=1, factor=0.5).


### PR DESCRIPTION
First of five PRs replacing inferred price coverage with a stored one. This PR
adds the table and the write path; nothing reads it yet, so behaviour is
unchanged.

## Problem

`PriceCoverage` is `range_agg(daterange(price_date, price_date + 1))` over
`eod_prices`, so "covered" means nothing more than "rows happen to exist here".
There is no way to record that a provider was asked and had nothing to give.

The cost is concrete: the fetcher does a bare `continue` on `ErrNoData`
(`worker.go:210`) and silently skips gaps beyond `max_history_days`
(`worker.go:182-190`). Neither writes anything, so those ranges are recomputed
as gaps and refetched every cycle, forever -- a delisted or pre-IPO instrument
is retried indefinitely.

Corporate events already model this correctly with `corporate_event_coverage`,
and adr/0005 already states that an empty result is authoritative coverage.
Prices never got the same treatment, so the same word means two different things
in two halves of the same spec section.

## Changes

- `price_coverage`, mirroring `corporate_event_coverage`: per `(instrument,
  plugin)` half-open `[covered_from, covered_before)` spans, merged on insert,
  cascading with the instrument.
- Both price write paths record coverage **in the same transaction as the rows**,
  so no API exists that stores a price without declaring what it covers.
  - `UpsertPricesWithFill` records the range it was asked about, whether or not
    bars came back.
  - `UpsertPrices` has no range to declare, so each bar covers its own date and
    nothing more. Consecutive days merge into runs; a gap between supplied bars
    stays a gap, preserving today's documented import behaviour.
- The merge logic was identical to the corporate event one, so it moves to
  `upsertCoverageSpan` and is named by table rather than duplicated.

## The invariant

Every `eod_prices` row lies within some `price_coverage` span for its instrument.
The converse deliberately does **not** hold -- a covered span with no rows is
exactly "we asked and there is nothing there", the case row presence cannot
express. Asserted in tests by `assertCoverageContains`.

## Testing

`make test` passes. New db-layer tests cover the declared range being recorded,
an empty result still covering, supplied-dates-only coverage for rangeless
writes, disjoint periods staying disjoint, per-plugin independence, and the
cascade. The existing corporate event coverage tests exercise the shared merge
helper unchanged.

## Follow-ups in this stack

2. Gap analysis reads `price_coverage`; fetcher records `ErrNoData` and history-limit truncation.
3. Derive the LOCF fill at read time and drop synthetic rows.
4. Export/import read and store coverage.
5. Spec updates and an ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)