### PR TITLE
Compute price gaps from stored coverage

### DIFF
--- a/server/db/db.go
+++ b/server/db/db.go
@@ -109,10 +109,16 @@ type PriceCacheDB interface {
 	// HeldRanges computes system-wide date ranges during which any user held
 	// a non-zero position in each identified instrument.
 	HeldRanges(ctx context.Context, opts HeldRangesOpts) ([]InstrumentDateRanges, error)
-	// PriceCoverage returns contiguous date ranges for which eod_prices has data.
+	// PriceCoverage returns the date ranges some plugin has answered for, merged
+	// across plugins. A range covered with no bars counts: it records that a
+	// provider was asked and had nothing, which row presence cannot express.
 	// If instrumentIDs is non-empty, only those instruments are returned.
 	PriceCoverage(ctx context.Context, instrumentIDs []string) ([]InstrumentDateRanges, error)
-	// PriceGaps computes needed ranges minus cached ranges per instrument.
+	// PriceCoverageByPlugin returns the same spans keyed instrument -> plugin ->
+	// ranges, for deciding what to ask each plugin rather than whether anyone has
+	// answered at all.
+	PriceCoverageByPlugin(ctx context.Context, instrumentIDs []string) (map[string]map[string][]DateRange, error)
+	// PriceGaps computes needed ranges minus covered ranges per instrument.
 	PriceGaps(ctx context.Context, opts HeldRangesOpts) ([]InstrumentDateRanges, error)
 	// FXGaps computes date ranges where FX rates are needed (non-USD instruments
 	// are held) but not yet cached. Returns gaps keyed by FX pair instrument ID.

--- a/server/db/postgres/price_cache.go
+++ b/server/db/postgres/price_cache.go
@@ -97,28 +97,40 @@ func (p *Postgres) HeldRanges(ctx context.Context, opts db.HeldRangesOpts) ([]db
 	return result, nil
 }
 
-// PriceCoverage implements db.PriceCacheDB.
-func (p *Postgres) PriceCoverage(ctx context.Context, instrumentIDs []string) ([]db.InstrumentDateRanges, error) {
+// coverageFilter turns instrument IDs into a query argument, or nil for all.
+func coverageFilter(instrumentIDs []string) (interface{}, error) {
 	var uuids []uuid.UUID
 	for _, id := range instrumentIDs {
 		u, err := uuid.Parse(id)
 		if err != nil {
-			return nil, fmt.Errorf("price coverage: invalid instrument id %q: %w", id, err)
+			return nil, fmt.Errorf("invalid instrument id %q: %w", id, err)
 		}
 		uuids = append(uuids, u)
 	}
+	if len(uuids) == 0 {
+		return nil, nil
+	}
+	return pq.Array(uuids), nil
+}
 
-	var filter interface{}
-	if len(uuids) > 0 {
-		filter = pq.Array(uuids)
+// PriceCoverage implements db.PriceCacheDB.
+//
+// Coverage is read from price_coverage, not inferred from which dates happen to
+// have rows: a span a provider answered with no bars at all is coverage, and
+// row presence cannot say so. Spans are merged across plugins, since for "has
+// anyone answered for this range" it does not matter who did.
+func (p *Postgres) PriceCoverage(ctx context.Context, instrumentIDs []string) ([]db.InstrumentDateRanges, error) {
+	filter, err := coverageFilter(instrumentIDs)
+	if err != nil {
+		return nil, fmt.Errorf("price coverage: %w", err)
 	}
 
 	rows, err := p.q.QueryContext(ctx, `
 		SELECT instrument_id, lower(r) AS range_from, upper(r) AS range_before
 		FROM (
 			SELECT instrument_id,
-				unnest(range_agg(daterange(price_date, price_date + 1))) AS r
-			FROM eod_prices
+				unnest(range_agg(daterange(covered_from, covered_before))) AS r
+			FROM price_coverage
 			WHERE ($1::uuid[] IS NULL OR instrument_id = ANY($1))
 			GROUP BY instrument_id
 		) sub
@@ -152,10 +164,49 @@ func (p *Postgres) PriceCoverage(ctx context.Context, instrumentIDs []string) ([
 
 	result := make([]db.InstrumentDateRanges, len(order))
 	for i, id := range order {
-		entry := *byInst[id]
-		// No bridging needed: the price fetcher worker writes synthetic
-		// (LOCF) rows for non-trading days, so coverage is contiguous.
-		result[i] = entry
+		result[i] = *byInst[id]
+	}
+	return result, nil
+}
+
+// PriceCoverageByPlugin implements db.PriceCacheDB.
+//
+// Keeping the plugin distinction is what lets a range one plugin declined still
+// be offered to another, and lets a newly configured plugin be asked about
+// history the existing ones could not reach.
+func (p *Postgres) PriceCoverageByPlugin(ctx context.Context, instrumentIDs []string) (map[string]map[string][]db.DateRange, error) {
+	filter, err := coverageFilter(instrumentIDs)
+	if err != nil {
+		return nil, fmt.Errorf("price coverage by plugin: %w", err)
+	}
+
+	rows, err := p.q.QueryContext(ctx, `
+		SELECT instrument_id, plugin_id, covered_from, covered_before
+		FROM price_coverage
+		WHERE ($1::uuid[] IS NULL OR instrument_id = ANY($1))
+		ORDER BY instrument_id, plugin_id, covered_from
+	`, filter)
+	if err != nil {
+		return nil, fmt.Errorf("price coverage by plugin query: %w", err)
+	}
+	defer rows.Close()
+
+	result := make(map[string]map[string][]db.DateRange)
+	for rows.Next() {
+		var instID uuid.UUID
+		var pluginID string
+		var from, before time.Time
+		if err := rows.Scan(&instID, &pluginID, &from, &before); err != nil {
+			return nil, fmt.Errorf("price coverage by plugin scan: %w", err)
+		}
+		id := instID.String()
+		if result[id] == nil {
+			result[id] = make(map[string][]db.DateRange)
+		}
+		result[id][pluginID] = append(result[id][pluginID], db.DateRange{From: from, Before: before})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("price coverage by plugin rows: %w", err)
 	}
 	return result, nil
 }

--- a/server/db/postgres/price_cache_test.go
+++ b/server/db/postgres/price_cache_test.go
@@ -58,7 +58,9 @@ func insertTxs(t *testing.T, p *Postgres, userID, instID string, txs []*apiv1.Tx
 	}
 }
 
-// insertPrice inserts a single eod_prices row.
+// insertPrice inserts a single eod_prices row and the coverage that goes with
+// it. Fixtures record both so they cannot construct a state the write path
+// never produces: a bar outside any covered span.
 func insertPrice(t *testing.T, p *Postgres, instID string, priceDate time.Time, close float64) {
 	t.Helper()
 	ctx := context.Background()
@@ -68,6 +70,18 @@ func insertPrice(t *testing.T, p *Postgres, instID string, priceDate time.Time, 
 	`, instID, priceDate, close)
 	if err != nil {
 		t.Fatalf("insert price: %v", err)
+	}
+	insertCoverage(t, p, instID, priceDate, priceDate.Add(db.Day))
+}
+
+// insertCoverage records a covered span without any bars in it.
+func insertCoverage(t *testing.T, p *Postgres, instID string, from, before time.Time) {
+	t.Helper()
+	err := p.runInTx(context.Background(), func(exec queryable) error {
+		return upsertCoverageSpan(context.Background(), exec, priceCoverageTable, instID, "test", from, before, nil)
+	})
+	if err != nil {
+		t.Fatalf("insert coverage: %v", err)
 	}
 }
 
@@ -502,6 +516,64 @@ func TestPriceGaps_PartialCoverage(t *testing.T) {
 	})
 }
 
+// A range a provider answered with nothing is not a gap. This is the case the
+// old row-presence inference could not express, and the reason the fetcher used
+// to re-ask about delisted and pre-IPO ranges on every cycle.
+func TestPriceGaps_EmptyCoverageIsNotAGap(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID := setupUser(t, p)
+	instID := setupInstrument(t, p, "GAPEMPTY")
+
+	insertTxs(t, p, userID, instID, []*apiv1.Tx{
+		{Timestamp: ts(2024, 1, 1), InstrumentDescription: "GAPEMPTY", Type: apiv1.TxType_BUYSTOCK, Quantity: 10, Account: "A"},
+		{Timestamp: ts(2024, 1, 10), InstrumentDescription: "GAPEMPTY", Type: apiv1.TxType_SELLSTOCK, Quantity: -10, Account: "A"},
+	})
+
+	// The whole held period was asked about and came back with no bars at all.
+	insertCoverage(t, p, instID, d(2024, 1, 1), d(2024, 1, 10))
+
+	got, err := p.PriceGaps(ctx, db.HeldRangesOpts{})
+	if err != nil {
+		t.Fatalf("price gaps: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected no gaps for a fully covered period, got %+v", got)
+	}
+}
+
+// Coverage is kept per plugin so that what one plugin settled does not hide the
+// range from another that has never been asked.
+func TestPriceCoverageByPlugin_SeparatesPlugins(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	instID := setupInstrument(t, p, "PERPLUGIN")
+
+	if err := p.UpsertPricesWithFill(ctx, instID, "massive", nil, d(2024, 1, 1), d(2024, 1, 11), nil); err != nil {
+		t.Fatalf("upsert massive: %v", err)
+	}
+	if err := p.UpsertPricesWithFill(ctx, instID, "eodhd", nil, d(2024, 2, 1), d(2024, 2, 11), nil); err != nil {
+		t.Fatalf("upsert eodhd: %v", err)
+	}
+
+	got, err := p.PriceCoverageByPlugin(ctx, []string{instID})
+	if err != nil {
+		t.Fatalf("coverage by plugin: %v", err)
+	}
+	assertRanges(t, got[instID]["massive"], []db.DateRange{{From: d(2024, 1, 1), Before: d(2024, 1, 11)}})
+	assertRanges(t, got[instID]["eodhd"], []db.DateRange{{From: d(2024, 2, 1), Before: d(2024, 2, 11)}})
+
+	// Merged across plugins, both spans show up for the instrument.
+	merged, err := p.PriceCoverage(ctx, []string{instID})
+	if err != nil {
+		t.Fatalf("coverage: %v", err)
+	}
+	assertInstrumentRanges(t, merged, instID, []db.DateRange{
+		{From: d(2024, 1, 1), Before: d(2024, 1, 11)},
+		{From: d(2024, 2, 1), Before: d(2024, 2, 11)},
+	})
+}
+
 func TestPriceGaps_Empty(t *testing.T) {
 	p := testDBTx(t)
 	ctx := context.Background()
@@ -802,18 +874,31 @@ func TestUpsertPricesWithFill_NoSeedNoBars(t *testing.T) {
 	ctx := context.Background()
 	instID := setupInstrument(t, p, "FILL3")
 
-	// No seed, no bars — nothing should be inserted.
+	// No seed, no bars: nothing to insert, but the range was still asked about
+	// and answered, so it is covered. That is the distinction row presence
+	// cannot draw and the reason coverage is stored separately.
 	err := p.UpsertPricesWithFill(ctx, instID, "test", nil, d(2024, 1, 1), d(2024, 1, 4), nil)
 	if err != nil {
 		t.Fatalf("upsert with fill: %v", err)
 	}
+
+	var rowCount int
+	if err := p.q.QueryRowContext(ctx, `
+		SELECT count(*) FROM eod_prices WHERE instrument_id = $1::uuid
+	`, instID).Scan(&rowCount); err != nil {
+		t.Fatalf("count rows: %v", err)
+	}
+	if rowCount != 0 {
+		t.Errorf("expected no price rows, got %d", rowCount)
+	}
+
 	cov, err := p.PriceCoverage(ctx, []string{instID})
 	if err != nil {
 		t.Fatalf("coverage: %v", err)
 	}
-	if len(cov) != 0 {
-		t.Errorf("expected no coverage, got %d instruments", len(cov))
-	}
+	assertInstrumentRanges(t, cov, instID, []db.DateRange{
+		{From: d(2024, 1, 1), Before: d(2024, 1, 4)},
+	})
 }
 
 func TestUpsertPricesWithFill_NoSeedAtStart(t *testing.T) {

--- a/server/pricefetcher/worker.go
+++ b/server/pricefetcher/worker.go
@@ -135,11 +135,21 @@ func runCycle(ctx context.Context, database db.DB, registry *Registry, counter t
 		instByID[r.ID] = r
 	}
 
-	processGaps(ctx, database, plugins, allGaps, instByID, blocked, log)
+	// Per-plugin coverage, so a range one plugin has already answered for is not
+	// put to it again -- including ranges it answered with nothing.
+	coverage, err := database.PriceCoverageByPlugin(ctx, instIDs)
+	if err != nil {
+		if log != nil {
+			log.ErrorContext(ctx, "price fetch: load coverage", "err", err)
+		}
+		return
+	}
+
+	processGaps(ctx, database, plugins, allGaps, instByID, blocked, coverage, log)
 }
 
 // processGaps iterates instrument gaps and fetches prices from matching plugins.
-func processGaps(ctx context.Context, database db.DB, plugins []pluginEntry, gaps []db.InstrumentDateRanges, instByID map[string]*db.InstrumentRow, blocked map[string]map[string]bool, log *slog.Logger) {
+func processGaps(ctx context.Context, database db.DB, plugins []pluginEntry, gaps []db.InstrumentDateRanges, instByID map[string]*db.InstrumentRow, blocked map[string]map[string]bool, coverage map[string]map[string][]db.DateRange, log *slog.Logger) {
 	// One fetch time for the whole cycle, so every row a back-adjusting plugin
 	// returns shares the same share count basis.
 	now := time.Now()
@@ -175,16 +185,34 @@ func processGaps(ctx context.Context, database db.DB, plugins []pluginEntry, gap
 				continue
 			}
 
+			// Ranges this plugin has already answered for are not put to it
+			// again, whether it returned a series or nothing at all.
+			outstanding := db.SubtractRanges(ig.Ranges, coverage[ig.InstrumentID][pe.id])
+			if len(outstanding) == 0 {
+				// Nothing left to ask this one. It has not handled the
+				// instrument, so the next plugin still gets its turn.
+				continue
+			}
+
 			pfIDs := toPricefetcherIDs(ids)
 			allOK := true
-			for _, gap := range ig.Ranges {
+			for _, gap := range outstanding {
 				gap := gap // copy for truncation
 				if pe.maxHistDays != nil && *pe.maxHistDays > 0 {
 					cutoff := time.Now().UTC().Truncate(db.Day).AddDate(0, 0, -*pe.maxHistDays)
 					if !gap.Before.After(cutoff) {
-						continue // entire gap older than history limit
+						// The plugin cannot reach this far back and never will,
+						// so record it as covered by this plugin rather than
+						// rediscovering the same gap every cycle. Other plugins
+						// keep their own coverage and are still offered it.
+						coverRange(ctx, database, ig.InstrumentID, pe.id, gap, "history limit", log)
+						continue
 					}
 					if gap.From.Before(cutoff) {
+						// The unreachable head is settled for this plugin even
+						// though the tail is about to be fetched.
+						coverRange(ctx, database, ig.InstrumentID, pe.id,
+							db.DateRange{From: gap.From, Before: cutoff}, "history limit", log)
 						gap.From = cutoff
 					}
 				}
@@ -207,6 +235,11 @@ func processGaps(ctx context.Context, database db.DB, plugins []pluginEntry, gap
 						break // skip remaining ranges, try next plugin
 					}
 					if err == ErrNoData {
+						// "Nothing here" is an answer, not a failure to answer:
+						// record it so a pre-IPO, delisted or untraded range is
+						// settled for this plugin instead of being asked about
+						// on every cycle forever.
+						coverRange(ctx, database, ig.InstrumentID, pe.id, gap, "no data", log)
 						continue
 					}
 					if log != nil {
@@ -233,6 +266,19 @@ func processGaps(ctx context.Context, database db.DB, plugins []pluginEntry, gap
 			// On error, try next plugin for this instrument.
 		}
 		_ = fetchedByPlugin
+	}
+}
+
+// coverRange records that a plugin has settled a range without supplying bars.
+// A failure to record is logged rather than propagated: the fetch itself
+// succeeded, and the only cost is asking again next cycle.
+func coverRange(ctx context.Context, database db.DB, instrumentID, pluginID string, r db.DateRange, reason string, log *slog.Logger) {
+	if !r.Before.After(r.From) {
+		return
+	}
+	if err := database.UpsertPricesWithFill(ctx, instrumentID, pluginID, nil, r.From, r.Before, nil); err != nil && log != nil {
+		log.WarnContext(ctx, "price fetch: record empty coverage",
+			"plugin", pluginID, "instrument", instrumentID, "reason", reason, "err", err)
 	}
 }
 

--- a/server/pricefetcher/worker_test.go
+++ b/server/pricefetcher/worker_test.go
@@ -149,6 +149,7 @@ func TestRunCycle_FXGapsProcessed(t *testing.T) {
 		{PluginID: pluginID, Precedence: 10, Config: []byte("{}")},
 	}, nil)
 	mockDB.EXPECT().BlockedPluginsForInstruments(gomock.Any(), []string{fxInstID}).Return(nil, nil)
+	mockDB.EXPECT().PriceCoverageByPlugin(gomock.Any(), []string{fxInstID}).Return(nil, nil)
 	mockDB.EXPECT().ListInstrumentsByIDs(gomock.Any(), []string{fxInstID}).Return([]*db.InstrumentRow{
 		{
 			ID:         fxInstID,
@@ -194,6 +195,10 @@ type fetchStub struct {
 	err     error
 }
 
+func d(year int, month time.Month, day int) time.Time {
+	return time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+}
+
 func (s *fetchStub) SupportedIdentifierTypes() []string { return s.idTypes }
 func (s *fetchStub) FetchPrices(_ context.Context, _ []byte, _ []Identifier, _ string, _, _ time.Time) (*FetchResult, error) {
 	s.calls++
@@ -228,6 +233,7 @@ func TestRunCycle_BlockedPluginSkipped(t *testing.T) {
 	// Return blocked for this (instrument, plugin) pair.
 	mockDB.EXPECT().BlockedPluginsForInstruments(gomock.Any(), []string{instID}).Return(
 		map[string]map[string]bool{instID: {pluginID: true}}, nil)
+	mockDB.EXPECT().PriceCoverageByPlugin(gomock.Any(), []string{instID}).Return(nil, nil)
 	mockDB.EXPECT().ListInstrumentsByIDs(gomock.Any(), []string{instID}).Return([]*db.InstrumentRow{
 		{
 			ID:         instID,
@@ -271,6 +277,7 @@ func TestRunCycle_ErrPermanentCreatesBlock(t *testing.T) {
 		{PluginID: pluginID, Precedence: 10, Config: []byte("{}")},
 	}, nil)
 	mockDB.EXPECT().BlockedPluginsForInstruments(gomock.Any(), []string{instID}).Return(nil, nil)
+	mockDB.EXPECT().PriceCoverageByPlugin(gomock.Any(), []string{instID}).Return(nil, nil)
 	mockDB.EXPECT().ListInstrumentsByIDs(gomock.Any(), []string{instID}).Return([]*db.InstrumentRow{
 		{
 			ID:         instID,
@@ -320,6 +327,7 @@ func TestRunCycle_MaxHistoryTruncation(t *testing.T) {
 		{PluginID: pluginID, Precedence: 10, Config: []byte("{}"), MaxHistoryDays: &maxDays},
 	}, nil)
 	mockDB.EXPECT().BlockedPluginsForInstruments(gomock.Any(), []string{instID}).Return(nil, nil)
+	mockDB.EXPECT().PriceCoverageByPlugin(gomock.Any(), []string{instID}).Return(nil, nil)
 	mockDB.EXPECT().ListInstrumentsByIDs(gomock.Any(), []string{instID}).Return([]*db.InstrumentRow{
 		{
 			ID:         instID,
@@ -329,7 +337,11 @@ func TestRunCycle_MaxHistoryTruncation(t *testing.T) {
 			},
 		},
 	}, nil)
-	mockDB.EXPECT().UpsertPricesWithFill(gomock.Any(), instID, pluginID, gomock.Any(), gomock.Any(), to, gomock.Any()).Return(nil)
+	cutoff := now.AddDate(0, 0, -maxDays)
+	// The head the plugin cannot reach is settled as covered by it, so the same
+	// unreachable range is not rediscovered as a gap on the next cycle.
+	mockDB.EXPECT().UpsertPricesWithFill(gomock.Any(), instID, pluginID, nil, from, cutoff, gomock.Any()).Return(nil)
+	mockDB.EXPECT().UpsertPricesWithFill(gomock.Any(), instID, pluginID, gomock.Any(), cutoff, to, gomock.Any()).Return(nil)
 
 	runCycle(ctx, mockDB, reg, nil, nil, nil)
 
@@ -367,6 +379,7 @@ func TestRunCycle_MaxHistorySkipsOldGap(t *testing.T) {
 		{PluginID: pluginID, Precedence: 10, Config: []byte("{}"), MaxHistoryDays: &maxDays},
 	}, nil)
 	mockDB.EXPECT().BlockedPluginsForInstruments(gomock.Any(), []string{instID}).Return(nil, nil)
+	mockDB.EXPECT().PriceCoverageByPlugin(gomock.Any(), []string{instID}).Return(nil, nil)
 	mockDB.EXPECT().ListInstrumentsByIDs(gomock.Any(), []string{instID}).Return([]*db.InstrumentRow{
 		{
 			ID:         instID,
@@ -376,11 +389,130 @@ func TestRunCycle_MaxHistorySkipsOldGap(t *testing.T) {
 			},
 		},
 	}, nil)
+	// Wholly out of reach for this plugin, so it is recorded as covered by it
+	// rather than being asked about again every cycle.
+	mockDB.EXPECT().UpsertPricesWithFill(gomock.Any(), instID, pluginID, nil, from, to, gomock.Any()).Return(nil)
 
 	runCycle(ctx, mockDB, reg, nil, nil, nil)
 
 	if stub.calls != 0 {
 		t.Errorf("expected 0 FetchPrices calls for gap older than max history, got %d", stub.calls)
+	}
+}
+
+// ErrNoData is an answer, not a failure to answer. Recording it as coverage is
+// what stops a pre-IPO, delisted or untraded range being asked about forever.
+func TestRunCycle_NoDataRecordsCoverage(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockDB := mock.NewMockDB(ctrl)
+	ctx := context.Background()
+
+	instID := "inst-1"
+	pluginID := "test-plugin"
+	from, to := d(2024, 1, 1), d(2024, 1, 11)
+
+	stub := &fetchStub{idTypes: []string{"MIC_TICKER"}, err: ErrNoData}
+	reg := NewRegistry()
+	reg.Register(pluginID, stub)
+
+	mockDB.EXPECT().FXGaps(gomock.Any(), gomock.Any()).Return(nil, nil)
+	mockDB.EXPECT().PriceGaps(gomock.Any(), gomock.Any()).Return([]db.InstrumentDateRanges{
+		{InstrumentID: instID, Ranges: []db.DateRange{{From: from, Before: to}}},
+	}, nil)
+	mockDB.EXPECT().ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryPrice).Return([]db.PluginConfigRow{
+		{PluginID: pluginID, Precedence: 10, Config: []byte("{}")},
+	}, nil)
+	mockDB.EXPECT().BlockedPluginsForInstruments(gomock.Any(), []string{instID}).Return(nil, nil)
+	mockDB.EXPECT().PriceCoverageByPlugin(gomock.Any(), []string{instID}).Return(nil, nil)
+	mockDB.EXPECT().ListInstrumentsByIDs(gomock.Any(), []string{instID}).Return([]*db.InstrumentRow{
+		{ID: instID, AssetClass: strPtr("STOCK"), Identifiers: []db.IdentifierInput{{Type: "MIC_TICKER", Value: "AAPL"}}},
+	}, nil)
+	mockDB.EXPECT().UpsertPricesWithFill(gomock.Any(), instID, pluginID, nil, from, to, gomock.Any()).Return(nil)
+
+	runCycle(ctx, mockDB, reg, nil, nil, nil)
+
+	if stub.calls != 1 {
+		t.Errorf("expected 1 FetchPrices call, got %d", stub.calls)
+	}
+}
+
+// A range this plugin has already answered for is not put to it again, which is
+// what makes the previous test's recording worth anything.
+func TestRunCycle_CoveredRangeNotRefetched(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockDB := mock.NewMockDB(ctrl)
+	ctx := context.Background()
+
+	instID := "inst-1"
+	pluginID := "test-plugin"
+	from, to := d(2024, 1, 1), d(2024, 1, 11)
+
+	stub := &fetchStub{idTypes: []string{"MIC_TICKER"}, err: ErrNoData}
+	reg := NewRegistry()
+	reg.Register(pluginID, stub)
+
+	mockDB.EXPECT().FXGaps(gomock.Any(), gomock.Any()).Return(nil, nil)
+	mockDB.EXPECT().PriceGaps(gomock.Any(), gomock.Any()).Return([]db.InstrumentDateRanges{
+		{InstrumentID: instID, Ranges: []db.DateRange{{From: from, Before: to}}},
+	}, nil)
+	mockDB.EXPECT().ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryPrice).Return([]db.PluginConfigRow{
+		{PluginID: pluginID, Precedence: 10, Config: []byte("{}")},
+	}, nil)
+	mockDB.EXPECT().BlockedPluginsForInstruments(gomock.Any(), []string{instID}).Return(nil, nil)
+	mockDB.EXPECT().PriceCoverageByPlugin(gomock.Any(), []string{instID}).Return(
+		map[string]map[string][]db.DateRange{instID: {pluginID: {{From: from, Before: to}}}}, nil)
+	mockDB.EXPECT().ListInstrumentsByIDs(gomock.Any(), []string{instID}).Return([]*db.InstrumentRow{
+		{ID: instID, AssetClass: strPtr("STOCK"), Identifiers: []db.IdentifierInput{{Type: "MIC_TICKER", Value: "AAPL"}}},
+	}, nil)
+
+	runCycle(ctx, mockDB, reg, nil, nil, nil)
+
+	if stub.calls != 0 {
+		t.Errorf("expected no FetchPrices call for an already covered range, got %d", stub.calls)
+	}
+}
+
+// Coverage is per plugin, so what one plugin has settled does not silence
+// another -- including a plugin configured after the first gave up.
+func TestRunCycle_OtherPluginStillAskedAfterCoverage(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockDB := mock.NewMockDB(ctrl)
+	ctx := context.Background()
+
+	instID := "inst-1"
+	coveredID, freshID := "covered-plugin", "fresh-plugin"
+	from, to := d(2024, 1, 1), d(2024, 1, 11)
+
+	covered := &fetchStub{idTypes: []string{"MIC_TICKER"}, err: ErrNoData}
+	fresh := &fetchStub{idTypes: []string{"MIC_TICKER"},
+		result: &FetchResult{Bars: []DailyBar{{Date: d(2024, 1, 3), Close: 100}}}}
+	reg := NewRegistry()
+	reg.Register(coveredID, covered)
+	reg.Register(freshID, fresh)
+
+	mockDB.EXPECT().FXGaps(gomock.Any(), gomock.Any()).Return(nil, nil)
+	mockDB.EXPECT().PriceGaps(gomock.Any(), gomock.Any()).Return([]db.InstrumentDateRanges{
+		{InstrumentID: instID, Ranges: []db.DateRange{{From: from, Before: to}}},
+	}, nil)
+	mockDB.EXPECT().ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryPrice).Return([]db.PluginConfigRow{
+		{PluginID: coveredID, Precedence: 20, Config: []byte("{}")},
+		{PluginID: freshID, Precedence: 10, Config: []byte("{}")},
+	}, nil)
+	mockDB.EXPECT().BlockedPluginsForInstruments(gomock.Any(), []string{instID}).Return(nil, nil)
+	mockDB.EXPECT().PriceCoverageByPlugin(gomock.Any(), []string{instID}).Return(
+		map[string]map[string][]db.DateRange{instID: {coveredID: {{From: from, Before: to}}}}, nil)
+	mockDB.EXPECT().ListInstrumentsByIDs(gomock.Any(), []string{instID}).Return([]*db.InstrumentRow{
+		{ID: instID, AssetClass: strPtr("STOCK"), Identifiers: []db.IdentifierInput{{Type: "MIC_TICKER", Value: "AAPL"}}},
+	}, nil)
+	mockDB.EXPECT().UpsertPricesWithFill(gomock.Any(), instID, freshID, gomock.Any(), from, to, gomock.Any()).Return(nil)
+
+	runCycle(ctx, mockDB, reg, nil, nil, nil)
+
+	if covered.calls != 0 {
+		t.Errorf("covered plugin should not be asked again, got %d calls", covered.calls)
+	}
+	if fresh.calls != 1 {
+		t.Errorf("expected the uncovered plugin to be asked once, got %d", fresh.calls)
 	}
 }
 


### PR DESCRIPTION
Second of five. **Stacked on #296** -- review that first; this PR's diff
against `main` will include it until #296 merges.

## Changes

`PriceCoverage` reads `price_coverage` instead of `range_agg` over `eod_prices`.
A range a provider answered with no bars now counts as covered -- the case row
presence cannot express, and the reason the fetcher rediscovered the same
delisted or pre-IPO range as a gap on every cycle.

The fetcher records the negative answers it used to drop:

- `ErrNoData` covers the range for that plugin, instead of a bare `continue`.
- A gap outside a plugin's `max_history_days` covers the unreachable part for
  that plugin -- the whole gap when it is entirely out of reach, or just the head
  when the tail is fetchable.

## Why coverage is per-plugin

Recording "nothing here" against the instrument alone would be wrong: it would
silence every other plugin for that range, including one configured later
precisely because it has deeper history. So coverage keeps the `(instrument,
plugin)` key that `corporate_event_coverage` already uses, and
`PriceCoverageByPlugin` exposes it to the worker, which subtracts each plugin's
own coverage before asking it.

One consequence worth flagging: a plugin with nothing outstanding is now skipped
rather than treated as having handled the instrument. Without that, a fully
covered plugin would `break` the precedence loop and starve the plugins behind
it -- caught by `TestRunCycle_OtherPluginStillAskedAfterCoverage`.

## Test changes that are behaviour changes

- `TestUpsertPricesWithFill_NoSeedNoBars` asserted that no bars means no
  coverage. It now asserts the opposite, which is the point of the change: no
  rows inserted, but the range is covered.
- The two `max_history` tests now assert the coverage write.
- `insertPrice` records coverage alongside the row, so fixtures cannot construct
  a bar outside any covered span -- a state the write path cannot produce.

## Testing

`make test` passes. New: `TestPriceGaps_EmptyCoverageIsNotAGap`,
`TestPriceCoverageByPlugin_SeparatesPlugins`, `TestRunCycle_NoDataRecordsCoverage`,
`TestRunCycle_CoveredRangeNotRefetched`,
`TestRunCycle_OtherPluginStillAskedAfterCoverage`.

## Next in the stack

3. Derive the LOCF fill at read time and drop synthetic rows.
4. Export/import read and store coverage.
5. Spec updates and an ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)