### PR TITLE
Derive the price carry-forward at read time

### DIFF
--- a/client/app/admin/prices/page.tsx
+++ b/client/app/admin/prices/page.tsx
@@ -311,10 +311,7 @@ function PriceList({
 
 function PriceRow({ price: p }: { price: EODPriceProto }) {
   return (
-    <tr className={
-      "border-b border-border/40 last:border-0 hover:bg-primary-light/10" +
-      (p.synthetic ? " opacity-60" : "")
-    }>
+    <tr className="border-b border-border/40 last:border-0 hover:bg-primary-light/10">
       <td className="px-4 py-2 font-medium text-text-primary">
         {p.instrumentDisplayName}
       </td>
@@ -337,14 +334,7 @@ function PriceRow({ price: p }: { price: EODPriceProto }) {
       <td className="px-4 py-2 text-right font-mono text-text-muted">
         {fmtVolume(p.volume)}
       </td>
-      <td className="px-4 py-2 text-text-muted">
-        {p.dataProvider}
-        {p.synthetic && (
-          <span className="ml-2 inline-block rounded-sm bg-amber-100 px-1.5 py-0.5 text-[10px] font-medium uppercase text-amber-700">
-            Synthetic
-          </span>
-        )}
-      </td>
+      <td className="px-4 py-2 text-text-muted">{p.dataProvider}</td>
     </tr>
   );
 }

--- a/client/lib/csv/prices.ts
+++ b/client/lib/csv/prices.ts
@@ -44,7 +44,7 @@ function fmtOptBigint(v: bigint | undefined): string {
  * Serialize ExportPriceRow[] to CSV text.
  *
  * Coverage spans are written as "# coverage=" headers in the specific form.
- * They matter: the export omits synthetic rows, so the spans are what let a
+ * They matter: a span is not derivable from the rows, so it is what lets a
  * re-import regenerate the filled days rather than leaving them as gaps.
  */
 export function pricesToCsv(rows: ExportPriceRow[], exportedAt?: Date, coverage?: ExportCoverage[]): string {

--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -666,7 +666,6 @@ message EODPriceProto {
   // Knowledge time: when this row was last fetched. Staleness only -- it says
   // nothing about the prices themselves.
   google.protobuf.Timestamp last_fetched_at = 11;
-  bool synthetic = 12;
   // The share count the raw values are denominated in, as "YYYY-MM-DD".
   string share_count_basis = 13;
 }
@@ -691,9 +690,10 @@ message ListPricesResponse {
 message ExportPricesRequest {}
 
 // ExportCoverage is one half-open [from, before) coverage span for an
-// instrument, streamed alongside the rows it covers. Re-importing rows without
-// their coverage does not reproduce the exported state: only real bars are
-// exported, so the synthetic days between them are regenerated from coverage.
+// instrument, streamed alongside the rows it covers. It records that a provider
+// answered for the range, which the rows cannot say on their own: a span with no
+// rows in it means the provider was asked and had nothing. Re-importing rows
+// without their coverage loses that.
 message ExportCoverage {
   string identifier_type = 1;
   string identifier_value = 2;
@@ -753,9 +753,10 @@ message ImportPriceRow {
 
 message ImportPricesRequest {
   repeated ImportPriceRow prices = 1;
-  // Optional coverage ranges. When set for an instrument, the server uses
-  // UpsertPricesWithFill to generate synthetic LOCF prices for non-trading
-  // days within each range. When absent, prices are upserted as-is.
+  // Optional coverage ranges. When set for an instrument, the server records
+  // the range as covered, so valuation carries prices forward across
+  // non-trading days within it. When absent, each row covers only its own date
+  // and gaps between rows stay gaps.
   repeated ImportCoverage coverage = 2;
   // Knowledge time: when the supplied data was current. OCC symbols are
   // split-adjusted to this point during instrument resolution, and imported
@@ -764,9 +765,10 @@ message ImportPricesRequest {
   google.protobuf.Timestamp exported_at = 3;
 }
 
-// ImportCoverage declares that the caller intends to cover a half-open
-// [from, before) date range for an instrument. The server fills gaps within
-// this range with synthetic prices.
+// ImportCoverage declares that the caller has authoritative coverage of a
+// half-open [from, before) date range for an instrument. The server stores it,
+// so the range is not re-fetched and prices carry forward across non-trading
+// days inside it.
 message ImportCoverage {
   string identifier_type = 1;
   string identifier_value = 2;

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -28,6 +28,10 @@ const (
 	CorporateEventProviderBroker = "broker"
 )
 
+// PriceProviderImport tags price coverage that came from an import rather than a
+// plugin, so the fetcher does not treat a hand-curated range as one of its own.
+const PriceProviderImport = "import"
+
 // Job type constants for the ingestion_jobs table.
 const (
 	JobTypeTx             = "tx"
@@ -97,7 +101,6 @@ type EODPrice struct {
 	// basis and typically including dividend adjustment. Stored for cross-checking
 	// only; never an input to valuation. nil when the provider does not supply it.
 	AdjustedClose *float64
-	Synthetic     bool       // true for forward-filled non-trading day prices
 	LastFetchedAt *time.Time // when this row was fetched; nil defaults to now()
 	// ShareCountBasis is the date at which the share count these raw values are
 	// denominated in was current. nil defaults to PriceDate (as-traded).
@@ -123,14 +126,14 @@ type PriceCacheDB interface {
 	// FXGaps computes date ranges where FX rates are needed (non-USD instruments
 	// are held) but not yet cached. Returns gaps keyed by FX pair instrument ID.
 	FXGaps(ctx context.Context, opts HeldRangesOpts) ([]InstrumentDateRanges, error)
-	// UpsertPrices inserts or updates EOD prices. On conflict (instrument_id, price_date)
-	// real prices always overwrite; synthetic prices only insert when no row exists
-	// or the existing row is also synthetic.
+	// UpsertPrices inserts or updates EOD prices, each covering its own date.
+	// Use it when the caller has no range to declare beyond the days it names.
 	UpsertPrices(ctx context.Context, prices []EODPrice) error
-	// UpsertPricesWithFill inserts real bars and generates synthetic LOCF prices
-	// for every date in [from, before) that has no real bar, all in a single SQL
-	// statement. The last non-synthetic close before `from` seeds the forward-fill.
-	UpsertPricesWithFill(ctx context.Context, instrumentID, provider string, bars []EODPrice, from, before time.Time, fetchedAt *time.Time) error
+	// UpsertPricesForRange stores bars and records [from, before) as coverage in
+	// one transaction, whether or not any bars came back. Days in the range with
+	// no bar stay absent: the carry-forward is applied at read time and bounded
+	// by this coverage, so it is never stored.
+	UpsertPricesForRange(ctx context.Context, instrumentID, provider string, bars []EODPrice, from, before time.Time, fetchedAt *time.Time) error
 }
 
 // PluginConfigDB provides unified plugin config CRUD for all categories.
@@ -359,7 +362,6 @@ type EODPriceRow struct {
 	AdjustedClose         *float64
 	Volume                *int64
 	DataProvider          string
-	Synthetic             bool
 	LastFetchedAt         time.Time
 	ShareCountBasis       time.Time
 }

--- a/server/db/postgres/coverage_test.go
+++ b/server/db/postgres/coverage_test.go
@@ -75,9 +75,9 @@ func assertCoverageContains(t *testing.T, p *Postgres) {
 	}
 }
 
-// UpsertPricesWithFill records its declared range, not merely the days it wrote
+// UpsertPricesForRange records its declared range, not merely the days it wrote
 // rows for: the range is what the provider was asked about.
-func TestUpsertPricesWithFill_RecordsDeclaredRange(t *testing.T) {
+func TestUpsertPricesForRange_RecordsDeclaredRange(t *testing.T) {
 	p := testDBTx(t)
 	ctx := context.Background()
 	instID := setupInstrument(t, p, "AAPL")
@@ -86,8 +86,8 @@ func TestUpsertPricesWithFill_RecordsDeclaredRange(t *testing.T) {
 		{InstrumentID: instID, PriceDate: d(2024, 1, 3), Close: 10},
 		{InstrumentID: instID, PriceDate: d(2024, 1, 5), Close: 12},
 	}
-	if err := p.UpsertPricesWithFill(ctx, instID, "massive", bars, d(2024, 1, 1), d(2024, 1, 11), nil); err != nil {
-		t.Fatalf("upsert with fill: %v", err)
+	if err := p.UpsertPricesForRange(ctx, instID, "massive", bars, d(2024, 1, 1), d(2024, 1, 11), nil); err != nil {
+		t.Fatalf("upsert for range: %v", err)
 	}
 
 	assertRanges(t, readPriceCoverage(t, p, instID), []db.DateRange{
@@ -98,13 +98,13 @@ func TestUpsertPricesWithFill_RecordsDeclaredRange(t *testing.T) {
 
 // A provider that returns nothing has still covered the range. This is the case
 // row presence alone cannot express, and the reason the table exists.
-func TestUpsertPricesWithFill_EmptyResultStillCovers(t *testing.T) {
+func TestUpsertPricesForRange_EmptyResultStillCovers(t *testing.T) {
 	p := testDBTx(t)
 	ctx := context.Background()
 	instID := setupInstrument(t, p, "DELISTED")
 
-	if err := p.UpsertPricesWithFill(ctx, instID, "massive", nil, d(2024, 1, 1), d(2024, 1, 11), nil); err != nil {
-		t.Fatalf("upsert with fill: %v", err)
+	if err := p.UpsertPricesForRange(ctx, instID, "massive", nil, d(2024, 1, 1), d(2024, 1, 11), nil); err != nil {
+		t.Fatalf("upsert for range: %v", err)
 	}
 
 	assertRanges(t, readPriceCoverage(t, p, instID), []db.DateRange{
@@ -139,17 +139,17 @@ func TestUpsertPrices_CoversSuppliedDatesOnly(t *testing.T) {
 
 // Two disjoint held periods stay disjoint: the hole between them is a fact
 // about what was fetched, and merging would erase it.
-func TestUpsertPricesWithFill_DisjointPeriodsStayDisjoint(t *testing.T) {
+func TestUpsertPricesForRange_DisjointPeriodsStayDisjoint(t *testing.T) {
 	p := testDBTx(t)
 	ctx := context.Background()
 	instID := setupInstrument(t, p, "AAPL")
 
 	first := []db.EODPrice{{InstrumentID: instID, PriceDate: d(2023, 1, 3), Close: 10}}
-	if err := p.UpsertPricesWithFill(ctx, instID, "massive", first, d(2023, 1, 1), d(2023, 7, 1), nil); err != nil {
+	if err := p.UpsertPricesForRange(ctx, instID, "massive", first, d(2023, 1, 1), d(2023, 7, 1), nil); err != nil {
 		t.Fatalf("upsert first period: %v", err)
 	}
 	second := []db.EODPrice{{InstrumentID: instID, PriceDate: d(2024, 1, 3), Close: 20}}
-	if err := p.UpsertPricesWithFill(ctx, instID, "massive", second, d(2024, 1, 1), d(2024, 7, 1), nil); err != nil {
+	if err := p.UpsertPricesForRange(ctx, instID, "massive", second, d(2024, 1, 1), d(2024, 7, 1), nil); err != nil {
 		t.Fatalf("upsert second period: %v", err)
 	}
 
@@ -162,15 +162,15 @@ func TestUpsertPricesWithFill_DisjointPeriodsStayDisjoint(t *testing.T) {
 
 // Coverage is per plugin, so a range one plugin declined does not stop another
 // being asked. Both spans coexist for the same instrument.
-func TestUpsertPricesWithFill_CoverageIsPerPlugin(t *testing.T) {
+func TestUpsertPricesForRange_CoverageIsPerPlugin(t *testing.T) {
 	p := testDBTx(t)
 	ctx := context.Background()
 	instID := setupInstrument(t, p, "AAPL")
 
-	if err := p.UpsertPricesWithFill(ctx, instID, "massive", nil, d(2024, 1, 1), d(2024, 1, 11), nil); err != nil {
+	if err := p.UpsertPricesForRange(ctx, instID, "massive", nil, d(2024, 1, 1), d(2024, 1, 11), nil); err != nil {
 		t.Fatalf("upsert massive: %v", err)
 	}
-	if err := p.UpsertPricesWithFill(ctx, instID, "eodhd", nil, d(2024, 1, 1), d(2024, 1, 11), nil); err != nil {
+	if err := p.UpsertPricesForRange(ctx, instID, "eodhd", nil, d(2024, 1, 1), d(2024, 1, 11), nil); err != nil {
 		t.Fatalf("upsert eodhd: %v", err)
 	}
 
@@ -192,7 +192,7 @@ func TestPriceCoverage_CascadesOnInstrumentDelete(t *testing.T) {
 	ctx := context.Background()
 	instID := setupInstrument(t, p, "AAPL")
 
-	if err := p.UpsertPricesWithFill(ctx, instID, "massive", nil, d(2024, 1, 1), d(2024, 1, 11), nil); err != nil {
+	if err := p.UpsertPricesForRange(ctx, instID, "massive", nil, d(2024, 1, 1), d(2024, 1, 11), nil); err != nil {
 		t.Fatalf("upsert: %v", err)
 	}
 	if _, err := p.q.ExecContext(ctx, `DELETE FROM instruments WHERE id = $1::uuid`, instID); err != nil {

--- a/server/db/postgres/eod_prices.go
+++ b/server/db/postgres/eod_prices.go
@@ -49,7 +49,7 @@ func (p *Postgres) ListPrices(ctx context.Context, search string, dateFrom, date
 	q, args, err := psql.Select(
 		"ep.instrument_id", "i.name AS display_name",
 		"ep.price_date", "ep.open", "ep.high", "ep.low", "ep.close", "ep.adjusted_close",
-		"ep.volume", "ep.data_provider", "ep.synthetic", "ep.last_fetched_at",
+		"ep.volume", "ep.data_provider", "ep.last_fetched_at",
 		"ep.share_count_basis",
 	).
 		From("eod_prices ep").
@@ -76,7 +76,7 @@ func (p *Postgres) ListPrices(ctx context.Context, search string, dateFrom, date
 		if err := rows.Scan(
 			&r.InstrumentID, &r.InstrumentDisplayName,
 			&r.PriceDate, &open, &high, &low, &r.Close, &adjClose,
-			&volume, &r.DataProvider, &r.Synthetic, &r.LastFetchedAt, &r.ShareCountBasis,
+			&volume, &r.DataProvider, &r.LastFetchedAt, &r.ShareCountBasis,
 		); err != nil {
 			return nil, 0, "", err
 		}
@@ -137,7 +137,6 @@ func (p *Postgres) ListPricesForExport(ctx context.Context) ([]db.ExportPriceRow
 		FROM eod_prices ep
 		JOIN instruments i ON i.id = ep.instrument_id
 		` + bestIdentifierJoin + `
-		WHERE NOT ep.synthetic
 		ORDER BY best_id.identifier_type, best_id.value, ep.price_date
 	`
 	var rows []exportPriceRow
@@ -189,17 +188,17 @@ func toExportCoverageRows(rows []exportCoverageRow) []db.ExportCoverageRow {
 
 // ListPriceCoverageForExport implements db.EODPriceListDB.
 //
-// Synthetic rows are included in the aggregation even though
-// ListPricesForExport omits them: the span is exactly what tells an import
-// which days to regenerate.
+// Spans come from price_coverage, so a range a provider answered with no bars
+// travels with the file. Merged across plugins: an import stores everything
+// under one provider, so the distinction cannot survive the round trip.
 func (p *Postgres) ListPriceCoverageForExport(ctx context.Context) ([]db.ExportCoverageRow, error) {
 	q := `
 		SELECT best_id.identifier_type, best_id.value, COALESCE(best_id.domain, '') AS domain,
 			lower(sub.r) AS covered_from, upper(sub.r) AS covered_before
 		FROM (
 			SELECT instrument_id,
-				unnest(range_agg(daterange(price_date, price_date + 1))) AS r
-			FROM eod_prices
+				unnest(range_agg(daterange(covered_from, covered_before))) AS r
+			FROM price_coverage
 			GROUP BY instrument_id
 		) sub
 		JOIN instruments i ON i.id = sub.instrument_id

--- a/server/db/postgres/eod_prices_test.go
+++ b/server/db/postgres/eod_prices_test.go
@@ -19,6 +19,7 @@ func insertPriceWithProvider(t *testing.T, p *Postgres, instID string, priceDate
 	if err != nil {
 		t.Fatalf("insert price: %v", err)
 	}
+	insertCoverage(t, p, instID, priceDate, priceDate.Add(db.Day))
 }
 
 // insertPriceFull inserts a price row with all OHLCV fields.
@@ -32,6 +33,7 @@ func insertPriceFull(t *testing.T, p *Postgres, instID string, priceDate time.Ti
 	if err != nil {
 		t.Fatalf("insert price: %v", err)
 	}
+	insertCoverage(t, p, instID, priceDate, priceDate.Add(db.Day))
 }
 
 func TestListPrices_Empty(t *testing.T) {
@@ -345,18 +347,18 @@ func setupTickerInstrument(t *testing.T, p *Postgres, ticker string) string {
 	return id
 }
 
-// The export omits synthetic rows, so the coverage span is the only thing that
-// tells an import which days to regenerate. It must therefore span them.
-func TestListPriceCoverageForExport_SpansSyntheticRows(t *testing.T) {
+// The exported span is the declared range, not the dates that happen to have
+// rows: the days between the bars are covered and must travel with the file.
+func TestListPriceCoverageForExport_SpansDeclaredRange(t *testing.T) {
 	p := testDBTx(t)
 	ctx := context.Background()
 
 	instID := setupTickerInstrument(t, p, "AAPL")
-	if err := p.UpsertPricesWithFill(ctx, instID, "test", []db.EODPrice{
+	if err := p.UpsertPricesForRange(ctx, instID, "test", []db.EODPrice{
 		{InstrumentID: instID, PriceDate: d(2024, 1, 15), Close: 100},
 		{InstrumentID: instID, PriceDate: d(2024, 1, 18), Close: 110},
 	}, d(2024, 1, 15), d(2024, 1, 19), nil); err != nil {
-		t.Fatalf("upsert prices with fill: %v", err)
+		t.Fatalf("upsert prices for range: %v", err)
 	}
 
 	rows, err := p.ListPricesForExport(ctx)

--- a/server/db/postgres/price_cache.go
+++ b/server/db/postgres/price_cache.go
@@ -449,8 +449,6 @@ func displayCurrencyFXValues(currencies []string) []string {
 
 // UpsertPrices implements db.PriceCacheDB.
 // It bulk inserts EOD prices using unnest arrays, updating on conflict.
-// Real prices (synthetic=false) always overwrite existing rows. Synthetic
-// prices only overwrite when the existing row is also synthetic.
 //
 // Each supplied bar covers its own date and nothing more: a caller with no
 // range to declare is asserting the days it names, not the span between them.
@@ -466,6 +464,26 @@ func (p *Postgres) UpsertPrices(ctx context.Context, prices []db.EODPrice) error
 		}
 		return coverSuppliedDates(ctx, exec, prices)
 	})
+}
+
+// dedupeByInstrumentDate keeps the last bar supplied for each (instrument, date).
+func dedupeByInstrumentDate(prices []db.EODPrice) []db.EODPrice {
+	type key struct {
+		instrumentID string
+		date         time.Time
+	}
+	seen := make(map[key]int, len(prices))
+	out := make([]db.EODPrice, 0, len(prices))
+	for _, pr := range prices {
+		k := key{pr.InstrumentID, pr.PriceDate.Truncate(db.Day)}
+		if i, ok := seen[k]; ok {
+			out[i] = pr
+			continue
+		}
+		seen[k] = len(out)
+		out = append(out, pr)
+	}
+	return out
 }
 
 // coverSuppliedDates records one coverage span per contiguous run of supplied
@@ -490,6 +508,9 @@ func coverSuppliedDates(ctx context.Context, exec queryable, prices []db.EODPric
 }
 
 func upsertPrices(ctx context.Context, exec queryable, prices []db.EODPrice) error {
+	// ON CONFLICT DO UPDATE cannot touch the same row twice in one statement, and
+	// providers do repeat a date within a response. Last one supplied wins.
+	prices = dedupeByInstrumentDate(prices)
 
 	instIDs := make([]string, len(prices))
 	dates := make([]time.Time, len(prices))
@@ -499,7 +520,6 @@ func upsertPrices(ctx context.Context, exec queryable, prices []db.EODPrice) err
 	closes := make([]float64, len(prices))
 	volumes := make([]*int64, len(prices))
 	providers := make([]string, len(prices))
-	synthetics := make([]bool, len(prices))
 	fetchedAts := make([]time.Time, len(prices))
 	bases := make([]time.Time, len(prices))
 	adjCloses := make([]*float64, len(prices))
@@ -514,7 +534,6 @@ func upsertPrices(ctx context.Context, exec queryable, prices []db.EODPrice) err
 		closes[i] = pr.Close
 		volumes[i] = pr.Volume
 		providers[i] = pr.DataProvider
-		synthetics[i] = pr.Synthetic
 		adjCloses[i] = pr.AdjustedClose
 		if pr.LastFetchedAt != nil {
 			fetchedAts[i] = *pr.LastFetchedAt
@@ -531,13 +550,13 @@ func upsertPrices(ctx context.Context, exec queryable, prices []db.EODPrice) err
 	}
 
 	_, err := exec.ExecContext(ctx, `
-		INSERT INTO eod_prices (instrument_id, price_date, open, high, low, close, volume, data_provider, synthetic, last_fetched_at, share_count_basis, adjusted_close)
+		INSERT INTO eod_prices (instrument_id, price_date, open, high, low, close, volume, data_provider, last_fetched_at, share_count_basis, adjusted_close)
 		SELECT unnest($1::uuid[]), unnest($2::date[]), unnest($3::double precision[]),
 			unnest($4::double precision[]), unnest($5::double precision[]),
 			unnest($6::double precision[]), unnest($7::bigint[]),
-			unnest($8::text[]), unnest($9::boolean[]),
-			unnest($10::timestamptz[]), unnest($11::date[]),
-			unnest($12::double precision[])
+			unnest($8::text[]),
+			unnest($9::timestamptz[]), unnest($10::date[]),
+			unnest($11::double precision[])
 		ON CONFLICT (instrument_id, price_date) DO UPDATE SET
 			open = EXCLUDED.open,
 			high = EXCLUDED.high,
@@ -545,16 +564,14 @@ func upsertPrices(ctx context.Context, exec queryable, prices []db.EODPrice) err
 			close = EXCLUDED.close,
 			volume = EXCLUDED.volume,
 			data_provider = EXCLUDED.data_provider,
-			synthetic = EXCLUDED.synthetic,
 			last_fetched_at = EXCLUDED.last_fetched_at,
 			-- Basis travels with the raw values it describes; restating one
 			-- without the other would leave the row self-inconsistent.
 			share_count_basis = EXCLUDED.share_count_basis,
 			adjusted_close = EXCLUDED.adjusted_close
-		WHERE eod_prices.synthetic = true OR EXCLUDED.synthetic = false
 	`, pq.Array(instIDs), pq.Array(dates), pq.Array(opens),
 		pq.Array(highs), pq.Array(lows), pq.Array(closes),
-		pq.Array(volumes), pq.Array(providers), pq.Array(synthetics),
+		pq.Array(volumes), pq.Array(providers),
 		pq.Array(fetchedAts), pq.Array(bases), pq.Array(adjCloses))
 	if err != nil {
 		return fmt.Errorf("upsert prices: %w", err)
@@ -562,141 +579,32 @@ func upsertPrices(ctx context.Context, exec queryable, prices []db.EODPrice) err
 	return nil
 }
 
-// UpsertPricesWithFill implements db.PriceCacheDB.
-// It inserts real bars and generates synthetic LOCF prices for every date in
-// [from, before) that has no real bar, all in a single SQL round-trip. The last
-// non-synthetic close price before `from` seeds the forward-fill for dates
-// preceding the first real bar.
+// UpsertPricesForRange implements db.PriceCacheDB.
 //
-// [from, before) is recorded as coverage in the same transaction, whether or not
-// any bars came back: a provider that answered "nothing here" has covered the
-// range just as authoritatively as one that returned a full series.
-func (p *Postgres) UpsertPricesWithFill(ctx context.Context, instrumentID, provider string, bars []db.EODPrice, from, before time.Time, fetchedAt *time.Time) error {
+// The bars are stored as supplied and [from, before) is recorded as coverage, in
+// one transaction. Days inside the range with no bar are left absent rather than
+// filled: the carry-forward happens at read time, bounded by this same coverage,
+// so storing it as well would only be a second copy of a derivable fact.
+//
+// Coverage is recorded whether or not any bars came back. A provider that
+// answered "nothing here" has covered the range just as authoritatively as one
+// that returned a full series.
+func (p *Postgres) UpsertPricesForRange(ctx context.Context, instrumentID, provider string, bars []db.EODPrice, from, before time.Time, fetchedAt *time.Time) error {
 	return p.runInTx(ctx, func(exec queryable) error {
-		if err := upsertPricesWithFill(ctx, exec, instrumentID, provider, bars, from, before, fetchedAt); err != nil {
-			return err
+		if len(bars) > 0 {
+			priced := make([]db.EODPrice, len(bars))
+			for i, b := range bars {
+				b.InstrumentID = instrumentID
+				b.DataProvider = provider
+				if b.LastFetchedAt == nil {
+					b.LastFetchedAt = fetchedAt
+				}
+				priced[i] = b
+			}
+			if err := upsertPrices(ctx, exec, priced); err != nil {
+				return err
+			}
 		}
 		return upsertCoverageSpan(ctx, exec, priceCoverageTable, instrumentID, provider, from, before, fetchedAt)
 	})
-}
-
-func upsertPricesWithFill(ctx context.Context, exec queryable, instrumentID, provider string, bars []db.EODPrice, from, before time.Time, fetchedAt *time.Time) error {
-	id, err := uuid.Parse(instrumentID)
-	if err != nil {
-		return fmt.Errorf("upsert prices with fill: invalid id %q: %w", instrumentID, err)
-	}
-
-	if fetchedAt == nil {
-		now := time.Now()
-		fetchedAt = &now
-	}
-
-	// Deduplicate bars by date, keeping the last occurrence.
-	seen := make(map[time.Time]int, len(bars))
-	deduped := make([]db.EODPrice, 0, len(bars))
-	for _, b := range bars {
-		d := b.PriceDate.Truncate(24 * time.Hour)
-		if idx, ok := seen[d]; ok {
-			deduped[idx] = b
-		} else {
-			seen[d] = len(deduped)
-			deduped = append(deduped, b)
-		}
-	}
-	bars = deduped
-
-	dates := make([]time.Time, len(bars))
-	opens := make([]*float64, len(bars))
-	highs := make([]*float64, len(bars))
-	lows := make([]*float64, len(bars))
-	closes := make([]float64, len(bars))
-	volumes := make([]*int64, len(bars))
-	bases := make([]time.Time, len(bars))
-	adjCloses := make([]*float64, len(bars))
-	for i, b := range bars {
-		dates[i] = b.PriceDate
-		opens[i] = b.Open
-		highs[i] = b.High
-		lows[i] = b.Low
-		closes[i] = b.Close
-		volumes[i] = b.Volume
-		adjCloses[i] = b.AdjustedClose
-		// Undeclared basis means as-traded.
-		if b.ShareCountBasis != nil {
-			bases[i] = *b.ShareCountBasis
-		} else {
-			bases[i] = b.PriceDate
-		}
-	}
-
-	_, err = exec.ExecContext(ctx, `
-		WITH
-		seed AS (
-			SELECT close, share_count_basis FROM eod_prices
-			WHERE instrument_id = $1 AND price_date < $2::date AND NOT synthetic
-			ORDER BY price_date DESC LIMIT 1
-		),
-		new_bars AS (
-			SELECT unnest($4::date[]) AS price_date,
-				unnest($5::double precision[]) AS bopen,
-				unnest($6::double precision[]) AS bhigh,
-				unnest($7::double precision[]) AS blow,
-				unnest($8::double precision[]) AS bclose,
-				unnest($9::bigint[]) AS bvolume,
-				unnest($12::date[]) AS bbasis,
-				unnest($13::double precision[]) AS badjclose
-		),
-		all_points AS (
-			-- Virtual seed point before range start for LOCF initialization.
-			SELECT ($2::date - 1) AS price_date,
-				NULL::double precision AS bopen, NULL::double precision AS bhigh,
-				NULL::double precision AS blow, s.close AS bclose,
-				NULL::bigint AS bvolume, s.share_count_basis AS bbasis,
-				NULL::double precision AS badjclose
-			FROM seed s
-			UNION ALL
-			-- Every date in [from, before) with real bar if available.
-			SELECT d::date, nb.bopen, nb.bhigh, nb.blow, nb.bclose, nb.bvolume, nb.bbasis, nb.badjclose
-			FROM generate_series($2::date, $3::date - interval '1 day', '1 day') d
-			LEFT JOIN new_bars nb ON nb.price_date = d::date
-		),
-		grouped AS (
-			SELECT *,
-				COUNT(bclose) OVER (ORDER BY price_date) AS grp
-			FROM all_points
-		),
-		locf AS (
-			SELECT price_date,
-				bopen AS open, bhigh AS high, blow AS low,
-				FIRST_VALUE(bclose) OVER (PARTITION BY grp ORDER BY price_date) AS close,
-				bvolume AS volume,
-				badjclose AS adjusted_close,
-				(bclose IS NULL) AS synthetic,
-				-- A forward-filled row carries the value of the bar it copied, so
-				-- it is denominated in that bar's share count, not its own date's.
-				FIRST_VALUE(bbasis) OVER (PARTITION BY grp ORDER BY price_date) AS share_count_basis
-			FROM grouped
-		)
-		INSERT INTO eod_prices (instrument_id, price_date, open, high, low, close, volume, data_provider, synthetic, last_fetched_at, share_count_basis, adjusted_close)
-		SELECT $1::uuid, price_date, open, high, low, close, volume, $10::text, synthetic, $11::timestamptz,
-			COALESCE(share_count_basis, price_date), adjusted_close
-		FROM locf
-		WHERE price_date >= $2::date AND close IS NOT NULL
-		ON CONFLICT (instrument_id, price_date) DO UPDATE SET
-			open = EXCLUDED.open, high = EXCLUDED.high, low = EXCLUDED.low,
-			close = EXCLUDED.close, volume = EXCLUDED.volume,
-			data_provider = EXCLUDED.data_provider, synthetic = EXCLUDED.synthetic,
-			last_fetched_at = EXCLUDED.last_fetched_at,
-			-- Basis travels with the raw values it describes; restating one
-			-- without the other would leave the row self-inconsistent.
-			share_count_basis = EXCLUDED.share_count_basis,
-			adjusted_close = EXCLUDED.adjusted_close
-		WHERE eod_prices.synthetic = true OR EXCLUDED.synthetic = false
-	`, id, from, before, pq.Array(dates), pq.Array(opens), pq.Array(highs),
-		pq.Array(lows), pq.Array(closes), pq.Array(volumes), provider, fetchedAt,
-		pq.Array(bases), pq.Array(adjCloses))
-	if err != nil {
-		return fmt.Errorf("upsert prices with fill: %w", err)
-	}
-	return nil
 }

--- a/server/db/postgres/price_cache_test.go
+++ b/server/db/postgres/price_cache_test.go
@@ -549,10 +549,10 @@ func TestPriceCoverageByPlugin_SeparatesPlugins(t *testing.T) {
 	ctx := context.Background()
 	instID := setupInstrument(t, p, "PERPLUGIN")
 
-	if err := p.UpsertPricesWithFill(ctx, instID, "massive", nil, d(2024, 1, 1), d(2024, 1, 11), nil); err != nil {
+	if err := p.UpsertPricesForRange(ctx, instID, "massive", nil, d(2024, 1, 1), d(2024, 1, 11), nil); err != nil {
 		t.Fatalf("upsert massive: %v", err)
 	}
-	if err := p.UpsertPricesWithFill(ctx, instID, "eodhd", nil, d(2024, 2, 1), d(2024, 2, 11), nil); err != nil {
+	if err := p.UpsertPricesForRange(ctx, instID, "eodhd", nil, d(2024, 2, 1), d(2024, 2, 11), nil); err != nil {
 		t.Fatalf("upsert eodhd: %v", err)
 	}
 
@@ -699,280 +699,88 @@ func TestUpsertPrices_Empty(t *testing.T) {
 	}
 }
 
-func TestUpsertPrices_SyntheticNeverOverwritesReal(t *testing.T) {
-	p := testDBTx(t)
-	ctx := context.Background()
-	instID := setupInstrument(t, p, "SYNTH1")
-
-	// Insert a real price.
-	err := p.UpsertPrices(ctx, []db.EODPrice{
-		{InstrumentID: instID, PriceDate: d(2024, 1, 5), Close: 100.0, DataProvider: "real", Synthetic: false},
-	})
-	if err != nil {
-		t.Fatalf("upsert real: %v", err)
-	}
-
-	// Attempt to overwrite with synthetic.
-	err = p.UpsertPrices(ctx, []db.EODPrice{
-		{InstrumentID: instID, PriceDate: d(2024, 1, 5), Close: 99.0, DataProvider: "real", Synthetic: true},
-	})
-	if err != nil {
-		t.Fatalf("upsert synthetic: %v", err)
-	}
-
-	// Verify real price is preserved.
-	var close float64
-	var synthetic bool
-	err = p.q.QueryRowContext(ctx,
-		`SELECT close, synthetic FROM eod_prices WHERE instrument_id = $1::uuid AND price_date = $2`,
-		instID, d(2024, 1, 5)).Scan(&close, &synthetic)
-	if err != nil {
-		t.Fatalf("query: %v", err)
-	}
-	if close != 100.0 {
-		t.Errorf("close = %v, want 100.0 (real preserved)", close)
-	}
-	if synthetic {
-		t.Error("synthetic = true, want false (real preserved)")
-	}
-}
-
-func TestUpsertPrices_RealOverwritesSynthetic(t *testing.T) {
-	p := testDBTx(t)
-	ctx := context.Background()
-	instID := setupInstrument(t, p, "SYNTH2")
-
-	// Insert a synthetic price.
-	err := p.UpsertPrices(ctx, []db.EODPrice{
-		{InstrumentID: instID, PriceDate: d(2024, 1, 6), Close: 100.0, DataProvider: "old", Synthetic: true},
-	})
-	if err != nil {
-		t.Fatalf("upsert synthetic: %v", err)
-	}
-
-	// Overwrite with real.
-	err = p.UpsertPrices(ctx, []db.EODPrice{
-		{InstrumentID: instID, PriceDate: d(2024, 1, 6), Close: 105.0, DataProvider: "real", Synthetic: false},
-	})
-	if err != nil {
-		t.Fatalf("upsert real: %v", err)
-	}
-
-	// Verify real price overwrote synthetic.
-	var close float64
-	var synthetic bool
-	err = p.q.QueryRowContext(ctx,
-		`SELECT close, synthetic FROM eod_prices WHERE instrument_id = $1::uuid AND price_date = $2`,
-		instID, d(2024, 1, 6)).Scan(&close, &synthetic)
-	if err != nil {
-		t.Fatalf("query: %v", err)
-	}
-	if close != 105.0 {
-		t.Errorf("close = %v, want 105.0", close)
-	}
-	if synthetic {
-		t.Error("synthetic = true, want false")
-	}
-}
-
-func TestUpsertPricesWithFill_BasicWeekend(t *testing.T) {
+// Non-trading days get no row. The filled series is derived at read time from
+// (bars, coverage), so storing it would be a second copy of a derivable fact.
+func TestUpsertPricesForRange_StoresOnlyRealBars(t *testing.T) {
 	p := testDBTx(t)
 	ctx := context.Background()
 	instID := setupInstrument(t, p, "FILL1")
 
-	// Mon-Fri real bars, gap range Mon-Mon (7 days).
+	// Mon-Fri real bars over a Mon-Mon range, so Sat and Sun have no bar.
 	mon := d(2024, 1, 1)
-	bars := []db.EODPrice{
-		{InstrumentID: instID, PriceDate: mon, Close: 102.0},
-		{InstrumentID: instID, PriceDate: mon.AddDate(0, 0, 1), Close: 103.0},
-		{InstrumentID: instID, PriceDate: mon.AddDate(0, 0, 2), Close: 104.0},
-		{InstrumentID: instID, PriceDate: mon.AddDate(0, 0, 3), Close: 105.0},
-		{InstrumentID: instID, PriceDate: mon.AddDate(0, 0, 4), Close: 106.0}, // Fri
-	}
-	to := mon.AddDate(0, 0, 7)
-	err := p.UpsertPricesWithFill(ctx, instID, "test", bars, mon, to, nil)
-	if err != nil {
-		t.Fatalf("upsert with fill: %v", err)
-	}
-
-	// Should have 7 rows: 5 real + 2 synthetic (Sat, Sun).
-	rows, err := p.q.QueryContext(ctx,
-		`SELECT price_date, close, synthetic FROM eod_prices WHERE instrument_id = $1::uuid ORDER BY price_date`, instID)
-	if err != nil {
-		t.Fatalf("query: %v", err)
-	}
-	defer rows.Close()
-
-	type row struct {
-		date      time.Time
-		close     float64
-		synthetic bool
-	}
-	var got []row
-	for rows.Next() {
-		var r row
-		if err := rows.Scan(&r.date, &r.close, &r.synthetic); err != nil {
-			t.Fatalf("scan: %v", err)
-		}
-		got = append(got, r)
-	}
-	if len(got) != 7 {
-		t.Fatalf("expected 7 rows, got %d", len(got))
-	}
+	var bars []db.EODPrice
 	for i := 0; i < 5; i++ {
-		if got[i].synthetic {
-			t.Errorf("day %d: expected real", i)
-		}
+		bars = append(bars, db.EODPrice{
+			InstrumentID: instID, PriceDate: mon.AddDate(0, 0, i), Close: 102.0 + float64(i),
+		})
 	}
-	for i := 5; i < 7; i++ {
-		if !got[i].synthetic {
-			t.Errorf("day %d: expected synthetic", i)
-		}
-		if got[i].close != 106.0 {
-			t.Errorf("day %d: close = %v, want 106.0", i, got[i].close)
-		}
+	if err := p.UpsertPricesForRange(ctx, instID, "test", bars, mon, mon.AddDate(0, 0, 7), nil); err != nil {
+		t.Fatalf("upsert for range: %v", err)
 	}
+
+	var count int
+	if err := p.q.QueryRowContext(ctx,
+		`SELECT count(*) FROM eod_prices WHERE instrument_id = $1::uuid`, instID).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if count != 5 {
+		t.Errorf("expected 5 stored bars and no filled rows, got %d", count)
+	}
+	assertRanges(t, readPriceCoverage(t, p, instID), []db.DateRange{
+		{From: mon, Before: mon.AddDate(0, 0, 7)},
+	})
+	assertCoverageContains(t, p)
 }
 
-func TestUpsertPricesWithFill_SeedFromDB(t *testing.T) {
-	p := testDBTx(t)
-	ctx := context.Background()
-	instID := setupInstrument(t, p, "FILL2")
-
-	// Insert a real price on Friday.
-	insertPrice(t, p, instID, d(2024, 1, 5), 100.0)
-
-	// Gap fill Sat-Mon with no new bars (seed from Friday's close).
-	from := d(2024, 1, 6) // Sat
-	to := d(2024, 1, 9)   // Tue (exclusive)
-	err := p.UpsertPricesWithFill(ctx, instID, "test", nil, from, to, nil)
-	if err != nil {
-		t.Fatalf("upsert with fill: %v", err)
-	}
-
-	// Sat, Sun, Mon should be synthetic with close=100.
-	for _, day := range []time.Time{d(2024, 1, 6), d(2024, 1, 7), d(2024, 1, 8)} {
-		var close float64
-		var synthetic bool
-		err := p.q.QueryRowContext(ctx,
-			`SELECT close, synthetic FROM eod_prices WHERE instrument_id = $1::uuid AND price_date = $2`,
-			instID, day).Scan(&close, &synthetic)
-		if err != nil {
-			t.Fatalf("query %v: %v", day, err)
-		}
-		if !synthetic {
-			t.Errorf("%v: expected synthetic", day.Format("2006-01-02"))
-		}
-		if close != 100.0 {
-			t.Errorf("%v: close = %v, want 100.0", day.Format("2006-01-02"), close)
-		}
-	}
-}
-
-func TestUpsertPricesWithFill_NoSeedNoBars(t *testing.T) {
+// The declared range is coverage even where it holds no bars, so a range asked
+// about and answered with nothing is not mistaken for one never asked about.
+func TestUpsertPricesForRange_NoBarsStillCovers(t *testing.T) {
 	p := testDBTx(t)
 	ctx := context.Background()
 	instID := setupInstrument(t, p, "FILL3")
 
-	// No seed, no bars: nothing to insert, but the range was still asked about
-	// and answered, so it is covered. That is the distinction row presence
-	// cannot draw and the reason coverage is stored separately.
-	err := p.UpsertPricesWithFill(ctx, instID, "test", nil, d(2024, 1, 1), d(2024, 1, 4), nil)
-	if err != nil {
-		t.Fatalf("upsert with fill: %v", err)
+	if err := p.UpsertPricesForRange(ctx, instID, "test", nil, d(2024, 1, 1), d(2024, 1, 4), nil); err != nil {
+		t.Fatalf("upsert for range: %v", err)
 	}
 
-	var rowCount int
-	if err := p.q.QueryRowContext(ctx, `
-		SELECT count(*) FROM eod_prices WHERE instrument_id = $1::uuid
-	`, instID).Scan(&rowCount); err != nil {
-		t.Fatalf("count rows: %v", err)
+	var count int
+	if err := p.q.QueryRowContext(ctx,
+		`SELECT count(*) FROM eod_prices WHERE instrument_id = $1::uuid`, instID).Scan(&count); err != nil {
+		t.Fatalf("count: %v", err)
 	}
-	if rowCount != 0 {
-		t.Errorf("expected no price rows, got %d", rowCount)
+	if count != 0 {
+		t.Errorf("expected no price rows, got %d", count)
 	}
-
-	cov, err := p.PriceCoverage(ctx, []string{instID})
-	if err != nil {
-		t.Fatalf("coverage: %v", err)
-	}
-	assertInstrumentRanges(t, cov, instID, []db.DateRange{
+	assertRanges(t, readPriceCoverage(t, p, instID), []db.DateRange{
 		{From: d(2024, 1, 1), Before: d(2024, 1, 4)},
 	})
 }
 
-func TestUpsertPricesWithFill_NoSeedAtStart(t *testing.T) {
+// Providers can repeat a date within one response; the last one supplied wins.
+func TestUpsertPricesForRange_DuplicateDates(t *testing.T) {
 	p := testDBTx(t)
 	ctx := context.Background()
-	instID := setupInstrument(t, p, "FILL4")
+	instID := setupInstrument(t, p, "FILL5")
 
-	// No seed, bar on day 3. Days 1-2 should have no price.
+	day := d(2024, 1, 2)
 	bars := []db.EODPrice{
-		{InstrumentID: instID, PriceDate: d(2024, 1, 3), Close: 50.0},
+		{InstrumentID: instID, PriceDate: day, Close: 100.0},
+		{InstrumentID: instID, PriceDate: day, Close: 101.0},
 	}
-	err := p.UpsertPricesWithFill(ctx, instID, "test", bars, d(2024, 1, 1), d(2024, 1, 5), nil)
-	if err != nil {
-		t.Fatalf("upsert with fill: %v", err)
-	}
-
-	// Day 3 real, day 4 synthetic. Days 1-2 absent.
-	var count int
-	if err := p.q.QueryRowContext(ctx, `SELECT COUNT(*) FROM eod_prices WHERE instrument_id = $1::uuid`, instID).Scan(&count); err != nil {
-		t.Fatalf("count: %v", err)
-	}
-	if count != 2 {
-		t.Fatalf("expected 2 rows, got %d", count)
-	}
-
-	var synthetic bool
-	if err := p.q.QueryRowContext(ctx,
-		`SELECT synthetic FROM eod_prices WHERE instrument_id = $1::uuid AND price_date = $2`,
-		instID, d(2024, 1, 3)).Scan(&synthetic); err != nil {
-		t.Fatalf("day 3: %v", err)
-	}
-	if synthetic {
-		t.Error("day 3: expected real")
-	}
-	if err := p.q.QueryRowContext(ctx,
-		`SELECT synthetic FROM eod_prices WHERE instrument_id = $1::uuid AND price_date = $2`,
-		instID, d(2024, 1, 4)).Scan(&synthetic); err != nil {
-		t.Fatalf("day 4: %v", err)
-	}
-	if !synthetic {
-		t.Error("day 4: expected synthetic")
-	}
-}
-
-func TestUpsertPricesWithFill_DuplicateDates(t *testing.T) {
-	p := testDBTx(t)
-	ctx := context.Background()
-	instID := setupInstrument(t, p, "FILLDUP")
-
-	// Bars with duplicate dates — last occurrence should win.
-	mon := d(2024, 1, 1)
-	bars := []db.EODPrice{
-		{InstrumentID: instID, PriceDate: mon, Close: 100.0},
-		{InstrumentID: instID, PriceDate: mon, Close: 101.0}, // duplicate
-		{InstrumentID: instID, PriceDate: mon.AddDate(0, 0, 1), Close: 102.0},
-	}
-	to := mon.AddDate(0, 0, 2)
-	err := p.UpsertPricesWithFill(ctx, instID, "test", bars, mon, to, nil)
-	if err != nil {
-		t.Fatalf("upsert with fill: %v", err)
+	if err := p.UpsertPricesForRange(ctx, instID, "test", bars, d(2024, 1, 1), d(2024, 1, 4), nil); err != nil {
+		t.Fatalf("upsert for range: %v", err)
 	}
 
 	var close float64
 	if err := p.q.QueryRowContext(ctx,
 		`SELECT close FROM eod_prices WHERE instrument_id = $1::uuid AND price_date = $2`,
-		instID, mon).Scan(&close); err != nil {
-		t.Fatalf("scan close: %v", err)
+		instID, day).Scan(&close); err != nil {
+		t.Fatalf("query: %v", err)
 	}
 	if close != 101.0 {
-		t.Errorf("duplicate date: close = %v, want 101.0 (last occurrence)", close)
+		t.Errorf("close = %v, want 101.0 (last supplied wins)", close)
 	}
 }
-
-// --- FXGaps tests ---
 
 // setupInstrumentWithCurrency creates an instrument with a specific asset class and currency.
 func setupInstrumentWithCurrency(t *testing.T, p *Postgres, desc, assetClass, currency string) string {

--- a/server/db/postgres/valuation.go
+++ b/server/db/postgres/valuation.go
@@ -91,17 +91,6 @@ daily_holdings AS (
     FROM date_series ds
     CROSS JOIN inst_list i
 ),
-prices AS (
-    -- Adjusted quantity above pairs with adjusted close here: both are
-    -- denominated in today's share count. Mixing one of each would scale the
-    -- value by the split factor either side of an ex-date. See
-    -- docs/spec/bitemporality.md.
-    SELECT instrument_id, price_date AS val_date, split_adjusted_close AS close
-    FROM eod_prices
-    WHERE instrument_id = ANY(SELECT DISTINCT instrument_id FROM cumulative WHERE instrument_id IS NOT NULL)
-      AND price_date >= $2::date
-      AND price_date < $3::date
-),
 -- Map held instruments to their FX pair instrument IDs (for currencies != display).
 fx_instruments AS (
     SELECT DISTINCT
@@ -115,27 +104,106 @@ fx_instruments AS (
       AND inst.currency IS NOT NULL
       AND inst.currency != 'USD'
 ),
+-- The display currency's own pair (DISPLAY/USD), only when display != USD.
+display_fx_instrument AS (
+    SELECT ii.instrument_id
+    FROM instrument_identifiers ii
+    WHERE ii.identifier_type = 'FX_PAIR'
+      AND ii.value = $4 || 'USD'
+      AND $4 != 'USD'
+),
+-- Every instrument this query needs a price series for.
+price_instruments AS (
+    SELECT DISTINCT instrument_id FROM cumulative WHERE instrument_id IS NOT NULL
+    UNION
+    SELECT fx_instrument_id FROM fx_instruments
+    UNION
+    SELECT instrument_id FROM display_fx_instrument
+),
+-- Only real bars are stored, so the days a market was shut have no row. The
+-- next four CTEs carry the last close forward over them.
+--
+-- Spans merged across plugins: for "should this day have a price" it does not
+-- matter which provider answered.
+coverage_spans AS (
+    SELECT instrument_id,
+        unnest(range_agg(daterange(covered_from, covered_before))) AS span
+    FROM price_coverage
+    WHERE instrument_id IN (SELECT instrument_id FROM price_instruments)
+    GROUP BY instrument_id
+),
+-- Carry-forward is bounded by coverage, so a delisted instrument's last close
+-- stops at the end of the span rather than being held for ever. Partitioning by
+-- span below makes that fall out of the grouping instead of needing a guard.
+covered_grid AS (
+    SELECT cs.instrument_id, ds.val_date, lower(cs.span) AS span_from
+    FROM coverage_spans cs
+    JOIN date_series ds
+        ON ds.val_date >= lower(cs.span) AND ds.val_date < upper(cs.span)
+),
+-- A window opening mid-span would otherwise read as unpriced until the first
+-- bar inside it. One lookup per (instrument, span), not per day.
+span_seeds AS (
+    SELECT g.instrument_id, g.span_from, s.close, s.split_adjusted_close
+    FROM (SELECT DISTINCT instrument_id, span_from FROM covered_grid) g
+    CROSS JOIN LATERAL (
+        SELECT ep.close, ep.split_adjusted_close
+        FROM eod_prices ep
+        WHERE ep.instrument_id = g.instrument_id
+          AND ep.price_date >= g.span_from
+          AND ep.price_date < $2::date
+        ORDER BY ep.price_date DESC
+        LIMIT 1
+    ) s
+),
+price_points AS (
+    -- Virtual point before the window start, seeding the carry-forward.
+    SELECT instrument_id, span_from, ($2::date - 1) AS val_date, close, split_adjusted_close
+    FROM span_seeds
+    UNION ALL
+    SELECT g.instrument_id, g.span_from, g.val_date, ep.close, ep.split_adjusted_close
+    FROM covered_grid g
+    LEFT JOIN eod_prices ep
+        ON ep.instrument_id = g.instrument_id AND ep.price_date = g.val_date
+),
+-- PostgreSQL window functions have no IGNORE NULLS, so count() labels each run
+-- that starts at a real bar and first_value() spreads that bar across the run.
+price_islands AS (
+    SELECT instrument_id, span_from, val_date, close, split_adjusted_close,
+        count(close) OVER (PARTITION BY instrument_id, span_from ORDER BY val_date) AS island
+    FROM price_points
+),
+filled_prices AS (
+    SELECT instrument_id, val_date,
+        first_value(close) OVER w AS close,
+        first_value(split_adjusted_close) OVER w AS split_adjusted_close
+    FROM price_islands
+    WINDOW w AS (PARTITION BY instrument_id, span_from, island ORDER BY val_date)
+),
+prices AS (
+    -- Adjusted quantity above pairs with adjusted close here: both are
+    -- denominated in today's share count. Mixing one of each would scale the
+    -- value by the split factor either side of an ex-date. See
+    -- docs/spec/bitemporality.md.
+    SELECT instrument_id, val_date, split_adjusted_close AS close
+    FROM filled_prices
+    WHERE val_date >= $2::date AND split_adjusted_close IS NOT NULL
+),
 -- FX rates for each base currency (BASE/USD close values).
 -- Raw close, not split_adjusted_close: an exchange rate is not denominated in
 -- a share count, so it has no basis to adjust and never carries splits.
 fx_rates AS (
-    SELECT fi.base_currency, ep.price_date AS val_date, ep.close AS rate
+    SELECT fi.base_currency, fp.val_date, fp.close AS rate
     FROM fx_instruments fi
-    JOIN eod_prices ep ON ep.instrument_id = fi.fx_instrument_id
-    WHERE ep.price_date >= $2::date
-      AND ep.price_date < $3::date
+    JOIN filled_prices fp ON fp.instrument_id = fi.fx_instrument_id
+    WHERE fp.val_date >= $2::date AND fp.close IS NOT NULL
 ),
 -- Rate for the display currency (DISPLAY/USD), only when display != USD.
 display_fx_rate AS (
-    SELECT ep.price_date AS val_date, ep.close AS rate
-    FROM eod_prices ep
-    INNER JOIN instrument_identifiers ii
-        ON ii.instrument_id = ep.instrument_id
-        AND ii.identifier_type = 'FX_PAIR'
-        AND ii.value = $4 || 'USD'
-    WHERE $4 != 'USD'
-      AND ep.price_date >= $2::date
-      AND ep.price_date < $3::date
+    SELECT fp.val_date, fp.close AS rate
+    FROM display_fx_instrument dfi
+    JOIN filled_prices fp ON fp.instrument_id = dfi.instrument_id
+    WHERE fp.val_date >= $2::date AND fp.close IS NOT NULL
 ),
 -- Compute fx_rate per holding: converts from instrument currency to display currency.
 valued AS (
@@ -233,9 +301,9 @@ ORDER BY val_date
 
 // GetPortfolioValuation computes daily portfolio values over the half-open
 // [dateFrom, dateBefore) range.
-// Prices (including synthetic LOCF rows for non-trading days) are joined
-// directly from eod_prices. Holdings are forward-filled from the last
-// transaction date. Holdings are converted to displayCurrency via FX rates.
+// Only real bars are stored, so prices are carried forward over non-trading days
+// at read time, bounded by price_coverage. Holdings are forward-filled from the
+// last transaction date. Holdings are converted to displayCurrency via FX rates.
 func (p *Postgres) GetPortfolioValuation(ctx context.Context, portfolioID string, dateFrom, dateBefore time.Time, displayCurrency string) ([]db.ValuationPoint, error) {
 	portUUID, err := uuid.Parse(portfolioID)
 	if err != nil {

--- a/server/db/postgres/valuation_bench_test.go
+++ b/server/db/postgres/valuation_bench_test.go
@@ -1,0 +1,134 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// seedValuationLoad builds a portfolio of instruments each holding years of
+// weekday bars, which is the shape the valuation query is slowest on: a wide
+// date grid over a hypertable with a gap at every weekend.
+func seedValuationLoad(t testing.TB, p *Postgres, instruments, years int) (string, time.Time, time.Time) {
+	t.Helper()
+	ctx := context.Background()
+
+	userID, err := p.GetOrCreateUser(ctx, "sub|bench", "Bench", "bench@bench.com")
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+
+	from := d(2020, 1, 1)
+	before := from.AddDate(years, 0, 0)
+	buy := time.Date(2019, 12, 31, 12, 0, 0, 0, time.UTC)
+
+	// One ReplaceTxsInPeriod call for all of them: it replaces everything in the
+	// window, so per-instrument calls would each wipe the last.
+	var txs []*apiv1.Tx
+	var instIDs []string
+	for i := 0; i < instruments; i++ {
+		desc := fmt.Sprintf("BENCH%03d", i)
+		instID, err := p.EnsureInstrument(ctx, "STOCK", "", "USD", desc, "", "", []db.IdentifierInput{
+			{Type: "BROKER_DESCRIPTION", Domain: "BENCH", Value: desc, Canonical: false},
+		}, "", nil, nil, nil)
+		if err != nil {
+			t.Fatalf("ensure instrument: %v", err)
+		}
+		txs = append(txs, &apiv1.Tx{
+			Timestamp: timestamppb.New(buy), InstrumentDescription: desc,
+			Type: apiv1.TxType_BUYSTOCK, Quantity: 100, Account: "main",
+		})
+		instIDs = append(instIDs, instID)
+	}
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "BENCH", "",
+		timestamppb.New(buy.Add(-time.Hour)), timestamppb.New(buy.Add(time.Hour)),
+		txs, instIDs, nil); err != nil {
+		t.Fatalf("replace txs: %v", err)
+	}
+
+	for _, instID := range instIDs {
+		var bars []db.EODPrice
+		for day := from; day.Before(before); day = day.Add(db.Day) {
+			if day.Weekday() == time.Saturday || day.Weekday() == time.Sunday {
+				continue
+			}
+			bars = append(bars, db.EODPrice{
+				InstrumentID: instID, PriceDate: day,
+				Close: 100 + float64(day.YearDay()%50), DataProvider: "bench",
+			})
+		}
+		if err := p.UpsertPricesForRange(ctx, instID, "bench", bars, from, before, nil); err != nil {
+			t.Fatalf("upsert bars: %v", err)
+		}
+	}
+	return userID, from, before
+}
+
+// TestValuationQueryPerformance times the read-time carry-forward and prints the
+// plan. It reports rather than asserts: a threshold here would only be flaky.
+//
+// Measured when the carry-forward moved out of the write path: 860ms mean for
+// 50 instruments over 5 years, against 739ms for the same query with the price
+// CTE reduced to the flat scan the stored-fill design used. The 16% is an
+// overstatement, since that comparison scans only the real bars while the
+// stored-fill design also held a row for every weekend and holiday.
+//
+// Run with: BENCH_VALUATION=1 make db-test
+func TestValuationQueryPerformance(t *testing.T) {
+	if os.Getenv("BENCH_VALUATION") == "" {
+		t.Skip("set BENCH_VALUATION=1 to run")
+	}
+	p := testDBTx(t)
+	ctx := context.Background()
+
+	const instruments, years = 50, 5
+	seedStart := time.Now()
+	userID, from, before := seedValuationLoad(t, p, instruments, years)
+	t.Logf("seeded %d instruments x %d years in %s", instruments, years, time.Since(seedStart).Round(time.Millisecond))
+
+	// Warm caches, then time.
+	if _, err := p.GetUserValuation(ctx, userID, from, before, "USD"); err != nil {
+		t.Fatalf("warmup: %v", err)
+	}
+	const runs = 5
+	var total time.Duration
+	for i := 0; i < runs; i++ {
+		start := time.Now()
+		points, err := p.GetUserValuation(ctx, userID, from, before, "USD")
+		if err != nil {
+			t.Fatalf("valuation: %v", err)
+		}
+		total += time.Since(start)
+		if len(points) == 0 {
+			t.Fatal("no valuation points")
+		}
+	}
+	t.Logf("read-time carry-forward: %s mean over %d runs (%d instruments x %d days)",
+		(total / runs).Round(time.Millisecond), runs, instruments, int(before.Sub(from).Hours()/24))
+
+	// The pre-change shape for comparison: a flat scan of eod_prices joined by
+	// exact date, which is what the query did when every non-trading day had a
+	// stored row. Values differ (weekends read as unpriced), but the cost of the
+	// price step is comparable and that is what is being measured.
+	var plan string
+	rows, err := p.q.QueryContext(ctx,
+		`EXPLAIN (ANALYZE, BUFFERS) `+valuationQuery(false), userID, from, before, "USD")
+	if err != nil {
+		t.Fatalf("explain: %v", err)
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var line string
+		if err := rows.Scan(&line); err != nil {
+			t.Fatalf("scan plan: %v", err)
+		}
+		plan += line + "\n"
+	}
+	t.Logf("plan:\n%s", plan)
+}

--- a/server/db/postgres/valuation_test.go
+++ b/server/db/postgres/valuation_test.go
@@ -1055,3 +1055,148 @@ func TestGetUserValuation_FXUnaffectedByASplit(t *testing.T) {
 		}
 	}
 }
+
+// setupHeldInstrument creates a user holding one instrument from buyDate on.
+func setupHeldInstrument(t *testing.T, p *Postgres, sub, desc string, qty float64, buyDate time.Time) (string, string) {
+	t.Helper()
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, sub, "U", sub+"@locf.com")
+	instID, err := p.EnsureInstrument(ctx, "STOCK", "", "USD", desc, "", "", []db.IdentifierInput{
+		{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: desc, Canonical: false},
+	}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+	ts := time.Date(buyDate.Year(), buyDate.Month(), buyDate.Day(), 12, 0, 0, 0, time.UTC)
+	txs := []*apiv1.Tx{
+		{Timestamp: timestamppb.New(ts), InstrumentDescription: desc, Type: apiv1.TxType_BUYSTOCK, Quantity: qty, Account: "main"},
+	}
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "",
+		timestamppb.New(ts.Add(-time.Hour)), timestamppb.New(ts.Add(time.Hour)),
+		txs, []string{instID}, nil); err != nil {
+		t.Fatalf("replace txs: %v", err)
+	}
+	return userID, instID
+}
+
+// Weekends have no stored row now, so the close must be carried forward at read
+// time or every Saturday would read as unpriced.
+func TestGetUserValuation_CarriesForwardOverNonTradingDays(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, instID := setupHeldInstrument(t, p, "sub|locf1", "LOCF1", 10, d(2024, 1, 1))
+
+	// Fri 5 Jan is the last bar; Sat and Sun have none.
+	bars := []db.EODPrice{{InstrumentID: instID, PriceDate: d(2024, 1, 5), Close: 100}}
+	if err := p.UpsertPricesForRange(ctx, instID, "test", bars, d(2024, 1, 5), d(2024, 1, 8), nil); err != nil {
+		t.Fatalf("upsert for range: %v", err)
+	}
+
+	points, err := p.GetUserValuation(ctx, userID, d(2024, 1, 5), d(2024, 1, 8), "USD")
+	if err != nil {
+		t.Fatalf("valuation: %v", err)
+	}
+	for _, day := range []time.Time{d(2024, 1, 5), d(2024, 1, 6), d(2024, 1, 7)} {
+		if got := valueOn(t, points, day); !approxEq(got, 1000) {
+			t.Errorf("%s: got %v want 1000", day.Format("2006-01-02"), got)
+		}
+	}
+}
+
+// Carry-forward stops at the end of the covered span. Without that bound a
+// delisted instrument would hold its last close for ever.
+func TestGetUserValuation_CarryForwardStopsAtCoverageEnd(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, instID := setupHeldInstrument(t, p, "sub|locf2", "LOCF2", 10, d(2024, 1, 1))
+
+	bars := []db.EODPrice{{InstrumentID: instID, PriceDate: d(2024, 1, 5), Close: 100}}
+	if err := p.UpsertPricesForRange(ctx, instID, "test", bars, d(2024, 1, 5), d(2024, 1, 7), nil); err != nil {
+		t.Fatalf("upsert for range: %v", err)
+	}
+
+	points, err := p.GetUserValuation(ctx, userID, d(2024, 1, 5), d(2024, 1, 9), "USD")
+	if err != nil {
+		t.Fatalf("valuation: %v", err)
+	}
+	if got := valueOn(t, points, d(2024, 1, 6)); !approxEq(got, 1000) {
+		t.Errorf("inside coverage: got %v want 1000", got)
+	}
+	// 7 Jan is past covered_before, so the position is unpriced, not stale.
+	if got := valueOn(t, points, d(2024, 1, 7)); !approxEq(got, 0) {
+		t.Errorf("past coverage end: got %v want 0 (unpriced, not carried)", got)
+	}
+	if !unpricedOn(t, points, d(2024, 1, 7)) {
+		t.Error("past coverage end: expected the instrument to be reported unpriced")
+	}
+}
+
+// Two disjoint covered periods must not bleed into each other: the first
+// period's close is not a price for a day in the gap or in the second period
+// before its own first bar.
+func TestGetUserValuation_DisjointCoverageDoesNotBleed(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, instID := setupHeldInstrument(t, p, "sub|locf3", "LOCF3", 10, d(2024, 1, 1))
+
+	first := []db.EODPrice{{InstrumentID: instID, PriceDate: d(2024, 1, 2), Close: 100}}
+	if err := p.UpsertPricesForRange(ctx, instID, "test", first, d(2024, 1, 2), d(2024, 1, 4), nil); err != nil {
+		t.Fatalf("upsert first: %v", err)
+	}
+	second := []db.EODPrice{{InstrumentID: instID, PriceDate: d(2024, 1, 9), Close: 200}}
+	if err := p.UpsertPricesForRange(ctx, instID, "test", second, d(2024, 1, 8), d(2024, 1, 10), nil); err != nil {
+		t.Fatalf("upsert second: %v", err)
+	}
+
+	points, err := p.GetUserValuation(ctx, userID, d(2024, 1, 2), d(2024, 1, 10), "USD")
+	if err != nil {
+		t.Fatalf("valuation: %v", err)
+	}
+	if got := valueOn(t, points, d(2024, 1, 3)); !approxEq(got, 1000) {
+		t.Errorf("inside first span: got %v want 1000", got)
+	}
+	// In the uncovered gap, and on the second span's first day which precedes
+	// its own first bar: neither may inherit the first span's close.
+	for _, day := range []time.Time{d(2024, 1, 5), d(2024, 1, 8)} {
+		if got := valueOn(t, points, day); !approxEq(got, 0) {
+			t.Errorf("%s: got %v want 0 (must not inherit the earlier span's close)",
+				day.Format("2006-01-02"), got)
+		}
+	}
+	if got := valueOn(t, points, d(2024, 1, 9)); !approxEq(got, 2000) {
+		t.Errorf("inside second span: got %v want 2000", got)
+	}
+}
+
+// A window opening mid-span must pick up the last bar before it, or the chart
+// would show the position unpriced until the next bar lands.
+func TestGetUserValuation_SeedsFromBarBeforeWindow(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, instID := setupHeldInstrument(t, p, "sub|locf4", "LOCF4", 10, d(2024, 1, 1))
+
+	bars := []db.EODPrice{{InstrumentID: instID, PriceDate: d(2024, 1, 2), Close: 100}}
+	if err := p.UpsertPricesForRange(ctx, instID, "test", bars, d(2024, 1, 1), d(2024, 1, 20), nil); err != nil {
+		t.Fatalf("upsert for range: %v", err)
+	}
+
+	// The window starts well after the only bar, which is still its price.
+	points, err := p.GetUserValuation(ctx, userID, d(2024, 1, 10), d(2024, 1, 12), "USD")
+	if err != nil {
+		t.Fatalf("valuation: %v", err)
+	}
+	if got := valueOn(t, points, d(2024, 1, 10)); !approxEq(got, 1000) {
+		t.Errorf("window opening mid-span: got %v want 1000", got)
+	}
+}
+
+func unpricedOn(t *testing.T, points []db.ValuationPoint, want time.Time) bool {
+	t.Helper()
+	for _, pt := range points {
+		if pt.Date.Equal(want) {
+			return len(pt.UnpricedInstruments) > 0
+		}
+	}
+	t.Fatalf("no valuation point for %s", want.Format("2006-01-02"))
+	return false
+}

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -370,9 +370,10 @@ WHERE
            AND t.instrument_id::text IN (SELECT filter_value FROM portfolio_filters WHERE portfolio_id = p.id AND filter_type = 'instrument')));
 
 -- EOD price cache. Stores end-of-day OHLCV data per instrument per date.
--- Rows with synthetic = true are forward-filled (LOCF) prices for non-trading
--- days (weekends, holidays). They are generated at write time by the price
--- fetcher worker so that the valuation query can use a simple join.
+-- Every row is a bar a provider actually reported: non-trading days (weekends,
+-- holidays) simply have no row. Valuation carries the last close forward over
+-- them at read time, bounded by price_coverage, so the filled series is derived
+-- from (bars, coverage) rather than stored alongside them.
 -- share_count_basis is the date at which the share count the raw OHLCV is
 -- denominated in was current. It is declared by whoever supplied the row -- as
 -- price_date for an as-traded series, or the fetch date for a provider that
@@ -402,7 +403,6 @@ CREATE TABLE eod_prices (
   volume                 BIGINT,
   split_adjusted_volume  BIGINT,
   data_provider          TEXT        NOT NULL,
-  synthetic              BOOLEAN     NOT NULL DEFAULT false,
   share_count_basis      DATE        NOT NULL,
   -- Staleness only: when this row was last fetched. It carries no meaning about
   -- the prices themselves. See docs/spec/bitemporality.md.

--- a/server/pricefetcher/worker.go
+++ b/server/pricefetcher/worker.go
@@ -251,7 +251,7 @@ func processGaps(ctx context.Context, database db.DB, plugins []pluginEntry, gap
 				}
 
 				prices := barsToEODPrices(ig.InstrumentID, pe.id, result.Bars, result.ShareCountBasis, now)
-				if err := database.UpsertPricesWithFill(ctx, ig.InstrumentID, pe.id, prices, gap.From, gap.Before, nil); err != nil {
+				if err := database.UpsertPricesForRange(ctx, ig.InstrumentID, pe.id, prices, gap.From, gap.Before, nil); err != nil {
 					if log != nil {
 						log.ErrorContext(ctx, "price fetch: upsert", "instrument", ig.InstrumentID, "err", err)
 					}
@@ -276,7 +276,7 @@ func coverRange(ctx context.Context, database db.DB, instrumentID, pluginID stri
 	if !r.Before.After(r.From) {
 		return
 	}
-	if err := database.UpsertPricesWithFill(ctx, instrumentID, pluginID, nil, r.From, r.Before, nil); err != nil && log != nil {
+	if err := database.UpsertPricesForRange(ctx, instrumentID, pluginID, nil, r.From, r.Before, nil); err != nil && log != nil {
 		log.WarnContext(ctx, "price fetch: record empty coverage",
 			"plugin", pluginID, "instrument", instrumentID, "reason", reason, "err", err)
 	}

--- a/server/pricefetcher/worker_test.go
+++ b/server/pricefetcher/worker_test.go
@@ -160,7 +160,7 @@ func TestRunCycle_FXGapsProcessed(t *testing.T) {
 			},
 		},
 	}, nil)
-	mockDB.EXPECT().UpsertPricesWithFill(gomock.Any(), fxInstID, pluginID, gomock.Any(), from, to, gomock.Any()).Return(nil)
+	mockDB.EXPECT().UpsertPricesForRange(gomock.Any(), fxInstID, pluginID, gomock.Any(), from, to, gomock.Any()).Return(nil)
 
 	runCycle(ctx, mockDB, reg, nil, nil, nil)
 
@@ -340,8 +340,8 @@ func TestRunCycle_MaxHistoryTruncation(t *testing.T) {
 	cutoff := now.AddDate(0, 0, -maxDays)
 	// The head the plugin cannot reach is settled as covered by it, so the same
 	// unreachable range is not rediscovered as a gap on the next cycle.
-	mockDB.EXPECT().UpsertPricesWithFill(gomock.Any(), instID, pluginID, nil, from, cutoff, gomock.Any()).Return(nil)
-	mockDB.EXPECT().UpsertPricesWithFill(gomock.Any(), instID, pluginID, gomock.Any(), cutoff, to, gomock.Any()).Return(nil)
+	mockDB.EXPECT().UpsertPricesForRange(gomock.Any(), instID, pluginID, nil, from, cutoff, gomock.Any()).Return(nil)
+	mockDB.EXPECT().UpsertPricesForRange(gomock.Any(), instID, pluginID, gomock.Any(), cutoff, to, gomock.Any()).Return(nil)
 
 	runCycle(ctx, mockDB, reg, nil, nil, nil)
 
@@ -391,7 +391,7 @@ func TestRunCycle_MaxHistorySkipsOldGap(t *testing.T) {
 	}, nil)
 	// Wholly out of reach for this plugin, so it is recorded as covered by it
 	// rather than being asked about again every cycle.
-	mockDB.EXPECT().UpsertPricesWithFill(gomock.Any(), instID, pluginID, nil, from, to, gomock.Any()).Return(nil)
+	mockDB.EXPECT().UpsertPricesForRange(gomock.Any(), instID, pluginID, nil, from, to, gomock.Any()).Return(nil)
 
 	runCycle(ctx, mockDB, reg, nil, nil, nil)
 
@@ -427,7 +427,7 @@ func TestRunCycle_NoDataRecordsCoverage(t *testing.T) {
 	mockDB.EXPECT().ListInstrumentsByIDs(gomock.Any(), []string{instID}).Return([]*db.InstrumentRow{
 		{ID: instID, AssetClass: strPtr("STOCK"), Identifiers: []db.IdentifierInput{{Type: "MIC_TICKER", Value: "AAPL"}}},
 	}, nil)
-	mockDB.EXPECT().UpsertPricesWithFill(gomock.Any(), instID, pluginID, nil, from, to, gomock.Any()).Return(nil)
+	mockDB.EXPECT().UpsertPricesForRange(gomock.Any(), instID, pluginID, nil, from, to, gomock.Any()).Return(nil)
 
 	runCycle(ctx, mockDB, reg, nil, nil, nil)
 
@@ -504,7 +504,7 @@ func TestRunCycle_OtherPluginStillAskedAfterCoverage(t *testing.T) {
 	mockDB.EXPECT().ListInstrumentsByIDs(gomock.Any(), []string{instID}).Return([]*db.InstrumentRow{
 		{ID: instID, AssetClass: strPtr("STOCK"), Identifiers: []db.IdentifierInput{{Type: "MIC_TICKER", Value: "AAPL"}}},
 	}, nil)
-	mockDB.EXPECT().UpsertPricesWithFill(gomock.Any(), instID, freshID, gomock.Any(), from, to, gomock.Any()).Return(nil)
+	mockDB.EXPECT().UpsertPricesForRange(gomock.Any(), instID, freshID, gomock.Any(), from, to, gomock.Any()).Return(nil)
 
 	runCycle(ctx, mockDB, reg, nil, nil, nil)
 

--- a/server/service/api/prices.go
+++ b/server/service/api/prices.go
@@ -45,7 +45,6 @@ func (s *Server) ListPrices(ctx context.Context, req *apiv1.ListPricesRequest) (
 			DataProvider:          r.DataProvider,
 			LastFetchedAt:         timestamppb.New(r.LastFetchedAt),
 			ShareCountBasis:       r.ShareCountBasis.Format("2006-01-02"),
-			Synthetic:             r.Synthetic,
 		}
 		if r.Open != nil {
 			p.Open = r.Open
@@ -73,9 +72,9 @@ func (s *Server) ListPrices(ctx context.Context, req *apiv1.ListPricesRequest) (
 }
 
 // ExportPrices streams all cached EOD prices with the best identifier per
-// instrument. Coverage spans come first, then the rows: only real bars are
-// exported, so the spans are what let an import regenerate the synthetic days
-// between them. Admin only.
+// instrument. Coverage spans come first, then the rows. The spans are not
+// derivable from the rows: one covering dates with no rows records that a
+// provider was asked and had nothing. Admin only.
 func (s *Server) ExportPrices(req *apiv1.ExportPricesRequest, stream apiv1.ApiService_ExportPricesServer) error {
 	ctx := stream.Context()
 	if _, authErr := auth.RequireAdmin(ctx); authErr != nil {

--- a/server/service/ingestion/price_worker.go
+++ b/server/service/ingestion/price_worker.go
@@ -178,8 +178,10 @@ func coverageKey(idType, domain, value string) string {
 	return idType + "\x00" + domain + "\x00" + value
 }
 
-// upsertWithCoverage upserts prices, using UpsertPricesWithFill for instruments
-// that have coverage ranges and plain UpsertPrices for the rest.
+// upsertWithCoverage stores prices, recording each declared range as coverage so
+// valuation carries prices forward across the non-trading days inside it. Rows
+// falling outside every declared range cover only their own dates, which keeps
+// the gaps between them gaps.
 func upsertWithCoverage(ctx context.Context, database db.DB, prices []db.EODPrice, coverage []*apiv1.ImportCoverage, resolveCache map[string]*resolveEntry) error {
 	if len(coverage) == 0 {
 		return database.UpsertPrices(ctx, prices)
@@ -211,14 +213,9 @@ func upsertWithCoverage(ctx context.Context, database db.DB, prices []db.EODPric
 		byInst[p.InstrumentID] = append(byInst[p.InstrumentID], p)
 	}
 
-	// Upsert each instrument: with fill if coverage exists, plain otherwise.
-	var uncovered []db.EODPrice
-	for instID, instPrices := range byInst {
-		ranges, hasCoverage := instCoverage[instID]
-		if !hasCoverage {
-			uncovered = append(uncovered, instPrices...)
-			continue
-		}
+	uncovered := make([]db.EODPrice, 0, len(prices))
+	for instID, ranges := range instCoverage {
+		instPrices := byInst[instID]
 		covered := make(map[int]bool)
 		for _, r := range ranges {
 			// Filter prices within this range.
@@ -229,27 +226,30 @@ func upsertWithCoverage(ctx context.Context, database db.DB, prices []db.EODPric
 					covered[i] = true
 				}
 			}
-			provider := "import"
-			if len(inRange) > 0 {
-				provider = inRange[0].DataProvider
-			}
 			var fetchedAt *time.Time
 			if len(inRange) > 0 {
 				fetchedAt = inRange[0].LastFetchedAt
 			}
-			if err := database.UpsertPricesWithFill(ctx, instID, provider, inRange, r.from, r.before, fetchedAt); err != nil {
+			// A declared range with no rows in it is not a no-op: it says the
+			// caller asked about those dates and there was nothing to report.
+			if err := database.UpsertPricesForRange(ctx, instID, db.PriceProviderImport, inRange, r.from, r.before, fetchedAt); err != nil {
 				return err
 			}
 		}
-		// Prices outside all coverage ranges get plain upsert.
+		// Prices outside all coverage ranges cover only their own dates.
 		for i, p := range instPrices {
 			if !covered[i] {
 				uncovered = append(uncovered, p)
 			}
 		}
 	}
+	// Instruments the file declared no coverage for at all.
+	for instID, instPrices := range byInst {
+		if _, declared := instCoverage[instID]; !declared {
+			uncovered = append(uncovered, instPrices...)
+		}
+	}
 
-	// Upsert any prices without coverage.
 	if len(uncovered) > 0 {
 		return database.UpsertPrices(ctx, uncovered)
 	}

--- a/server/service/ingestion/price_worker_test.go
+++ b/server/service/ingestion/price_worker_test.go
@@ -164,9 +164,9 @@ func TestProcessPriceImport_WithCoverage_UsesUpsertWithFill(t *testing.T) {
 		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").
 		Return("inst-aapl", "", "XNAS", "", nil)
 	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-price-cov").Return(nil)
-	// Expect UpsertPricesWithFill (not UpsertPrices) because coverage was provided.
+	// Expect UpsertPricesForRange (not UpsertPrices) because coverage was provided.
 	database.EXPECT().
-		UpsertPricesWithFill(gomock.Any(), "inst-aapl", "import", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		UpsertPricesForRange(gomock.Any(), "inst-aapl", "import", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil)
 	database.EXPECT().
 		SetJobStatus(gomock.Any(), "job-price-cov", apiv1.JobStatus_SUCCESS).


### PR DESCRIPTION
Third of five. **Stacked on #297**, which is stacked on #296.

## Why this belongs with the coverage work

Synthetic LOCF rows existed for two reasons: to make *inferred* coverage look
contiguous (stated outright at the old `price_cache.go:156`), and to keep the
valuation join a plain equijoin. Storing coverage removes the first reason
outright. The second is served by carrying the close forward in the query.

The result is that nothing in the price tables is derived: `eod_prices` holds
only bars a provider reported, `price_coverage` says which ranges were answered
for, and the filled series is computed from the two. There is no third thing to
keep in step.

## The query

`date_series` joined to `price_coverage` gives the covered grid; real bars are
left-joined onto it; the fill is the two-window gaps-and-islands idiom, since
PostgreSQL has no `IGNORE NULLS`.

Partitioning by span is what bounds the carry-forward: a delisted instrument
stops at the end of its coverage rather than holding its last close for ever,
and that falls out of the grouping instead of needing a guard. Each span is
seeded with the last bar before the window, so a window opening mid-span is not
unpriced until its first bar -- one lookup per `(instrument, span)`, not per day.

A per-`(instrument, date)` lateral would have been the obvious shape, mirroring
what `daily_holdings` does for quantities, and the wrong one: `eod_prices` is a
hypertable, and a lookup whose answer lies at a data-dependent distance in the
past defeats chunk exclusion.

## Performance

| shape | mean, 50 instruments x 5 years |
| --- | --- |
| read-time carry-forward (this PR) | 860ms |
| flat scan, as the stored-fill design did | 739ms |

The 16% overstates it: the comparison scans only the 65k real bars, while the
stored-fill design also stored a row for every weekend and holiday (~91k). Both
are dominated by the pre-existing correlated subquery for holdings (~306ms).
Not enough to justify the `price_series` cache, so it is not built.
`TestValuationQueryPerformance` (skipped unless `BENCH_VALUATION=1`) records the
measurement and prints the plan.

## Removed

- `UpsertPricesWithFill` and its ~120 lines of `generate_series` and seed logic,
  replaced by `UpsertPricesForRange` which stores bars and records the range.
- The `synthetic` column and the two `WHERE eod_prices.synthetic = true OR
  EXCLUDED.synthetic = false` conflict rules.
- `WHERE NOT ep.synthetic` from the export.
- `Synthetic` through `EODPrice`, `EODPriceProto` and the admin prices table.

## Two things worth a look

- **Dedup moved into `upsertPrices`.** It lived in the deleted fill function, and
  is still needed: `ON CONFLICT DO UPDATE` cannot touch a row twice in one
  statement and providers do repeat a date. Caught by an existing test.
- **The import path landed here rather than in PR 4**, because removing the fill
  forced it. Declared ranges are stored as coverage, and a declared range with no
  rows now survives instead of being dropped -- for prices as for corporate
  events, that says the caller asked and there was nothing.
  `ListPriceCoverageForExport` also moved to `price_coverage` here, since
  aggregating price dates would now fragment at every weekend.

## Testing

`make test` passes. New valuation tests cover: carry-forward over non-trading
days; carry-forward stopping at `covered_before`; two disjoint covered periods
not bleeding into each other, either across the gap or before the second span's
first bar; and a window opening mid-span picking up the earlier bar.

The two `Synthetic*OverwritesReal` tests are deleted -- they existed only to
protect synthetic rows. The write-time fill tests are replaced by ones asserting
that only real bars are stored and the declared range is covered.

`insertPriceWithProvider` and `insertPriceFull` now record coverage like
`insertPrice` does, so no fixture can build a bar outside a covered span.

🤖 Generated with [Claude Code](https://claude.com/claude-code)