### PR TITLE
Export coverage as a global plus exceptions

### DIFF
--- a/client/lib/csv/prices.test.ts
+++ b/client/lib/csv/prices.test.ts
@@ -392,3 +392,103 @@ describe("price CSV coverage round trip", () => {
     expect(pricesToCsv([makeRow()])).not.toContain("# coverage=");
   });
 });
+
+describe("pricesToCsv coverage compression", () => {
+  const span = (value: string, from: string, before: string) =>
+    create(ExportCoverageSchema, {
+      identifierType: "MIC_TICKER",
+      identifierValue: value,
+      identifierDomain: "XNAS",
+      from,
+      before,
+    });
+  const row = (value: string, priceDate = "2024-02-01") =>
+    makeRow({ identifierType: "MIC_TICKER", identifierValue: value, identifierDomain: "XNAS", priceDate });
+
+  const coverageLines = (csv: string) =>
+    csv.split("\n").filter((l) => l.startsWith("# coverage="));
+
+  it("collapses a shared span to one global line", () => {
+    const csv = pricesToCsv(
+      [row("AAPL"), row("MSFT"), row("GOOG")],
+      undefined,
+      [span("AAPL", "2022-01-01", "2025-07-07"),
+       span("MSFT", "2022-01-01", "2025-07-07"),
+       span("GOOG", "2022-01-01", "2025-07-07")],
+    );
+    expect(coverageLines(csv)).toEqual(["# coverage=2022-01-01,2025-07-07"]);
+  });
+
+  it("writes the odd one out as an exception beside the global", () => {
+    const csv = pricesToCsv(
+      [row("AAPL"), row("MSFT"), row("ATVI")],
+      undefined,
+      [span("AAPL", "2022-01-01", "2025-07-07"),
+       span("MSFT", "2022-01-01", "2025-07-07"),
+       span("ATVI", "2021-12-31", "2023-10-14")],
+    );
+    expect(coverageLines(csv)).toEqual([
+      "# coverage=2022-01-01,2025-07-07",
+      "# coverage=MIC_TICKER,ATVI,XNAS,2021-12-31,2023-10-14",
+    ]);
+  });
+
+  it("keeps both spans of a two-period instrument explicit, since a specific overrides the global outright", () => {
+    const csv = pricesToCsv(
+      [row("AAPL"), row("MSFT"), row("TSLA")],
+      undefined,
+      [span("AAPL", "2022-01-01", "2025-07-07"),
+       span("MSFT", "2022-01-01", "2025-07-07"),
+       span("TSLA", "2022-01-01", "2022-06-01"),
+       span("TSLA", "2024-01-01", "2024-06-01")],
+    );
+    expect(coverageLines(csv)).toEqual([
+      "# coverage=2022-01-01,2025-07-07",
+      "# coverage=MIC_TICKER,TSLA,XNAS,2022-01-01,2022-06-01",
+      "# coverage=MIC_TICKER,TSLA,XNAS,2024-01-01,2024-06-01",
+    ]);
+  });
+
+  it("keeps a covered instrument with no rows explicit, since the global never reaches it", () => {
+    const csv = pricesToCsv(
+      [row("AAPL"), row("MSFT")],
+      undefined,
+      [span("AAPL", "2022-01-01", "2025-07-07"),
+       span("MSFT", "2022-01-01", "2025-07-07"),
+       span("DELISTED", "2022-01-01", "2025-07-07")],
+    );
+    expect(coverageLines(csv)).toEqual([
+      "# coverage=2022-01-01,2025-07-07",
+      "# coverage=MIC_TICKER,DELISTED,XNAS,2022-01-01,2025-07-07",
+    ]);
+  });
+
+  it("writes no global when no span is shared, which would save nothing", () => {
+    const csv = pricesToCsv(
+      [row("AAPL"), row("MSFT")],
+      undefined,
+      [span("AAPL", "2022-01-01", "2023-01-01"),
+       span("MSFT", "2024-01-01", "2025-01-01")],
+    );
+    expect(coverageLines(csv)).toEqual([
+      "# coverage=MIC_TICKER,AAPL,XNAS,2022-01-01,2023-01-01",
+      "# coverage=MIC_TICKER,MSFT,XNAS,2024-01-01,2025-01-01",
+    ]);
+  });
+
+  it("round trips the compressed form back to one entry per instrument per span", () => {
+    const coverage = [
+      span("AAPL", "2022-01-01", "2025-07-07"),
+      span("MSFT", "2022-01-01", "2025-07-07"),
+      span("ATVI", "2021-12-31", "2023-10-14"),
+    ];
+    const csv = pricesToCsv([row("AAPL"), row("MSFT"), row("ATVI")], undefined, coverage);
+    const result = csvToPrices(csv);
+    expect(result.errors).toEqual([]);
+    expect(result.coverage).toEqual([
+      expect.objectContaining({ identifierValue: "AAPL", from: "2022-01-01", before: "2025-07-07" }),
+      expect.objectContaining({ identifierValue: "MSFT", from: "2022-01-01", before: "2025-07-07" }),
+      expect.objectContaining({ identifierValue: "ATVI", from: "2021-12-31", before: "2023-10-14" }),
+    ]);
+  });
+});

--- a/client/lib/csv/prices.ts
+++ b/client/lib/csv/prices.ts
@@ -40,12 +40,75 @@ function fmtOptBigint(v: bigint | undefined): string {
   return v === undefined ? "" : String(v);
 }
 
+function coverageKey(c: { identifierType: string; identifierValue: string; identifierDomain: string }): string {
+  return `${c.identifierType}\x00${c.identifierValue}\x00${c.identifierDomain}`;
+}
+
+/**
+ * Choose the global declaration and the instruments it covers.
+ *
+ * A global is only a saving where many instruments share one span, which is the
+ * common case: a file exported from one instance covers the same period for
+ * everything except instruments that started or stopped trading partway through.
+ *
+ * Two constraints come from how a global is read back (see expandCoverage):
+ *
+ * - A specific declaration overrides the global outright rather than adding to
+ *   it, so only an instrument whose whole span list is exactly the global can be
+ *   left implicit. One with two spans always writes both.
+ * - The global is expanded against the instruments the file has rows for, so an
+ *   instrument covered but carrying no rows would never receive it. Those keep
+ *   an explicit declaration.
+ */
+function chooseGlobal(
+  coverage: ExportCoverage[],
+  withRows: Set<string>,
+): { global?: ExportCoverage; implicit: Set<string> } {
+  const byInstrument = new Map<string, ExportCoverage[]>();
+  for (const c of coverage) {
+    const key = coverageKey(c);
+    const existing = byInstrument.get(key);
+    if (existing) existing.push(c);
+    else byInstrument.set(key, [c]);
+  }
+
+  // Only single-span instruments that the file has rows for can be implicit.
+  const candidates = new Map<string, string[]>();
+  for (const [key, spans] of byInstrument) {
+    if (spans.length !== 1 || !withRows.has(key)) continue;
+    const span = `${spans[0].from},${spans[0].before}`;
+    const keys = candidates.get(span);
+    if (keys) keys.push(key);
+    else candidates.set(span, [key]);
+  }
+
+  let bestSpan: string | undefined;
+  let bestKeys: string[] = [];
+  for (const [span, keys] of candidates) {
+    if (keys.length > bestKeys.length) {
+      bestSpan = span;
+      bestKeys = keys;
+    }
+  }
+  // One instrument sharing the span saves nothing: the global line replaces
+  // exactly one specific line.
+  if (bestSpan === undefined || bestKeys.length < 2) return { implicit: new Set() };
+
+  const [from, before] = bestSpan.split(",");
+  const global = byInstrument.get(bestKeys[0])![0];
+  return {
+    global: { ...global, from, before },
+    implicit: new Set(bestKeys),
+  };
+}
+
 /**
  * Serialize ExportPriceRow[] to CSV text.
  *
- * Coverage spans are written as "# coverage=" headers in the specific form.
- * They matter: a span is not derivable from the rows, so it is what lets a
- * re-import regenerate the filled days rather than leaving them as gaps.
+ * Coverage spans are written as "# coverage=" headers: one global for the span
+ * most instruments share, then the exceptions. They are not derivable from the
+ * rows -- a span holding no rows records that a provider was asked and had
+ * nothing -- so dropping them loses information the rows cannot carry.
  */
 export function pricesToCsv(rows: ExportPriceRow[], exportedAt?: Date, coverage?: ExportCoverage[]): string {
   const data = rows.map((r) => [
@@ -65,7 +128,12 @@ export function pricesToCsv(rows: ExportPriceRow[], exportedAt?: Date, coverage?
   const csv = Papa.unparse({ fields: HEADER.split(","), data }, { newline: "\n" }) + "\n";
   const headers: string[] = [];
   if (exportedAt) headers.push(`${EXPORTED_AT_PREFIX}${exportedAt.toISOString()}`);
+
+  const withRows = new Set(rows.map(coverageKey));
+  const { global, implicit } = chooseGlobal(coverage ?? [], withRows);
+  if (global) headers.push(`${COVERAGE_PREFIX}${global.from},${global.before}`);
   for (const c of coverage ?? []) {
+    if (implicit.has(coverageKey(c))) continue;
     headers.push(
       `${COVERAGE_PREFIX}${c.identifierType},${c.identifierValue},${c.identifierDomain},${c.from},${c.before}`,
     );


### PR DESCRIPTION
Fourth of five. **Stacked on #298**, which is stacked on #297 and #296.

Smaller than planned: the server side of export/import landed in #298, because
removing the write-time fill forced the import path to change with it. What is
left is the file-size problem that started this whole thread.

## Problem

The exporter only ever wrote the five-field specific form -- one line per
instrument per span -- though the format has always supported a two-field global
and the parser has always accepted one. For a file exported from one instance
that is a line per instrument all repeating the same dates, when nearly every
instrument shares one span and only those that started or stopped trading
partway through differ.

## Change

`pricesToCsv` picks the most common single span as the global and writes only
the exceptions:

```
# coverage=2022-01-01,2025-07-07
# coverage=MIC_TICKER,ATVI,XNAS,2021-12-31,2023-10-14
```

## Two constraints, both load-bearing

Both come from how `expandCoverage` reads a global back, and getting either
wrong silently loses coverage:

- **A specific declaration overrides the global outright** rather than adding to
  it, so only an instrument whose entire span list is exactly the global may be
  left implicit. An instrument held over two separate periods writes both spans
  explicitly.
- **The global is expanded against the instruments the file has rows for**, so an
  instrument that is covered but carries no rows would never receive it. Those
  keep an explicit declaration. This is the case that matters most: a covered
  span with no rows is the only way the file can say a provider was asked and
  had nothing.

No global is written when fewer than two instruments share a span -- one global
line replacing one specific line saves nothing.

## Testing

`make test` passes. New tests cover the shared-span collapse, an exception
beside the global, a two-period instrument keeping both spans, a covered
instrument with no rows staying explicit, no global when nothing is shared, and
a round trip of the compressed form back to one entry per instrument per span.

## Next

5. Spec updates and the ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)