### PR TITLE
Document stored price coverage

### DIFF
--- a/docs/adr/0023-price-coverage-is-stored-not-inferred.md
+++ b/docs/adr/0023-price-coverage-is-stored-not-inferred.md
@@ -1,0 +1,65 @@
+# Price coverage is stored, and the carry-forward is derived
+
+Prices and corporate events both need to record which date ranges a provider has
+answered for. Corporate events always had a `corporate_event_coverage` table,
+because an event-free range is indistinguishable from an unfetched one and
+adr/0005 settled that an empty result is authoritative coverage. Prices inferred
+the same thing from `range_agg` over `eod_prices` -- covered meant "rows happen
+to exist here" -- and wrote a synthetic forward-filled row for every non-trading
+day so that the inference came out contiguous.
+
+The two are the same concept and now share `price_coverage`, keyed
+`(instrument, plugin)` like its counterpart. Inference could not express a
+negative answer: `ErrNoData` and ranges beyond a plugin's `max_history_days`
+recorded nothing, so a delisted or pre-IPO range was rediscovered as a gap and
+refetched on every cycle for ever.
+
+With coverage stored, the synthetic rows lost their reason to exist and the
+carry-forward moved into the valuation query, bounded by coverage. That leaves
+nothing derived in the price tables: `eod_prices` holds only bars a provider
+reported, `price_coverage` says which ranges were answered for, and the filled
+series is computed from the two. The invariant is one-way -- every price row lies
+within some span, but a span holding no rows is meaningful and is precisely what
+row presence could never say.
+
+## Considered options
+
+**Carry the synthetic rows in the export instead of coverage declarations.**
+Rejected once coverage became stored state: it is no longer derivable from rows,
+so the file must carry it, and the synthetic rows are then regenerable from
+(bars, coverage). Exporting them would be roughly 40% more rows for no
+information.
+
+**Keep materialising the fill as a rebuildable cache.** Deferred rather than
+rejected. Measured at 860ms for 50 instruments over 5 years against 739ms for
+the flat scan the stored-fill design used, and that 16% overstates it because
+the comparison scans only real bars while the old design also stored a row per
+weekend and holiday. If it ever becomes worth it, the cache must be a pure
+function of (bars, coverage) so it can be rebuilt and checked -- which is exactly
+what the synthetic rows were not, being written by the write path from the
+write's own parameters.
+
+**Infer the fill from the rows alone, with no declaration.** Rejected: it needs
+an arbitrary maximum gap to bridge, and guesses wrong on the case that motivated
+this -- an instrument held over two separate periods, where it would either
+invent months of stale prices across the gap or refuse to bridge a legitimate
+exchange closure.
+
+**A TimescaleDB continuous aggregate.** Not applicable. Continuous aggregates
+aggregate rows that exist into time buckets; they cannot invent a row for a day
+with no data, which is the entire job of a carry-forward.
+
+## Consequences
+
+A per-`(instrument, date)` lateral is the wrong shape for the read-time fill.
+`eod_prices` is a hypertable, and a lookup whose answer lies at a
+data-dependent distance in the past defeats chunk exclusion. The query uses a
+grid-plus-window fill instead: the covered grid joined to real bars, then the
+two-window gaps-and-islands idiom, PostgreSQL having no `IGNORE NULLS`.
+Partitioning by span is what bounds the carry-forward, so a delisted
+instrument's last close stops at the end of its coverage rather than being held
+for ever.
+
+Coverage is per plugin rather than per instrument. Recording "nothing here"
+against the instrument alone would silence every other plugin for that range,
+including one configured later precisely because it reaches further back.

--- a/docs/issues/0070-price-coverage-stored-not-inferred.md
+++ b/docs/issues/0070-price-coverage-stored-not-inferred.md
@@ -1,0 +1,23 @@
+---
+status: closed
+title: Store price coverage rather than inferring it from row presence
+---
+
+Price coverage was inferred: `PriceCoverage` was `range_agg` over `eod_prices`,
+so a covered range and one that happened to have rows were the same thing. That
+left no way to record a negative answer, and the fetcher dropped the ones it got
+-- `ErrNoData` and gaps outside a plugin's `max_history_days` recorded nothing,
+so a delisted or pre-IPO range was rediscovered as a gap and refetched on every
+cycle for ever.
+
+Adds `price_coverage`, mirroring `corporate_event_coverage`, and removes the
+synthetic forward-filled rows that existed largely to make the inference come
+out contiguous. The carry-forward moved into the valuation query, bounded by
+coverage, so nothing in the price tables is derived.
+
+Delivered across five PRs: the table and write path; gap analysis and the
+fetcher recording negative answers; read-time carry-forward and the removal of
+the `synthetic` column; the export emitting a global declaration plus
+exceptions; and the spec and ADR.
+
+See adr/0023-price-coverage-is-stored-not-inferred.md.

--- a/docs/spec/bitemporality.md
+++ b/docs/spec/bitemporality.md
@@ -41,6 +41,7 @@ clock every read API means by "as of".
 | `holding_declarations` | `as_of_date` | The date the user's declaration refers to. |
 | `instruments` | `valid_from`, `valid_before`, `expiry` | When the instrument was tradeable. Descriptive only for `valid_from` / `valid_before` -- see [Instrument identity](#instrument-identity) below. |
 | `instruments` | `identity_as_of` | The point in market time the stored identity reflects -- see [Instrument identity](#instrument-identity) below. |
+| `price_coverage` | `covered_from`, `covered_before` | The valid-time interval a plugin was asked about for prices. |
 | `corporate_event_coverage` | `covered_from`, `covered_before` | The valid-time interval a plugin was asked about. |
 | `inflation_indices` | `month` | The month the index value describes. |
 | `ingestion_jobs` | `period_from`, `period_before` | The valid-time window a bulk upload replaces. |
@@ -107,6 +108,7 @@ a revision occurred, which follows from rule 8 below
 | `stock_splits` | `first_known_at` | First known. Preserved across corporate-event export and import; not read by option adjustment, which keys off `ex_date` (see adr/0017-option-identity-reflects-ex-date.md). |
 | `cash_dividends` | `first_known_at` | First known. |
 | `eod_prices` | `last_fetched_at` | Staleness only. It carries no semantics about the price itself -- that is what `share_count_basis` is for. |
+| `price_coverage` | `last_fetched_at` | When the span was last confirmed. Merged the same way as `corporate_event_coverage` below. |
 | `corporate_event_coverage` | `last_fetched_at` | When the span was last confirmed. Merging spans keeps the oldest constituent's, since a union is only as freshly confirmed as its stalest part. |
 | `inflation_indices` | `last_fetched_at` | Staleness only. |
 | `price_fetch_blocks` | `first_blocked_at` | First known. |

--- a/docs/spec/csv-format.md
+++ b/docs/spec/csv-format.md
@@ -86,7 +86,7 @@ It declares the share count the file's quantities and unit prices are denominate
 
 A CSV of EOD prices imported via the `ImportPrices` API, and the format `ExportPrices` writes.
 
-The export omits synthetic forward-filled rows, so a file holds only the days its source actually reported. Its [coverage declarations](#coverage-declarations) are what let a re-import regenerate the days between, which is what makes the round trip reproduce the exported state.
+A file holds only the days its source actually reported. Its [coverage declarations](#coverage-declarations) say which ranges were answered for, which the rows cannot: a declared range holding no rows records that a provider was asked and had nothing. Dropping them loses that, and leaves valuation treating the days between reported bars as unpriced.
 
 ### Columns
 
@@ -135,7 +135,7 @@ OCC,NVDA250620P00110000,,2024-06-11,,,,13.42,,,OPTION,USD
 
 Stock splits are imported via the `ImportCorporateEvents` API as JSON, and `ExportCorporateEvents` writes the same shape. Cash dividends are part of the API but are not yet carried by this file format.
 
-Coverage is stored per (instrument, plugin), but an import records every span as `data_provider = "import"`, so the export merges spans across plugins rather than preserving a distinction that cannot survive the round trip.
+Coverage is stored per (instrument, plugin) for both prices and corporate events, but an import records every span against the `import` sentinel, so both exports merge spans across plugins rather than preserving a distinction that cannot survive the round trip.
 
 The canonical shape is an object with an `events` array and an optional `coverage` array. A bare array is accepted as events-only.
 
@@ -174,10 +174,12 @@ When the importer sees an unknown `(identifier_type, identifier_domain, identifi
 
 A coverage declaration records that the caller has authoritative coverage of a date interval. Both the price CSV and the corporate event JSON accept them, with the same semantics and the same fields; only the syntax differs.
 
-What the server does with one depends on the import:
+Both store the declaration, tagged as coming from an import so the background fetcher does not re-query the same interval from a plugin and cannot overwrite hand-curated data with provider data.
 
-- **Prices** -- non-trading days within the interval are filled with synthetic last-observation-carried-forward rows, so a file can carry only the days its source actually moved on. Without a declaration, rows are stored exactly as supplied and any gap stays a gap: valuation matches prices by exact date and has no read-time carry-forward.
-- **Corporate events** -- a `corporate_event_coverage` row is stored tagged `data_provider = "import"`, so the background fetcher does not re-query the same interval from a plugin and cannot overwrite hand-curated events with provider data.
+- **Prices** -- a `price_coverage` row. Valuation carries the last close forward across the non-trading days inside the interval, so a file can carry only the days its source actually moved on. Without a declaration each row covers only its own date, so any gap between rows stays a gap.
+- **Corporate events** -- a `corporate_event_coverage` row.
+
+In both cases a declared interval containing nothing is meaningful, and is the only way a file can say the caller asked about those dates and there was nothing to report. See adr/0023-price-coverage-is-stored-not-inferred.md.
 
 ### Fields
 
@@ -200,7 +202,9 @@ A declaration carrying no identifier at all is **global**: it applies to every i
 - Several specific declarations for one instrument are all applied, so an instrument can carry more than one interval.
 - A partly-written identifier -- a type with no value, or a domain alone -- is an error rather than a global declaration.
 
-Most files need one global and a handful of exceptions: instruments that started or stopped trading partway through the period the file covers.
+Most files need one global and a handful of exceptions: instruments that started or stopped trading partway through the period the file covers. That is what the export writes -- the span most instruments share as the global, then the exceptions.
+
+Two cases the export always writes out in full, both following from the override rule above. An instrument carrying more than one span writes all of them, since a specific declaration replaces the global rather than adding to it. An instrument that is covered but has no rows in the file also writes its own, since the global is expanded against the instruments the file names and would never reach it.
 
 ### Syntax
 

--- a/docs/spec/performance.md
+++ b/docs/spec/performance.md
@@ -75,15 +75,21 @@ or empty, it defaults to the user's stored `display_currency` preference.
 ### Unpriced handling for missing FX rates
 
 When an instrument requires FX conversion but the rate is unavailable for a
-given date (the `gapfilled_fx_rates` LEFT JOIN produces NULL), the instrument
-is reported in `unpriced_instruments` alongside instruments missing price
-data. The same orange-dot indicator appears on the chart.
+given date (the `fx_rates` LEFT JOIN produces NULL), the instrument is reported
+in `unpriced_instruments` alongside instruments missing price data. The same
+orange-dot indicator appears on the chart.
 
 ## Unpriced instrument handling
 
-An instrument is "unpriced" only when it has never had a price up to that date
-(i.e., `locf()` returns NULL because there is no prior observation). Weekend
-gaps where `locf()` successfully fills are NOT reported as unpriced.
+An instrument is "unpriced" on a date when the carry-forward yields no price:
+either no bar precedes the date inside the same covered span, or the date falls
+outside every covered span. Weekend and holiday gaps that the carry-forward
+fills are NOT reported as unpriced.
+
+The coverage bound is what separates "we have no price for this day" from "the
+last price we ever saw is still valid". Past the end of an instrument's
+coverage -- a delisting, say -- it reads as unpriced rather than holding its
+final close for ever. See prices.md and adr/0023-price-coverage-is-stored-not-inferred.md.
 
 On the chart, unpriced dates are indicated with orange dots and the custom
 tooltip lists the affected instrument names. An info banner appears above the

--- a/docs/spec/prices.md
+++ b/docs/spec/prices.md
@@ -32,6 +32,39 @@ The price cache.
 
 **Index:** A TimescaleDB hypertable on `price_date`.
 
+Every row is a bar a provider actually reported. Non-trading days have no row;
+valuation carries the last close forward over them at read time, bounded by
+`price_coverage`. See [Component 2](#component-2-coverage-inventory-pricecoverage).
+
+### Table: `price_coverage`
+
+Which date ranges have been answered for, per `(instrument, plugin)`.
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `instrument_id` | `UUID` NOT NULL | FK to `instruments`, `ON DELETE CASCADE` |
+| `plugin_id` | `text` NOT NULL | Which plugin answered; `import` for coverage declared by an import |
+| `covered_from` | `date` NOT NULL | Inclusive |
+| `covered_before` | `date` NOT NULL | Exclusive; `CHECK (covered_before > covered_from)` |
+| `last_fetched_at` | `timestamptz` NOT NULL | Staleness only. A merged span keeps the oldest constituent value |
+
+**Primary key:** `(instrument_id, plugin_id, covered_from)`
+
+Overlapping or abutting spans for one `(instrument, plugin)` are merged on
+insert, so the table never holds two spans that touch. This mirrors
+`corporate_event_coverage` exactly, and the merge is shared between them.
+
+A span covers a range whether or not any bars came back: a provider that
+answered "nothing here" -- a delisted, pre-IPO or untraded range -- has covered
+it as authoritatively as one that returned a full series. Row presence cannot
+express that, which is why coverage is stored rather than inferred. See
+adr/0023-price-coverage-is-stored-not-inferred.md.
+
+**Invariant.** Every `eod_prices` row lies within some `price_coverage` span for
+its instrument. The converse deliberately does not hold. Coverage is written in
+the same transaction as the rows, so no write path can store a price without
+recording what it covers.
+
 The table carries three closing prices and they are not interchangeable:
 
 - `close` is the raw value as the provider supplied it, denominated in the share count the provider expressed it in.
@@ -45,7 +78,7 @@ A price plugin declares the denomination of the bars it returns on its `FetchRes
 - `AsTraded` -- each bar is denominated in the share count current on its own date. Both current plugins return this: massive sends `?adjusted=false`, and EODHD's `/api/eod` OHLC is as-traded.
 - `AsOfFetch` -- the provider back-adjusted the whole series to the share count current when it answered.
 
-A forward-filled synthetic row carries the value of the bar it copied, so it inherits that bar's basis rather than taking its own date. Import rows default to `price_date`, matching PortfolioDB's own export, and may declare `share_count_basis` when the file holds a back-adjusted series.
+A carried-forward value keeps the basis of the bar it came from, since it is that bar's price rather than one of its own date. Import rows default to `price_date`, matching PortfolioDB's own export, and may declare `share_count_basis` when the file holds a back-adjusted series.
 
 ---
 
@@ -82,7 +115,10 @@ type HeldRangesOpts struct {
 type PriceCacheDB interface {
     HeldRanges(ctx context.Context, opts HeldRangesOpts) ([]InstrumentDateRanges, error)
     PriceCoverage(ctx context.Context, instrumentIDs []string) ([]InstrumentDateRanges, error)
+    PriceCoverageByPlugin(ctx context.Context, instrumentIDs []string) (map[string]map[string][]DateRange, error)
     PriceGaps(ctx context.Context, opts HeldRangesOpts) ([]InstrumentDateRanges, error)
+    UpsertPrices(ctx context.Context, prices []EODPrice) error
+    UpsertPricesForRange(ctx context.Context, instrumentID, provider string, bars []EODPrice, from, before time.Time, fetchedAt *time.Time) error
 }
 ```
 
@@ -109,13 +145,15 @@ Compute the date ranges during which any user held a non-zero position in each i
 
 ### Purpose
 
-For each instrument present in the `eod_prices` table, return the date ranges for which we already have cached data, as maximally merged non-overlapping ranges.
+For each instrument, return the date ranges some plugin has answered for, as maximally merged non-overlapping ranges. This is read from `price_coverage`, never inferred from which dates happen to have rows.
 
 ### Behaviour
 
-1. For each instrument (or specific instruments if `instrumentIDs` is non-empty), use PostgreSQL's `range_agg` to merge individual price dates into contiguous `daterange` values.
+1. For each instrument (or specific instruments if `instrumentIDs` is non-empty), use PostgreSQL's `range_agg` to merge the stored spans across plugins.
 2. Extract the lower and upper bounds as plain DATE values.
 3. Return as a slice of `InstrumentDateRanges`.
+
+Merging across plugins is right for "has anyone answered for this range". `PriceCoverageByPlugin` keeps the distinction, which is what the fetcher needs: a range one plugin declined must still be offered to another, and to a plugin configured later with deeper history.
 
 ### SQL approach
 
@@ -123,13 +161,31 @@ For each instrument present in the `eod_prices` table, return the date ranges fo
 SELECT instrument_id, lower(r) AS range_from, upper(r) AS range_before
 FROM (
     SELECT instrument_id,
-        unnest(range_agg(daterange(price_date, price_date + 1))) AS r
-    FROM eod_prices
+        unnest(range_agg(daterange(covered_from, covered_before))) AS r
+    FROM price_coverage
     WHERE ($1::uuid[] IS NULL OR instrument_id = ANY($1))
     GROUP BY instrument_id
 ) sub
 ORDER BY instrument_id, range_from
 ```
+
+### Read-time carry-forward
+
+Because only real bars are stored, valuation carries the last close forward over
+the days between them. The fill is derived from (bars, coverage) rather than
+stored, so there is no third thing to keep in step with them.
+
+The valuation query joins `date_series` to `price_coverage` to build the covered
+grid, left-joins real bars onto it, and forward-fills with the two-window
+gaps-and-islands idiom -- PostgreSQL has no `IGNORE NULLS`. Partitioning by span
+bounds the carry-forward: it cannot cross a span boundary, so a delisted
+instrument stops at the end of its coverage rather than holding its final close
+for ever. Each span is seeded with the last bar before the window so a window
+opening mid-span is not unpriced until its first bar.
+
+A per-`(instrument, date)` lateral is the wrong shape here: `eod_prices` is a
+hypertable, and a lookup whose answer lies at a data-dependent distance in the
+past defeats chunk exclusion. See adr/0023-price-coverage-is-stored-not-inferred.md.
 
 ---
 
@@ -142,9 +198,11 @@ For each instrument, compute the date ranges that are **needed** (from Component
 ### Behaviour
 
 1. Call `HeldRanges` to get needed ranges.
-2. Call `PriceCoverage` to get what we have (filtered to instruments from step 1).
+2. Call `PriceCoverage` to get what has been answered for (filtered to instruments from step 1).
 3. For each instrument, compute the set difference using `SubtractRanges` (Go utility in `server/db/daterange.go`).
 4. Return the resulting gap ranges.
+
+A range answered with no bars is not a gap. The fetcher additionally subtracts each plugin's own coverage before asking it, and records the negative answers it used to drop: `ErrNoData`, and any part of a gap outside the plugin's `max_history_days`. Without that, a delisted or pre-IPO range is rediscovered and refetched on every cycle for ever.
 
 ---
 
@@ -171,8 +229,10 @@ Each component should be independently testable:
 
 - **Range Utilities:** Table-driven unit tests for `MergeRanges` and `SubtractRanges`. No database required.
 - **Holdings Calculator:** Insert a known set of transactions (buy, sell, buy again), verify the output ranges match expectations. Test edge cases: position goes to zero and reopens the same day; position never closes; transactions with NULL instrument_id are excluded.
-- **Coverage Inventory:** Insert a known set of `eod_prices` rows with deliberate gaps, verify the contiguous ranges are detected correctly. Test: single day of data, data with weekend gaps, data with a genuine multi-day gap; filter by instrument_id.
-- **Gap Analysis:** Combine known holdings and known cached data, verify the gaps are correct. Test: fully cached (no gaps), no cache at all (gaps = holdings), partial overlap.
+- **Coverage Inventory:** Insert known spans and verify they merge correctly. Test: abutting and overlapping spans merging, a one-day hole staying unmerged, a span with no bars in it surviving, per-plugin spans staying separate, filter by instrument_id.
+- **Gap Analysis:** Combine known holdings and known coverage, verify the gaps are correct. Test: fully covered (no gaps), no coverage at all (gaps = holdings), partial overlap, and a range covered with no bars producing no gap.
+- **Carry-forward:** Verify the read-time fill spans non-trading days, stops at `covered_before`, does not bleed between two disjoint covered periods, and seeds a window that opens mid-span from the bar before it.
+- **Containment invariant:** After every write path, assert no `eod_prices` row lies outside its instrument's coverage.
 
 ---
 


### PR DESCRIPTION
Last of five. **Stacked on #299**, which is stacked on #298, #297 and #296.

Docs only, no code.

## adr/0023

Records why price coverage became a stored table and why the carry-forward is
derived rather than materialised, with the options turned down:

- **Exporting synthetic rows instead of coverage declarations** -- rejected once
  coverage became stored state, since it is then not derivable from rows and the
  file must carry it, which makes the synthetic rows redundant.
- **Keeping a materialised fill as a rebuildable cache** -- deferred, with the
  measured numbers, and with the condition it would have to meet: being a pure
  function of (bars, coverage), which is exactly what the synthetic rows were
  not.
- **Inferring the fill from rows alone** -- rejected; needs an arbitrary maximum
  gap and guesses wrong on the two-disjoint-periods case that started this.
- **A TimescaleDB continuous aggregate** -- does not apply. Continuous aggregates
  aggregate rows that exist; they cannot invent one for a day with no data.

## Spec

- **prices.md** -- documents `price_coverage`, the containment invariant, the
  read-time carry-forward and its coverage bound, and why gap analysis merges
  spans across plugins while the fetcher deliberately does not.
- **performance.md** -- the unpriced prose described a read-time `locf()` and had
  gone stale when the fill moved to write time. It is accurate again, plus the
  coverage bound, which is what separates "no price for this day" from "the last
  price we saw still stands". Also corrects a CTE name that no longer existed.
- **csv-format.md** -- the coverage section now describes one concept with one
  meaning across both formats, and records what the export writes: a global plus
  exceptions, with multi-span and covered-but-empty instruments always explicit.
- **bitemporality.md** -- adds `price_coverage` to the valid-time and
  knowledge-time column tables.

## Issue

0070 closed, describing the problem and pointing at the ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)