### PR TITLE
Close 0037: typed account classification for non-asset postings

### DIFF
--- a/client/app/transactions/page.tsx
+++ b/client/app/transactions/page.tsx
@@ -12,7 +12,7 @@ import { errorMessage } from "@/lib/errors";
 import { qk } from "@/lib/query-keys";
 import { listTxs } from "@/lib/portfolio-api";
 import { getBrokerLabel } from "@/lib/csv/converters";
-import { TxType, IdentifierType } from "@/gen/api/v1/api_pb";
+import { AccountType, TxType, IdentifierType } from "@/gen/api/v1/api_pb";
 import type { PortfolioTx } from "@/gen/api/v1/api_pb";
 import { timestampDate } from "@bufbuild/protobuf/wkt";
 
@@ -38,6 +38,17 @@ const TX_TYPE_LABEL: Record<number, string> = {
   [TxType.MARGININTEREST]: "Margin Interest",
   [TxType.CLOSUREOPT]: "Option Closure",
   [TxType.CASHFLOW]: "Cash Flow",
+};
+
+// Labels for the non-asset side of an event. USER postings are the ordinary case and
+// carry no badge; the rest are shown so that a group's legs can be told apart, which
+// is also how an imbalance becomes visible rather than silently absorbed.
+const ACCOUNT_TYPE_LABEL: Record<number, string> = {
+  [AccountType.EQUITY]: "Equity",
+  [AccountType.INCOME]: "Income",
+  [AccountType.EXPENSE]: "Expense",
+  [AccountType.IMBALANCE]: "Imbalance",
+  [AccountType.TRANSFER_CLEARING]: "In Flight",
 };
 
 export default function TxsPage() {
@@ -207,6 +218,7 @@ function TxRow({ ptx }: { ptx: PortfolioTx }) {
   if (!tx) return null;
 
   const isSynthetic = !!tx.syntheticPurpose;
+  const accountTypeLabel = ACCOUNT_TYPE_LABEL[tx.accountType];
   const ticker = ptx.instrument?.identifiers?.find(
     (id) => id.type === IdentifierType.MIC_TICKER || id.type === IdentifierType.OPENFIGI_TICKER
   )?.value;
@@ -231,13 +243,23 @@ function TxRow({ ptx }: { ptx: PortfolioTx }) {
         {label}
       </td>
       <td className="px-4 py-3 text-text-muted">
-        {isSynthetic ? (
-          <span className="inline-block rounded-sm bg-primary-dark/10 px-1.5 py-0.5 text-xs font-medium text-primary-dark">
-            {tx.syntheticPurpose}
-          </span>
-        ) : (
-          TX_TYPE_LABEL[tx.type] ?? "Unknown"
-        )}
+        <span className="flex flex-wrap items-center gap-1.5">
+          {isSynthetic ? (
+            <span className="inline-block rounded-sm bg-primary-dark/10 px-1.5 py-0.5 text-xs font-medium text-primary-dark">
+              {tx.syntheticPurpose}
+            </span>
+          ) : (
+            TX_TYPE_LABEL[tx.type] ?? "Unknown"
+          )}
+          {accountTypeLabel && (
+            <span
+              data-testid="tx-account-type"
+              className="inline-block rounded-sm bg-text-muted/10 px-1.5 py-0.5 text-xs font-medium text-text-muted"
+            >
+              {accountTypeLabel}
+            </span>
+          )}
+        </span>
       </td>
       <td data-testid="tx-qty" className="px-4 py-3 text-right font-mono tabular-nums text-text-primary">
         {parseFloat(tx.quantity.toFixed(4))}

--- a/client/lib/csv/standard.test.ts
+++ b/client/lib/csv/standard.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 import { parseStandardCSV } from "./standard";
-import { IdentifierType, TxType } from "@/gen/api/v1/api_pb";
+import { AccountType, IdentifierType, TxType } from "@/gen/api/v1/api_pb";
 
 describe("parseStandardCSV", () => {
   it("parses valid CSV and derives period from min/max dates", () => {
@@ -388,5 +388,72 @@ describe("group_ref", () => {
 
     expect(result.errors).toHaveLength(0);
     expect(result.txs[0].groupRef).toBe("");
+  });
+});
+
+describe("account_type", () => {
+  it("types the non-asset leg of a group", () => {
+    const csv = `date,instrument_description,type,quantity,account,group_ref,account_type
+2024-02-01,USD,INCOME,23.40,ACC1,div-8842,
+2024-02-01,USD,INCOME,-23.40,ACC1,div-8842,INCOME`;
+
+    const result = parseStandardCSV(csv);
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.txs).toHaveLength(2);
+    // The cash arriving in the account is an ordinary posting; the income it came
+    // from is the other side of the same event.
+    expect(result.txs[0].accountType).toBe(AccountType.USER);
+    expect(result.txs[1].accountType).toBe(AccountType.INCOME);
+    expect(result.txs[1].groupRef).toBe("div-8842");
+  });
+
+  it("is case-insensitive and accepts the whole vocabulary", () => {
+    const csv = `date,instrument_description,type,quantity,account_type
+2024-02-01,X,BUYSTOCK,1,equity
+2024-02-01,X,BUYSTOCK,1,Expense
+2024-02-01,X,BUYSTOCK,1,IMBALANCE
+2024-02-01,X,BUYSTOCK,1,transfer_clearing`;
+
+    const result = parseStandardCSV(csv);
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.txs.map((t) => t.accountType)).toEqual([
+      AccountType.EQUITY,
+      AccountType.EXPENSE,
+      AccountType.IMBALANCE,
+      AccountType.TRANSFER_CLEARING,
+    ]);
+  });
+
+  it("defaults to USER when the column is absent", () => {
+    const csv = `date,instrument_description,type,quantity
+2024-03-01,AAPL,BUYSTOCK,10`;
+
+    const result = parseStandardCSV(csv);
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.txs[0].accountType).toBe(AccountType.USER);
+  });
+
+  it("rejects an unknown value rather than falling back to USER", () => {
+    const csv = `date,instrument_description,type,quantity,account_type
+2024-03-01,AAPL,BUYSTOCK,10,Imbalance.USD`;
+
+    const result = parseStandardCSV(csv);
+
+    expect(result.txs).toHaveLength(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].field).toBe("account_type");
+  });
+
+  it("does not accept UNSPECIFIED as a written value", () => {
+    const csv = `date,instrument_description,type,quantity,account_type
+2024-03-01,AAPL,BUYSTOCK,10,UNSPECIFIED`;
+
+    const result = parseStandardCSV(csv);
+
+    expect(result.txs).toHaveLength(0);
+    expect(result.errors[0].field).toBe("account_type");
   });
 });

--- a/client/lib/csv/standard.ts
+++ b/client/lib/csv/standard.ts
@@ -9,6 +9,7 @@ import { timestampFromDate } from "@bufbuild/protobuf/wkt";
 import { startOfNextDay } from "@/lib/dates";
 import type { Tx } from "@/gen/api/v1/api_pb";
 import {
+  AccountType,
   IdentifierType,
   InstrumentIdentifierSchema,
   TxSchema,
@@ -59,12 +60,30 @@ const IDENTIFIER_TYPE_BY_NAME = new Map<string, IdentifierType>(
     .map(([k, v]) => [k, v as IdentifierType])
 );
 
+const ACCOUNT_TYPE_BY_NAME = new Map<string, AccountType>(
+  (Object.entries(AccountType) as [string, number][])
+    .filter(([k, v]) => typeof v === "number" && k !== "UNSPECIFIED")
+    .map(([k, v]) => [k, v as AccountType])
+);
+
 const EXCHANGE_TYPES = new Set(["MIC", "OPENFIGI"]);
 
 function parseTxType(value: string): TxType | null {
   const trimmed = value.trim().toUpperCase();
   if (trimmed === "" || trimmed === "TX_TYPE_UNSPECIFIED") return null;
   return TX_TYPE_BY_NAME.get(trimmed) ?? null;
+}
+
+/**
+ * Parse an account_type cell. An absent or empty value is USER: a row that says
+ * nothing about what kind of leg it is is an ordinary broker account posting.
+ * Returns null for a value that is not in the vocabulary, so the row can be
+ * rejected rather than silently treated as USER.
+ */
+function parseAccountType(value: string): AccountType | null {
+  const trimmed = value.trim().toUpperCase();
+  if (trimmed === "") return AccountType.USER;
+  return ACCOUNT_TYPE_BY_NAME.get(trimmed) ?? null;
 }
 
 function parseIdentifierType(value: string): IdentifierType | null {
@@ -91,7 +110,7 @@ export function parseCSVLine(line: string): string[] {
  * Parse standard-format CSV text into Tx array and period.
  * Header names are case-insensitive. Required: date (or timestamp), instrument_description, type, quantity.
  * Optional: trading_currency, settlement_currency, unit_price, account, symbol_type, symbol, exchange_type,
- * exchange, group_ref.
+ * exchange, group_ref, account_type.
  */
 export function parseStandardCSV(csvText: string): StandardParseResult {
   const errors: ParseError[] = [];
@@ -140,6 +159,7 @@ export function parseStandardCSV(csvText: string): StandardParseResult {
   const exchangeTypeCol = col("exchange_type");
   const exchangeCol = col("exchange");
   const groupRefCol = col("group_ref");
+  const accountTypeCol = col("account_type");
 
   if (dateCol < 0) errors.push({ rowIndex: 0, field: "header", message: "Missing required column: date or timestamp" });
   if (descCol < 0) errors.push({ rowIndex: 0, field: "header", message: "Missing required column: instrument_description" });
@@ -195,6 +215,13 @@ export function parseStandardCSV(csvText: string): StandardParseResult {
     const account = accountCol >= 0 ? get(accountCol) : "";
     const groupRef = groupRefCol >= 0 ? get(groupRefCol) : "";
 
+    const accountTypeStr = accountTypeCol >= 0 ? get(accountTypeCol) : "";
+    const accountType = parseAccountType(accountTypeStr);
+    if (accountType === null) {
+      errors.push({ rowIndex, field: "account_type", message: "Unknown account type" });
+      continue;
+    }
+
     // Parse exchange_type + exchange into a domain for the identifier hint.
     let domain: string | undefined;
     const exchangeTypeStr = exchangeTypeCol >= 0 ? get(exchangeTypeCol) : "";
@@ -240,6 +267,7 @@ export function parseStandardCSV(csvText: string): StandardParseResult {
         type: txType,
         quantity,
         account,
+        accountType,
         ...(groupRef ? { groupRef } : {}),
         ...(tradingCurrency ? { tradingCurrency } : {}),
         ...(settlementCurrency ? { settlementCurrency } : {}),

--- a/docs/issues/0037-typed-account-classification.md
+++ b/docs/issues/0037-typed-account-classification.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Typed account classification for non-asset postings
 milestone: M12
 dependencies: [0036]

--- a/docs/spec/csv-format.md
+++ b/docs/spec/csv-format.md
@@ -25,6 +25,7 @@ Header names are case-insensitive. Supported column names:
 | `exchange_type`          | No       | Exchange code system: `MIC` (ISO 10383) or `OPENFIGI` (Bloomberg exchange code). Required when `exchange` is present. |
 | `exchange`               | No       | Exchange code value (e.g. "XNAS" for MIC, "US" for OPENFIGI). Populates the domain field on the identifier hint. Required when `exchange_type` is present. |
 | `group_ref`              | No       | Opaque grouping key. Rows sharing a non-empty value are postings of one economic event. See [Transaction groups](#transaction-groups). |
+| `account_type`           | No       | What kind of leg the row is. Defaults to `USER`. See allowed values below. |
 
 ### Transaction groups
 
@@ -45,6 +46,20 @@ Allowed values for `type` (OFX-style):
 `SELLDEBT`, `SELLFUTURE`, `SELLMF`, `SELLOPT`, `SELLOTHER`, `SELLSTOCK`,
 `INCOME`, `INVEXPENSE`, `REINVEST`, `RETOFCAP`, `SPLIT`, `TRANSFER`,
 `JRNLFUND`, `JRNLSEC`, `MARGININTEREST`, `CLOSUREOPT`, `CASHFLOW`.
+
+### Account types (account_type column)
+
+Allowed values for `account_type`:
+`USER`, `EQUITY`, `INCOME`, `EXPENSE`, `IMBALANCE`, `TRANSFER_CLEARING`.
+
+An absent column or an empty cell means `USER`, so an ordinary export needs no such
+column. An unrecognised value is a row error rather than a silent fall back to `USER`.
+
+`account_type` is what makes a one-sided event balance: the income side of a dividend or
+the expense side of a charge is a second row in the same `group_ref`, carrying the same
+`broker` and `account` as the cash row it balances. It is distinct from `type`, which
+records what the broker called the event -- a dividend's cash row and its income row are
+both `type=INCOME`, and differ by `account_type`. See [postings.md](postings.md#account-types).
 
 ### Identifier hints
 
@@ -70,6 +85,15 @@ The optional `exchange_type` and `exchange` columns provide a domain for resolut
 date,instrument_description,type,quantity,trading_currency,unit_price,account,symbol_type,symbol,exchange_type,exchange
 2024-01-15,AAPL - Apple Inc.,BUYSTOCK,10,USD,185.50,ACC-1,MIC_TICKER,AAPL,MIC,XNAS
 2024-01-16,MSFT Option,BUYOPT,1,USD,12.50,ACC-1,OCC,MSFT  250117P00385000,,
+```
+
+A dividend as a balanced group: the cash arriving in the account, and the income it came
+from. Both rows carry the same `account` and `group_ref`; only `account_type` differs.
+
+```csv
+date,instrument_description,type,quantity,settlement_currency,account,group_ref,account_type
+2024-02-01,USD,INCOME,23.40,USD,ACC-1,div-8842,
+2024-02-01,USD,INCOME,-23.40,USD,ACC-1,div-8842,INCOME
 ```
 
 Any extra columns are ignored. Empty optional fields can be omitted or left blank.

--- a/docs/spec/postings.md
+++ b/docs/spec/postings.md
@@ -10,6 +10,7 @@ A posting is a signed amount of one commodity in one account at one point in tim
 | Concept   | Column                        |
 | --------- | ----------------------------- |
 | Account   | `broker` + `account`          |
+| Kind      | `account_type`                |
 | Commodity | `instrument_id`               |
 | Amount    | `quantity` (signed)           |
 | Date      | `timestamp`                   |
@@ -19,6 +20,79 @@ separate representation. Nothing in the read path distinguishes a cash posting f
 security posting: holdings, valuation, price coverage and holding declarations all
 aggregate `SUM(quantity)` grouped by instrument, and a cash balance is that sum over
 a currency instrument.
+
+## Account types
+
+Double-entry needs somewhere to post the other side of events that are one-sided in the
+source data: an INITIALIZE pad has no counterparty, most brokers report a dividend or a
+charge as a single cash row, and the two sides of a transfer arrive in separate
+statements. `account_type` classifies the account a posting lands in. The posting keeps
+the `broker` and `account` of the event it belongs to, so a residual stays attributable
+to the account that produced it.
+
+| Value               | Meaning                                                   |
+| ------------------- | --------------------------------------------------------- |
+| `USER`              | An ordinary broker account posting. The default.           |
+| `EQUITY`            | Value entering or leaving the user's holdings entirely.    |
+| `INCOME`            | Dividends, interest and other income.                      |
+| `EXPENSE`           | Commissions, levies, custody and service charges, taxes.   |
+| `IMBALANCE`         | The residual of a group that does not sum to zero.         |
+| `TRANSFER_CLEARING` | One side of a transfer whose other side is not yet known.  |
+
+Opening balances are `EQUITY` postings rather than a type of their own. An opening
+balance is one use of equity, and a withdrawal to a bank is an equity posting too; an
+enum that mixes roots with specific accounts ages badly.
+
+The type is a column rather than a reserved prefix on `account`, because `account` is
+user-supplied free text that a broker CSV can collide with, a name has nowhere to record
+which broker account a residual came from, and the currency is already the posting's
+commodity. See adr/0022-typed-per-account-cash-flow-boundary.md.
+
+Constraining an account to be unique per type would need an accounts table, and accounts
+today are implicit: distinct `(broker, account)` pairs in `txs`. Until then
+`(broker, account, account_type)` is the account identity by convention rather than by
+constraint.
+
+## The cash-flow boundary
+
+Classification is per account and fixed at ingest. Netting is per portfolio and resolved
+at query time. A posting in account A is an external flow of A iff its group has a leg
+outside A, and `account_type` says what kind of outside:
+
+- `EQUITY` is external, and never nets, since there is no counterparty side.
+- `INCOME`, `EXPENSE` and `IMBALANCE` are not flows. These are return and cost, and
+  treating them as external would strip dividends out of the return and report it gross
+  of fees. `IMBALANCE` is internal because a residual is usually a missing fee or a
+  missing cash leg, both of which are internal.
+- Another `USER` account is external to A, and nets against the other side when both
+  accounts belong to the portfolio being measured.
+- `TRANSFER_CLEARING` is external while unmatched, because one half is all we know. It
+  nets once the pair is matched and both accounts are members.
+
+Membership decides internal versus external; there is no per-portfolio user override.
+Membership already expresses the intent, and a toggle would be a second place to say the
+same thing that can disagree with the first.
+
+## Visibility
+
+Non-`USER` postings are excluded from holdings and from every quantity aggregation, so
+that no residual or in-flight position appears among a user's holdings and so that a
+counterparty leg cannot net against the holding it balances. The predicate is
+`account_type = 'USER'` and it is applied per call site rather than in
+`portfolio_matched_txs`, because valuation does not stay the same as holdings.
+
+Valuation is a different question. When a portfolio contains both sides of a matched
+transfer and the two sides are dated by their own statements, excluding
+`TRANSFER_CLEARING` makes the transferred holding vanish for the days in between -- a dip
+in portfolio value and a fake return blip. Holding value in transit is what a clearing
+account is for. So: exclude from holdings display always; include in valuation only for
+matched pairs where both accounts are members. Including an unmatched in-flight balance
+would assert the money is coming back to a member account, which is the thing we do not
+know. Valuation reads `USER` only until transfer matching supplies the pairing.
+
+The transaction list is not filtered. It is a ledger view, and hiding the counterparty
+legs would make groups look unbalanced and hide the residuals that make a converter's
+lossiness measurable.
 
 ## Groups
 

--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -48,6 +48,22 @@ enum TxType {
   SELLFUTURE     = 23;
 }
 
+// AccountType classifies the account a posting lands in, so that the non-asset side
+// of an event that is one-sided in the source data has somewhere to go. A posting
+// keeps the broker and account of the event it belongs to; the type says what kind
+// of leg it is. Values are prefixed because proto enum values share package scope
+// and TxType already defines INCOME and TRANSFER.
+// See docs/adr/0022-typed-per-account-cash-flow-boundary.md.
+enum AccountType {
+  ACCOUNT_TYPE_UNSPECIFIED = 0;       // Unset on upload; stored as USER.
+  ACCOUNT_TYPE_USER = 1;              // An ordinary broker account posting.
+  ACCOUNT_TYPE_EQUITY = 2;            // Value entering or leaving the user's holdings entirely.
+  ACCOUNT_TYPE_INCOME = 3;            // Dividends, interest and other income.
+  ACCOUNT_TYPE_EXPENSE = 4;           // Commissions, levies, custody and service charges, taxes.
+  ACCOUNT_TYPE_IMBALANCE = 5;         // The residual of a group that does not sum to zero.
+  ACCOUNT_TYPE_TRANSFER_CLEARING = 6; // One side of a transfer whose other side is not yet known.
+}
+
 // IdentifierType is the controlled vocabulary for instrument identifier types.
 // Stored in instrument_identifiers.identifier_type. Broker description identifiers use BROKER_DESCRIPTION with domain = source (e.g. "Fidelity:web:fidelity-csv").
 enum IdentifierType {
@@ -168,6 +184,11 @@ message Tx {
   // of a trade. Not a durable identifier: it is not stored and carries no
   // meaning across uploads.
   string group_ref = 14;
+  // What kind of leg this posting is. Set by the broker converter, which is the only
+  // thing that knows whether a row is the user's cash or the income it came from.
+  // Unset means USER, so an upload that says nothing about kind reads as an ordinary
+  // broker account posting.
+  AccountType account_type = 15 [(buf.validate.field).enum.defined_only = true];
 }
 
 // ApiService provides gRPC endpoints for the web front end: portfolio CRUD,

--- a/server/db/postgres/corporate_events.go
+++ b/server/db/postgres/corporate_events.go
@@ -500,7 +500,7 @@ func (p *Postgres) HeldEventBearingInstruments(ctx context.Context) ([]db.HeldIn
 			SELECT t.instrument_id, MIN(t.timestamp)::date AS earliest
 			FROM txs t
 			JOIN instruments i ON i.id = t.instrument_id
-			WHERE i.asset_class IN ('STOCK', 'ETF')
+			WHERE i.asset_class IN ('STOCK', 'ETF') AND t.account_type = 'USER'
 			GROUP BY t.instrument_id
 		),
 		via_derivative AS (
@@ -508,6 +508,7 @@ func (p *Postgres) HeldEventBearingInstruments(ctx context.Context) ([]db.HeldIn
 			FROM txs t
 			JOIN instruments i ON i.id = t.instrument_id
 			WHERE i.asset_class IN ('OPTION', 'FUTURE') AND i.underlying_id IS NOT NULL
+			  AND t.account_type = 'USER'
 			GROUP BY i.underlying_id
 		)
 		SELECT instrument_id, MIN(earliest) AS earliest

--- a/server/db/postgres/declarations.go
+++ b/server/db/postgres/declarations.go
@@ -138,7 +138,7 @@ func (p *Postgres) GetPortfolioStartDate(ctx context.Context, userID string) (*t
 	var t sql.NullTime
 	err = p.q.QueryRowContext(ctx, `
 		SELECT MIN(timestamp) FROM txs
-		WHERE user_id = $1 AND synthetic_purpose IS NULL
+		WHERE user_id = $1 AND synthetic_purpose IS NULL AND account_type = 'USER'
 	`, userUUID).Scan(&t)
 	if err != nil {
 		return nil, fmt.Errorf("get portfolio start date: %w", err)
@@ -165,6 +165,7 @@ func (p *Postgres) ComputeRunningBalance(ctx context.Context, userID, broker, ac
 		WHERE user_id = $1 AND broker = $2 AND account = $3 AND instrument_id = $4
 		  AND timestamp >= $5 AND timestamp < $6
 		  AND synthetic_purpose IS NULL
+		  AND account_type = 'USER'
 	`, userUUID, broker, account, instUUID, from, to).Scan(&balance)
 	if err != nil {
 		return 0, fmt.Errorf("compute running balance: %w", err)
@@ -191,6 +192,7 @@ func (p *Postgres) UpsertInitializeTx(ctx context.Context, userID, broker, accou
 			SELECT group_id FROM txs
 			WHERE user_id = $1 AND broker = $2 AND account = $3 AND instrument_id = $4
 			  AND synthetic_purpose = 'INITIALIZE'
+			  AND account_type = 'USER'
 		`, userUUID, broker, account, instUUID).Scan(&groupID)
 		switch {
 		case err == sql.ErrNoRows:
@@ -215,6 +217,7 @@ func (p *Postgres) UpsertInitializeTx(ctx context.Context, userID, broker, accou
 			UPDATE txs SET timestamp = $5, quantity = $6, tx_type = $7
 			WHERE user_id = $1 AND broker = $2 AND account = $3 AND instrument_id = $4
 			  AND synthetic_purpose = 'INITIALIZE'
+			  AND account_type = 'USER'
 		`, userUUID, broker, account, instUUID, timestamp, quantity, txType)
 		if err != nil {
 			return fmt.Errorf("update initialize tx: %w", err)

--- a/server/db/postgres/declarations_test.go
+++ b/server/db/postgres/declarations_test.go
@@ -304,3 +304,32 @@ func TestUpsertInitializeTx_GroupsThePosting(t *testing.T) {
 		t.Errorf("tx_groups after delete: want 0, got %d", got)
 	}
 }
+
+// TestComputeRunningBalance_excludesNonUser verifies the balance an INITIALIZE pad is
+// derived from counts only the user's own postings. A counterparty leg shares the
+// broker account and instrument, so summing it would halve the pad and restate the
+// declared opening balance.
+func TestComputeRunningBalance_excludesNonUser(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|decl-acct-type", "U", "u@rb.com")
+	instID, _ := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "RB2", Canonical: false}}, "", nil, nil, nil)
+
+	ts := time.Date(2025, 3, 1, 10, 0, 0, 0, time.UTC)
+	if err := p.CreateTx(ctx, userID, "IBKR", "acct1", "", &apiv1.Tx{Timestamp: timestamppb.New(ts), InstrumentDescription: "RB2", Type: apiv1.TxType_BUYSTOCK, Quantity: 100, Account: "acct1"}, instID, nil); err != nil {
+		t.Fatalf("create buy: %v", err)
+	}
+	if err := p.CreateTx(ctx, userID, "IBKR", "acct1", "", &apiv1.Tx{Timestamp: timestamppb.New(ts), InstrumentDescription: "RB2", Type: apiv1.TxType_BUYSTOCK, Quantity: -100, Account: "acct1", AccountType: apiv1.AccountType_ACCOUNT_TYPE_EQUITY}, instID, nil); err != nil {
+		t.Fatalf("create equity leg: %v", err)
+	}
+
+	from := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2025, 12, 31, 23, 59, 59, 0, time.UTC)
+	bal, err := p.ComputeRunningBalance(ctx, userID, "IBKR", "acct1", instID, from, to)
+	if err != nil {
+		t.Fatalf("compute: %v", err)
+	}
+	if bal != 100 {
+		t.Fatalf("running balance = %v, want 100: the EQUITY leg must not be summed", bal)
+	}
+}

--- a/server/db/postgres/holdings.go
+++ b/server/db/postgres/holdings.go
@@ -28,6 +28,10 @@ func (p *Postgres) ComputeHoldings(ctx context.Context, userID string, broker *a
 		From("txs t").
 		LeftJoin("instruments i ON i.id = t.instrument_id").
 		Where(sq.Eq{"t.user_id": userUUID}).
+		// Only the user's own postings are positions. The non-asset legs (income,
+		// charges, residuals, in-flight transfers) share the broker account and
+		// would otherwise net against the holding they belong to.
+		Where(sq.Eq{"t.account_type": "USER"}).
 		Where(sq.LtOrEq{"t.timestamp": asOfT}).
 		GroupBy("t.broker", "t.account", "t.instrument_id", "i.name").
 		Suffix("HAVING NOT qty_is_zero(SUM(t.quantity))")
@@ -75,7 +79,7 @@ func (p *Postgres) ComputeHoldingsForPortfolio(ctx context.Context, portfolioID 
 		FROM txs t
 		INNER JOIN portfolio_matched_txs m ON m.tx_id = t.id AND m.portfolio_id = $1
 		LEFT JOIN instruments i ON i.id = t.instrument_id
-		WHERE t.timestamp <= $2
+		WHERE t.timestamp <= $2 AND t.account_type = 'USER'
 		GROUP BY t.broker, t.account, t.instrument_id, i.name
 		HAVING NOT qty_is_zero(SUM(t.quantity))
 	`, portUUID, asOfT)

--- a/server/db/postgres/holdings_test.go
+++ b/server/db/postgres/holdings_test.go
@@ -94,3 +94,41 @@ func TestComputeHoldings_signedQuantity(t *testing.T) {
 		t.Fatalf("expected GOOG quantity -5 (signed quantity, no type-based flip), got %v", googQty)
 	}
 }
+
+// TestComputeHoldings_excludesNonUserAccountTypes verifies the counterparty leg of a
+// one-sided event does not net against the holding it balances. The EQUITY leg here is
+// what an INITIALIZE pad's counterparty looks like: same instrument, same broker
+// account, equal and opposite. Without the account_type predicate the two sum to zero
+// and the declared opening balance silently disappears.
+func TestComputeHoldings_excludesNonUserAccountTypes(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|acct-type-hold", "U", "u@ah.com")
+	now := time.Now()
+	from := timestamppb.New(now.Add(-1 * time.Hour))
+	to := timestamppb.New(now)
+	ts := timestamppb.New(now.Add(-30 * time.Minute))
+	instID, err := p.EnsureInstrument(ctx, "", "", "", "", "", "",
+		[]db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "TSCO", Canonical: false}}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+	txs := []*apiv1.Tx{
+		{Timestamp: ts, InstrumentDescription: "TSCO", Type: apiv1.TxType_BUYSTOCK, Quantity: 40, Account: "A", GroupRef: "pad"},
+		{Timestamp: ts, InstrumentDescription: "TSCO", Type: apiv1.TxType_BUYSTOCK, Quantity: -40, Account: "A", GroupRef: "pad", AccountType: apiv1.AccountType_ACCOUNT_TYPE_EQUITY},
+	}
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID, instID}, nil); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+
+	holdings, _, err := p.ComputeHoldings(ctx, userID, nil, "", nil)
+	if err != nil {
+		t.Fatalf("holdings: %v", err)
+	}
+	if len(holdings) != 1 {
+		t.Fatalf("expected 1 holding, got %d", len(holdings))
+	}
+	if got := holdings[0].Quantity; got != 40 {
+		t.Errorf("holding quantity = %v, want 40: the EQUITY counter-leg must not net against the position", got)
+	}
+}

--- a/server/db/postgres/portfolios.go
+++ b/server/db/postgres/portfolios.go
@@ -201,7 +201,7 @@ func (p *Postgres) ListBrokersAndAccounts(ctx context.Context, userID string) ([
 	}
 	rows, err := p.q.QueryContext(ctx, `
 		SELECT DISTINCT broker, account FROM txs
-		WHERE user_id = $1
+		WHERE user_id = $1 AND account_type = 'USER'
 		ORDER BY broker, account
 	`, userUUID)
 	if err != nil {

--- a/server/db/postgres/portfolios_test.go
+++ b/server/db/postgres/portfolios_test.go
@@ -91,3 +91,31 @@ func TestListPortfolioFilters_SetPortfolioFilters(t *testing.T) {
 		t.Fatalf("expected single broker=SCHB filter, got %v", list)
 	}
 }
+
+// TestListBrokersAndAccounts_excludesNonUser verifies the account picker offers only
+// real broker accounts. Non-USER postings keep the broker and account of the event they
+// belong to, so without the predicate they add no new pair -- but a residual posted
+// against an account the user never traded in would, and it is not a filter target.
+func TestListBrokersAndAccounts_excludesNonUser(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|ba-acct-type", "U", "u@ba.com")
+	if _, err := p.q.ExecContext(ctx, `
+		INSERT INTO txs (user_id, broker, account, timestamp, instrument_description,
+		                 tx_type, quantity, split_adjusted_quantity, share_count_basis, account_type)
+		VALUES ($1, 'IBKR', 'A', now(), 'X', 'BUYSTOCK', 1, 1, current_date, 'USER'),
+		       ($1, 'IBKR', 'CLEARING', now(), 'X', 'TRANSFER', 1, 1, current_date, 'TRANSFER_CLEARING')
+	`, userID); err != nil {
+		t.Fatalf("insert txs: %v", err)
+	}
+	got, err := p.ListBrokersAndAccounts(ctx, userID)
+	if err != nil {
+		t.Fatalf("ListBrokersAndAccounts: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("want 1 broker/account pair, got %d: %+v", len(got), got)
+	}
+	if got[0].Account != "A" {
+		t.Errorf("account = %q, want %q", got[0].Account, "A")
+	}
+}

--- a/server/db/postgres/postgres.go
+++ b/server/db/postgres/postgres.go
@@ -92,6 +92,36 @@ func strToTxType(s string) apiv1.TxType {
 	return apiv1.TxType(v)
 }
 
+// accountTypePrefix is stripped from the enum name to get the stored form. The proto
+// values are prefixed because enum values share package scope and TxType already
+// defines INCOME and TRANSFER; the column stores the bare vocabulary the CHECK
+// constraint and the specs use.
+const accountTypePrefix = "ACCOUNT_TYPE_"
+
+// accountTypeToStr returns the stored form of an account type: its enum name without
+// the prefix. Unspecified is USER rather than an error -- an upload that says nothing
+// about a posting's kind is an ordinary broker account posting, which is what almost
+// every row is. Derived from the generated names rather than mapped by hand so a new
+// type cannot be stored under a spelling that strToAccountType does not recognise.
+func accountTypeToStr(a apiv1.AccountType) (string, error) {
+	if a == apiv1.AccountType_ACCOUNT_TYPE_UNSPECIFIED {
+		return "USER", nil
+	}
+	s, ok := apiv1.AccountType_name[int32(a)]
+	if !ok {
+		return "", fmt.Errorf("unknown account type: %v", a)
+	}
+	return strings.TrimPrefix(s, accountTypePrefix), nil
+}
+
+func strToAccountType(s string) apiv1.AccountType {
+	v, ok := apiv1.AccountType_value[accountTypePrefix+s]
+	if !ok {
+		return apiv1.AccountType_ACCOUNT_TYPE_UNSPECIFIED
+	}
+	return apiv1.AccountType(v)
+}
+
 func jobStatusToStr(s apiv1.JobStatus) string {
 	switch s {
 	case apiv1.JobStatus_PENDING:
@@ -307,6 +337,7 @@ type txRow struct {
 	SplitAdjUnitPrice *float64  `db:"split_adjusted_unit_price"`
 	InstID            *string   `db:"instrument_id"`
 	SyntheticPurpose  *string   `db:"synthetic_purpose"`
+	AccountType       string    `db:"account_type"`
 }
 
 func (r *txRow) toProto() *apiv1.PortfolioTx {
@@ -317,6 +348,7 @@ func (r *txRow) toProto() *apiv1.PortfolioTx {
 		Quantity:              r.Quantity,
 		SplitAdjustedQuantity: r.SplitAdjQty,
 		Account:               r.Account,
+		AccountType:           strToAccountType(r.AccountType),
 	}
 	if r.TradingCcy != nil {
 		tx.TradingCurrency = *r.TradingCcy

--- a/server/db/postgres/price_cache.go
+++ b/server/db/postgres/price_cache.go
@@ -17,7 +17,7 @@ func (p *Postgres) HeldRanges(ctx context.Context, opts db.HeldRangesOpts) ([]db
 		WITH daily_net AS (
 			SELECT instrument_id, timestamp::date AS tx_date, SUM(quantity) AS day_qty
 			FROM txs
-			WHERE instrument_id IS NOT NULL
+			WHERE instrument_id IS NOT NULL AND account_type = 'USER'
 			GROUP BY instrument_id, timestamp::date
 		)
 		SELECT instrument_id, tx_date,

--- a/server/db/postgres/txs.go
+++ b/server/db/postgres/txs.go
@@ -20,13 +20,13 @@ var psql = sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
 const insertPostingSQL = `
 	WITH g AS (
 		INSERT INTO tx_groups (user_id, timestamp, job_id)
-		VALUES ($1, $4, $13)
+		VALUES ($1, $4, $14)
 		RETURNING id
 	)
 	INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type,
 	                 quantity, trading_currency, settlement_currency, unit_price,
-	                 instrument_id, share_count_basis, group_id)
-	SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::date, g.id FROM g
+	                 instrument_id, share_count_basis, account_type, group_id)
+	SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::date, $13, g.id FROM g
 	RETURNING group_id
 `
 
@@ -35,8 +35,8 @@ const insertPostingSQL = `
 const insertPostingInGroupSQL = `
 	INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type,
 	                 quantity, trading_currency, settlement_currency, unit_price,
-	                 instrument_id, share_count_basis, group_id)
-	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::date, $13)
+	                 instrument_id, share_count_basis, account_type, group_id)
+	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::date, $13, $14)
 `
 
 // groupResolver hands out the tx group for a tx's group_ref. An empty group_ref
@@ -135,11 +135,15 @@ func (p *Postgres) ReplaceTxsInPeriod(ctx context.Context, userID, broker, jobID
 			if err != nil {
 				return err
 			}
+			acctTypeStr, err := accountTypeToStr(t.GetAccountType())
+			if err != nil {
+				return err
+			}
 			acc := t.GetAccount()
 			args := []interface{}{
 				userUUID, broker, acc, ts, t.InstrumentDescription, txTypeStr, t.Quantity,
 				nullStr(t.TradingCurrency), nullStr(t.SettlementCurrency), nullFloat(t.UnitPrice),
-				instUUID, shareCountBasis,
+				instUUID, shareCountBasis, acctTypeStr,
 			}
 			ref := t.GetGroupRef()
 			if groupID, ok := resolver.group(ref); ok {
@@ -182,10 +186,14 @@ func (p *Postgres) CreateTx(ctx context.Context, userID, broker, account, jobID 
 	if err != nil {
 		return err
 	}
+	acctTypeStr, err := accountTypeToStr(tx.GetAccountType())
+	if err != nil {
+		return err
+	}
 	_, err = p.q.ExecContext(ctx, insertPostingSQL,
 		userUUID, broker, account, ts, tx.InstrumentDescription, txTypeStr, tx.Quantity,
 		nullStr(tx.TradingCurrency), nullStr(tx.SettlementCurrency), nullFloat(tx.UnitPrice),
-		instUUID, shareCountBasis, jobUUID)
+		instUUID, shareCountBasis, acctTypeStr, jobUUID)
 	if err != nil {
 		return fmt.Errorf("create tx: %w", err)
 	}
@@ -215,7 +223,7 @@ func (p *Postgres) ListTxs(ctx context.Context, userID string, broker *apiv1.Bro
 	if limit <= 0 || limit > 100 {
 		limit = 50
 	}
-	qb := psql.Select("broker", "account", "timestamp", "instrument_description", "tx_type", "quantity", "split_adjusted_quantity", "trading_currency", "settlement_currency", "unit_price", "split_adjusted_unit_price", "instrument_id", "synthetic_purpose").
+	qb := psql.Select("broker", "account", "timestamp", "instrument_description", "tx_type", "quantity", "split_adjusted_quantity", "trading_currency", "settlement_currency", "unit_price", "split_adjusted_unit_price", "instrument_id", "synthetic_purpose", "account_type").
 		From("txs").
 		Where(sq.Eq{"user_id": userUUID}).
 		OrderBy(txOrderBy("", descending)...)
@@ -275,7 +283,7 @@ func (p *Postgres) ListTxsByPortfolio(ctx context.Context, portfolioID string, b
 	if limit <= 0 || limit > 100 {
 		limit = 50
 	}
-	qb := psql.Select("t.broker", "t.account", "t.timestamp", "t.instrument_description", "t.tx_type", "t.quantity", "t.split_adjusted_quantity", "t.trading_currency", "t.settlement_currency", "t.unit_price", "t.split_adjusted_unit_price", "t.instrument_id", "t.synthetic_purpose").
+	qb := psql.Select("t.broker", "t.account", "t.timestamp", "t.instrument_description", "t.tx_type", "t.quantity", "t.split_adjusted_quantity", "t.trading_currency", "t.settlement_currency", "t.unit_price", "t.split_adjusted_unit_price", "t.instrument_id", "t.synthetic_purpose", "t.account_type").
 		From("txs t").
 		Join("portfolio_matched_txs m ON m.tx_id = t.id AND m.portfolio_id = ?", portUUID).
 		OrderBy(txOrderBy("t.", descending)...)

--- a/server/db/postgres/txs_test.go
+++ b/server/db/postgres/txs_test.go
@@ -740,3 +740,73 @@ func TestListTxsByPortfolio_ANDBetweenCategories(t *testing.T) {
 		t.Fatalf("expected total quantity 3, got %v", totalQty)
 	}
 }
+
+// TestReplaceTxsInPeriod_RoundTripsAccountType verifies a posting's account_type
+// survives the write and comes back on the read, and that an upload which says
+// nothing about kind stores USER rather than an unspecified value.
+func TestReplaceTxsInPeriod_RoundTripsAccountType(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|acct-type", "U", "u@acct.com")
+	instID, err := p.EnsureInstrument(ctx, "", "", "", "", "", "",
+		[]db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "USD", Canonical: false}}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+	base := time.Date(2025, 5, 1, 0, 0, 0, 0, time.UTC)
+	// A dividend as a balanced group: cash into the account, and the income it
+	// came from. Both legs keep the same broker and account.
+	txs := []*apiv1.Tx{
+		{Timestamp: timestamppb.New(base.Add(time.Hour)), InstrumentDescription: "USD", Type: apiv1.TxType_INCOME, Quantity: 23.4, Account: "A", GroupRef: "div-1"},
+		{Timestamp: timestamppb.New(base.Add(time.Hour)), InstrumentDescription: "USD", Type: apiv1.TxType_INCOME, Quantity: -23.4, Account: "A", GroupRef: "div-1", AccountType: apiv1.AccountType_ACCOUNT_TYPE_INCOME},
+	}
+	from, to := timestamppb.New(base), timestamppb.New(base.Add(24*time.Hour))
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID, instID}, nil); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+
+	var user, income int
+	if err := p.q.QueryRowContext(ctx, `
+		SELECT count(*) FILTER (WHERE account_type = 'USER'),
+		       count(*) FILTER (WHERE account_type = 'INCOME')
+		FROM txs WHERE user_id = $1
+	`, userID).Scan(&user, &income); err != nil {
+		t.Fatalf("count by account type: %v", err)
+	}
+	if user != 1 || income != 1 {
+		t.Errorf("stored account types: want 1 USER and 1 INCOME, got %d and %d", user, income)
+	}
+
+	// The ledger view is not filtered: both legs come back, so a group can be seen
+	// to balance.
+	got, _, err := p.ListTxs(ctx, userID, nil, "", nil, nil, false, 50, "")
+	if err != nil {
+		t.Fatalf("ListTxs: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("ListTxs returned %d postings, want both legs", len(got))
+	}
+	seen := map[apiv1.AccountType]bool{}
+	for _, ptx := range got {
+		seen[ptx.GetTx().GetAccountType()] = true
+	}
+	if !seen[apiv1.AccountType_ACCOUNT_TYPE_USER] || !seen[apiv1.AccountType_ACCOUNT_TYPE_INCOME] {
+		t.Errorf("ListTxs account types: want USER and INCOME, got %v", seen)
+	}
+}
+
+// TestTxs_AccountTypeCheckConstraint verifies the vocabulary is enforced by the
+// database, not only by the enum on the way in.
+func TestTxs_AccountTypeCheckConstraint(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|acct-check", "U", "u@check.com")
+	_, err := p.q.ExecContext(ctx, `
+		INSERT INTO txs (user_id, broker, account, timestamp, instrument_description,
+		                 tx_type, quantity, split_adjusted_quantity, share_count_basis, account_type)
+		VALUES ($1, 'IBKR', 'A', now(), 'X', 'BUYSTOCK', 1, 1, current_date, 'Imbalance.USD')
+	`, userID)
+	if err == nil {
+		t.Fatal("insert with an account_type outside the vocabulary: want error, got none")
+	}
+}

--- a/server/db/postgres/valuation.go
+++ b/server/db/postgres/valuation.go
@@ -20,15 +20,20 @@ import (
 // and $4 for displayCurrency.
 func valuationQuery(portfolioMode bool) string {
 	var txSource string
+	// Only USER postings are valued. Income, charges and residuals are not positions,
+	// and an unmatched TRANSFER_CLEARING balance would assert that money in transit is
+	// coming back to an account we hold, which is the thing we do not know. Matched
+	// pairs whose accounts are both portfolio members are value in transit and belong
+	// in valuation; including them needs the pairing from 0068.
 	if portfolioMode {
 		txSource = `
     FROM txs t
     INNER JOIN portfolio_matched_txs m ON m.tx_id = t.id AND m.portfolio_id = $1
-    WHERE t.timestamp::date < $3`
+    WHERE t.timestamp::date < $3 AND t.account_type = 'USER'`
 	} else {
 		txSource = `
     FROM txs t
-    WHERE t.user_id = $1 AND t.timestamp::date < $3`
+    WHERE t.user_id = $1 AND t.timestamp::date < $3 AND t.account_type = 'USER'`
 	}
 
 	return `

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -62,6 +62,11 @@ CREATE INDEX idx_tx_groups_job_id ON tx_groups (job_id);
 -- by replace-by-period (user_id, broker, period). Single-tx ingestion is append-only.
 -- group_id is the economic event this row is a posting of. Deleting a group deletes
 -- its postings, which makes the group the unit of deletion for replace-by-period.
+-- account_type classifies the account this row lands in. USER is an ordinary broker
+-- account posting; the others are the non-asset side of an event that is one-sided in
+-- the source data and keep the broker and account of the event they belong to, so a
+-- residual stays attributable to the account that produced it. Holdings and the other
+-- quantity aggregations read USER only. See docs/adr/0022-typed-per-account-cash-flow-boundary.md.
 -- share_count_basis is the date at which the share count the raw quantity and
 -- unit_price are denominated in was current. It defaults to timestamp::date --
 -- the as-traded assumption, that a broker log line accounts only for events
@@ -89,6 +94,9 @@ CREATE TABLE txs (
   split_adjusted_unit_price DOUBLE PRECISION,
   share_count_basis         DATE NOT NULL,
   synthetic_purpose         TEXT CHECK (synthetic_purpose IS NULL OR synthetic_purpose = 'INITIALIZE'),
+  account_type              TEXT NOT NULL DEFAULT 'USER'
+                              CHECK (account_type IN ('USER', 'EQUITY', 'INCOME', 'EXPENSE',
+                                                      'IMBALANCE', 'TRANSFER_CLEARING')),
   group_id                  UUID REFERENCES tx_groups (id) ON DELETE CASCADE,
   created_at                TIMESTAMPTZ NOT NULL DEFAULT now()
 );
@@ -347,8 +355,12 @@ ALTER TABLE txs ADD COLUMN instrument_id UUID REFERENCES instruments (id);
 
 CREATE INDEX idx_txs_instrument_id ON txs (instrument_id);
 
+-- At most one INITIALIZE posting per holding per account type. account_type is part of
+-- the key because the pad's counterparty is an equal-and-opposite posting of the same
+-- instrument in the same broker account, and is synthetic for the same reason the pad
+-- is; without it the two collide.
 CREATE UNIQUE INDEX idx_txs_initialize_unique
-  ON txs (user_id, broker, account, instrument_id)
+  ON txs (user_id, broker, account, instrument_id, account_type)
   WHERE synthetic_purpose = 'INITIALIZE';
 
 -- Portfolio filter matching view: returns (portfolio_id, tx_id) pairs for txs


### PR DESCRIPTION
Adds `txs.account_type` so the non-asset side of an event that is one-sided in the source data has somewhere to go. A posting keeps the `broker` and `account` of the event it belongs to; the type says what kind of leg it is. Vocabulary: `USER`, `EQUITY`, `INCOME`, `EXPENSE`, `IMBALANCE`, `TRANSFER_CLEARING`.

Implements 0037. See adr/0022-typed-per-account-cash-flow-boundary.md.

Nothing routes to a non-`USER` type yet, so every stored row is `USER` and behaviour is unchanged. What lands is the mechanism, plus the one part that has to precede the routing.

## The read-path predicate has to land first

0038 gives an INITIALIZE pad an `EQUITY` counterparty: an equal and opposite posting of the *same instrument* in the *same* broker account. Unfiltered, it cancels the pad out of `SUM(quantity)` and the declared opening balance silently reads zero. So holdings, valuation, price coverage, the declaration running balance, corporate event discovery and the account picker all read `USER` only.

Two more places key off `synthetic_purpose` alone and would match that counterparty leg. Both take `account_type` into their key here rather than leaving 0038 to trip over them:

- `idx_txs_initialize_unique` -- the counterparty leg is synthetic for the same reason the pad is, so it would collide.
- `UpsertInitializeTx`'s lookup and update -- would otherwise clobber both legs to the same quantity on every declaration recalc.

## Two deliberate non-changes

**The predicate is per call site, not in `portfolio_matched_txs`.** Valuation does not stay the same as holdings: in-flight value belongs in a valuation once a transfer's two sides are matched and both accounts are members (0068). Burying the predicate in the shared view would make that unexpressible.

**The transaction list is not filtered.** It is a ledger view; hiding counterparty legs would make groups look unbalanced and hide the residuals that make a converter's lossiness measurable in 0039. `ListTxs` instead returns `account_type`, and the page badges non-`USER` postings.

## Proto

Enum values are prefixed (`ACCOUNT_TYPE_USER`) because proto enum values share package scope and `TxType` already defines unprefixed `INCOME` and `TRANSFER` -- unprefixed would not compile. The column stores the bare vocabulary, so the db mapper strips the prefix rather than using `String()` as `txTypeToStr` does.

`UNSPECIFIED` means `USER` rather than being an error, so every existing converter, test literal and raw-SQL fixture keeps working untouched. `buf lint` reports no new violations.

## CSV

The standard CSV gains an optional `account_type` column so converters can emit typed legs. No converter is changed to do so yet -- that is 0040. An unrecognised value is a row error rather than a silent fall back to `USER`.

## Testing

`make test` (server, client, db, integration, extension), `make lint` and `make e2e-test` (29 specs) all pass. New coverage:

- `TestComputeHoldings_excludesNonUserAccountTypes` -- the one that guards the hazard above: an `EQUITY` leg equal and opposite to a pad, asserting the position still reads 40.
- `TestComputeRunningBalance_excludesNonUser`, `TestListBrokersAndAccounts_excludesNonUser`
- `TestReplaceTxsInPeriod_RoundTripsAccountType` -- a dividend as a balanced group, both legs returned by `ListTxs`
- `TestTxs_AccountTypeCheckConstraint` -- the vocabulary is enforced by the database
- Client: parsing, case-insensitivity, default-to-`USER`, and rejection of an unknown value

## Out of scope

0038 (routing residuals, the INITIALIZE `EQUITY` leg), 0039 (imbalance report), 0040 (converters emitting expense legs), 0041 (balance constraint), 0068 (transfer matching and valuation's matched-pair inclusion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)