### PR TITLE
Give unit_price proto3 field presence

### DIFF
--- a/client/app/transactions/page.tsx
+++ b/client/app/transactions/page.tsx
@@ -265,7 +265,7 @@ function TxRow({ ptx }: { ptx: PortfolioTx }) {
         {parseFloat(tx.quantity.toFixed(4))}
       </td>
       <td className="px-4 py-3 text-right font-mono tabular-nums text-text-muted">
-        {tx.unitPrice ? tx.unitPrice.toFixed(2) : "\u2014"}
+        {tx.unitPrice !== undefined ? tx.unitPrice.toFixed(2) : "\u2014"}
       </td>
       <td data-testid="tx-adj-qty" className="px-4 py-3 text-right font-mono tabular-nums text-text-muted">
         {tx.splitAdjustedQuantity !== undefined && tx.splitAdjustedQuantity !== tx.quantity

--- a/client/lib/csv/standard.test.ts
+++ b/client/lib/csv/standard.test.ts
@@ -457,3 +457,19 @@ describe("account_type", () => {
     expect(result.errors[0].field).toBe("account_type");
   });
 });
+
+describe("unit_price", () => {
+  it("keeps a declared zero distinct from an empty cell", () => {
+    // An option expiring worthless is priced at zero and its group balances; a
+    // row whose converter supplied no price cannot be converted at all.
+    const csv = `date,instrument_description,type,quantity,unit_price
+2024-02-01,OPT,CLOSUREOPT,-1,0
+2024-02-01,OPT,BUYOPT,1,`;
+
+    const result = parseStandardCSV(csv);
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.txs[0].unitPrice).toBe(0);
+    expect(result.txs[1].unitPrice).toBeUndefined();
+  });
+});

--- a/docs/spec/csv-format.md
+++ b/docs/spec/csv-format.md
@@ -18,7 +18,7 @@ Header names are case-insensitive. Supported column names:
 | `quantity`              | Yes      | Signed number: positive for buys/adds, negative for sells/reductions. |
 | `trading_currency`       | No       | Instrument trading currency (e.g. EUR); used as plugin hint. |
 | `settlement_currency`    | No       | Settlement/payment currency (e.g. GBP). |
-| `unit_price`             | No       | Unit price as reported by broker (optional). |
+| `unit_price`             | No       | Unit price as reported by broker. An empty cell means the source gave no price; `0` is a price of zero, which is not the same thing: balancing a group converts a purchase or sale at its price, so an option expiring worthless converts at zero while a row with no price cannot convert at all. |
 | `account`                | No       | Opaque account identifier. |
 | `symbol_type`            | No       | Identifier type name matching the IdentifierType enum. See allowed values below. |
 | `symbol`                 | No       | Identifier value (e.g. "AAPL", "US0378331005", "AAPL  240119C00185000"). Required when `symbol_type` is present. |

--- a/extension/src/brokers/fidelity-json.test.ts
+++ b/extension/src/brokers/fidelity-json.test.ts
@@ -78,6 +78,16 @@ describe("convertFidelityJson", () => {
     ]);
   });
 
+  it("keeps a reported price of zero rather than dropping it as absent", () => {
+    // A zero price is a price -- an option expiring worthless. Only a row that
+    // reports none at all leaves unitPrice unset.
+    const priced = convertFidelityJson(json({ ...BUY, pricePerUnit: 0 }));
+    expect(priced.txs[0]!.unitPrice).toBe(0);
+
+    const { pricePerUnit: _omitted, ...unpriced } = BUY;
+    expect(convertFidelityJson(json(unpriced)).txs[0]!.unitPrice).toBeUndefined();
+  });
+
   it("negates a disposal", () => {
     const result = convertFidelityJson(
       json({ ...BUY, transactionType: "Sell", debitCreditIndicator: "DEBIT" })

--- a/extension/src/brokers/fidelity-json.ts
+++ b/extension/src/brokers/fidelity-json.ts
@@ -178,7 +178,8 @@ export function convertFidelityJson(
         account: row.accountNumber ?? "",
         ...(currency ? { settlementCurrency: currency } : {}),
         ...(currency && isCashTxType(ofxType) ? { tradingCurrency: currency } : {}),
-        ...(row.pricePerUnit ? { unitPrice: row.pricePerUnit } : {}),
+        // Presence, not truthiness: a reported price of zero is a price.
+        ...(row.pricePerUnit !== undefined ? { unitPrice: row.pricePerUnit } : {}),
         ...(identifierHints.length > 0 ? { identifierHints } : {}),
       })
     );

--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -163,7 +163,13 @@ message Tx {
   // Currency used to pay/settle the transaction (e.g. GBP when buying in a UK account). Optional. Set from user input (e.g. Fidelity converter) for all transactions.
   string settlement_currency = 6;
   // Unit price as reported by broker. Optional; not used for valuation.
-  double unit_price = 7;
+  // Explicitly optional because a declared price of zero is not the same as no
+  // price. Balancing converts a purchase or sale to its settlement currency at
+  // this price, so an option that expires worthless converts at zero and its
+  // group balances, while a row whose converter supplied no price cannot convert
+  // and leaves a residual in the security itself. Collapsing the two would let a
+  // missing price balance silently. See docs/spec/postings.md.
+  optional double unit_price = 7;
   // Resolved instrument id (UUID). Set by identification during ingestion.
   string instrument_id = 8;
   // Account (opaque string). Required.
@@ -175,8 +181,9 @@ message Tx {
   // Split-adjusted quantity (quantity * cumulative split factor). Equal to
   // quantity when no splits exist for the instrument.
   double split_adjusted_quantity = 12;
-  // Split-adjusted unit price (unit_price / cumulative split factor).
-  double split_adjusted_unit_price = 13;
+  // Split-adjusted unit price (unit_price / cumulative split factor). Optional
+  // for the same reason as unit_price, and absent exactly when it is.
+  optional double split_adjusted_unit_price = 13;
   // Opaque grouping key, scoped to a single upload. Txs sharing a non-empty
   // group_ref are postings of one economic event and are stored in one tx group.
   // Empty means the tx is its own single-posting group. Set by the broker

--- a/server/db/postgres/corporate_events_test.go
+++ b/server/db/postgres/corporate_events_test.go
@@ -8,6 +8,7 @@ import (
 
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
 	"github.com/leedenison/portfoliodb/server/db"
+	"google.golang.org/protobuf/proto"
 )
 
 // approxEq compares two floats with relative tolerance suitable for the
@@ -560,7 +561,7 @@ func TestRecomputeSplitAdjustments_Txs(t *testing.T) {
 			Type:                  apiv1.TxType_BUYSTOCK,
 			Timestamp:             ts(2010, 6, 1),
 			Quantity:              100,
-			UnitPrice:             280.0,
+			UnitPrice:             proto.Float64(280),
 			InstrumentDescription: "AAPL",
 		},
 	})
@@ -911,7 +912,7 @@ func TestApplyOptionSplit(t *testing.T) {
 		Type:                  apiv1.TxType_BUYSTOCK,
 		Timestamp:             ts(2024, 6, 1),
 		Quantity:              1,
-		UnitPrice:             150,
+		UnitPrice:             proto.Float64(150),
 		InstrumentDescription: "AAPL 250117C00150000",
 	}})
 

--- a/server/db/postgres/postgres.go
+++ b/server/db/postgres/postgres.go
@@ -217,11 +217,14 @@ func nullTime(t *time.Time) interface{} {
 	return *t
 }
 
-func nullFloat(f float64) interface{} {
-	if f == 0 {
+// nullFloat maps an absent value to SQL NULL, keying off presence rather than
+// zero. A price of zero is a real price -- an option that expires worthless --
+// and must survive the round trip distinctly from no price at all.
+func nullFloat(f *float64) interface{} {
+	if f == nil {
 		return nil
 	}
-	return f
+	return *f
 }
 
 func decodePageToken(token string) int64 {
@@ -356,12 +359,9 @@ func (r *txRow) toProto() *apiv1.PortfolioTx {
 	if r.SettleCcy != nil {
 		tx.SettlementCurrency = *r.SettleCcy
 	}
-	if r.UnitPrice != nil {
-		tx.UnitPrice = *r.UnitPrice
-	}
-	if r.SplitAdjUnitPrice != nil {
-		tx.SplitAdjustedUnitPrice = *r.SplitAdjUnitPrice
-	}
+	// Carried as pointers so a stored price of zero stays distinct from no price.
+	tx.UnitPrice = r.UnitPrice
+	tx.SplitAdjustedUnitPrice = r.SplitAdjUnitPrice
 	if r.InstID != nil {
 		tx.InstrumentId = *r.InstID
 	}

--- a/server/db/postgres/txs_test.go
+++ b/server/db/postgres/txs_test.go
@@ -7,6 +7,7 @@ import (
 
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
 	"github.com/leedenison/portfoliodb/server/db"
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -808,5 +809,60 @@ func TestTxs_AccountTypeCheckConstraint(t *testing.T) {
 	`, userID)
 	if err == nil {
 		t.Fatal("insert with an account_type outside the vocabulary: want error, got none")
+	}
+}
+
+// TestReplaceTxsInPeriod_RoundTripsZeroUnitPrice verifies a declared price of
+// zero stays distinct from no price at all. Balancing converts a purchase or
+// sale at its price, so an option expiring worthless converts at zero and its
+// group balances, while a row whose converter supplied no price cannot convert.
+// Collapsing the two would let a missing price balance silently.
+func TestReplaceTxsInPeriod_RoundTripsZeroUnitPrice(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|zero-price", "U", "u@zero.com")
+	instID, err := p.EnsureInstrument(ctx, "", "", "", "", "", "",
+		[]db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "OPT", Canonical: false}}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+	base := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+	txs := []*apiv1.Tx{
+		{Timestamp: timestamppb.New(base.Add(time.Hour)), InstrumentDescription: "OPT", Type: apiv1.TxType_CLOSUREOPT, Quantity: -1, Account: "A", UnitPrice: proto.Float64(0)},
+		{Timestamp: timestamppb.New(base.Add(2 * time.Hour)), InstrumentDescription: "OPT", Type: apiv1.TxType_BUYOPT, Quantity: 1, Account: "A"},
+	}
+	from, to := timestamppb.New(base), timestamppb.New(base.Add(24*time.Hour))
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID, instID}, nil); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+
+	var zeros, nulls int
+	if err := p.q.QueryRowContext(ctx, `
+		SELECT count(*) FILTER (WHERE unit_price = 0),
+		       count(*) FILTER (WHERE unit_price IS NULL)
+		FROM txs WHERE user_id = $1
+	`, userID).Scan(&zeros, &nulls); err != nil {
+		t.Fatalf("count by unit_price: %v", err)
+	}
+	if zeros != 1 || nulls != 1 {
+		t.Errorf("stored unit_price: want one zero and one NULL, got %d and %d", zeros, nulls)
+	}
+
+	got, _, err := p.ListTxs(ctx, userID, nil, "", nil, nil, false, 50, "")
+	if err != nil {
+		t.Fatalf("ListTxs: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("ListTxs returned %d postings, want 2", len(got))
+	}
+	byType := map[apiv1.TxType]*apiv1.Tx{}
+	for _, ptx := range got {
+		byType[ptx.GetTx().GetType()] = ptx.GetTx()
+	}
+	if p := byType[apiv1.TxType_CLOSUREOPT].UnitPrice; p == nil || *p != 0 {
+		t.Errorf("expired option unit_price: want a present zero, got %v", p)
+	}
+	if p := byType[apiv1.TxType_BUYOPT].UnitPrice; p != nil {
+		t.Errorf("unpriced buy unit_price: want absent, got %v", *p)
 	}
 }


### PR DESCRIPTION
First of three PRs implementing [0038](docs/issues/0038-derive-cash-legs-imbalance.md). Independent of the INITIALIZE EQUITY counterparty PR; a prerequisite of the residual routing PR.

## Why

A declared price of zero is not the same as no price, and 0038 needs to tell them apart.

Balancing a group converts a purchase or sale to its settlement currency at its price. So an option that expires worthless converts at zero and its group balances with no residual, while a row whose converter supplied no price cannot convert at all and leaves a residual denominated in the security itself. That share-denominated residual is diagnostic in a way nothing else is -- a missing fee or a missing cash row can never produce one. Collapsing the two cases would let a missing price balance silently and let shares appear from nowhere with no signal.

The distinction was lost end to end. `api.proto` declared a bare proto3 `double` with no presence, and `nullFloat` mapped zero to SQL NULL on the way in. Only the column was ever able to hold the distinction, and nothing could put it there. The client CSV parser already keeps an empty cell apart from `"0"`; the information was thrown away at the proto boundary.

## What changed

- `unit_price` and `split_adjusted_unit_price` become `optional double`.
- `nullFloat` keys off presence rather than zero. Its only two callers were both `unit_price`, so it changes shape rather than gaining a sibling. The read mapper hands the pointers straight through.
- Two client sites tested the value for truthiness and so would have dropped a reported zero: the extension's Fidelity JSON converter, and the unit price cell in the transaction list, which rendered zero as an em-dash.

## Tests

- `TestReplaceTxsInPeriod_RoundTripsZeroUnitPrice` -- a zero stores as zero and an absent price as NULL, and both survive the read back.
- The standard CSV parser keeps `"0"` distinct from an empty cell.
- The extension converter keeps a reported zero and leaves `unitPrice` unset only when the source reports none.

`make server-test`, `make db-test`, `make client-test`, `make extension-test`, `make lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)