### PR TITLE
Write the INITIALIZE pad with its EQUITY counterparty

### DIFF
--- a/docs/spec/fixed-point.md
+++ b/docs/spec/fixed-point.md
@@ -52,7 +52,15 @@ Holdings are computed aggregates (there is no holdings table), so a holding is i
 
 **Constraints:**
 
-- `UNIQUE (user_id, broker, account, instrument_id) WHERE synthetic_purpose = 'INITIALIZE'` -- at most one INITIALIZE transaction per holding per user (partial unique index).
+- `UNIQUE (user_id, broker, account, instrument_id, account_type) WHERE synthetic_purpose = 'INITIALIZE'` -- at most one INITIALIZE posting per holding per account type (partial unique index). `account_type` is part of the key because the pad is written with a counterparty (see below) that shares everything else; without it the two would collide.
+
+### The EQUITY counterparty
+
+A pad has no counterparty in the source data -- that is what makes it a pad -- so one is written for it: an equal and opposite `EQUITY` posting of the same instrument, in the same broker account, in the same group. It is what makes the group sum to zero, and value entering the user's holdings from before their history begins is exactly what `EQUITY` is for. See [postings.md](postings.md#account-types) and adr/0022-typed-per-account-cash-flow-boundary.md.
+
+The counterparty is synthetic for the same reason the pad is, carries the same `timestamp` and `share_count_basis`, and moves with it: both legs are recalculated together, so a stock split adjusts them identically and the pair cannot drift.
+
+It is excluded from holdings and from every other quantity aggregation, along with all non-`USER` postings. That exclusion is what stops it netting the pad out to nothing, which would make a declared opening balance read as zero. The transaction list is not filtered, so both legs are visible there.
 
 ## Business Logic
 
@@ -75,6 +83,7 @@ Holdings are computed aggregates (there is no holdings table), so a holding is i
    - `quantity` = the value computed in step 4
    - `broker`, `account`, `instrument_id` = copied from the declaration
    - `synthetic_purpose` = `'INITIALIZE'`
+6. Create (or replace) its `EQUITY` counterparty in the same group, identical but for `account_type` and a negated `quantity`.
 
 **Note on quantity:** The INITIALIZE quantity may be negative. This represents a short position at portfolio inception and is permitted.
 
@@ -84,7 +93,7 @@ The user may edit the declared quantity or the `as_of_date`. The procedure is id
 
 ### Deleting a Declaration
 
-When a user deletes a declaration, delete both the declaration record and the associated INITIALIZE transaction. The holding's history will revert to showing only real transactions, with an implied zero balance at portfolio inception.
+When a user deletes a declaration, delete both the declaration record and the associated INITIALIZE group. Deleting the group takes both postings, so no path can leave the counterparty behind without the pad it balances. The holding's history will revert to showing only real transactions, with an implied zero balance at portfolio inception.
 
 ### Recalculation Triggers
 

--- a/docs/spec/postings.md
+++ b/docs/spec/postings.md
@@ -41,7 +41,10 @@ to the account that produced it.
 
 Opening balances are `EQUITY` postings rather than a type of their own. An opening
 balance is one use of equity, and a withdrawal to a bank is an equity posting too; an
-enum that mixes roots with specific accounts ages badly.
+enum that mixes roots with specific accounts ages badly. An INITIALIZE pad is written
+with exactly such a counterparty -- equal and opposite, same instrument, same account,
+same group -- which is what lets its group sum to zero. See
+[fixed-point.md](fixed-point.md#the-equity-counterparty).
 
 The type is a column rather than a reserved prefix on `account`, because `account` is
 user-supplied free text that a broker CSV can collide with, a name has nowhere to record

--- a/server/db/postgres/declarations.go
+++ b/server/db/postgres/declarations.go
@@ -183,9 +183,16 @@ func (p *Postgres) UpsertInitializeTx(ctx context.Context, userID, broker, accou
 	if err != nil {
 		return fmt.Errorf("invalid instrument id: %w", err)
 	}
-	// The INITIALIZE posting and its group are updated in place rather than
+	// The INITIALIZE postings and their group are updated in place rather than
 	// re-inserted, so that recalculating a declaration does not orphan a group.
 	// The group has no job: it is derived from the declaration, not ingested.
+	//
+	// A pad has no counterparty in the source data, so it is written with one: an
+	// equal and opposite EQUITY posting of the same instrument in the same broker
+	// account, which is what makes the group balance. Both legs are upserted on
+	// the same key, so a recalculation moves them together and neither can drift
+	// from the other. See docs/spec/postings.md and
+	// docs/adr/0022-typed-per-account-cash-flow-boundary.md.
 	return p.runInTx(ctx, func(exec queryable) error {
 		var groupID uuid.NullUUID
 		err := exec.QueryRowContext(ctx, `
@@ -202,25 +209,35 @@ func (p *Postgres) UpsertInitializeTx(ctx context.Context, userID, broker, accou
 			`, userUUID, timestamp).Scan(&newGroupID); err != nil {
 				return fmt.Errorf("insert initialize tx group: %w", err)
 			}
-			_, err := exec.ExecContext(ctx, `
-				INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type, quantity, instrument_id, synthetic_purpose, group_id)
-				VALUES ($1, $2, $3, $4, 'INITIALIZE', $7, $5, $6, 'INITIALIZE', $8)
-			`, userUUID, broker, account, timestamp, quantity, instUUID, txType, newGroupID)
-			if err != nil {
-				return fmt.Errorf("insert initialize tx: %w", err)
-			}
-			return nil
+			groupID = uuid.NullUUID{UUID: newGroupID, Valid: true}
 		case err != nil:
 			return fmt.Errorf("find initialize tx: %w", err)
 		}
-		_, err = exec.ExecContext(ctx, `
-			UPDATE txs SET timestamp = $5, quantity = $6, tx_type = $7
-			WHERE user_id = $1 AND broker = $2 AND account = $3 AND instrument_id = $4
-			  AND synthetic_purpose = 'INITIALIZE'
-			  AND account_type = 'USER'
-		`, userUUID, broker, account, instUUID, timestamp, quantity, txType)
-		if err != nil {
-			return fmt.Errorf("update initialize tx: %w", err)
+		// Upsert rather than update: the EQUITY leg is absent from any pad written
+		// before it existed, and inserting it there is the same operation as
+		// keeping it in step afterwards. The conflict target is the partial unique
+		// index on INITIALIZE postings, which has account_type in its key so the
+		// two legs do not collide.
+		for _, leg := range []struct {
+			accountType string
+			quantity    float64
+		}{
+			{"USER", quantity},
+			{"EQUITY", -quantity},
+		} {
+			if _, err := exec.ExecContext(ctx, `
+				INSERT INTO txs (user_id, broker, account, timestamp, instrument_description,
+				                 tx_type, quantity, instrument_id, synthetic_purpose,
+				                 account_type, group_id)
+				VALUES ($1, $2, $3, $4, 'INITIALIZE', $7, $5, $6, 'INITIALIZE', $8, $9)
+				ON CONFLICT (user_id, broker, account, instrument_id, account_type)
+				  WHERE synthetic_purpose = 'INITIALIZE'
+				DO UPDATE SET timestamp = EXCLUDED.timestamp,
+				              quantity = EXCLUDED.quantity,
+				              tx_type = EXCLUDED.tx_type
+			`, userUUID, broker, account, timestamp, leg.quantity, instUUID, txType, leg.accountType, groupID); err != nil {
+				return fmt.Errorf("upsert initialize %s posting: %w", leg.accountType, err)
+			}
 		}
 		if !groupID.Valid {
 			return nil

--- a/server/db/postgres/declarations_test.go
+++ b/server/db/postgres/declarations_test.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"maps"
 	"testing"
 	"time"
 
@@ -193,54 +194,64 @@ func TestUpsertAndDeleteInitializeTx(t *testing.T) {
 		t.Fatalf("upsert: %v", err)
 	}
 
-	// Verify it shows up in ListTxs
-	txs, _, err := p.ListTxs(ctx, userID, nil, "", nil, nil, false, 50, "")
-	if err != nil {
-		t.Fatalf("list: %v", err)
-	}
-	var found bool
-	for _, pt := range txs {
-		if pt.GetTx().GetSyntheticPurpose() == "INITIALIZE" {
-			found = true
-			if pt.GetTx().GetQuantity() != 50 {
-				t.Fatalf("expected qty 50, got %v", pt.GetTx().GetQuantity())
-			}
-		}
-	}
-	if !found {
-		t.Fatal("INITIALIZE tx not found in list")
+	// The ledger view is unfiltered, so both legs of the pad show up: the pad
+	// itself and the EQUITY counterparty that balances it.
+	if got := initQtyByAccountType(t, p, userID); !maps.Equal(got, map[apiv1.AccountType]float64{
+		apiv1.AccountType_ACCOUNT_TYPE_USER:   50,
+		apiv1.AccountType_ACCOUNT_TYPE_EQUITY: -50,
+	}) {
+		t.Fatalf("INITIALIZE legs after create: got %v", got)
 	}
 
-	// Upsert again with different qty (should update, not duplicate)
+	// Upsert again with different qty (should update, not duplicate). Both legs
+	// move together: a recalculation that shifted only the pad would leave the
+	// group unbalanced.
 	err = p.UpsertInitializeTx(ctx, userID, "IBKR", "acct1", instID, "BUYSTOCK", ts, 75)
 	if err != nil {
 		t.Fatalf("upsert update: %v", err)
 	}
-	txs, _, _ = p.ListTxs(ctx, userID, nil, "", nil, nil, false, 50, "")
-	var initCount int
-	for _, pt := range txs {
-		if pt.GetTx().GetSyntheticPurpose() == "INITIALIZE" {
-			initCount++
-			if pt.GetTx().GetQuantity() != 75 {
-				t.Fatalf("expected qty 75 after update, got %v", pt.GetTx().GetQuantity())
-			}
-		}
-	}
-	if initCount != 1 {
-		t.Fatalf("expected 1 INITIALIZE tx, got %d", initCount)
+	if got := initQtyByAccountType(t, p, userID); !maps.Equal(got, map[apiv1.AccountType]float64{
+		apiv1.AccountType_ACCOUNT_TYPE_USER:   75,
+		apiv1.AccountType_ACCOUNT_TYPE_EQUITY: -75,
+	}) {
+		t.Fatalf("INITIALIZE legs after recalculation: got %v", got)
 	}
 
-	// Delete
+	// Deleting takes both legs: the group is the unit of deletion, so no code path
+	// can leave half the event behind.
 	err = p.DeleteInitializeTx(ctx, userID, "IBKR", "acct1", instID)
 	if err != nil {
 		t.Fatalf("delete: %v", err)
 	}
-	txs, _, _ = p.ListTxs(ctx, userID, nil, "", nil, nil, false, 50, "")
-	for _, pt := range txs {
-		if pt.GetTx().GetSyntheticPurpose() == "INITIALIZE" {
-			t.Fatal("INITIALIZE tx should have been deleted")
-		}
+	if got := initQtyByAccountType(t, p, userID); len(got) != 0 {
+		t.Fatalf("INITIALIZE legs after delete: want none, got %v", got)
 	}
+	if got := countOrphanGroups(t, p, userID); got != 0 {
+		t.Errorf("orphan tx_groups after delete: want 0, got %d", got)
+	}
+}
+
+// initQtyByAccountType returns the quantity of each INITIALIZE posting a user
+// has, keyed by account type. It reads through ListTxs, which is deliberately
+// unfiltered, so both the pad and its counterparty are visible.
+func initQtyByAccountType(t *testing.T, p *Postgres, userID string) map[apiv1.AccountType]float64 {
+	t.Helper()
+	txs, _, err := p.ListTxs(context.Background(), userID, nil, "", nil, nil, false, 50, "")
+	if err != nil {
+		t.Fatalf("list txs: %v", err)
+	}
+	out := map[apiv1.AccountType]float64{}
+	for _, pt := range txs {
+		if pt.GetTx().GetSyntheticPurpose() != "INITIALIZE" {
+			continue
+		}
+		at := pt.GetTx().GetAccountType()
+		if _, dup := out[at]; dup {
+			t.Fatalf("more than one INITIALIZE posting of account type %v", at)
+		}
+		out[at] = pt.GetTx().GetQuantity()
+	}
+	return out
 }
 
 func TestUpsertInitializeTx_GroupsThePosting(t *testing.T) {
@@ -259,7 +270,7 @@ func TestUpsertInitializeTx_GroupsThePosting(t *testing.T) {
 	var jobID *string
 	var groupTs time.Time
 	err := p.q.QueryRowContext(ctx, `
-		SELECT g.id, g.job_id, g.timestamp FROM txs t JOIN tx_groups g ON g.id = t.group_id
+		SELECT DISTINCT g.id, g.job_id, g.timestamp FROM txs t JOIN tx_groups g ON g.id = t.group_id
 		WHERE t.user_id = $1 AND t.synthetic_purpose = 'INITIALIZE'
 	`, userID).Scan(&groupID, &jobID, &groupTs)
 	if err != nil {
@@ -281,7 +292,7 @@ func TestUpsertInitializeTx_GroupsThePosting(t *testing.T) {
 	var groupID2 string
 	var groupTs2 time.Time
 	err = p.q.QueryRowContext(ctx, `
-		SELECT g.id, g.timestamp FROM txs t JOIN tx_groups g ON g.id = t.group_id
+		SELECT DISTINCT g.id, g.timestamp FROM txs t JOIN tx_groups g ON g.id = t.group_id
 		WHERE t.user_id = $1 AND t.synthetic_purpose = 'INITIALIZE'
 	`, userID).Scan(&groupID2, &groupTs2)
 	if err != nil {
@@ -302,6 +313,55 @@ func TestUpsertInitializeTx_GroupsThePosting(t *testing.T) {
 	}
 	if got := countGroups(t, p, userID); got != 0 {
 		t.Errorf("tx_groups after delete: want 0, got %d", got)
+	}
+}
+
+// TestUpsertInitializeTx_WritesTheEquityCounterparty verifies the pad is written
+// with the leg that balances it. A pad has no counterparty in the source data, so
+// the EQUITY posting is what lets the group sum to zero. It has to be equal and
+// opposite, in the same account, instrument, group and share count basis --
+// otherwise a stock split adjusts the two legs differently and the pair drifts.
+func TestUpsertInitializeTx_WritesTheEquityCounterparty(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|init-equity", "U", "u@eq.com")
+	instID, _ := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "EQ1", Canonical: false}}, "", nil, nil, nil)
+
+	at := time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)
+	if err := p.UpsertInitializeTx(ctx, userID, "IBKR", "acct1", instID, "BUYSTOCK", at, 50); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	var legs, groups, bases, sum float64
+	if err := p.q.QueryRowContext(ctx, `
+		SELECT count(*), count(DISTINCT group_id), count(DISTINCT share_count_basis), sum(quantity)
+		FROM txs
+		WHERE user_id = $1 AND synthetic_purpose = 'INITIALIZE'
+		  AND broker = 'IBKR' AND account = 'acct1' AND instrument_id = $2
+	`, userID, instID).Scan(&legs, &groups, &bases, &sum); err != nil {
+		t.Fatalf("read legs: %v", err)
+	}
+	if legs != 2 {
+		t.Errorf("INITIALIZE postings: want 2, got %v", legs)
+	}
+	if groups != 1 {
+		t.Errorf("the pad and its counterparty must share one group, got %v groups", groups)
+	}
+	if bases != 1 {
+		t.Errorf("the two legs must share a share_count_basis, got %v distinct", bases)
+	}
+	if sum != 0 {
+		t.Errorf("the pad's group must sum to zero, got %v", sum)
+	}
+
+	// The counterparty is excluded from holdings, so the declared opening balance
+	// still reads as declared rather than netting to nothing.
+	holdings, _, err := p.ComputeHoldings(ctx, userID, nil, "", nil)
+	if err != nil {
+		t.Fatalf("holdings: %v", err)
+	}
+	if len(holdings) != 1 || holdings[0].Quantity != 50 {
+		t.Fatalf("holdings: want a single holding of 50, got %+v", holdings)
 	}
 }
 

--- a/server/db/postgres/txs_test.go
+++ b/server/db/postgres/txs_test.go
@@ -135,10 +135,18 @@ func TestReplaceTxsInPeriod_PreservesSyntheticInitializeTx(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list txs: %v", err)
 	}
-	var sawInit, sawBuy, sawSell bool
+	var sawInit, sawInitEquity, sawBuy, sawSell bool
 	var sawOldBuy bool
 	for _, r := range rows {
 		switch {
+		// The pad and its EQUITY counterparty are one group, so a replace has to
+		// spare both or neither.
+		case r.GetTx().GetSyntheticPurpose() == "INITIALIZE" &&
+			r.GetTx().GetAccountType() == apiv1.AccountType_ACCOUNT_TYPE_EQUITY:
+			sawInitEquity = true
+			if r.GetTx().GetQuantity() != -42 {
+				t.Errorf("synthetic counterparty qty: want -42, got %v", r.GetTx().GetQuantity())
+			}
 		case r.GetTx().GetSyntheticPurpose() == "INITIALIZE":
 			sawInit = true
 			if r.GetTx().GetQuantity() != 42 {
@@ -152,8 +160,8 @@ func TestReplaceTxsInPeriod_PreservesSyntheticInitializeTx(t *testing.T) {
 			sawOldBuy = true
 		}
 	}
-	if !sawInit {
-		t.Error("synthetic INITIALIZE tx was deleted by ReplaceTxsInPeriod")
+	if !sawInit || !sawInitEquity {
+		t.Errorf("synthetic INITIALIZE group was deleted by ReplaceTxsInPeriod: pad=%v counterparty=%v", sawInit, sawInitEquity)
 	}
 	if !sawBuy || !sawSell {
 		t.Errorf("new real txs missing: buy=%v sell=%v", sawBuy, sawSell)


### PR DESCRIPTION
Second of three PRs implementing [0038](docs/issues/0038-derive-cash-legs-imbalance.md). Independent of the other two.

## Why

A pad has no counterparty in the source data -- that is what makes it a pad. So one is written for it: an equal and opposite `EQUITY` posting of the same instrument, in the same broker account, in the same group. That is what lets the group sum to zero, and value entering the user's holdings from before their history begins is exactly what `EQUITY` is for.

The schema has anticipated this since 0037. `idx_txs_initialize_unique` carries `account_type` in its key precisely so the pad and its counterparty do not collide. Nothing wrote the second leg.

## What changed

- `UpsertInitializeTx` writes both legs and upserts them on that partial unique index rather than updating in place. Upserting is what keeps a recalculation moving them together -- an update that shifted only the pad would leave the group unbalanced -- and it is also how a pad written before the counterparty existed acquires one, which is the same operation.
- Deleting is unchanged: it drops the group and lets the cascade take both postings, so no path can leave the counterparty behind without the pad it balances.
- The two legs share a `timestamp` and therefore a `share_count_basis`. That matters: `RecomputeTxSplitAdjustments` would otherwise adjust them differently and the pair would drift apart across a split.
- `fixed-point.md` documented a four-column unique index that 0037 had already widened. Corrected, with the reason, plus the counterparty itself.

## No read path changes

Every quantity aggregation already filters to `USER` postings, which is what stops the counterparty netting the pad out and making a declared opening balance read as zero. The transaction list is deliberately unfiltered, so both legs are visible there -- and the existing tests that read through it now assert on the pair rather than on a single row.

## Tests

- `TestUpsertInitializeTx_WritesTheEquityCounterparty` -- two legs, one group, one shared `share_count_basis`, summing to zero, and holdings still reading the declared 50 rather than netting to nothing.
- `TestUpsertAndDeleteInitializeTx` now asserts both legs are created, both move on recalculation, and both go on delete leaving no orphan group.
- `TestReplaceTxsInPeriod_PreservesSyntheticInitializeTx` asserts the replace spares both legs, not just the pad.

`make server-test`, `make db-test`, `make integration-test`, `make lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)