### PR TITLE
Open 0071: report fees and charges to the user by period

### DIFF
--- a/docs/issues/0071-fee-and-charge-reporting.md
+++ b/docs/issues/0071-fee-and-charge-reporting.md
@@ -1,0 +1,53 @@
+---
+status: open
+title: Report fees and charges to the user by period
+dependencies: [0040]
+---
+
+Show the user what their holdings cost them to run: a periodic tally of `EXPENSE`
+postings, grouped by period and broker.
+
+## Motivation
+
+Nothing surfaces charges to the user today. Once trades carry their commission as
+its own posting, the data to answer "what did I pay this year" is already there and
+needs only aggregating. Costs are one of the few things about a portfolio a user can
+actually control, so this is worth its own surface rather than a footnote on
+performance.
+
+## Scope
+
+All postings with `account_type = EXPENSE`, not just trade commission. That type
+covers commissions, levies, custody and service charges, and taxes
+(proto/api/v1/api.proto), and the recurring platform and custody charges are the
+ones that compound against long-run returns. Scoping this to commission alone would
+miss the point of the report.
+
+## Design
+
+- A plain aggregate over postings: sum by period, broker, account and commodity.
+  The currency comes from the posting's instrument, so no name parsing is needed.
+- Portfolio-scoped and presented under **Analysis** in
+  docs/spec/information-architecture.md, alongside the other breakdowns of a
+  portfolio. It is not an admin surface; 0039 is the admin view of the same ledger
+  and answers a different question.
+- Expressing the total as a percentage of portfolio value is what makes the number
+  interpretable, but it needs a defensible denominator (average value over the
+  period, not closing value). Worth doing, worth doing deliberately.
+
+## Completeness has to be visible
+
+The tally is only as complete as the converters. Where a broker nets commission into
+a cash total and 0040 has not yet covered it, the charge is either conflated into
+consideration or sitting in `Imbalance`, and the report will under-report. A number
+presented without that caveat reads as authoritative when it is not.
+
+Carry a caveat driven by the 0039 aggregate -- charges for the period, plus the
+count and value of groups in it with an unresolved imbalance. That is what makes it
+shippable before every converter is complete, and it reuses the imbalance query
+rather than duplicating it.
+
+## Sequencing
+
+Depends on 0040 for the same reason: before the converters emit their expense legs,
+the report is systematically wrong rather than merely incomplete.


### PR DESCRIPTION
Adds `docs/issues/0071-fee-and-charge-reporting.md`. Documentation only -- no code
changes.

Nothing in the tracker plans to surface charges to the user. Once 0040 has the
converters emitting their expense legs, a periodic tally of `EXPENSE` postings is a
plain aggregate over data the posting model already holds, so this is worth recording
now rather than rediscovering later.

Three things the issue pins down:

- **Scope is all `EXPENSE` postings**, not just trade commission. That type already
  covers levies, custody and service charges and taxes, and the recurring platform
  charges are the ones that compound against long-run returns.
- **It is a user surface, under Analysis** -- distinct from the admin imbalance report
  in 0039, which reads the same ledger to answer a different question.
- **Completeness has to be visible.** Where a converter still nets commission into a
  cash total, the charge is conflated or sitting in `Imbalance`, so the tally
  under-reports. The issue requires a caveat driven by the 0039 aggregate rather than
  presenting an incomplete number as authoritative.

Unscheduled rather than M12, since it is a user-facing analysis feature rather than
part of moving to the posting model. `dependencies: [0040]` because before the
converters emit their expense legs the report is systematically wrong, not merely
incomplete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)