### PR TITLE
Aggregate residual balances in the db layer (0039)

### DIFF
--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -313,6 +313,12 @@ service ApiService {
   rpc ListUnhandledCorporateEvents(ListUnhandledCorporateEventsRequest) returns (ListUnhandledCorporateEventsResponse);
   rpc CountUnhandledCorporateEvents(CountUnhandledCorporateEventsRequest) returns (CountUnhandledCorporateEventsResponse);
   rpc ResolveUnhandledCorporateEvent(ResolveUnhandledCorporateEventRequest) returns (ResolveUnhandledCorporateEventResponse);
+
+  // Residual balances (admin-only). The net IMBALANCE and TRANSFER_CLEARING value
+  // left in each broker account: a direct measure of how lossy each broker
+  // converter is, and of which transfers are missing a side.
+  rpc ListResidualBalances(ListResidualBalancesRequest) returns (ListResidualBalancesResponse);
+  rpc CountResidualBalances(CountResidualBalancesRequest) returns (CountResidualBalancesResponse);
 }
 
 // Portfolio is a user-owned container for transactions and holdings.
@@ -1206,3 +1212,61 @@ message ResolveUnhandledCorporateEventRequest {
 }
 
 message ResolveUnhandledCorporateEventResponse {}
+
+// Residual balances.
+
+// ResidualBalance is the net value left in one non-asset account: what events of
+// one tx type left over in one broker account in one commodity. An IMBALANCE
+// balance is a group that did not sum to zero -- a missing fee, or an
+// uncategorised dividend whose income leg the converter does not yet emit. A
+// TRANSFER_CLEARING balance is one side of a journal. Nothing pairs the two
+// sides until transfers are matched, so a transfer balance means a transfer was
+// imported rather than that its second side is missing.
+//
+// Balances are per commodity and are never converted: one in a currency is money,
+// one in a security is a quantity of shares, and the two are not summed. See
+// docs/spec/postings.md.
+message ResidualBalance {
+  AccountType account_type = 1;  // IMBALANCE or TRANSFER_CLEARING
+  Broker broker = 2;
+  string account = 3;
+  string instrument_id = 4;
+  string commodity = 5;          // instrument name: the ISO code for money, the ticker for a security
+  AssetClass asset_class = 6;    // CASH means the balance is money; anything else is a quantity
+  TxType tx_type = 7;            // the kind of event that left the balance
+  double balance = 8;            // signed sum over the contributing postings
+  int32 posting_count = 9;
+  // The oldest and newest postings contributing to the balance. For a transfer
+  // these are not the age of a missing side: see the note above.
+  google.protobuf.Timestamp oldest_timestamp = 10;
+  google.protobuf.Timestamp newest_timestamp = 11;
+}
+
+// ListResidualBalances returns residual balances across all users, grouped by
+// broker, account, commodity and tx type. Admin only: it measures converter
+// quality rather than any one portfolio, and carries no user identity.
+message ListResidualBalancesRequest {
+  // Half-open [period_from, period_before) over the posting timestamp; an unset
+  // bound is open-ended.
+  google.protobuf.Timestamp period_from = 1;    // inclusive
+  google.protobuf.Timestamp period_before = 2;  // exclusive
+  // Restrict to one account type. ACCOUNT_TYPE_UNSPECIFIED returns both IMBALANCE
+  // and TRANSFER_CLEARING.
+  AccountType account_type = 3 [(buf.validate.field).enum.defined_only = true];
+}
+
+message ListResidualBalancesResponse {
+  repeated ResidualBalance balances = 1;
+}
+
+// CountResidualBalances returns the headline counts for the admin dashboard, over
+// all of history. The transfer count is bounded by age alone and includes settled
+// transfers, so it counts imported transfers rather than problems.
+message CountResidualBalancesRequest {
+  int32 stale_after_days = 1 [(buf.validate.field).int32.gte = 0];  // 0 selects the server default
+}
+
+message CountResidualBalancesResponse {
+  int32 imbalance_count = 1;       // non-zero IMBALANCE balances
+  int32 stale_transfer_count = 2;  // TRANSFER_CLEARING balances older than the window
+}

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -57,6 +57,7 @@ type DB interface {
 	IgnoredAssetClassDB
 	InflationIndexDB
 	CorporateEventDB
+	ResidualBalanceDB
 }
 
 // PriceFetchBlockDB manages permanently blocked (instrument, plugin) pairs.
@@ -966,4 +967,54 @@ type ExportCashDividend struct {
 	Frequency        string
 	Type             string
 	FirstKnownAt     time.Time
+}
+
+// ResidualBalance is the net value left in one non-asset account, aggregated over
+// every user: what events of one tx type left in one broker account in one
+// commodity. An IMBALANCE balance is a group that did not sum to zero -- a missing
+// fee or an uncategorised dividend; a TRANSFER_CLEARING balance is one side of a
+// journal, whether or not the other side has arrived.
+//
+// It carries no user identity: the report measures how lossy each broker converter
+// is, not what is in any one portfolio.
+type ResidualBalance struct {
+	AccountType  apiv1.AccountType
+	Broker       apiv1.Broker
+	Account      string
+	InstrumentID string
+	// Commodity is the instrument's name: the ISO code for money, the ticker for a
+	// security. AssetClass says which, and is empty when the instrument was never
+	// identified.
+	Commodity    string
+	AssetClass   string
+	TxType       apiv1.TxType
+	Balance      float64
+	PostingCount int32
+	// Oldest and Newest bound the postings that contribute to the balance. For a
+	// transfer they are not the age of a missing side: nothing pairs the two sides
+	// of a journal until 0068, so a settled transfer is reported like an open one.
+	Oldest *time.Time
+	Newest *time.Time
+}
+
+// ResidualBalanceOpts filters the residual balance report. From and Before are a
+// half-open [From, Before) window over the posting timestamp; nil bounds are
+// open-ended. An AccountType of ACCOUNT_TYPE_UNSPECIFIED returns both residual
+// types.
+type ResidualBalanceOpts struct {
+	From        *time.Time
+	Before      *time.Time
+	AccountType apiv1.AccountType
+}
+
+// ResidualBalanceDB aggregates the residual postings -- the IMBALANCE and
+// TRANSFER_CLEARING legs routed to balance groups their source data left one-sided
+// -- across all users.
+type ResidualBalanceDB interface {
+	ListResidualBalances(ctx context.Context, opts ResidualBalanceOpts) ([]ResidualBalance, error)
+	// CountResidualBalances returns the number of non-zero IMBALANCE balances and
+	// the number of TRANSFER_CLEARING balances older than staleBefore, over all of
+	// history. The transfer count includes settled transfers, and will until
+	// matching (0068) makes the two distinguishable.
+	CountResidualBalances(ctx context.Context, staleBefore time.Time) (imbalances, staleTransfers int32, err error)
 }

--- a/server/db/postgres/residual_balances.go
+++ b/server/db/postgres/residual_balances.go
@@ -1,0 +1,126 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+)
+
+// residualBalanceAgg aggregates the residual postings -- the IMBALANCE and
+// TRANSFER_CLEARING legs routed to balance groups whose source data was one-sided
+// -- across every user. $1/$2 are a half-open [from, before) window over the
+// posting timestamp, either of which may be NULL for an open bound; $3 restricts to
+// one account type, or is the empty string for both.
+//
+// The commodity is the instrument's name, not its currency: for money the two
+// agree, but a residual left by an unpaired JRNLSEC is a quantity of shares whose
+// instrument currency would render it as money and misstate it.
+//
+// Both sides of a completed journal are TRANSFER_CLEARING postings in different
+// broker accounts, and nothing pairs them: matching is 0068. Until it lands a
+// settled transfer is indistinguishable from an unmatched one and both are
+// reported, so a TRANSFER_CLEARING balance says a transfer was imported, not that
+// a side is missing. The list and the count share this text so the two cannot
+// disagree about what a balance is.
+const residualBalanceAgg = `
+	SELECT t.account_type, t.broker, t.account, t.instrument_id,
+		COALESCE(i.name, t.instrument_id::text) AS commodity,
+		COALESCE(i.asset_class, '')             AS asset_class,
+		t.tx_type,
+		SUM(t.quantity)   AS balance,
+		COUNT(*)::int     AS posting_count,
+		MIN(t.timestamp)  AS oldest,
+		MAX(t.timestamp)  AS newest
+	FROM txs t
+	LEFT JOIN instruments i ON i.id = t.instrument_id
+	WHERE t.account_type IN ('IMBALANCE', 'TRANSFER_CLEARING')
+		-- Routing drops a residual it cannot resolve an instrument for, so this
+		-- excludes nothing in practice; it is here so a NULL commodity cannot
+		-- reach the scan.
+		AND t.instrument_id IS NOT NULL
+		AND ($1::timestamptz IS NULL OR t.timestamp >= $1)
+		AND ($2::timestamptz IS NULL OR t.timestamp <  $2)
+		AND ($3 = '' OR t.account_type = $3)
+	GROUP BY t.account_type, t.broker, t.account, t.instrument_id, i.name, i.asset_class, t.tx_type
+	HAVING NOT qty_is_zero(SUM(t.quantity))`
+
+// residualBalanceRow is the sqlx-scannable shape for a residual balance.
+type residualBalanceRow struct {
+	AccountType  string     `db:"account_type"`
+	Broker       string     `db:"broker"`
+	Account      string     `db:"account"`
+	InstID       *string    `db:"instrument_id"`
+	Commodity    string     `db:"commodity"`
+	AssetClass   string     `db:"asset_class"`
+	TxType       string     `db:"tx_type"`
+	Balance      float64    `db:"balance"`
+	PostingCount int32      `db:"posting_count"`
+	Oldest       *time.Time `db:"oldest"`
+	Newest       *time.Time `db:"newest"`
+}
+
+func (r *residualBalanceRow) toDomain() db.ResidualBalance {
+	b := db.ResidualBalance{
+		AccountType:  strToAccountType(r.AccountType),
+		Broker:       strToBroker(r.Broker),
+		Account:      r.Account,
+		Commodity:    r.Commodity,
+		AssetClass:   r.AssetClass,
+		TxType:       strToTxType(r.TxType),
+		Balance:      r.Balance,
+		PostingCount: r.PostingCount,
+		Oldest:       r.Oldest,
+		Newest:       r.Newest,
+	}
+	if r.InstID != nil {
+		b.InstrumentID = *r.InstID
+	}
+	return b
+}
+
+// ListResidualBalances implements db.ResidualBalanceDB.
+func (p *Postgres) ListResidualBalances(ctx context.Context, opts db.ResidualBalanceOpts) ([]db.ResidualBalance, error) {
+	accountType := ""
+	if opts.AccountType != apiv1.AccountType_ACCOUNT_TYPE_UNSPECIFIED {
+		s, err := accountTypeToStr(opts.AccountType)
+		if err != nil {
+			return nil, err
+		}
+		accountType = s
+	}
+	q := residualBalanceAgg + `
+		ORDER BY t.broker, t.account, commodity, t.tx_type`
+	var rows []residualBalanceRow
+	if err := p.q.SelectContext(ctx, &rows, q, opts.From, opts.Before, accountType); err != nil {
+		return nil, fmt.Errorf("list residual balances: %w", err)
+	}
+	out := make([]db.ResidualBalance, len(rows))
+	for i := range rows {
+		out[i] = rows[i].toDomain()
+	}
+	return out, nil
+}
+
+// CountResidualBalances implements db.ResidualBalanceDB. It counts over all of
+// history: the dashboard asks whether anything is wrong, not what was wrong during
+// some window.
+func (p *Postgres) CountResidualBalances(ctx context.Context, staleBefore time.Time) (int32, int32, error) {
+	q := "WITH r AS (" + residualBalanceAgg + `
+		)
+		SELECT
+			COUNT(*) FILTER (WHERE r.account_type = 'IMBALANCE')::int AS imbalances,
+			COUNT(*) FILTER (WHERE r.account_type = 'TRANSFER_CLEARING'
+				AND COALESCE(r.oldest, r.newest) < $4)::int AS stale_transfers
+		FROM r`
+	var counts struct {
+		Imbalances     int32 `db:"imbalances"`
+		StaleTransfers int32 `db:"stale_transfers"`
+	}
+	if err := p.q.GetContext(ctx, &counts, q, nil, nil, "", staleBefore); err != nil {
+		return 0, 0, fmt.Errorf("count residual balances: %w", err)
+	}
+	return counts.Imbalances, counts.StaleTransfers, nil
+}

--- a/server/db/postgres/residual_balances_test.go
+++ b/server/db/postgres/residual_balances_test.go
@@ -1,0 +1,308 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// residualSeed is one residual posting to seed. Each is appended as its own group,
+// which is what the routing path produces for a one-sided source row.
+type residualSeed struct {
+	broker      string
+	account     string
+	instID      string
+	txType      apiv1.TxType
+	accountType apiv1.AccountType
+	qty         float64
+	daysAgo     int
+}
+
+func seedResiduals(t *testing.T, p *Postgres, userID string, seeds ...residualSeed) {
+	t.Helper()
+	ctx := context.Background()
+	now := time.Now().UTC()
+	for _, s := range seeds {
+		tx := &apiv1.Tx{
+			Timestamp:             timestamppb.New(now.AddDate(0, 0, -s.daysAgo)),
+			InstrumentDescription: "residual",
+			Type:                  s.txType,
+			Quantity:              s.qty,
+			AccountType:           s.accountType,
+		}
+		if err := createTx(ctx, p, userID, s.broker, s.account, "", tx, s.instID, nil); err != nil {
+			t.Fatalf("seed residual %s/%s: %v", s.broker, s.account, err)
+		}
+	}
+}
+
+func usdInstrument(t *testing.T, p *Postgres) string {
+	t.Helper()
+	id, err := p.EnsureInstrument(context.Background(), "CASH", "", "USD", "USD", "", "",
+		[]db.IdentifierInput{{Type: "CURRENCY", Value: "USD", Canonical: true}}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure USD: %v", err)
+	}
+	return id
+}
+
+func newUser(t *testing.T, p *Postgres, sub string) string {
+	t.Helper()
+	id, err := p.GetOrCreateUser(context.Background(), sub, "U", sub+"@u.com")
+	if err != nil {
+		t.Fatalf("create user %s: %v", sub, err)
+	}
+	return id
+}
+
+// findBalance returns the single balance matching broker, account and tx type.
+func findBalance(t *testing.T, rows []db.ResidualBalance, broker apiv1.Broker, account string, txType apiv1.TxType) db.ResidualBalance {
+	t.Helper()
+	var found []db.ResidualBalance
+	for _, r := range rows {
+		if r.Broker == broker && r.Account == account && r.TxType == txType {
+			found = append(found, r)
+		}
+	}
+	if len(found) != 1 {
+		t.Fatalf("expected 1 balance for %v/%s/%v, got %d (rows: %+v)", broker, account, txType, len(found), rows)
+	}
+	return found[0]
+}
+
+// TestListResidualBalances_GroupsByTxType verifies the breakdown the report exists
+// for: an uncategorised dividend and a missing fee under the same broker account
+// are separate rows, because they lead to different converter work.
+func TestListResidualBalances_GroupsByTxType(t *testing.T) {
+	p := testDBTx(t)
+	userID := newUser(t, p, "sub|grouping")
+	usd := usdInstrument(t, p)
+
+	seedResiduals(t, p, userID,
+		residualSeed{"IBKR", "A1", usd, apiv1.TxType_INCOME, apiv1.AccountType_ACCOUNT_TYPE_IMBALANCE, -100, 1},
+		residualSeed{"IBKR", "A1", usd, apiv1.TxType_INCOME, apiv1.AccountType_ACCOUNT_TYPE_IMBALANCE, -50, 2},
+		residualSeed{"IBKR", "A1", usd, apiv1.TxType_BUYSTOCK, apiv1.AccountType_ACCOUNT_TYPE_IMBALANCE, 3.5, 3},
+	)
+
+	rows, err := p.ListResidualBalances(context.Background(), db.ResidualBalanceOpts{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d: %+v", len(rows), rows)
+	}
+	income := findBalance(t, rows, apiv1.Broker_IBKR, "A1", apiv1.TxType_INCOME)
+	if income.Balance != -150 {
+		t.Errorf("income balance = %v, want -150", income.Balance)
+	}
+	if income.PostingCount != 2 {
+		t.Errorf("income posting count = %d, want 2", income.PostingCount)
+	}
+	if income.Commodity != "USD" {
+		t.Errorf("income commodity = %q, want USD", income.Commodity)
+	}
+	if income.AssetClass != "CASH" {
+		t.Errorf("income asset class = %q, want CASH", income.AssetClass)
+	}
+	if income.AccountType != apiv1.AccountType_ACCOUNT_TYPE_IMBALANCE {
+		t.Errorf("income account type = %v, want IMBALANCE", income.AccountType)
+	}
+	buy := findBalance(t, rows, apiv1.Broker_IBKR, "A1", apiv1.TxType_BUYSTOCK)
+	if buy.Balance != 3.5 {
+		t.Errorf("buy balance = %v, want 3.5", buy.Balance)
+	}
+}
+
+// TestListResidualBalances_OffsettingImbalancesDrop verifies that a key whose
+// residuals cancel is not reported: there is nothing left to fix.
+func TestListResidualBalances_OffsettingImbalancesDrop(t *testing.T) {
+	p := testDBTx(t)
+	userID := newUser(t, p, "sub|offset")
+	usd := usdInstrument(t, p)
+
+	seedResiduals(t, p, userID,
+		residualSeed{"IBKR", "A1", usd, apiv1.TxType_INCOME, apiv1.AccountType_ACCOUNT_TYPE_IMBALANCE, 100, 1},
+		residualSeed{"IBKR", "A1", usd, apiv1.TxType_INCOME, apiv1.AccountType_ACCOUNT_TYPE_IMBALANCE, -100, 2},
+	)
+
+	rows, err := p.ListResidualBalances(context.Background(), db.ResidualBalanceOpts{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("expected no rows, got %+v", rows)
+	}
+}
+
+// TestListResidualBalances_SecurityCommodity verifies a residual in shares reports
+// the ticker and its asset class, not the currency the instrument trades in. The
+// report would otherwise render a share count as money.
+func TestListResidualBalances_SecurityCommodity(t *testing.T) {
+	p := testDBTx(t)
+	userID := newUser(t, p, "sub|security")
+	stockID, err := p.EnsureInstrument(context.Background(), "STOCK", "", "USD", "", "", "",
+		[]db.IdentifierInput{{Type: "MIC_TICKER", Domain: "XNAS", Value: "AAPL", Canonical: true}}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure stock: %v", err)
+	}
+
+	seedResiduals(t, p, userID,
+		residualSeed{"IBKR", "A1", stockID, apiv1.TxType_JRNLSEC, apiv1.AccountType_ACCOUNT_TYPE_TRANSFER_CLEARING, 50, 1},
+	)
+
+	rows, err := p.ListResidualBalances(context.Background(), db.ResidualBalanceOpts{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %+v", rows)
+	}
+	if rows[0].Commodity != "AAPL" {
+		t.Errorf("commodity = %q, want AAPL", rows[0].Commodity)
+	}
+	if rows[0].AssetClass != "STOCK" {
+		t.Errorf("asset class = %q, want STOCK (a quantity, not money)", rows[0].AssetClass)
+	}
+}
+
+// TestListResidualBalances_SettledTransferIsStillReported pins the limitation this
+// report has until transfers are matched (0068): both sides of a completed journal
+// are TRANSFER_CLEARING postings in different accounts, nothing pairs them, and the
+// report cannot tell a settled transfer from one whose second side never arrived.
+// Both sides are reported. Update this test when 0068 makes them distinguishable.
+func TestListResidualBalances_SettledTransferIsStillReported(t *testing.T) {
+	p := testDBTx(t)
+	userID := newUser(t, p, "sub|settled")
+	usd := usdInstrument(t, p)
+
+	seedResiduals(t, p, userID,
+		residualSeed{"IBKR", "A1", usd, apiv1.TxType_JRNLFUND, apiv1.AccountType_ACCOUNT_TYPE_TRANSFER_CLEARING, 500, 40},
+		residualSeed{"IBKR", "A2", usd, apiv1.TxType_JRNLFUND, apiv1.AccountType_ACCOUNT_TYPE_TRANSFER_CLEARING, -500, 38},
+	)
+
+	rows, err := p.ListResidualBalances(context.Background(), db.ResidualBalanceOpts{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected both sides reported, got %+v", rows)
+	}
+	out := findBalance(t, rows, apiv1.Broker_IBKR, "A1", apiv1.TxType_JRNLFUND)
+	if out.Balance != 500 {
+		t.Errorf("A1 balance = %v, want 500", out.Balance)
+	}
+	if out.Oldest == nil || out.Newest == nil {
+		t.Error("expected the contributing postings to be dated")
+	}
+}
+
+// TestListResidualBalances_ImbalancesDoNotNetAcrossAccounts verifies imbalances are
+// not netted the way transfers are. Two offsetting converter defects are two
+// defects, and netting them would report neither.
+func TestListResidualBalances_ImbalancesDoNotNetAcrossAccounts(t *testing.T) {
+	p := testDBTx(t)
+	userID := newUser(t, p, "sub|noimbnet")
+	usd := usdInstrument(t, p)
+
+	seedResiduals(t, p, userID,
+		residualSeed{"IBKR", "A1", usd, apiv1.TxType_INCOME, apiv1.AccountType_ACCOUNT_TYPE_IMBALANCE, 500, 5},
+		residualSeed{"IBKR", "A2", usd, apiv1.TxType_INCOME, apiv1.AccountType_ACCOUNT_TYPE_IMBALANCE, -500, 5},
+	)
+
+	rows, err := p.ListResidualBalances(context.Background(), db.ResidualBalanceOpts{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected both imbalances, got %+v", rows)
+	}
+}
+
+// TestListResidualBalances_PeriodBounds verifies the window is half-open.
+func TestListResidualBalances_PeriodBounds(t *testing.T) {
+	p := testDBTx(t)
+	userID := newUser(t, p, "sub|period")
+	usd := usdInstrument(t, p)
+
+	seedResiduals(t, p, userID,
+		residualSeed{"IBKR", "A1", usd, apiv1.TxType_INCOME, apiv1.AccountType_ACCOUNT_TYPE_IMBALANCE, -10, 30},
+		residualSeed{"IBKR", "A1", usd, apiv1.TxType_BUYSTOCK, apiv1.AccountType_ACCOUNT_TYPE_IMBALANCE, -20, 2},
+	)
+
+	from := time.Now().UTC().AddDate(0, 0, -10)
+	rows, err := p.ListResidualBalances(context.Background(), db.ResidualBalanceOpts{From: &from})
+	if err != nil {
+		t.Fatalf("list from: %v", err)
+	}
+	if len(rows) != 1 || rows[0].TxType != apiv1.TxType_BUYSTOCK {
+		t.Fatalf("expected only the recent residual, got %+v", rows)
+	}
+
+	before := time.Now().UTC().AddDate(0, 0, -10)
+	rows, err = p.ListResidualBalances(context.Background(), db.ResidualBalanceOpts{Before: &before})
+	if err != nil {
+		t.Fatalf("list before: %v", err)
+	}
+	if len(rows) != 1 || rows[0].TxType != apiv1.TxType_INCOME {
+		t.Fatalf("expected only the old residual, got %+v", rows)
+	}
+}
+
+// TestListResidualBalances_AccountTypeFilter verifies each tab can ask for its own
+// rows.
+func TestListResidualBalances_AccountTypeFilter(t *testing.T) {
+	p := testDBTx(t)
+	userID := newUser(t, p, "sub|filter")
+	usd := usdInstrument(t, p)
+
+	seedResiduals(t, p, userID,
+		residualSeed{"IBKR", "A1", usd, apiv1.TxType_INCOME, apiv1.AccountType_ACCOUNT_TYPE_IMBALANCE, -10, 2},
+		residualSeed{"IBKR", "A1", usd, apiv1.TxType_JRNLFUND, apiv1.AccountType_ACCOUNT_TYPE_TRANSFER_CLEARING, 500, 2},
+	)
+
+	ctx := context.Background()
+	rows, err := p.ListResidualBalances(ctx, db.ResidualBalanceOpts{AccountType: apiv1.AccountType_ACCOUNT_TYPE_IMBALANCE})
+	if err != nil {
+		t.Fatalf("list imbalance: %v", err)
+	}
+	if len(rows) != 1 || rows[0].AccountType != apiv1.AccountType_ACCOUNT_TYPE_IMBALANCE {
+		t.Fatalf("expected only the imbalance, got %+v", rows)
+	}
+	rows, err = p.ListResidualBalances(ctx, db.ResidualBalanceOpts{AccountType: apiv1.AccountType_ACCOUNT_TYPE_TRANSFER_CLEARING})
+	if err != nil {
+		t.Fatalf("list transfers: %v", err)
+	}
+	if len(rows) != 1 || rows[0].AccountType != apiv1.AccountType_ACCOUNT_TYPE_TRANSFER_CLEARING {
+		t.Fatalf("expected only the transfer, got %+v", rows)
+	}
+}
+
+// TestCountResidualBalances_StalenessBoundary verifies a recently imported transfer
+// is quiet and an old one is loud. Every imbalance counts whatever its age.
+func TestCountResidualBalances_StalenessBoundary(t *testing.T) {
+	p := testDBTx(t)
+	userID := newUser(t, p, "sub|stale")
+	usd := usdInstrument(t, p)
+
+	seedResiduals(t, p, userID,
+		residualSeed{"IBKR", "A1", usd, apiv1.TxType_INCOME, apiv1.AccountType_ACCOUNT_TYPE_IMBALANCE, -10, 1},
+		residualSeed{"IBKR", "A1", usd, apiv1.TxType_JRNLFUND, apiv1.AccountType_ACCOUNT_TYPE_TRANSFER_CLEARING, 100, 6},
+		residualSeed{"IBKR", "A2", usd, apiv1.TxType_JRNLFUND, apiv1.AccountType_ACCOUNT_TYPE_TRANSFER_CLEARING, 200, 8},
+	)
+
+	staleBefore := time.Now().UTC().AddDate(0, 0, -7)
+	imbalances, stale, err := p.CountResidualBalances(context.Background(), staleBefore)
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if imbalances != 1 {
+		t.Errorf("imbalances = %d, want 1", imbalances)
+	}
+	if stale != 1 {
+		t.Errorf("stale transfers = %d, want 1 (the 8-day-old side, not the 6-day-old one)", stale)
+	}
+}

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -355,6 +355,15 @@ ALTER TABLE txs ADD COLUMN instrument_id UUID REFERENCES instruments (id);
 
 CREATE INDEX idx_txs_instrument_id ON txs (instrument_id);
 
+-- Residual postings -- the IMBALANCE and TRANSFER_CLEARING legs routed to balance a
+-- group its source data left one-sided -- are a small minority of txs, and the report
+-- that aggregates them reads every one across all users. A partial index over just
+-- those rows answers it without carrying the USER postings that dominate the table.
+-- Column order follows the report's GROUP BY.
+CREATE INDEX idx_txs_residual_postings
+  ON txs (account_type, user_id, broker, account, instrument_id, tx_type)
+  WHERE account_type IN ('IMBALANCE', 'TRANSFER_CLEARING');
+
 -- At most one INITIALIZE posting per holding per account type. account_type is part of
 -- the key because the pad's counterparty is an equal-and-opposite posting of the same
 -- instrument in the same broker account, and is synthetic for the same reason the pad


### PR DESCRIPTION
First of three PRs for 0039. Schema, proto and db layer only -- no handlers and no
UI, so nothing is reachable yet.

Adds `ListResidualBalances` / `CountResidualBalances`: the net `IMBALANCE` and
`TRANSFER_CLEARING` value left in each broker account, grouped by broker, account,
commodity and tx type across all users. No user identity leaves the db layer; the
report measures how lossy each converter is, not what is in any one portfolio.

The tx type breakdown the issue asks for comes free -- `routedFor` already copies the
group's type onto the residual, so separating "this broker reports no fees" from "we
do not yet categorise this broker's dividends" is a plain `GROUP BY` with no join
back to sibling postings.

## The transfer half is limited until 0068

Both sides of a completed journal are `TRANSFER_CLEARING` postings in *different*
broker accounts, and nothing pairs them -- matching is 0068, which says exactly this
in its own motivation. A settled transfer and one whose second side never arrived are
therefore the same shape, and both are reported. A `TRANSFER_CLEARING` balance here
means a transfer was imported, not that a side is missing.

Inferring the pairing from balances was tried and removed. Any such rule has to guess
which side settled, and misattributes as soon as an account has more than one
transfer open: it reports the right total against the wrong account and the wrong
age, while looking authoritative. Over-reporting and saying so beats quietly pointing
at the wrong row, and 0068 is the actual fix.
`TestListResidualBalances_SettledTransferIsStillReported` pins the behaviour so it is
visible in the tests rather than discovered later.

## Smaller decisions

- **Commodity is `instruments.name`, not `instruments.currency`.** They agree for
  money, but a residual left by an unpaired `JRNLSEC` is a share count whose
  instrument currency would render it as money and misstate it. `asset_class` rides
  along so the caller knows which rows are money.
- **No pagination.** The row set is bounded by defects rather than data volume: a
  broken converter emits one row per (account, commodity, tx type) it touches, a
  working one emits none. The per-broker headline needs the whole set anyway.
- **One SQL text shared** by the list and the count, so the two cannot disagree about
  what a balance is.
- **Partial index** on the two residual account types rather than a bare
  `(account_type)`, which would carry every `USER` row to answer a query that only
  wants the rare minority. Added to `001_initial.sql` per the pre-release no-new-
  migrations rule.

## Known edge

Dropping `user_id` for the report key means two users with the same broker, account
string, commodity and tx type merge into one row. That is intended -- it is a
statement about the converter -- but if their balances exactly offset, the row is
dropped. It needs an exact cancellation between two users who also share an account
name, and the alternative (reporting a zero-balance row) reads worse.

## Testing

`make check`, `make server-test` and `make db-test` pass. Eight new db integration
tests: the tx type breakdown, offsetting residuals dropping, the security-commodity
guard, settled transfers still being reported, imbalances never netting across
accounts, the half-open period bounds, the account type filter, and the count
staleness boundary at 6 vs 8 days.

Next: PR 2 adds the admin-gated handlers and the client transport; PR 3 the
`/admin/imbalance` page, dashboard card and e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)