### PR TITLE
Serve residual balances over the API (0039)

### DIFF
--- a/client/app/transactions/page.tsx
+++ b/client/app/transactions/page.tsx
@@ -12,44 +12,10 @@ import { errorMessage } from "@/lib/errors";
 import { qk } from "@/lib/query-keys";
 import { listTxs } from "@/lib/portfolio-api";
 import { getBrokerLabel } from "@/lib/csv/converters";
-import { AccountType, TxType, IdentifierType } from "@/gen/api/v1/api_pb";
+import { ACCOUNT_TYPE_LABEL, TX_TYPE_LABEL } from "@/lib/tx-type";
+import { IdentifierType } from "@/gen/api/v1/api_pb";
 import type { PortfolioTx } from "@/gen/api/v1/api_pb";
 import { timestampDate } from "@bufbuild/protobuf/wkt";
-
-const TX_TYPE_LABEL: Record<number, string> = {
-  [TxType.BUYDEBT]: "Buy Debt",
-  [TxType.BUYMF]: "Buy MF",
-  [TxType.BUYOPT]: "Buy Option",
-  [TxType.BUYOTHER]: "Buy Other",
-  [TxType.BUYSTOCK]: "Buy Stock",
-  [TxType.SELLDEBT]: "Sell Debt",
-  [TxType.SELLMF]: "Sell MF",
-  [TxType.SELLOPT]: "Sell Option",
-  [TxType.SELLOTHER]: "Sell Other",
-  [TxType.SELLSTOCK]: "Sell Stock",
-  [TxType.INCOME]: "Income",
-  [TxType.INVEXPENSE]: "Expense",
-  [TxType.REINVEST]: "Reinvest",
-  [TxType.RETOFCAP]: "Return of Capital",
-  [TxType.SPLIT]: "Split",
-  [TxType.TRANSFER]: "Transfer",
-  [TxType.JRNLFUND]: "Journal Fund",
-  [TxType.JRNLSEC]: "Journal Security",
-  [TxType.MARGININTEREST]: "Margin Interest",
-  [TxType.CLOSUREOPT]: "Option Closure",
-  [TxType.CASHFLOW]: "Cash Flow",
-};
-
-// Labels for the non-asset side of an event. USER postings are the ordinary case and
-// carry no badge; the rest are shown so that a group's legs can be told apart, which
-// is also how an imbalance becomes visible rather than silently absorbed.
-const ACCOUNT_TYPE_LABEL: Record<number, string> = {
-  [AccountType.EQUITY]: "Equity",
-  [AccountType.INCOME]: "Income",
-  [AccountType.EXPENSE]: "Expense",
-  [AccountType.IMBALANCE]: "Imbalance",
-  [AccountType.TRANSFER_CLEARING]: "In Flight",
-};
 
 export default function TxsPage() {
   const { state, authError } = useAuth();

--- a/client/lib/portfolio-api.test.ts
+++ b/client/lib/portfolio-api.test.ts
@@ -1,13 +1,19 @@
 import { create, toBinary } from "@bufbuild/protobuf";
 import {
+  CountResidualBalancesResponseSchema,
   CreatePortfolioResponseSchema,
   GetJobResponseSchema,
   ListInstrumentsResponseSchema,
   ListPortfoliosResponseSchema,
+  ListResidualBalancesResponseSchema,
   UpdatePortfolioResponseSchema,
+  AccountType,
   AssetClass,
+  Broker,
   IdentifierType,
+  TxType,
 } from "@/gen/api/v1/api_pb";
+import { timestampFromDate } from "@bufbuild/protobuf/wkt";
 import { JobStatus } from "@/gen/api/v1/api_pb";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
@@ -17,6 +23,8 @@ import {
   deletePortfolio,
   getJob,
   listInstruments,
+  listResidualBalances,
+  countResidualBalances,
 } from "./portfolio-api";
 import * as grpcWeb from "./grpc-web";
 
@@ -266,6 +274,82 @@ describe("portfolio-api", () => {
       expect(result.validationErrors[0]).toMatchObject({ rowIndex: 0, field: "timestamp", message: "required" });
       expect(result.identificationErrors).toHaveLength(1);
       expect(result.identificationErrors[0].instrumentDescription).toBe("FOO");
+    });
+  });
+  describe("listResidualBalances", () => {
+    it("maps balances and converts timestamps to Dates", async () => {
+      const oldest = new Date("2026-03-01T12:00:00Z");
+      mockUnaryFetch.mockResolvedValue(
+        toBinary(
+          ListResidualBalancesResponseSchema,
+          create(ListResidualBalancesResponseSchema, {
+            balances: [
+              {
+                accountType: AccountType.IMBALANCE,
+                broker: Broker.FIDELITY,
+                account: "X123",
+                instrumentId: "inst-1",
+                commodity: "USD",
+                assetClass: AssetClass.CASH,
+                txType: TxType.INCOME,
+                balance: -1234.56,
+                postingCount: 7,
+                oldestTimestamp: timestampFromDate(oldest),
+              },
+            ],
+          })
+        )
+      );
+
+      const balances = await listResidualBalances();
+
+      expect(balances).toHaveLength(1);
+      expect(balances[0]).toMatchObject({
+        accountType: AccountType.IMBALANCE,
+        broker: Broker.FIDELITY,
+        account: "X123",
+        commodity: "USD",
+        assetClass: AssetClass.CASH,
+        txType: TxType.INCOME,
+        balance: -1234.56,
+        postingCount: 7,
+      });
+      expect(balances[0].oldestTimestamp?.getTime()).toBe(oldest.getTime());
+      // A row with no posting on the outstanding side stays undated rather than
+      // acquiring the epoch.
+      expect(balances[0].newestTimestamp).toBeUndefined();
+      expect(mockUnaryFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        "portfoliodb.api.v1.ApiService/ListResidualBalances",
+        expect.any(Uint8Array),
+        { credentials: "include" }
+      );
+    });
+
+    it("returns an empty list when nothing is outstanding", async () => {
+      mockUnaryFetch.mockResolvedValue(
+        toBinary(ListResidualBalancesResponseSchema, create(ListResidualBalancesResponseSchema, {}))
+      );
+      expect(await listResidualBalances()).toEqual([]);
+    });
+  });
+
+  describe("countResidualBalances", () => {
+    it("returns both headline counts", async () => {
+      mockUnaryFetch.mockResolvedValue(
+        toBinary(
+          CountResidualBalancesResponseSchema,
+          create(CountResidualBalancesResponseSchema, { imbalanceCount: 3, staleTransferCount: 1 })
+        )
+      );
+
+      expect(await countResidualBalances()).toEqual({ imbalanceCount: 3, staleTransferCount: 1 });
+      expect(mockUnaryFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        "portfoliodb.api.v1.ApiService/CountResidualBalances",
+        expect.any(Uint8Array),
+        { credentials: "include" }
+      );
     });
   });
 });

--- a/client/lib/portfolio-api.ts
+++ b/client/lib/portfolio-api.ts
@@ -99,6 +99,11 @@ import {
   ListUnhandledCorporateEventsRequestSchema,
   ListUnhandledCorporateEventsResponseSchema,
   ResolveUnhandledCorporateEventRequestSchema,
+  ListResidualBalancesRequestSchema,
+  ListResidualBalancesResponseSchema,
+  CountResidualBalancesRequestSchema,
+  CountResidualBalancesResponseSchema,
+  AccountType,
   AssetClass,
   JobStatus,
   WorkerState,
@@ -124,6 +129,7 @@ import type {
   Portfolio as GenPortfolio,
   PortfolioFilterProto,
   PortfolioTx,
+  ResidualBalance as ResidualBalanceProto,
   ValidationError,
   Worker as WorkerProto,
 } from "@/gen/api/v1/api_pb";
@@ -1091,4 +1097,81 @@ export async function resolveUnhandledCorporateEvent(id: string): Promise<void> 
   await unaryFetch(base, ApiServicePrefix + "ResolveUnhandledCorporateEvent", toBinary(ResolveUnhandledCorporateEventRequestSchema, req), {
     credentials: "include",
   });
+}
+
+// Residual balances
+
+/**
+ * The net value left in one non-asset account: what events of one tx type left
+ * over in one broker account in one commodity. Balances are per commodity and are
+ * never converted, so `assetClass` decides whether a row is money or a quantity.
+ */
+export interface ResidualBalance {
+  accountType: AccountType;
+  broker: number;
+  account: string;
+  instrumentId: string;
+  commodity: string;
+  assetClass: AssetClass;
+  txType: number;
+  balance: number;
+  postingCount: number;
+  /**
+   * Oldest and newest postings contributing to the balance. For a transfer these
+   * are not the age of a missing side: nothing pairs the two sides of a journal
+   * until transfers are matched, so a settled transfer is reported like an open
+   * one.
+   */
+  oldestTimestamp?: Date;
+  newestTimestamp?: Date;
+}
+
+/**
+ * List residual balances across all users (admin only). Omitting the period
+ * bounds reports all of history.
+ */
+export async function listResidualBalances(params?: {
+  periodFrom?: Date;
+  periodBefore?: Date;
+  accountType?: AccountType;
+}): Promise<ResidualBalance[]> {
+  const base = getBaseUrl();
+  const req = create(ListResidualBalancesRequestSchema, {
+    periodFrom: params?.periodFrom ? timestampFromDate(params.periodFrom) : undefined,
+    periodBefore: params?.periodBefore ? timestampFromDate(params.periodBefore) : undefined,
+    accountType: params?.accountType ?? AccountType.UNSPECIFIED,
+  });
+  const resBytes = await unaryFetch(base, ApiServicePrefix + "ListResidualBalances", toBinary(ListResidualBalancesRequestSchema, req), {
+    credentials: "include",
+  });
+  const res = fromBinary(ListResidualBalancesResponseSchema, resBytes);
+  return (res.balances ?? []).map((b: ResidualBalanceProto) => ({
+    accountType: b.accountType,
+    broker: b.broker,
+    account: b.account,
+    instrumentId: b.instrumentId,
+    commodity: b.commodity,
+    assetClass: b.assetClass,
+    txType: b.txType,
+    balance: b.balance,
+    postingCount: b.postingCount,
+    oldestTimestamp: b.oldestTimestamp ? timestampDate(b.oldestTimestamp) : undefined,
+    newestTimestamp: b.newestTimestamp ? timestampDate(b.newestTimestamp) : undefined,
+  }));
+}
+
+export interface ResidualBalanceCounts {
+  imbalanceCount: number;
+  staleTransferCount: number;
+}
+
+/** Headline counts for the admin dashboard (admin only). */
+export async function countResidualBalances(staleAfterDays?: number): Promise<ResidualBalanceCounts> {
+  const base = getBaseUrl();
+  const req = create(CountResidualBalancesRequestSchema, { staleAfterDays: staleAfterDays ?? 0 });
+  const resBytes = await unaryFetch(base, ApiServicePrefix + "CountResidualBalances", toBinary(CountResidualBalancesRequestSchema, req), {
+    credentials: "include",
+  });
+  const res = fromBinary(CountResidualBalancesResponseSchema, resBytes);
+  return { imbalanceCount: res.imbalanceCount, staleTransferCount: res.staleTransferCount };
 }

--- a/client/lib/query-keys.ts
+++ b/client/lib/query-keys.ts
@@ -44,4 +44,10 @@ export const qk = {
   job: (jobId: string) => ["job", jobId] as const,
   inflationIndices: (currency: string, dateFrom: string, dateTo: string) =>
     ["inflation-indices", currency, dateFrom, dateTo] as const,
+  // Called with no arguments to invalidate every period variant.
+  residualBalances: (periodFrom?: string, periodBefore?: string) =>
+    periodFrom === undefined
+      ? (["residual-balances"] as const)
+      : (["residual-balances", periodFrom, periodBefore ?? ""] as const),
+  residualBalanceCounts: () => ["residual-balance-counts"] as const,
 };

--- a/client/lib/residual-balance.test.ts
+++ b/client/lib/residual-balance.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from "vitest";
+import { AccountType, AssetClass, Broker, TxType } from "@/gen/api/v1/api_pb";
+import type { ResidualBalance } from "./portfolio-api";
+import { ageInDays, groupByBroker, isMoney, transferAgeBucket } from "./residual-balance";
+
+const NOW = new Date("2026-08-03T12:00:00Z");
+
+function daysAgo(n: number): Date {
+  return new Date(NOW.getTime() - n * 24 * 60 * 60 * 1000);
+}
+
+function balance(overrides: Partial<ResidualBalance> = {}): ResidualBalance {
+  return {
+    accountType: AccountType.IMBALANCE,
+    broker: Broker.IBKR,
+    account: "A1",
+    instrumentId: "inst-usd",
+    commodity: "USD",
+    assetClass: AssetClass.CASH,
+    txType: TxType.INCOME,
+    balance: -100,
+    postingCount: 1,
+    ...overrides,
+  };
+}
+
+describe("transferAgeBucket", () => {
+  const cases: { name: string; days: number; want: string }[] = [
+    { name: "just imported", days: 0, want: "fresh" },
+    { name: "still within the window", days: 6, want: "fresh" },
+    { name: "on the stale boundary", days: 7, want: "stale" },
+    { name: "late but not missing", days: 29, want: "stale" },
+    { name: "on the loud boundary", days: 30, want: "loud" },
+    { name: "long gone", days: 400, want: "loud" },
+  ];
+  for (const c of cases) {
+    it(`${c.name} (${c.days}d) is ${c.want}`, () => {
+      expect(transferAgeBucket(daysAgo(c.days), NOW)).toBe(c.want);
+    });
+  }
+
+  it("treats an undated balance as fresh rather than drawing attention to it", () => {
+    expect(transferAgeBucket(undefined, NOW)).toBe("fresh");
+  });
+});
+
+describe("ageInDays", () => {
+  it("floors to whole days", () => {
+    expect(ageInDays(daysAgo(3.7), NOW)).toBe(3);
+  });
+
+  it("is null when the row cannot be dated", () => {
+    expect(ageInDays(undefined, NOW)).toBeNull();
+  });
+});
+
+describe("isMoney", () => {
+  it("is true for a currency", () => {
+    expect(isMoney(balance())).toBe(true);
+  });
+
+  it("is false for a security, whose balance is a share count", () => {
+    expect(isMoney(balance({ assetClass: AssetClass.STOCK, commodity: "AAPL" }))).toBe(false);
+  });
+
+  it("is false for an unidentified instrument, which we cannot call money", () => {
+    expect(isMoney(balance({ assetClass: AssetClass.UNSPECIFIED }))).toBe(false);
+  });
+});
+
+describe("groupByBroker", () => {
+  it("subtotals per commodity and never sums across them", () => {
+    const groups = groupByBroker([
+      balance({ balance: -100, commodity: "USD" }),
+      balance({ balance: -50, commodity: "USD", txType: TxType.BUYSTOCK }),
+      balance({ balance: 25, commodity: "AAPL", assetClass: AssetClass.STOCK }),
+    ]);
+
+    expect(groups).toHaveLength(1);
+    const subtotals = groups[0].subtotals;
+    expect(subtotals).toHaveLength(2);
+    expect(subtotals.find((s) => s.commodity === "USD")).toMatchObject({
+      balance: -150,
+      postingCount: 2,
+    });
+    expect(subtotals.find((s) => s.commodity === "AAPL")).toMatchObject({ balance: 25 });
+  });
+
+  it("puts the broker with the largest exposure first", () => {
+    const groups = groupByBroker([
+      balance({ broker: Broker.IBKR, balance: -10 }),
+      balance({ broker: Broker.FIDELITY, balance: -5000 }),
+      balance({ broker: Broker.SCHB, balance: -200 }),
+    ]);
+    expect(groups.map((g) => g.broker)).toEqual([Broker.FIDELITY, Broker.SCHB, Broker.IBKR]);
+  });
+
+  it("orders rows within a broker by magnitude, sign aside", () => {
+    const groups = groupByBroker([
+      balance({ balance: 5, account: "small" }),
+      balance({ balance: -900, account: "big" }),
+      balance({ balance: 40, account: "middle" }),
+    ]);
+    expect(groups[0].rows.map((r) => r.account)).toEqual(["big", "middle", "small"]);
+  });
+
+  it("returns nothing for no rows", () => {
+    expect(groupByBroker([])).toEqual([]);
+  });
+});

--- a/client/lib/residual-balance.ts
+++ b/client/lib/residual-balance.ts
@@ -1,0 +1,106 @@
+import { AssetClass } from "@/gen/api/v1/api_pb";
+import type { ResidualBalance } from "./portfolio-api";
+
+/**
+ * How old a transfer balance must be before it is worth a second look. This is
+ * age alone: nothing pairs the two sides of a journal until transfers are
+ * matched, so an old balance may be a settled transfer rather than a missing
+ * side.
+ */
+export const TRANSFER_STALE_DAYS = 7;
+
+export const TRANSFER_LOUD_DAYS = 30;
+
+export type AgeBucket = "fresh" | "stale" | "loud";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Bucket a transfer balance by the age of its oldest posting. An undated one is
+ * treated as fresh: the report should not draw attention to something it cannot
+ * date.
+ */
+export function transferAgeBucket(oldest: Date | undefined, now: Date): AgeBucket {
+  if (!oldest) return "fresh";
+  const days = (now.getTime() - oldest.getTime()) / DAY_MS;
+  if (days >= TRANSFER_LOUD_DAYS) return "loud";
+  if (days >= TRANSFER_STALE_DAYS) return "stale";
+  return "fresh";
+}
+
+/** Whole days since the oldest contributing posting. */
+export function ageInDays(oldest: Date | undefined, now: Date): number | null {
+  if (!oldest) return null;
+  return Math.floor((now.getTime() - oldest.getTime()) / DAY_MS);
+}
+
+/**
+ * A balance in a currency is money; one in a security is a quantity of shares.
+ * The two are never summed and never formatted the same way. An unidentified
+ * instrument counts as a quantity: rendering an unknown commodity as money would
+ * assert something the data does not say.
+ */
+export function isMoney(b: ResidualBalance): boolean {
+  return b.assetClass === AssetClass.CASH;
+}
+
+export interface CommoditySubtotal {
+  commodity: string;
+  assetClass: AssetClass;
+  balance: number;
+  postingCount: number;
+}
+
+export interface BrokerGroup {
+  broker: number;
+  /** Per-commodity totals: the headline number for this broker. */
+  subtotals: CommoditySubtotal[];
+  rows: ResidualBalance[];
+}
+
+/**
+ * Group rows by broker, with a per-commodity subtotal each. Commodities are kept
+ * apart rather than summed because a residual in USD and one in AAPL shares are
+ * not addable, and a single "total" over them would be a fiction.
+ *
+ * Brokers are ordered by their largest single commodity exposure, and rows within
+ * a broker by magnitude, so the converter worth fixing first is at the top.
+ */
+export function groupByBroker(rows: ResidualBalance[]): BrokerGroup[] {
+  const byBroker = new Map<number, ResidualBalance[]>();
+  for (const r of rows) {
+    const existing = byBroker.get(r.broker);
+    if (existing) existing.push(r);
+    else byBroker.set(r.broker, [r]);
+  }
+
+  const groups: BrokerGroup[] = [];
+  for (const [broker, brokerRows] of byBroker) {
+    const byCommodity = new Map<string, CommoditySubtotal>();
+    for (const r of brokerRows) {
+      const existing = byCommodity.get(r.commodity);
+      if (existing) {
+        existing.balance += r.balance;
+        existing.postingCount += r.postingCount;
+      } else {
+        byCommodity.set(r.commodity, {
+          commodity: r.commodity,
+          assetClass: r.assetClass,
+          balance: r.balance,
+          postingCount: r.postingCount,
+        });
+      }
+    }
+    groups.push({
+      broker,
+      subtotals: [...byCommodity.values()].sort((a, b) => Math.abs(b.balance) - Math.abs(a.balance)),
+      rows: [...brokerRows].sort((a, b) => Math.abs(b.balance) - Math.abs(a.balance)),
+    });
+  }
+
+  return groups.sort((a, b) => {
+    const aMax = Math.max(...a.subtotals.map((s) => Math.abs(s.balance)));
+    const bMax = Math.max(...b.subtotals.map((s) => Math.abs(s.balance)));
+    return bMax - aMax;
+  });
+}

--- a/client/lib/tx-type.ts
+++ b/client/lib/tx-type.ts
@@ -1,0 +1,39 @@
+import { AccountType, TxType } from "@/gen/api/v1/api_pb";
+
+/** Human-readable labels for each tx type. */
+export const TX_TYPE_LABEL: Record<number, string> = {
+  [TxType.BUYDEBT]: "Buy Debt",
+  [TxType.BUYMF]: "Buy MF",
+  [TxType.BUYOPT]: "Buy Option",
+  [TxType.BUYOTHER]: "Buy Other",
+  [TxType.BUYSTOCK]: "Buy Stock",
+  [TxType.SELLDEBT]: "Sell Debt",
+  [TxType.SELLMF]: "Sell MF",
+  [TxType.SELLOPT]: "Sell Option",
+  [TxType.SELLOTHER]: "Sell Other",
+  [TxType.SELLSTOCK]: "Sell Stock",
+  [TxType.INCOME]: "Income",
+  [TxType.INVEXPENSE]: "Expense",
+  [TxType.REINVEST]: "Reinvest",
+  [TxType.RETOFCAP]: "Return of Capital",
+  [TxType.SPLIT]: "Split",
+  [TxType.TRANSFER]: "Transfer",
+  [TxType.JRNLFUND]: "Journal Fund",
+  [TxType.JRNLSEC]: "Journal Security",
+  [TxType.MARGININTEREST]: "Margin Interest",
+  [TxType.CLOSUREOPT]: "Option Closure",
+  [TxType.CASHFLOW]: "Cash Flow",
+  [TxType.BUYFUTURE]: "Buy Future",
+  [TxType.SELLFUTURE]: "Sell Future",
+};
+
+// Labels for the non-asset side of an event. USER postings are the ordinary case and
+// carry no badge; the rest are shown so that a group's legs can be told apart, which
+// is also how an imbalance becomes visible rather than silently absorbed.
+export const ACCOUNT_TYPE_LABEL: Record<number, string> = {
+  [AccountType.EQUITY]: "Equity",
+  [AccountType.INCOME]: "Income",
+  [AccountType.EXPENSE]: "Expense",
+  [AccountType.IMBALANCE]: "Imbalance",
+  [AccountType.TRANSFER_CLEARING]: "In Flight",
+};

--- a/server/service/api/residual_balances.go
+++ b/server/service/api/residual_balances.go
@@ -1,0 +1,95 @@
+package api
+
+import (
+	"context"
+	"time"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	"github.com/leedenison/portfoliodb/server/auth"
+	"github.com/leedenison/portfoliodb/server/db"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// defaultStaleTransferDays is how long a journal side may wait for its pair before
+// it is worth raising. Brokers report the two sides on separate statements, so a
+// balance is expected immediately after an import and only means something once it
+// persists.
+const defaultStaleTransferDays = 7
+
+// ListResidualBalances returns the residual balances left in non-asset accounts.
+// Admin only: it measures how lossy each broker converter is, not what is in any one
+// portfolio.
+func (s *Server) ListResidualBalances(ctx context.Context, req *apiv1.ListResidualBalancesRequest) (*apiv1.ListResidualBalancesResponse, error) {
+	if _, authErr := auth.RequireAdmin(ctx); authErr != nil {
+		return nil, authErr
+	}
+
+	opts := db.ResidualBalanceOpts{
+		From:        tsToTimePtr(req.GetPeriodFrom()),
+		Before:      tsToTimePtr(req.GetPeriodBefore()),
+		AccountType: req.GetAccountType(),
+	}
+	balances, err := s.db.ListResidualBalances(ctx, opts)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "list residual balances: %v", err)
+	}
+
+	out := make([]*apiv1.ResidualBalance, len(balances))
+	for i, b := range balances {
+		out[i] = &apiv1.ResidualBalance{
+			AccountType:     b.AccountType,
+			Broker:          b.Broker,
+			Account:         b.Account,
+			InstrumentId:    b.InstrumentID,
+			Commodity:       b.Commodity,
+			AssetClass:      db.StrToAssetClass(b.AssetClass),
+			TxType:          b.TxType,
+			Balance:         b.Balance,
+			PostingCount:    b.PostingCount,
+			OldestTimestamp: timePtrToTs(b.Oldest),
+			NewestTimestamp: timePtrToTs(b.Newest),
+		}
+	}
+	return &apiv1.ListResidualBalancesResponse{Balances: out}, nil
+}
+
+// CountResidualBalances returns the dashboard headline counts. Admin only.
+func (s *Server) CountResidualBalances(ctx context.Context, req *apiv1.CountResidualBalancesRequest) (*apiv1.CountResidualBalancesResponse, error) {
+	if _, authErr := auth.RequireAdmin(ctx); authErr != nil {
+		return nil, authErr
+	}
+
+	days := req.GetStaleAfterDays()
+	if days <= 0 {
+		days = defaultStaleTransferDays
+	}
+	// The db method takes an instant rather than a duration so that what counts as
+	// stale is decided in one place and its tests are not clock-dependent.
+	staleBefore := time.Now().UTC().AddDate(0, 0, -int(days))
+
+	imbalances, staleTransfers, err := s.db.CountResidualBalances(ctx, staleBefore)
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "count residual balances: %v", err)
+	}
+	return &apiv1.CountResidualBalancesResponse{
+		ImbalanceCount:     imbalances,
+		StaleTransferCount: staleTransfers,
+	}, nil
+}
+
+func tsToTimePtr(ts *timestamppb.Timestamp) *time.Time {
+	if ts == nil || !ts.IsValid() {
+		return nil
+	}
+	t := ts.AsTime()
+	return &t
+}
+
+func timePtrToTs(t *time.Time) *timestamppb.Timestamp {
+	if t == nil {
+		return nil
+	}
+	return timestamppb.New(*t)
+}

--- a/server/service/api/residual_balances_test.go
+++ b/server/service/api/residual_balances_test.go
@@ -1,0 +1,237 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	dbpkg "github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/testutil"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+func TestListResidualBalances_NonAdmin_PermissionDenied(t *testing.T) {
+	srv, _ := newAPIServerWithMock(t)
+	_, err := srv.ListResidualBalances(authCtx("user-1", "sub|1"), &apiv1.ListResidualBalancesRequest{})
+	testutil.RequireGRPCCode(t, err, codes.PermissionDenied)
+}
+
+func TestListResidualBalances_Unauthenticated(t *testing.T) {
+	srv, _ := newAPIServerWithMock(t)
+	_, err := srv.ListResidualBalances(ctxNoAuth(), &apiv1.ListResidualBalancesRequest{})
+	testutil.RequireGRPCCode(t, err, codes.Unauthenticated)
+}
+
+func TestListResidualBalances_Empty(t *testing.T) {
+	srv, db := newAPIServerWithMock(t)
+	db.EXPECT().ListResidualBalances(gomock.Any(), gomock.Any()).Return(nil, nil)
+
+	resp, err := srv.ListResidualBalances(adminCtx("user-1", "sub|1"), &apiv1.ListResidualBalancesRequest{})
+	if err != nil {
+		t.Fatalf("ListResidualBalances: %v", err)
+	}
+	if len(resp.GetBalances()) != 0 {
+		t.Fatalf("expected 0 balances, got %d", len(resp.GetBalances()))
+	}
+}
+
+func TestListResidualBalances_Success(t *testing.T) {
+	srv, db := newAPIServerWithMock(t)
+	oldest := time.Date(2026, 3, 1, 12, 0, 0, 0, time.UTC)
+	newest := time.Date(2026, 4, 1, 12, 0, 0, 0, time.UTC)
+	db.EXPECT().ListResidualBalances(gomock.Any(), gomock.Any()).Return([]dbpkg.ResidualBalance{
+		{
+			AccountType:  apiv1.AccountType_ACCOUNT_TYPE_IMBALANCE,
+			Broker:       apiv1.Broker_FIDELITY,
+			Account:      "X123",
+			InstrumentID: "inst-1",
+			Commodity:    "USD",
+			AssetClass:   "CASH",
+			TxType:       apiv1.TxType_INCOME,
+			Balance:      -1234.56,
+			PostingCount: 7,
+			Oldest:       &oldest,
+			Newest:       &newest,
+		},
+		{
+			// A transfer with no posting on the outstanding side reports no age.
+			AccountType:  apiv1.AccountType_ACCOUNT_TYPE_TRANSFER_CLEARING,
+			Broker:       apiv1.Broker_IBKR,
+			Account:      "U9",
+			InstrumentID: "inst-2",
+			Commodity:    "AAPL",
+			AssetClass:   "STOCK",
+			TxType:       apiv1.TxType_JRNLSEC,
+			Balance:      50,
+			PostingCount: 1,
+		},
+	}, nil)
+
+	resp, err := srv.ListResidualBalances(adminCtx("user-1", "sub|1"), &apiv1.ListResidualBalancesRequest{})
+	if err != nil {
+		t.Fatalf("ListResidualBalances: %v", err)
+	}
+	if len(resp.GetBalances()) != 2 {
+		t.Fatalf("expected 2 balances, got %d", len(resp.GetBalances()))
+	}
+
+	got := resp.GetBalances()[0]
+	if got.GetAccountType() != apiv1.AccountType_ACCOUNT_TYPE_IMBALANCE {
+		t.Errorf("account type = %v, want IMBALANCE", got.GetAccountType())
+	}
+	if got.GetBroker() != apiv1.Broker_FIDELITY {
+		t.Errorf("broker = %v, want FIDELITY", got.GetBroker())
+	}
+	if got.GetAccount() != "X123" || got.GetInstrumentId() != "inst-1" {
+		t.Errorf("account/instrument = %q/%q, want X123/inst-1", got.GetAccount(), got.GetInstrumentId())
+	}
+	if got.GetCommodity() != "USD" {
+		t.Errorf("commodity = %q, want USD", got.GetCommodity())
+	}
+	if got.GetAssetClass() != apiv1.AssetClass_ASSET_CLASS_CASH {
+		t.Errorf("asset class = %v, want CASH", got.GetAssetClass())
+	}
+	if got.GetTxType() != apiv1.TxType_INCOME {
+		t.Errorf("tx type = %v, want INCOME", got.GetTxType())
+	}
+	if got.GetBalance() != -1234.56 {
+		t.Errorf("balance = %v, want -1234.56", got.GetBalance())
+	}
+	if got.GetPostingCount() != 7 {
+		t.Errorf("posting count = %d, want 7", got.GetPostingCount())
+	}
+	if !got.GetOldestTimestamp().AsTime().Equal(oldest) {
+		t.Errorf("oldest = %v, want %v", got.GetOldestTimestamp().AsTime(), oldest)
+	}
+	if !got.GetNewestTimestamp().AsTime().Equal(newest) {
+		t.Errorf("newest = %v, want %v", got.GetNewestTimestamp().AsTime(), newest)
+	}
+
+	second := resp.GetBalances()[1]
+	if second.GetOldestTimestamp() != nil || second.GetNewestTimestamp() != nil {
+		t.Errorf("expected unset timestamps for a balance with none, got %v/%v",
+			second.GetOldestTimestamp(), second.GetNewestTimestamp())
+	}
+	if second.GetAssetClass() != apiv1.AssetClass_ASSET_CLASS_STOCK {
+		t.Errorf("asset class = %v, want STOCK (a quantity, not money)", second.GetAssetClass())
+	}
+}
+
+// TestListResidualBalances_Filters verifies the request bounds and account type
+// reach the db layer, since a filter silently dropped here would show a report of
+// the wrong period without saying so.
+func TestListResidualBalances_Filters(t *testing.T) {
+	srv, db := newAPIServerWithMock(t)
+	from := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+
+	var got dbpkg.ResidualBalanceOpts
+	db.EXPECT().ListResidualBalances(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ any, opts dbpkg.ResidualBalanceOpts) ([]dbpkg.ResidualBalance, error) {
+			got = opts
+			return nil, nil
+		})
+
+	_, err := srv.ListResidualBalances(adminCtx("user-1", "sub|1"), &apiv1.ListResidualBalancesRequest{
+		PeriodFrom:   timestamppb.New(from),
+		PeriodBefore: timestamppb.New(before),
+		AccountType:  apiv1.AccountType_ACCOUNT_TYPE_TRANSFER_CLEARING,
+	})
+	if err != nil {
+		t.Fatalf("ListResidualBalances: %v", err)
+	}
+	if got.From == nil || !got.From.Equal(from) {
+		t.Errorf("from = %v, want %v", got.From, from)
+	}
+	if got.Before == nil || !got.Before.Equal(before) {
+		t.Errorf("before = %v, want %v", got.Before, before)
+	}
+	if got.AccountType != apiv1.AccountType_ACCOUNT_TYPE_TRANSFER_CLEARING {
+		t.Errorf("account type = %v, want TRANSFER_CLEARING", got.AccountType)
+	}
+}
+
+// TestListResidualBalances_UnsetPeriodIsOpen verifies an omitted bound is open
+// rather than becoming the zero time, which would filter everything out.
+func TestListResidualBalances_UnsetPeriodIsOpen(t *testing.T) {
+	srv, db := newAPIServerWithMock(t)
+	var got dbpkg.ResidualBalanceOpts
+	db.EXPECT().ListResidualBalances(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ any, opts dbpkg.ResidualBalanceOpts) ([]dbpkg.ResidualBalance, error) {
+			got = opts
+			return nil, nil
+		})
+
+	if _, err := srv.ListResidualBalances(adminCtx("user-1", "sub|1"), &apiv1.ListResidualBalancesRequest{}); err != nil {
+		t.Fatalf("ListResidualBalances: %v", err)
+	}
+	if got.From != nil || got.Before != nil {
+		t.Errorf("expected open bounds, got from=%v before=%v", got.From, got.Before)
+	}
+}
+
+func TestCountResidualBalances_NonAdmin_PermissionDenied(t *testing.T) {
+	srv, _ := newAPIServerWithMock(t)
+	_, err := srv.CountResidualBalances(authCtx("user-1", "sub|1"), &apiv1.CountResidualBalancesRequest{})
+	testutil.RequireGRPCCode(t, err, codes.PermissionDenied)
+}
+
+func TestCountResidualBalances_Unauthenticated(t *testing.T) {
+	srv, _ := newAPIServerWithMock(t)
+	_, err := srv.CountResidualBalances(ctxNoAuth(), &apiv1.CountResidualBalancesRequest{})
+	testutil.RequireGRPCCode(t, err, codes.Unauthenticated)
+}
+
+func TestCountResidualBalances_Success(t *testing.T) {
+	srv, db := newAPIServerWithMock(t)
+	db.EXPECT().CountResidualBalances(gomock.Any(), gomock.Any()).Return(int32(3), int32(1), nil)
+
+	resp, err := srv.CountResidualBalances(adminCtx("user-1", "sub|1"), &apiv1.CountResidualBalancesRequest{})
+	if err != nil {
+		t.Fatalf("CountResidualBalances: %v", err)
+	}
+	if resp.GetImbalanceCount() != 3 {
+		t.Errorf("imbalance count = %d, want 3", resp.GetImbalanceCount())
+	}
+	if resp.GetStaleTransferCount() != 1 {
+		t.Errorf("stale transfer count = %d, want 1", resp.GetStaleTransferCount())
+	}
+}
+
+// TestCountResidualBalances_StaleWindow verifies the request's stale window is
+// applied, and that omitting it selects the default rather than counting every open
+// transfer as stale.
+func TestCountResidualBalances_StaleWindow(t *testing.T) {
+	cases := []struct {
+		name     string
+		days     int32
+		wantDays int
+	}{
+		{"default", 0, defaultStaleTransferDays},
+		{"explicit", 30, 30},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv, db := newAPIServerWithMock(t)
+			var got time.Time
+			db.EXPECT().CountResidualBalances(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ any, staleBefore time.Time) (int32, int32, error) {
+					got = staleBefore
+					return 0, 0, nil
+				})
+
+			before := time.Now().UTC()
+			if _, err := srv.CountResidualBalances(adminCtx("user-1", "sub|1"),
+				&apiv1.CountResidualBalancesRequest{StaleAfterDays: tc.days}); err != nil {
+				t.Fatalf("CountResidualBalances: %v", err)
+			}
+			// A window rather than an equality: the handler reads the clock itself.
+			want := before.AddDate(0, 0, -tc.wantDays)
+			if got.Before(want.Add(-time.Minute)) || got.After(want.Add(time.Minute)) {
+				t.Errorf("staleBefore = %v, want ~%v (%d days back)", got, want, tc.wantDays)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Second of three PRs for 0039. **Stacked on #306** -- review that first; this PR's
diff is against it.

Adds the admin-gated handlers over the db aggregate, plus the client transport and
the display logic that needs testing. Nothing is reachable in the UI yet; PR 3 adds
the page.

## Server

`ListResidualBalances` and `CountResidualBalances`, gated by `auth.RequireAdmin` per
handler like the rest of the admin surface.

The count bounds transfers by age alone, defaulting to seven days. That is not a
count of problems: until transfers are matched (0068) a settled transfer is
indistinguishable from an open one, so it counts old imported transfers and the UI
presents it as a fact rather than something to act on.

The handler resolves the window to an absolute instant before calling the db layer,
so what counts as stale is decided in one place and the db tests are not
clock-dependent.

## Client

- `listResidualBalances` / `countResidualBalances` in the usual transport shape.
- `lib/residual-balance.ts` holds the parts worth testing -- age bucketing and
  per-broker, per-commodity subtotals. It lives in `lib` because page components have
  no unit coverage in this repo. Commodities are subtotalled separately and never
  summed: a residual in USD and one in AAPL shares are not addable, and a single
  total over them would be a fiction.
- `TX_TYPE_LABEL` / `ACCOUNT_TYPE_LABEL` move out of the transactions page into
  `lib/tx-type.ts`, a pure move, so the report shares them instead of growing a
  second copy. The move also picked up `BUYFUTURE` / `SELLFUTURE`, which the original
  map was missing.

## Testing

`make check`, `make server-test` and `make client-test` pass. New: nine handler tests
(auth on both RPCs, field mapping including unset timestamps, filters reaching the db
opts, unset bounds staying open, and the default vs explicit stale window) and 16
client tests over the bucket boundaries, money-vs-quantity, subtotals and ordering,
plus transport coverage for both calls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)