### PR TITLE
Report residual balances in the admin UI (0039)

### DIFF
--- a/client/app/admin/imbalance/page.tsx
+++ b/client/app/admin/imbalance/page.tsx
@@ -1,0 +1,292 @@
+"use client";
+
+import { useState } from "react";
+import { useAuthedQuery } from "@/hooks/use-authed-query";
+import { errorMessage } from "@/lib/errors";
+import { qk } from "@/lib/query-keys";
+import { dayAfter } from "@/lib/dates";
+import { formatCurrency } from "@/lib/format";
+import { getBrokerLabel } from "@/lib/csv/converters";
+import { ACCOUNT_TYPE_LABEL, TX_TYPE_LABEL } from "@/lib/tx-type";
+import { ErrorAlert } from "@/app/components/error-alert";
+import { listResidualBalances, type ResidualBalance } from "@/lib/portfolio-api";
+import { ageInDays, groupByBroker, isMoney, transferAgeBucket } from "@/lib/residual-balance";
+import { AccountType, AssetClass, TxType, type Broker } from "@/gen/api/v1/api_pb";
+
+type Tab = "imbalance" | "transfers";
+
+function TabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick?: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      className={
+        active
+          ? "border-b-2 border-accent px-4 py-2 text-sm font-medium text-accent"
+          : "px-4 py-2 text-sm font-medium text-text-muted hover:text-text-primary"
+      }
+      onClick={onClick}
+    >
+      {children}
+    </button>
+  );
+}
+
+/**
+ * A balance in a currency is money; one in a security is a quantity of shares.
+ * They are formatted differently and never added together.
+ */
+function amount(b: { balance: number; commodity: string; assetClass: AssetClass }): string {
+  if (isMoney(b)) return formatCurrency(b.balance, b.commodity);
+  return `${b.balance.toLocaleString(undefined, { maximumFractionDigits: 4 })} ${b.commodity}`;
+}
+
+export default function AdminImbalancePage() {
+  const [tab, setTab] = useState<Tab>("imbalance");
+  const [dateFrom, setDateFrom] = useState("");
+  const [dateTo, setDateTo] = useState("");
+
+  const {
+    data: balances = [],
+    isPending: loading,
+    error: loadError,
+  } = useAuthedQuery<ResidualBalance[]>({
+    queryKey: qk.residualBalances(dateFrom, dateTo),
+    queryFn: () => {
+      // The pickers are inclusive; the API bound is exclusive.
+      const before = dayAfter(dateTo);
+      return listResidualBalances({
+        periodFrom: dateFrom ? new Date(dateFrom) : undefined,
+        periodBefore: before ? new Date(before) : undefined,
+      });
+    },
+  });
+
+  const error = loadError ? errorMessage(loadError, "Failed to load residual balances") : null;
+  const imbalances = balances.filter((b) => b.accountType === AccountType.IMBALANCE);
+  const transfers = balances
+    .filter((b) => b.accountType === AccountType.TRANSFER_CLEARING)
+    .sort((a, b) => (a.oldestTimestamp?.getTime() ?? Infinity) - (b.oldestTimestamp?.getTime() ?? Infinity));
+
+  return (
+    <div data-testid="page-imbalance" className="space-y-4">
+      <h1 className="font-display text-xl font-bold text-text-primary">Imbalance</h1>
+      <p className="max-w-3xl text-sm text-text-muted">
+        What each broker converter failed to capture. A group whose postings do not sum
+        to zero has its residual routed to {ACCOUNT_TYPE_LABEL[AccountType.IMBALANCE]},
+        so the size of these balances is a direct measure of how lossy each converter
+        is. Balances are per commodity and are never converted between them.
+      </p>
+
+      {error && <ErrorAlert>{error}</ErrorAlert>}
+
+      <div className="flex flex-wrap items-end gap-3">
+        <label className="flex flex-col gap-1 text-xs text-text-muted">
+          From
+          <input
+            type="date"
+            value={dateFrom}
+            onChange={(e) => setDateFrom(e.target.value)}
+            className="rounded-md border border-border bg-surface px-2 py-1.5 text-sm text-text-primary focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary/30"
+          />
+        </label>
+        <label className="flex flex-col gap-1 text-xs text-text-muted">
+          To
+          <input
+            type="date"
+            value={dateTo}
+            onChange={(e) => setDateTo(e.target.value)}
+            className="rounded-md border border-border bg-surface px-2 py-1.5 text-sm text-text-primary focus:border-primary focus:outline-hidden focus:ring-1 focus:ring-primary/30"
+          />
+        </label>
+        {(dateFrom || dateTo) && (
+          <button
+            type="button"
+            onClick={() => {
+              setDateFrom("");
+              setDateTo("");
+            }}
+            className="rounded-sm border border-border px-3 py-1.5 text-xs hover:bg-background"
+          >
+            Clear
+          </button>
+        )}
+      </div>
+
+      <div className="flex gap-0 border-b border-border">
+        <TabButton active={tab === "imbalance"} onClick={() => setTab("imbalance")}>
+          Imbalance
+        </TabButton>
+        <TabButton active={tab === "transfers"} onClick={() => setTab("transfers")}>
+          Unmatched transfers
+        </TabButton>
+      </div>
+
+      {tab === "imbalance" && (
+        <ImbalanceTab rows={imbalances} loading={loading} hasError={error !== null} />
+      )}
+      {tab === "transfers" && (
+        <TransfersTab rows={transfers} loading={loading} hasError={error !== null} />
+      )}
+    </div>
+  );
+}
+
+function ImbalanceTab({
+  rows,
+  loading,
+  hasError,
+}: {
+  rows: ResidualBalance[];
+  loading: boolean;
+  hasError: boolean;
+}) {
+  if (loading && rows.length === 0) return <p className="text-text-muted">Loading balances...</p>;
+  if (rows.length === 0 && !hasError) {
+    return <p className="text-text-muted">No imbalances. Every group balances.</p>;
+  }
+
+  const groups = groupByBroker(rows);
+  return (
+    <div className="space-y-3">
+      <p className="max-w-3xl text-xs text-text-muted">
+        Expect uncategorised income to dominate until each converter emits the income
+        and expense legs of its single-row dividends and charges. The tx type separates
+        the two: an {TX_TYPE_LABEL[TxType.INCOME]} balance is a dividend we do not categorise yet,
+        a trade balance is a fee the broker did not report. A negative balance is value
+        arriving from outside the ledger, which is what an uncategorised dividend looks
+        like.
+      </p>
+      <table data-testid="imbalance-table" className="w-full text-left text-sm">
+        <thead>
+          <tr className="border-b border-border text-text-muted">
+            <th className="py-2 pr-4 font-medium">Account</th>
+            <th className="py-2 pr-4 font-medium">Commodity</th>
+            <th className="py-2 pr-4 font-medium">Event</th>
+            <th className="py-2 pr-4 text-right font-medium">Balance</th>
+            <th className="py-2 text-right font-medium">Postings</th>
+          </tr>
+        </thead>
+        {groups.map((g) => (
+          <tbody key={g.broker} data-testid="imbalance-broker-group">
+            <tr className="border-b border-border bg-primary-dark/3">
+              <th colSpan={3} className="py-2 pr-4 text-left font-display font-semibold text-text-primary">
+                {getBrokerLabel(g.broker as Broker)}
+              </th>
+              <td
+                data-testid="imbalance-subtotal"
+                className="py-2 pr-4 text-right font-mono text-text-primary"
+              >
+                {g.subtotals.map((s) => (
+                  <span key={s.commodity} className="ml-3 inline-block">
+                    {amount(s)}
+                  </span>
+                ))}
+              </td>
+              <td className="py-2 text-right font-mono text-text-muted">
+                {g.subtotals.reduce((n, s) => n + s.postingCount, 0)}
+              </td>
+            </tr>
+            {g.rows.map((r) => (
+              <tr
+                key={`${r.account}|${r.instrumentId}|${r.txType}`}
+                data-testid="imbalance-row"
+                className="border-b border-border"
+              >
+                <td className="py-2 pr-4 pl-4 font-mono text-text-primary">{r.account || "\u2014"}</td>
+                <td className="py-2 pr-4 font-mono text-text-muted">{r.commodity}</td>
+                <td className="py-2 pr-4 text-text-muted">{TX_TYPE_LABEL[r.txType] ?? r.txType}</td>
+                <td className="py-2 pr-4 text-right font-mono tabular-nums text-text-primary">
+                  {amount(r)}
+                </td>
+                <td className="py-2 text-right font-mono tabular-nums text-text-muted">
+                  {r.postingCount}
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        ))}
+      </table>
+      <p className="text-xs text-text-muted">
+        Drilling into the groups behind a balance is not implemented yet.
+      </p>
+    </div>
+  );
+}
+
+function TransfersTab({
+  rows,
+  loading,
+  hasError,
+}: {
+  rows: ResidualBalance[];
+  loading: boolean;
+  hasError: boolean;
+}) {
+  if (loading && rows.length === 0) return <p className="text-text-muted">Loading transfers...</p>;
+  if (rows.length === 0 && !hasError) {
+    return <p className="text-text-muted">No transfer balances.</p>;
+  }
+
+  const now = new Date();
+  return (
+    <div className="space-y-3">
+      <div className="max-w-3xl rounded-md border border-border bg-surface p-3 text-xs text-text-muted">
+        <p className="font-semibold text-text-primary">
+          These are every imported transfer, not the unmatched ones.
+        </p>
+        <p className="mt-1">
+          Each side of a journal is posted against a clearing account and nothing
+          pairs the two, so a completed transfer is indistinguishable from one whose
+          second side never arrived. Both are listed here. Until transfer matching
+          lands, a balance below says a transfer was imported, and its age is the age
+          of the posting rather than of anything missing.
+        </p>
+      </div>
+      <table data-testid="transfers-table" className="w-full text-left text-sm">
+        <thead>
+          <tr className="border-b border-border text-text-muted">
+            <th className="py-2 pr-4 font-medium">Broker</th>
+            <th className="py-2 pr-4 font-medium">Account</th>
+            <th className="py-2 pr-4 font-medium">Commodity</th>
+            <th className="py-2 pr-4 font-medium">Event</th>
+            <th className="py-2 pr-4 text-right font-medium">Balance</th>
+            <th className="py-2 text-right font-medium">Waiting</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((r) => {
+            const bucket = transferAgeBucket(r.oldestTimestamp, now);
+            const days = ageInDays(r.oldestTimestamp, now);
+            return (
+              <tr
+                key={`${r.broker}|${r.account}|${r.instrumentId}|${r.txType}`}
+                data-testid="transfer-row"
+                data-age-bucket={bucket}
+                className="border-b border-border"
+              >
+                <td className="py-2 pr-4 text-text-primary">{getBrokerLabel(r.broker as Broker)}</td>
+                <td className="py-2 pr-4 font-mono text-text-primary">{r.account || "\u2014"}</td>
+                <td className="py-2 pr-4 font-mono text-text-muted">{r.commodity}</td>
+                <td className="py-2 pr-4 text-text-muted">{TX_TYPE_LABEL[r.txType] ?? r.txType}</td>
+                <td className="py-2 pr-4 text-right font-mono tabular-nums text-text-primary">
+                  {amount(r)}
+                </td>
+                <td className="py-2 text-right font-mono tabular-nums text-text-muted">
+                  {days === null ? "\u2014" : `${days}d`}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/client/app/admin/layout.tsx
+++ b/client/app/admin/layout.tsx
@@ -32,6 +32,7 @@ const adminNav: NavItem[] = [
   {
     section: "Diagnostics",
     children: [
+      { href: "/admin/imbalance", label: "Imbalance" },
       { href: "/admin/logs", label: "Logs", disabled: true },
       { href: "/admin/telemetry", label: "Telemetry" },
       { href: "/admin/workers", label: "Workers" },

--- a/client/app/admin/page.tsx
+++ b/client/app/admin/page.tsx
@@ -2,6 +2,7 @@
 
 import { useAuthedQuery } from "@/hooks/use-authed-query";
 import { qk } from "@/lib/query-keys";
+import { TRANSFER_STALE_DAYS } from "@/lib/residual-balance";
 import Link from "next/link";
 import {
   listIdentifierPlugins,
@@ -9,7 +10,9 @@ import {
   listPricePlugins,
   listWorkers,
   countUnhandledCorporateEvents,
+  countResidualBalances,
   WorkerState,
+  type ResidualBalanceCounts,
   type WorkerRow,
 } from "@/lib/portfolio-api";
 
@@ -74,6 +77,13 @@ const dashboardCards: {
     description: "View session token and fetch a Google ID token for scripts.",
   },
   {
+    id: "imbalance",
+    title: "Imbalance",
+    href: "/admin/imbalance",
+    description:
+      "Residual and unmatched-transfer balances by broker: how lossy each converter is.",
+  },
+  {
     id: "corporate-events",
     title: "Corporate Events",
     href: "/admin/corporate-events",
@@ -120,6 +130,14 @@ export default function AdminOverviewPage() {
     queryKey: qk.unhandledCorporateEventCount(),
     queryFn: countUnhandledCorporateEvents,
   });
+  const { data: residualCounts } = useAuthedQuery<ResidualBalanceCounts>({
+    queryKey: qk.residualBalanceCounts(),
+    queryFn: () => countResidualBalances(),
+  });
+  // Only imbalances draw attention. The transfer count includes settled
+  // transfers -- nothing pairs the two sides of a journal yet -- so it is
+  // reported as a fact rather than as something to act on.
+  const residualAttention = (residualCounts?.imbalanceCount ?? 0) > 0;
 
   function pluginSummary(
     id: string
@@ -142,6 +160,14 @@ export default function AdminOverviewPage() {
       return unhandledEventCount > 0
         ? `${unhandledEventCount} unhandled`
         : "No unhandled events";
+    }
+    if (id === "imbalance") {
+      if (!residualCounts) return null;
+      const imbalanced = residualAttention
+        ? `${residualCounts.imbalanceCount} imbalanced`
+        : "Everything balances";
+      // The count is bounded by age, so the window is named rather than implied.
+      return `${imbalanced}, ${residualCounts.staleTransferCount} transfers in flight over ${TRANSFER_STALE_DAYS}d`;
     }
     return null;
   }
@@ -176,7 +202,8 @@ export default function AdminOverviewPage() {
               <p className="mt-1.5 text-sm text-text-muted">{card.description}</p>
               {summary && (
                 <p className={`mt-3 font-mono text-xs ${
-                  card.id === "corporate-events" && unhandledEventCount > 0
+                  (card.id === "corporate-events" && unhandledEventCount > 0) ||
+                  (card.id === "imbalance" && residualAttention)
                     ? "text-amber-600 dark:text-amber-400"
                     : "text-text-muted"
                 }`}>

--- a/client/lib/residual-balance.ts
+++ b/client/lib/residual-balance.ts
@@ -40,7 +40,7 @@ export function ageInDays(oldest: Date | undefined, now: Date): number | null {
  * instrument counts as a quantity: rendering an unknown commodity as money would
  * assert something the data does not say.
  */
-export function isMoney(b: ResidualBalance): boolean {
+export function isMoney(b: { assetClass: AssetClass }): boolean {
   return b.assetClass === AssetClass.CASH;
 }
 

--- a/docs/issues/0039-imbalance-report.md
+++ b/docs/issues/0039-imbalance-report.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Imbalance and unmatched-transfer reporting
 milestone: M12
 dependencies: [0038]
@@ -52,6 +52,19 @@ becomes a problem when it persists, because the second side legitimately arrives
 in a later statement. Reporting the raw balance would flag every transfer ever
 imported. Age the balance -- how long a side has been waiting -- so that a
 recently imported transfer is quiet and a stale one is loud.
+
+**Not delivered, and deliberately so.** Age alone does not identify an unmatched
+transfer. Both sides of a completed journal are `TRANSFER_CLEARING` postings in
+different broker accounts, and nothing pairs them until 0068, so a settled
+transfer and one whose second side never arrived are the same shape and both are
+reported. The report therefore lists every imported transfer and says so on the
+page.
+
+Inferring the pairing from balances was tried and rejected: every rule for it
+misattributes as soon as an account has more than one transfer open, reporting
+the wrong account and the wrong age while looking authoritative. A report that
+over-reports and admits it is better than one that quietly points at the wrong
+row. 0068 is the fix, and the transfers view becomes meaningful when it lands.
 
 ## Note
 

--- a/docs/issues/0068-match-in-flight-transfers.md
+++ b/docs/issues/0068-match-in-flight-transfers.md
@@ -20,6 +20,12 @@ Without that job the clearing account only ever grows. Every transfer ever
 imported sits in it, so the unmatched-transfer signal in 0039 and the alert in
 0066 fire on correctly imported data and carry no information.
 
+0039 shipped on that basis: its transfers view lists every imported transfer and
+says on the page that it cannot tell a settled one from an unmatched one. When
+this lands, that view can report unmatched transfers, its caveat comes off, and
+the age it shows becomes the age of something actually missing. The dashboard
+count can then flag rather than merely state.
+
 It is also a correctness prerequisite, not only hygiene. Under 0037 the cash-flow
 boundary is per account and netting happens per portfolio at query time, so an
 unmatched transfer between two accounts of the same portfolio reads as a

--- a/docs/spec/information-architecture.md
+++ b/docs/spec/information-architecture.md
@@ -104,6 +104,7 @@ Admin pages live under `/admin` and use a dedicated layout with a left sidebar. 
 | **Plugins** | Identifier | `/admin/plugins/identifier` | Active |
 | **Plugins** | Description | `/admin/plugins/description` | Active |
 | **Plugins** | Price | `/admin/plugins/price` | Active |
+| **Diagnostics** | Imbalance | `/admin/imbalance` | Active |
 | **Diagnostics** | Logs | `/admin/logs` | Disabled |
 | **Diagnostics** | Telemetry | `/admin/telemetry` | Active |
 | **Diagnostics** | Authentication | `/admin/tools` | Active |
@@ -113,7 +114,8 @@ Admin pages live under `/admin` and use a dedicated layout with a left sidebar. 
  * **Dashboard** is the admin landing page and should provide a dashboard-style summary with quick links to the most important admin functions.
  * **Reference Data** groups Instruments and Prices.  These are the data stewardship pages the admin visits most frequently.  Both are active.
  * **Plugins** lists individual plugin types: Identifier (`/admin/plugins/identifier`), Description (`/admin/plugins/description`) and Price (`/admin/plugins/price`).  Each plugin page shows configuration and telemetry for that plugin type.  All are active.
- * **Diagnostics** groups Logs, Telemetry and Authentication.  Telemetry (`/admin/telemetry`) and Authentication (`/admin/tools`) are active; Logs is disabled until implemented.
+ * **Diagnostics** groups Imbalance, Logs, Telemetry and Authentication.  Telemetry (`/admin/telemetry`) and Authentication (`/admin/tools`) are active; Logs is disabled until implemented.
+ * **Imbalance** (`/admin/imbalance`) reports the residual and transfer-clearing balances left in non-asset accounts, aggregated across all users and grouped by broker, account, commodity and the event that left them.  It is an admin surface because it measures how lossy each broker converter is rather than what is in any one portfolio, and it carries no user identity.  The per-user view of the same data belongs with user alerts.  Until the two sides of a transfer are matched, the transfers view lists every imported transfer rather than the unmatched ones, and says so.
  * Section headers (Reference Data, Plugins, Diagnostics) are non-clickable labels that organise the sidebar visually.
 
 ### Mobile Considerations

--- a/e2e/fixtures/residual-balances.sql
+++ b/e2e/fixtures/residual-balances.sql
@@ -1,0 +1,57 @@
+-- Residual postings for the admin imbalance report.
+--
+-- In production these rows are written by ingestion, which routes the residual of
+-- an unbalanced group to IMBALANCE and each side of a journal to
+-- TRANSFER_CLEARING. Seeding them directly keeps the fixture about the report
+-- rather than about the converters.
+--
+-- Timestamps are relative to now() so the age assertions do not rot.
+
+-- A dividend the converter reported as cash only, so its income leg is missing and
+-- the whole value lands in Imbalance. Negative: value arriving from outside the
+-- ledger.
+INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type,
+                 quantity, trading_currency, settlement_currency, instrument_id, account_type)
+SELECT 'e2e00000-0000-0000-0000-000000000001', 'FIDELITY', 'ACC-1',
+       now() - INTERVAL '5 days', 'USD', 'INCOME', -137.08, 'USD', 'USD', i.instrument_id, 'IMBALANCE'
+FROM (SELECT instrument_id FROM instrument_identifiers
+      WHERE identifier_type = 'CURRENCY' AND value = 'USD' LIMIT 1) i;
+
+-- A trade whose price and cash total disagree: the commission the broker netted
+-- into the total and did not report separately.
+INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type,
+                 quantity, trading_currency, settlement_currency, instrument_id, account_type)
+SELECT 'e2e00000-0000-0000-0000-000000000001', 'FIDELITY', 'ACC-1',
+       now() - INTERVAL '6 days', 'USD', 'BUYSTOCK', 4.95, 'USD', 'USD', i.instrument_id, 'IMBALANCE'
+FROM (SELECT instrument_id FROM instrument_identifiers
+      WHERE identifier_type = 'CURRENCY' AND value = 'USD' LIMIT 1) i;
+
+-- A journal between two Schwab accounts whose second side did arrive. Both sides
+-- are TRANSFER_CLEARING postings, so the report has to consume them against each
+-- other; neither should appear.
+INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type,
+                 quantity, trading_currency, settlement_currency, instrument_id, account_type)
+SELECT 'e2e00000-0000-0000-0000-000000000001', 'SCHB', v.account,
+       now() - (v.days || ' days')::INTERVAL, 'USD', 'JRNLFUND', v.qty, 'USD', 'USD',
+       i.instrument_id, 'TRANSFER_CLEARING'
+FROM (VALUES ('SCH-1', 1000.00, '60'), ('SCH-2', -1000.00, '59')) AS v(account, qty, days),
+     (SELECT instrument_id FROM instrument_identifiers
+      WHERE identifier_type = 'CURRENCY' AND value = 'USD' LIMIT 1) i;
+
+-- One side of a transfer out of an IBKR account, long enough ago that the other
+-- side is not coming.
+INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type,
+                 quantity, trading_currency, settlement_currency, instrument_id, account_type)
+SELECT 'e2e00000-0000-0000-0000-000000000001', 'IBKR', 'U-OLD',
+       now() - INTERVAL '40 days', 'USD', 'JRNLFUND', 500.00, 'USD', 'USD', i.instrument_id, 'TRANSFER_CLEARING'
+FROM (SELECT instrument_id FROM instrument_identifiers
+      WHERE identifier_type = 'CURRENCY' AND value = 'USD' LIMIT 1) i;
+
+-- A transfer imported two days ago whose other side may still be on its way. It
+-- must stay quiet.
+INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type,
+                 quantity, trading_currency, settlement_currency, instrument_id, account_type)
+SELECT 'e2e00000-0000-0000-0000-000000000001', 'IBKR', 'U-NEW',
+       now() - INTERVAL '2 days', 'USD', 'JRNLFUND', 250.00, 'USD', 'USD', i.instrument_id, 'TRANSFER_CLEARING'
+FROM (SELECT instrument_id FROM instrument_identifiers
+      WHERE identifier_type = 'CURRENCY' AND value = 'USD' LIMIT 1) i;

--- a/e2e/tests/admin-imbalance.spec.ts
+++ b/e2e/tests/admin-imbalance.spec.ts
@@ -1,0 +1,90 @@
+import { test, expect } from "@playwright/test";
+import { seedSession, injectSession, closeRedis } from "../helpers/auth";
+import { resetAndSeedBase, seedFixture, closeDB } from "../helpers/db";
+
+test.beforeAll(async () => {
+  await resetAndSeedBase();
+  await seedFixture("residual-balances.sql");
+});
+
+test.afterAll(async () => {
+  await closeRedis();
+  await closeDB();
+});
+
+test.describe("admin imbalance page", () => {
+  let adminSessionId: string;
+
+  test.beforeAll(async () => {
+    adminSessionId = await seedSession("admin");
+  });
+
+  test("reports imbalances by broker, split by the event that left them", async ({
+    context,
+    page,
+  }) => {
+    await injectSession(context, adminSessionId);
+    await page.goto("/admin/imbalance");
+
+    await expect(page.locator("[data-testid='page-imbalance']")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    const table = page.locator("[data-testid='imbalance-table']");
+    await expect(table).toBeVisible({ timeout: 10_000 });
+
+    // The uncategorised dividend and the unreported fee are separate rows: they
+    // lead to different converter work.
+    const rows = page.locator("[data-testid='imbalance-row']");
+    await expect(rows).toHaveCount(2);
+    await expect(rows.filter({ hasText: "Income" })).toHaveCount(1);
+    await expect(rows.filter({ hasText: "Buy Stock" })).toHaveCount(1);
+
+    // One broker, and its subtotal nets the two.
+    await expect(page.locator("[data-testid='imbalance-broker-group']")).toHaveCount(1);
+    await expect(page.locator("[data-testid='imbalance-subtotal']")).toContainText("132.13");
+  });
+
+  test("lists every transfer balance, aged, until matching lands", async ({ context, page }) => {
+    await injectSession(context, adminSessionId);
+    await page.goto("/admin/imbalance");
+    await expect(page.locator("[data-testid='page-imbalance']")).toBeVisible({
+      timeout: 10_000,
+    });
+
+    await page.getByRole("button", { name: "Unmatched transfers" }).click();
+    await expect(page.locator("[data-testid='transfers-table']")).toBeVisible();
+
+    // Nothing pairs the two sides of a journal yet, so the completed Schwab
+    // transfer is listed alongside the two IBKR sides rather than being resolved
+    // away. The page says so rather than implying all four need attention.
+    const rows = page.locator("[data-testid='transfer-row']");
+    await expect(rows).toHaveCount(4);
+    await expect(rows.filter({ hasText: "SCH-" })).toHaveCount(2);
+    await expect(
+      page.getByText("These are every imported transfer, not the unmatched ones.")
+    ).toBeVisible();
+
+    // The age shown is the age of the posting.
+    await expect(rows.filter({ hasText: "U-OLD" })).toHaveAttribute("data-age-bucket", "loud");
+    await expect(rows.filter({ hasText: "U-NEW" })).toHaveAttribute("data-age-bucket", "fresh");
+  });
+
+  test("dashboard card summarises what needs attention", async ({ context, page }) => {
+    await injectSession(context, adminSessionId);
+    await page.goto("/admin");
+
+    // Scoped past the sidebar link to the same route.
+    const card = page.locator("a[href='/admin/imbalance']").filter({ hasText: "how lossy" });
+    await expect(card).toBeVisible({ timeout: 10_000 });
+    // Two imbalanced keys. The transfer count is stated, not flagged.
+    await expect(card).toContainText("2 imbalanced, 3 transfers in flight over 7d");
+  });
+
+  test("non-admin user sees access denied", async ({ context, page }) => {
+    const userSessionId = await seedSession("user");
+    await injectSession(context, userSessionId);
+    await page.goto("/admin/imbalance");
+    await expect(page.getByText("Access denied")).toBeVisible();
+  });
+});


### PR DESCRIPTION
Last of three PRs for 0039. **Stacked on #307**, which is stacked on #306. Closes
0039.

Adds `/admin/imbalance` under Diagnostics, plus the dashboard card.

## Imbalance tab

Groups by broker with a per-commodity subtotal as the headline -- the number that says
which converter to fix first -- then breaks each broker down by account, commodity and
the event that left the balance. Balances in a currency are formatted as money;
balances in a security are share counts and never join a money subtotal.

Two things a reader would otherwise get wrong, so the page states them:

- Uncategorised income will dominate until each converter emits the income and
  expense legs of its single-row dividends and charges. The tx type column is what
  separates that from the missing-fee residuals the report exists to find.
- A *negative* imbalance means value arriving from outside the ledger, which is what
  an uncategorised dividend looks like. The signed number is the truth, but it reads
  backwards without the explanation.

## Transfers tab lists everything, and leads with why

Nothing pairs the two sides of a journal until 0068, so a completed transfer and one
whose second side never arrived are the same shape. The tab therefore lists every
imported transfer and opens by saying so, rather than presenting rows as defects:

> These are every imported transfer, not the unmatched ones.

Consequences of that, all deliberate:

- The age column is neutral rather than escalating to amber and red. Colour would
  assert a problem the data cannot identify.
- The dashboard card *states* the transfer count ("3 transfers in flight over 7d")
  rather than flagging it, and only imbalances turn the card amber. The window is
  named in the label because the count is bounded by age.
- `data-age-bucket` stays on the rows, so colour can come back when the signal means
  something.

0068 gains a note describing what it unlocks here; 0039 records the limitation and
why inferring the pairing was rejected.

## Also

- `docs/spec/information-architecture.md` gains the sidebar row and a behaviour
  bullet. The table was already missing Workers, Corporate Events and Inflation;
  fixing that is out of scope here.
- Drill-through to the contributing groups is a text placeholder, per the CLAUDE.md
  rule.
- The e2e fixture seeds a completed Schwab journal alongside two open IBKR sides; the
  spec asserts all four appear and that the caveat is on the page.

## Testing

`make check`, `make client-test` and `make e2e-test` pass (33 e2e specs, four of them
new: both tabs, the dashboard card, and the mandatory non-admin access-denied case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)