### PR TITLE
Emit income and expense counter-legs from the Fidelity converters (0040)

### DIFF
--- a/client/lib/csv/converters/fidelity-csv.test.ts
+++ b/client/lib/csv/converters/fidelity-csv.test.ts
@@ -1,5 +1,7 @@
 import { describe, it, expect } from "vitest";
+import { AccountType, TxType } from "@/gen/api/v1/api_pb";
 import { convertFidelityToStandard, FIDELITY_TYPE_TO_OFX } from "./fidelity-csv";
+import { expectGroupsBalance } from "@/lib/csv/group-balance.test-utils";
 
 const HEADER =
   "Order date,Completion date,Transaction type,Investments,Account Number,Quantity,Price per unit";
@@ -64,7 +66,8 @@ describe("convertFidelityToStandard", () => {
     ].join("\n");
     const result = convertFidelityToStandard(csv, { currency: "USD" });
     expect(result.errors).toEqual([]);
-    expect(result.txs.length).toBe(1);
+    // The cash row plus the income it came from.
+    expect(result.txs.length).toBe(2);
     expect(result.txs[0]!.type).toBe(11); // INCOME
     expect(result.txs[0]!.quantity).toBe(3.27);
     expect(result.txs[0]!.settlementCurrency).toBe("USD");
@@ -81,8 +84,11 @@ describe("convertFidelityToStandard", () => {
     ].join("\n");
     const result = convertFidelityToStandard(csv, { currency: "GBP" });
     expect(result.errors).toEqual([]);
-    expect(result.txs.length).toBe(types.length);
-    expect(new Set(result.txs.map((tx) => tx.type))).toEqual(
+    // Counter-legs are appended for the one-sided rows, so count the postings
+    // that came from a source row: those are the ones a type maps to.
+    const source = result.txs.filter((tx) => tx.accountType === AccountType.UNSPECIFIED);
+    expect(source.length).toBe(types.length);
+    expect(new Set(source.map((tx) => tx.type))).toEqual(
       new Set(Object.values(FIDELITY_TYPE_TO_OFX))
     );
   });
@@ -243,14 +249,18 @@ describe("transaction grouping", () => {
     expect(result.txs[1].groupRef).toBe("563466632");
   });
 
-  it("leaves separately reported charges ungrouped", () => {
+  it("keeps a separately reported charge out of the trade's group", () => {
     const result = convert([
       row("Sell", "WISE PLC (WISE)", "AG1", "-7266.49", "1242", "5.85", "563466569"),
       row("Cash In From Sell", "Cash", "AG1", "7266.49", "7266.49", "1", "563466571"),
       row("Dealing Fee", "Cash", "AG1", "-10", "0", "0", "563466600", "8 Feb 2022"),
     ]);
 
-    expect(result.txs[2].groupRef).toBe("");
+    // It has a group of its own -- it needs one to hold its expense leg -- but
+    // Fidelity dates it on the order date while the trade settles later, so
+    // folding it into the trade would misdate it.
+    expect(result.txs[2].groupRef).not.toBe("");
+    expect(result.txs[2].groupRef).not.toBe(result.txs[0].groupRef);
   });
 
   it("does not cross-pair two sells settling the same day in one account", () => {
@@ -358,5 +368,94 @@ describe("transaction grouping", () => {
     expect(result.errors).toHaveLength(0);
     expect(result.txs).toHaveLength(1);
     expect(result.txs[0].groupRef).toBe("");
+  });
+});
+
+describe("counter-legs", () => {
+  const HEAD =
+    "Order date,Completion date,Transaction type,Investments,Product Wrapper,Account Number,Source investment,Amount,Quantity,Price per unit,Reference Number,Status";
+  const row = (
+    type: string,
+    investments: string,
+    account: string,
+    amount: string,
+    quantity: string,
+    price: string,
+    ref: string,
+    completion = "10 Feb 2022"
+  ) =>
+    `8 Feb 2022,${completion},${type},"${investments}",Investment Account,${account},,${amount},${quantity},${price},${ref},Completed`;
+
+  const convert = (rows: string[]) =>
+    convertFidelityToStandard([HEAD, ...rows].join("\n"), { currency: "GBP" });
+
+  it("names the account a charge went to", () => {
+    const result = convert([row("Dealing Fee", "Cash", "AG1", "-10", "10", "1", "563466600")]);
+
+    expect(result.txs).toHaveLength(2);
+    expect(result.txs[1].type).toBe(TxType.INVEXPENSE);
+    expect(result.txs[1].accountType).toBe(AccountType.EXPENSE);
+    expect(result.txs[1].quantity).toBe(10);
+    expect(result.txs[1].groupRef).toBe(result.txs[0].groupRef);
+    expectGroupsBalance(result.txs);
+  });
+
+  it("names the account a dividend came from", () => {
+    const result = convert([row("Cash Dividend", "Cash", "AG1", "23.40", "23.40", "1", "563466601")]);
+
+    expect(result.txs).toHaveLength(2);
+    expect(result.txs[1].accountType).toBe(AccountType.INCOME);
+    expect(result.txs[1].quantity).toBe(-23.4);
+    expectGroupsBalance(result.txs);
+  });
+
+  it("leaves a trade and its cash leg alone -- the source supplied both", () => {
+    const result = convert([
+      row("Sell", "WISE PLC (WISE)", "AG1", "-7265.70", "1242", "5.85", "563466569"),
+      row("Cash In From Sell", "Cash", "AG1", "7265.70", "7265.70", "1", "563466571"),
+    ]);
+
+    expect(result.txs).toHaveLength(2);
+    expectGroupsBalance(result.txs);
+  });
+
+  it("balances a trade, its cash leg and the charge reported beside it", () => {
+    const result = convert([
+      row("Sell", "WISE PLC (WISE)", "AG1", "-7265.70", "1242", "5.85", "563466569"),
+      row("Cash In From Sell", "Cash", "AG1", "7265.70", "7265.70", "1", "563466571"),
+      row("Dealing Fee", "Cash", "AG1", "-10", "10", "1", "563466600", "8 Feb 2022"),
+    ]);
+
+    expect(result.txs).toHaveLength(4);
+    expectGroupsBalance(result.txs);
+  });
+
+  it("does not invent a leg for a journal, whose other side is another account", () => {
+    const result = convert([row("Cash In", "Cash", "AG1", "5000", "5000", "1", "563466602")]);
+
+    expect(result.txs).toHaveLength(1);
+    expect(result.txs[0].type).toBe(TxType.JRNLFUND);
+  });
+});
+
+describe("trade cash legs", () => {
+  const HEAD =
+    "Order date,Completion date,Transaction type,Investments,Product Wrapper,Account Number,Source investment,Amount,Quantity,Price per unit,Reference Number,Status";
+  const convert = (rows: string[]) =>
+    convertFidelityToStandard([HEAD, ...rows].join("\n"), { currency: "GBP" });
+
+  // Typing these JRNLFUND made every trade group read as a transfer, so its
+  // residual was routed to TRANSFER_CLEARING instead of IMBALANCE.
+  it("are CASHFLOW, keeping their direction and currency", () => {
+    const result = convert([
+      "8 Feb 2022,10 Feb 2022,Cash Out For Buy,Cash,Investment Account,AG1,,-401,401,1,730493547,Completed",
+      "8 Feb 2022,10 Feb 2022,Cash In From Sell,Cash,Investment Account,AG1,,7265.70,7265.70,1,563466571,Completed",
+    ]);
+
+    expect(result.txs[0].type).toBe(TxType.CASHFLOW);
+    expect(result.txs[0].quantity).toBe(-401);
+    expect(result.txs[0].tradingCurrency).toBe("GBP");
+    expect(result.txs[1].type).toBe(TxType.CASHFLOW);
+    expect(result.txs[1].quantity).toBe(7265.7);
   });
 });

--- a/client/lib/csv/converters/fidelity-csv.ts
+++ b/client/lib/csv/converters/fidelity-csv.ts
@@ -13,6 +13,7 @@ import type { Tx } from "@/gen/api/v1/api_pb";
 import { TxSchema, TxType } from "@/gen/api/v1/api_pb";
 import type { StandardParseResult, ParseError } from "@/lib/csv/standard";
 import { parseCSVLine } from "@/lib/csv/standard";
+import { counterLegs } from "@/lib/csv/postings";
 
 const FIDELITY_DATE_FORMAT = /^(\d{1,2})\s+([A-Za-z]{3})\s+(\d{4})$/;
 const MONTHS: Record<string, number> = {
@@ -56,10 +57,16 @@ export const FIDELITY_TYPE_TO_OFX: Record<string, TxType> = {
   "Cash In Ring-fenced For Fees": TxType.TRANSFER,
   "Cash In": TxType.JRNLFUND,
   "Cash In Lump Sum": TxType.JRNLFUND,
-  "Cash In From Sell": TxType.JRNLFUND,
   "Cash In For Transfer": TxType.JRNLFUND,
-  "Cash Out For Buy": TxType.JRNLFUND,
-  "Cash Out For Buy From Transfer": TxType.JRNLFUND,
+  // The cash leg of a trade, not a journal: these pair 1:1 with their trade rows
+  // and settle inside the account. Typing them JRNLFUND made the whole trade
+  // group read as a transfer, so its residual was routed to TRANSFER_CLEARING
+  // rather than IMBALANCE and never reached the report that measures converter
+  // lossiness. The types above keep JRNLFUND because their other side really is
+  // outside the account.
+  "Cash In From Sell": TxType.CASHFLOW,
+  "Cash Out For Buy": TxType.CASHFLOW,
+  "Cash Out For Buy From Transfer": TxType.CASHFLOW,
 };
 
 export function isCashTxType(type: TxType): boolean {
@@ -69,7 +76,8 @@ export function isCashTxType(type: TxType): boolean {
     type === TxType.REINVEST ||
     type === TxType.TRANSFER ||
     type === TxType.MARGININTEREST ||
-    type === TxType.RETOFCAP
+    type === TxType.RETOFCAP ||
+    type === TxType.CASHFLOW
   );
 }
 
@@ -358,6 +366,10 @@ export function convertFidelityToStandard(
   assignFidelityGroups(legs).forEach((ref, i) => {
     if (ref) txs[i].groupRef = ref;
   });
+  // After the refs are stamped, since that loop is index-parallel with legs.
+  // Fidelity nets nothing into a trade total, so no fee is derived here: its
+  // charges arrive as their own rows and only need the account they went to.
+  txs.push(...counterLegs(txs));
 
   const periodFrom = minTime === Infinity ? new Date(0) : new Date(minTime);
   const periodBefore =

--- a/client/lib/csv/group-balance.test-utils.ts
+++ b/client/lib/csv/group-balance.test-utils.ts
@@ -1,0 +1,79 @@
+/**
+ * Checks converter output the way the server will: every group's postings
+ * weigh to zero.
+ *
+ * A group's postings are in different commodities, so a plain sum says nothing
+ * -- a buy is +10 AAPL and -1855 USD. This mirrors weightOf in
+ * server/service/ingestion/balance.go, reduced to the cases a converter can
+ * produce: a security leg converts to money at its price, and everything else
+ * weighs its own quantity in the settlement currency. It does not model a
+ * securities journal, whose commodity is neither.
+ *
+ * Not a test file itself -- the name keeps it out of vitest's include glob.
+ */
+
+import { expect } from "vitest";
+import type { Tx } from "@/gen/api/v1/api_pb";
+import { TxType } from "@/gen/api/v1/api_pb";
+
+/** Types whose counter-leg is money, so the posting converts at its price. */
+const EXCHANGE_TYPES = new Set<TxType>([
+  TxType.BUYDEBT,
+  TxType.BUYFUTURE,
+  TxType.BUYMF,
+  TxType.BUYOPT,
+  TxType.BUYOTHER,
+  TxType.BUYSTOCK,
+  TxType.SELLDEBT,
+  TxType.SELLFUTURE,
+  TxType.SELLMF,
+  TxType.SELLOPT,
+  TxType.SELLOTHER,
+  TxType.SELLSTOCK,
+  TxType.REINVEST,
+  TxType.CLOSUREOPT,
+]);
+
+/** Half a cent, matching moneyTolerance in balance.go. */
+const TOLERANCE = 0.005;
+
+/** What a posting contributes to its group's balance, and in what commodity. */
+export function weigh(tx: Tx): { amount: number; commodity: string } {
+  const settle = (tx.settlementCurrency || tx.tradingCurrency).toUpperCase();
+  if (EXCHANGE_TYPES.has(tx.type)) {
+    // With no price there is nothing to convert at, so the residual stays in the
+    // security -- which is the signal that the source omitted a price.
+    if (tx.unitPrice === undefined || !settle) {
+      return { amount: tx.quantity, commodity: tx.instrumentDescription };
+    }
+    return { amount: tx.quantity * tx.unitPrice, commodity: settle };
+  }
+  return { amount: tx.quantity, commodity: settle || tx.instrumentDescription };
+}
+
+/**
+ * What each group fails to account for, keyed by group_ref then commodity, with
+ * balanced groups and commodities left out. Empty when everything balances.
+ *
+ * A posting with no group_ref is its own group, as the server treats it.
+ */
+export function residuals(txs: Tx[]): Record<string, Record<string, number>> {
+  const sums: Record<string, Record<string, number>> = {};
+  txs.forEach((tx, i) => {
+    const ref = tx.groupRef || `#${i}`;
+    const { amount, commodity } = weigh(tx);
+    sums[ref] ??= {};
+    sums[ref][commodity] = (sums[ref][commodity] ?? 0) + amount;
+  });
+  const out: Record<string, Record<string, number>> = {};
+  for (const [ref, byCommodity] of Object.entries(sums)) {
+    const left = Object.entries(byCommodity).filter(([, v]) => Math.abs(v) >= TOLERANCE);
+    if (left.length > 0) out[ref] = Object.fromEntries(left);
+  }
+  return out;
+}
+
+/** Asserts every group in the batch balances. */
+export function expectGroupsBalance(txs: Tx[]): void {
+  expect(residuals(txs)).toEqual({});
+}

--- a/client/lib/csv/postings.test.ts
+++ b/client/lib/csv/postings.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from "vitest";
+import { create } from "@bufbuild/protobuf";
+import type { MessageInitShape } from "@bufbuild/protobuf";
+import { timestampFromDate } from "@bufbuild/protobuf/wkt";
+import type { Tx } from "@/gen/api/v1/api_pb";
+import { AccountType, IdentifierType, TxSchema, TxType } from "@/gen/api/v1/api_pb";
+import { counterLeg, counterLegs, feeLeg, refPrefix, FEE_EPSILON } from "./postings";
+import { expectGroupsBalance } from "./group-balance.test-utils";
+
+const tx = (fields: MessageInitShape<typeof TxSchema>): Tx =>
+  create(TxSchema, {
+    timestamp: timestampFromDate(new Date(2026, 1, 1)),
+    instrumentDescription: "GBP",
+    quantity: 0,
+    account: "ACC-1",
+    tradingCurrency: "GBP",
+    settlementCurrency: "GBP",
+    ...fields,
+  });
+
+describe("counterLeg", () => {
+  it("sends a charge to expense and a dividend to income", () => {
+    const charge = counterLeg(tx({ type: TxType.INVEXPENSE, quantity: -3.24 }));
+    expect(charge?.accountType).toBe(AccountType.EXPENSE);
+    expect(charge?.quantity).toBe(3.24);
+
+    const dividend = counterLeg(tx({ type: TxType.INCOME, quantity: 23.4 }));
+    expect(dividend?.accountType).toBe(AccountType.INCOME);
+    expect(dividend?.quantity).toBe(-23.4);
+  });
+
+  it("carries the group, account and currencies of the posting it mirrors", () => {
+    const source = tx({
+      type: TxType.INVEXPENSE,
+      quantity: -3.24,
+      groupRef: "fee-1",
+      account: "ACC-9",
+      tradingCurrency: "EUR",
+      settlementCurrency: "USD",
+    });
+    const leg = counterLeg(source)!;
+    expect(leg.groupRef).toBe("fee-1");
+    expect(leg.account).toBe("ACC-9");
+    expect(leg.tradingCurrency).toBe("EUR");
+    expect(leg.settlementCurrency).toBe("USD");
+    expect(leg.timestamp).toEqual(source.timestamp);
+  });
+
+  it("leaves the posting it mirrors alone", () => {
+    const source = tx({ type: TxType.INCOME, quantity: 23.4 });
+    counterLeg(source);
+    expect(source.quantity).toBe(23.4);
+    expect(source.accountType).toBe(AccountType.UNSPECIFIED);
+  });
+
+  it("returns nothing for a type whose other side the source already supplied", () => {
+    expect(counterLeg(tx({ type: TxType.BUYSTOCK, quantity: 10 }))).toBeUndefined();
+    expect(counterLeg(tx({ type: TxType.CASHFLOW, quantity: -10 }))).toBeUndefined();
+  });
+
+  it("returns nothing for a type whose other side is another account", () => {
+    // A journal's pair arrives in a different statement, which is 0068's problem.
+    expect(counterLeg(tx({ type: TxType.JRNLFUND, quantity: 500 }))).toBeUndefined();
+    expect(counterLeg(tx({ type: TxType.TRANSFER, quantity: 500 }))).toBeUndefined();
+  });
+
+  it("does not mirror a counter-leg", () => {
+    const leg = counterLeg(tx({ type: TxType.INVEXPENSE, quantity: -3.24 }))!;
+    expect(counterLeg(leg)).toBeUndefined();
+  });
+});
+
+describe("feeLeg", () => {
+  const trade = tx({ type: TxType.BUYSTOCK, quantity: 378, unitPrice: 61.06, groupRef: "t-1" });
+
+  it("posts the commission as cash leaving the account", () => {
+    const leg = feeLeg(trade, 11.54034)!;
+    expect(leg.type).toBe(TxType.INVEXPENSE);
+    expect(leg.quantity).toBe(-11.54034);
+    expect(leg.unitPrice).toBe(1);
+    expect(leg.accountType).toBe(AccountType.USER);
+    expect(leg.groupRef).toBe("t-1");
+    expect(leg.account).toBe("ACC-1");
+  });
+
+  it("is money in the settlement currency, not the instrument", () => {
+    const source = tx({
+      type: TxType.BUYSTOCK,
+      quantity: 378,
+      unitPrice: 61.06,
+      tradingCurrency: "EUR",
+      settlementCurrency: "USD",
+    });
+    const leg = feeLeg(source, 5)!;
+    expect(leg.instrumentDescription).toBe("USD");
+    expect(leg.tradingCurrency).toBe("USD");
+    expect(leg.settlementCurrency).toBe("USD");
+    expect(leg.identifierHints[0]?.type).toBe(IdentifierType.CURRENCY);
+    expect(leg.identifierHints[0]?.value).toBe("USD");
+  });
+
+  it("takes the magnitude, so a broker's sign convention does not flip it", () => {
+    expect(feeLeg(trade, -11.54)?.quantity).toBe(-11.54);
+  });
+
+  it("produces nothing below the tolerance the server routes at", () => {
+    expect(feeLeg(trade, 0)).toBeUndefined();
+    expect(feeLeg(trade, FEE_EPSILON / 2)).toBeUndefined();
+    expect(feeLeg(trade, NaN)).toBeUndefined();
+    expect(feeLeg(trade, FEE_EPSILON)).toBeDefined();
+  });
+
+  it("balances a netted trade once its counter-leg is added", () => {
+    // The broker reported -23092.22034 of cash with 11.54034 of it commission.
+    const legs = [
+      tx({ type: TxType.BUYSTOCK, quantity: 378, unitPrice: 61.06, groupRef: "t-1", instrumentDescription: "VUSA" }),
+      tx({ type: TxType.CASHFLOW, quantity: -23080.68, unitPrice: 1, groupRef: "t-1" }),
+    ];
+    legs.push(feeLeg(legs[0]!, 11.54034)!);
+    legs.push(...counterLegs(legs));
+
+    expectGroupsBalance(legs);
+    // The two cash postings in the user's own account still sum to the total the
+    // broker reported; splitting them changed where the money is attributed,
+    // not how much of it moved.
+    const cash = legs
+      .filter((l) => l.accountType !== AccountType.EXPENSE && l.type !== TxType.BUYSTOCK)
+      .reduce((sum, l) => sum + l.quantity, 0);
+    expect(cash).toBeCloseTo(-23092.22034, 5);
+  });
+});
+
+describe("refPrefix", () => {
+  it("avoids a ref the batch already uses", () => {
+    expect(refPrefix([tx({ type: TxType.INCOME, groupRef: "p0" })])).toBe("p_");
+    expect(
+      refPrefix([tx({ type: TxType.INCOME, groupRef: "p0" }), tx({ type: TxType.INCOME, groupRef: "p_1" })])
+    ).toBe("p__");
+  });
+
+  it("leaves broker refs that share no prefix alone", () => {
+    expect(refPrefix([tx({ type: TxType.INCOME, groupRef: "563466569" })])).toBe("p");
+  });
+});
+
+describe("counterLegs", () => {
+  it("groups a one-sided row with the leg that balances it", () => {
+    const txs = [tx({ type: TxType.INCOME, quantity: 23.4 })];
+    txs.push(...counterLegs(txs));
+
+    expect(txs).toHaveLength(2);
+    expect(txs[0]!.groupRef).not.toBe("");
+    expect(txs[1]!.groupRef).toBe(txs[0]!.groupRef);
+    expectGroupsBalance(txs);
+  });
+
+  it("keeps a group the converter already assigned", () => {
+    const txs = [tx({ type: TxType.INVEXPENSE, quantity: -3.24, groupRef: "563466600" })];
+    txs.push(...counterLegs(txs));
+    expect(txs[1]!.groupRef).toBe("563466600");
+  });
+
+  it("gives each one-sided row a group of its own", () => {
+    const txs = [
+      tx({ type: TxType.INCOME, quantity: 23.4 }),
+      tx({ type: TxType.INVEXPENSE, quantity: -3.24 }),
+    ];
+    txs.push(...counterLegs(txs));
+    expect(txs[0]!.groupRef).not.toBe(txs[1]!.groupRef);
+    expectGroupsBalance(txs);
+  });
+});

--- a/client/lib/csv/postings.ts
+++ b/client/lib/csv/postings.ts
@@ -1,0 +1,134 @@
+/**
+ * The postings a converter has to synthesise for a group to balance.
+ *
+ * Brokers report one-sided events: a dividend or a charge arrives as a single
+ * cash row, and a trade's commission is folded into one cash total. Under
+ * docs/adr/0021-converters-own-transaction-grouping.md the missing legs are the
+ * converter's to emit rather than the server's to infer, so these helpers build
+ * them and every converter produces the same shape.
+ *
+ * Kept free of React so the import extension can use it.
+ */
+
+import { clone, create } from "@bufbuild/protobuf";
+import { TimestampSchema } from "@bufbuild/protobuf/wkt";
+import type { Tx } from "@/gen/api/v1/api_pb";
+import {
+  AccountType,
+  IdentifierType,
+  InstrumentIdentifierSchema,
+  TxSchema,
+  TxType,
+} from "@/gen/api/v1/api_pb";
+
+/**
+ * Where the other side of a one-sided cash event came from or went to. A
+ * dividend's money comes from income and a charge's goes to expense; the broker
+ * reports only the cash. Types absent here either already balance against
+ * another posting the source supplied (a trade against its cash leg) or have
+ * their other side in a different account entirely (a journal), which is 0068's
+ * problem rather than a leg to invent.
+ */
+const COUNTER_TYPE = new Map<TxType, AccountType>([
+  [TxType.INCOME, AccountType.INCOME],
+  [TxType.RETOFCAP, AccountType.INCOME],
+  [TxType.INVEXPENSE, AccountType.EXPENSE],
+  [TxType.MARGININTEREST, AccountType.EXPENSE],
+]);
+
+/**
+ * Smallest fee worth a posting, in the settlement currency.
+ *
+ * Below this the server routes nothing (moneyTolerance in
+ * server/service/ingestion/balance.go), so a sub-cent commission would add two
+ * postings to every trade and change no balance.
+ */
+export const FEE_EPSILON = 0.005;
+
+/**
+ * The mirror of a one-sided cash posting: the same money in the account it came
+ * from or went to. Returns undefined when the type has no other side to name, or
+ * when the posting is itself a counter-leg.
+ */
+export function counterLeg(tx: Tx): Tx | undefined {
+  const accountType = COUNTER_TYPE.get(tx.type);
+  if (accountType === undefined) return undefined;
+  if (tx.accountType !== AccountType.USER && tx.accountType !== AccountType.UNSPECIFIED) {
+    return undefined;
+  }
+  const leg = clone(TxSchema, tx);
+  leg.quantity = -tx.quantity;
+  leg.accountType = accountType;
+  return leg;
+}
+
+/**
+ * The cash posting for a commission a broker folded into a trade's total.
+ *
+ * `fee` is the charge as the broker reports it, positive; the posting is
+ * negative because the money leaves the account. Its counter-leg comes from
+ * counterLeg, so a derived fee and a separately reported one end up identical.
+ * Returns undefined below FEE_EPSILON.
+ */
+export function feeLeg(from: Tx, fee: number): Tx | undefined {
+  if (!Number.isFinite(fee) || Math.abs(fee) < FEE_EPSILON) return undefined;
+  const currency = from.settlementCurrency || from.tradingCurrency;
+  return create(TxSchema, {
+    ...(from.timestamp ? { timestamp: clone(TimestampSchema, from.timestamp) } : {}),
+    // The currency code, matching how an ordinary cash row arrives, so nothing
+    // downstream has to treat a derived fee specially.
+    instrumentDescription: currency,
+    type: TxType.INVEXPENSE,
+    quantity: -Math.abs(fee),
+    unitPrice: 1,
+    account: from.account,
+    groupRef: from.groupRef,
+    accountType: AccountType.USER,
+    ...(currency
+      ? {
+          tradingCurrency: currency,
+          settlementCurrency: currency,
+          identifierHints: [
+            create(InstrumentIdentifierSchema, {
+              type: IdentifierType.CURRENCY,
+              value: currency,
+              canonical: false,
+            }),
+          ],
+        }
+      : {}),
+  });
+}
+
+/**
+ * A group_ref prefix no posting in the batch already starts with, so a
+ * synthesised ref cannot collide with a broker's own. Mirrors groupPostings in
+ * server/service/ingestion/balance.go.
+ */
+export function refPrefix(txs: Tx[]): string {
+  let prefix = "p";
+  for (const tx of txs) {
+    while (tx.groupRef.startsWith(prefix)) prefix += "_";
+  }
+  return prefix;
+}
+
+/**
+ * The counter-leg of every one-sided cash posting in the batch, for the caller
+ * to append. Postings that had no group_ref are given one in place, since a leg
+ * only balances the posting it mirrors if the two share a group.
+ */
+export function counterLegs(txs: Tx[]): Tx[] {
+  const prefix = refPrefix(txs);
+  const legs: Tx[] = [];
+  txs.forEach((tx, i) => {
+    const leg = counterLeg(tx);
+    if (!leg) return;
+    if (!tx.groupRef) {
+      tx.groupRef = `${prefix}${i}`;
+      leg.groupRef = tx.groupRef;
+    }
+    legs.push(leg);
+  });
+  return legs;
+}

--- a/docs/adr/0025-netted-cash-totals-are-split-into-legs.md
+++ b/docs/adr/0025-netted-cash-totals-are-split-into-legs.md
@@ -1,0 +1,32 @@
+# A netted cash total is split into orthogonal legs
+
+Brokers differ in how they report a trade's commission. Fidelity posts it as its
+own row on its own date; IBKR and Schwab fold it into a single cash total
+(`<TOTAL>`, `Amount`) while still reporting the commission separately
+(`<COMMISSION>`, `Fees & Comm`). Converters split the netted total into a
+consideration leg and a fee leg, so a trade group has the same shape whatever the
+broker reported and a commission is a posting everywhere rather than only where a
+broker happened to itemise it. A posting then represents one thing, which a
+netted total does not.
+
+Keeping the broker's total as a single posting and adding only the expense leg
+was considered. It balances just as well and reconciles to the statement line by
+line, but it leaves the cash posting meaning two things at once -- the
+consideration and the charge -- which is the conflation this exists to remove,
+and it makes the same trade look different depending on the broker.
+
+## Consequences
+
+The user's own cash postings still sum to the total the broker reported, so
+nothing about the cash balance changes; only its attribution does. The
+consideration leg is derived as `total + commission` rather than as
+`quantity * unit_price`, because the broker's own arithmetic is what the two cash
+legs have to add back up to, and a recomputed consideration would drift from the
+statement by the rounding in a quoted unit price.
+
+A converter with no commission to read cannot split anything, and its trades keep
+a residual in `IMBALANCE` (see adr/0021-converters-own-transaction-grouping.md).
+Deriving the fee as `|amount| - quantity * unit_price` was rejected for those:
+it is only the commission when the price and the cash total are already in the
+same currency and the price is exact, and where either fails the number is
+rounding or FX error wearing a commission's name.

--- a/docs/spec/csv-format.md
+++ b/docs/spec/csv-format.md
@@ -35,7 +35,7 @@ Each row is a **posting**: a signed amount of one commodity in one account (see 
 
 Grouping is the converter's job. The server persists what it is given: it does not infer a missing leg, pair rows, or fold a fee into a cash amount (see adr/0021-converters-own-transaction-grouping.md).
 
-**Fees are postings, not a column.** A commission, levy or duty is a row with `type=INVEXPENSE` and a negative `quantity` in the settlement currency. Put it in the trade's group when the broker charges it as part of the trade; leave it ungrouped when the broker reports it as a separate cash event on its own date. Where a broker nets commission into a single total and reports no separate charge, the converter derives the fee and emits the row itself.
+**Fees are postings, not a column.** A commission, levy or duty is a row with `type=INVEXPENSE` and a negative `quantity` in the settlement currency, paired with an `account_type=EXPENSE` row for the same money. Put the pair in the trade's group when the broker charges it as part of the trade; give it a group of its own when the broker reports it as a separate cash event on its own date. Where a broker folds the commission into a single cash total, the converter splits that total into a consideration row and a fee row rather than posting it as one (see adr/0025-netted-cash-totals-are-split-into-legs.md).
 
 A group whose postings do not sum to zero is accepted, not rejected. The server routes whatever is left over to an `IMBALANCE` posting -- or `TRANSFER_CLEARING` for a journal -- so the residual is made visible rather than silently absorbed. See [postings.md](postings.md#balancing).
 
@@ -94,6 +94,19 @@ from. Both rows carry the same `account` and `group_ref`; only `account_type` di
 date,instrument_description,type,quantity,settlement_currency,account,group_ref,account_type
 2024-02-01,USD,INCOME,23.40,USD,ACC-1,div-8842,
 2024-02-01,USD,INCOME,-23.40,USD,ACC-1,div-8842,INCOME
+```
+
+A trade whose broker charged 11.54 of commission and reported a single cash total
+of -23092.22. The commission is split out of that total, so the two rows in the
+user's own account still sum to what the broker reported and the third names the
+expense it went to.
+
+```csv
+date,instrument_description,type,quantity,settlement_currency,unit_price,account,group_ref,account_type
+2024-03-04,VUSA,BUYSTOCK,378,GBP,61.06,ACC-1,ord-4471,
+2024-03-04,GBP,CASHFLOW,-23080.68,GBP,1,ACC-1,ord-4471,
+2024-03-04,GBP,INVEXPENSE,-11.54,GBP,1,ACC-1,ord-4471,
+2024-03-04,GBP,INVEXPENSE,11.54,GBP,1,ACC-1,ord-4471,EXPENSE
 ```
 
 Any extra columns are ignored. Empty optional fields can be omitted or left blank.

--- a/extension/src/background/sync.test.ts
+++ b/extension/src/background/sync.test.ts
@@ -131,7 +131,8 @@ describe("sync", () => {
     expect(entry.status).toBe("warning");
     expect(entry.droppedCount).toBe(1);
     expect(entry.droppedTypes).toEqual(["Corporate Action Reinvestment"]);
-    expect(entry.txCount).toBe(1);
+    // The surviving Cash Interest row, plus the income leg that balances it.
+    expect(entry.txCount).toBe(2);
     expect(entry.rowCount).toBe(2);
     // The row itself, not just a count: a replace deleted whatever it stored, so
     // the run has to be able to say which row and why.

--- a/extension/src/brokers/fidelity-json.test.ts
+++ b/extension/src/brokers/fidelity-json.test.ts
@@ -4,7 +4,7 @@
  */
 
 import { describe, expect, it } from "vitest";
-import { IdentifierType, TxType } from "@/gen/api/v1/api_pb";
+import { AccountType, IdentifierType, TxType } from "@/gen/api/v1/api_pb";
 import { convertFidelityJson, isValidIsin } from "./fidelity-json";
 
 const BUY = {
@@ -145,7 +145,9 @@ describe("convertFidelityJson", () => {
     const result = convertFidelityJson(
       json({ ...BUY, status: "Cancelled", units: 0, valuation: 0 }, SERVICE_FEE)
     );
-    expect(result.txs).toHaveLength(1);
+    // The service fee and its expense leg; nothing from the cancelled buy.
+    expect(result.txs).toHaveLength(2);
+    expect(result.txs[0]!.type).toBe(TxType.INVEXPENSE);
     expect(result.errors).toEqual([]);
   });
 
@@ -234,7 +236,7 @@ describe("convertFidelityJson grouping", () => {
     expect(result.txs[1]!.groupRef).toBe("563466632");
   });
 
-  it("leaves a separately reported charge ungrouped", () => {
+  it("keeps a separately reported charge out of any trade's group", () => {
     const result = convertFidelityJson(
       json(
         trade({
@@ -248,7 +250,11 @@ describe("convertFidelityJson grouping", () => {
       )
     );
 
-    expect(result.txs[0]!.groupRef).toBe("");
+    // A group of its own, holding the charge and the expense it went to.
+    expect(result.txs).toHaveLength(2);
+    expect(result.txs[0]!.groupRef).not.toBe("");
+    expect(result.txs[1]!.groupRef).toBe(result.txs[0]!.groupRef);
+    expect(result.txs[1]!.accountType).toBe(AccountType.EXPENSE);
   });
 
   it("leaves rows ungrouped when the payload carries no reference", () => {

--- a/extension/src/brokers/fidelity-json.ts
+++ b/extension/src/brokers/fidelity-json.ts
@@ -23,6 +23,7 @@ import {
   isCashTxType,
 } from "@/lib/csv/converters/fidelity-csv";
 import type { ParseError, StandardParseResult } from "@/lib/csv/standard";
+import { counterLegs } from "@/lib/csv/postings";
 import { parseSlashDate } from "../lib/dates";
 
 /** The fields this converter reads. Fidelity sends many more. */
@@ -188,6 +189,8 @@ export function convertFidelityJson(
   assignFidelityGroups(legs).forEach((ref, i) => {
     if (ref) txs[i].groupRef = ref;
   });
+  // After the refs are stamped, since that loop is index-parallel with legs.
+  txs.push(...counterLegs(txs));
 
   return {
     txs,

--- a/extension/src/lib/messages.ts
+++ b/extension/src/lib/messages.ts
@@ -56,6 +56,7 @@ export interface DryRunResult {
   requested?: { from: string; to: string };
   /** Rows in the captured payload, before conversion. */
   rowCount?: number;
+  /** Postings the conversion produced, which a row can produce more than one of. */
   txCount?: number;
   /** Distinct broker transaction types the converter did not recognise. */
   droppedTypes?: string[];

--- a/extension/src/lib/run-log.ts
+++ b/extension/src/lib/run-log.ts
@@ -23,6 +23,11 @@ export interface RunLogEntry {
   /** The transaction the window was derived from, or null on a first run. */
   resumedFrom?: string | null;
   rowCount?: number;
+  /**
+   * Postings uploaded, which is not the row count: the converter emits the leg
+   * that balances a one-sided row -- the income a dividend came from, the
+   * expense a charge went to -- so a row can produce more than one posting.
+   */
   txCount?: number;
   droppedCount?: number;
   /**

--- a/extension/src/popup/main.ts
+++ b/extension/src/popup/main.ts
@@ -21,7 +21,7 @@ function describeDryRun(r: DryRunResult): string {
   const lines: string[] = [];
   if (r.requested) lines.push(`window     ${r.requested.from} to ${r.requested.to}`);
   if (r.rowCount !== undefined) lines.push(`rows       ${r.rowCount}`);
-  if (r.txCount !== undefined) lines.push(`converted  ${r.txCount}`);
+  if (r.txCount !== undefined) lines.push(`postings   ${r.txCount}`);
   if (r.droppedCount) lines.push(`dropped    ${r.droppedCount}`);
   if (r.droppedTypes?.length) lines.push(`unknown    ${r.droppedTypes.join(", ")}`);
   if (r.error) lines.push(`error      ${r.error}`);
@@ -35,7 +35,7 @@ function describeRun(r: RunLogEntry): string {
   const parts = [`${when}  ${r.status.toUpperCase()}`];
   if (r.window) parts.push(`  window ${r.window.from} to ${r.window.to}`);
   if (r.txCount !== undefined) {
-    parts.push(`  ${r.txCount} of ${r.rowCount ?? "?"} rows uploaded`);
+    parts.push(`  ${r.txCount} posting(s) from ${r.rowCount ?? "?"} row(s)`);
   }
   if (r.droppedCount) {
     // Dropped rows are the thing a reader must not miss: the replace deleted


### PR DESCRIPTION
First of two PRs for [0040](docs/issues/0040-csv-fees-net-amount.md). Fidelity nets nothing into a trade total, so there is no fee to derive here: what it needs is the leg that balances the one-sided rows it already reports. IBKR OFX, where a commission is folded into `<TOTAL>`, follows in the next PR.

## Counter-legs

A dividend and a charge each arrive as a single cash row, so the group does not sum to zero and its full value is routed to `IMBALANCE`. Under adr/0021 the missing leg is the converter's to emit rather than the server's to infer.

New `client/lib/csv/postings.ts` builds them:

- `counterLeg` -- the mirror posting, `INCOME`/`RETOFCAP` to an `INCOME` account and `INVEXPENSE`/`MARGININTEREST` to an `EXPENSE` one.
- `feeLeg` -- the cash posting for a commission a broker folded into a trade total. Unused here; it is what the OFX parser will call.
- `counterLegs` -- the batch form, assigning a `group_ref` where the source supplied none.

Called from both `fidelity-csv.ts` and `extension/src/brokers/fidelity-json.ts`, which already share the type map and the grouping rules. Charges stay in groups of their own: Fidelity dates them on the order date while the trade settles later, so folding them into the trade would misdate them (0064).

Nothing wrote an `account_type` before this, so 0071 had no `EXPENSE` postings to aggregate.

## Trade cash legs are CASHFLOW, not JRNLFUND

`Cash In From Sell` and `Cash Out For Buy` mapped to `JRNLFUND`, which is a `transferType` in `server/service/ingestion/balance.go`. That made every Fidelity trade group read as a journal, so its residual went to `TRANSFER_CLEARING` instead of `IMBALANCE` -- away from the 0039 report that measures converter lossiness, and into the transfers view that 0068 is meant to clear.

They are the cash leg of a trade: they pair 1:1 with their trade rows in both sample exports (55/55 and 36/36 sells), and `local/scripts/convert-fidelity.py` already called them `CASHFLOW`. `Withdrawal`, `Cash In` and `Cash In Lump Sum` keep `JRNLFUND` -- their other side really is outside the account.

`CASHFLOW` also joins `isCashTxType`, which is load-bearing: `isCashMovement` is defined as `isCashTxType || JRNLFUND`, and it is what makes a cash row take its signed `Amount` as the quantity. Fidelity's `Quantity` column is an unsigned magnitude, so without it these rows would silently lose their direction and their `trading_currency`.

Expect this to move Fidelity trade residuals to the imbalance tab rather than eliminate them. What is left is price rounding: pairing tolerates 0.5% between a cash leg and `quantity * unit_price` because the export rounds the price.

## Testing

`client/lib/csv/group-balance.test-utils.ts` mirrors `weightOf` from `balance.go` and asserts a batch's groups sum to zero per commodity, which is what catches a sign error. Used by the new `postings.test.ts` and by the Fidelity counter-leg cases.

The extension's `txCount` now counts postings rather than rows, so the popup says "N posting(s) from M row(s)" instead of "N of M rows uploaded".

`make check`, `make client-test`, `make extension-test` all pass.

## Not in this PR

The `local/scripts` regeneration (`local/` is gitignored) and the IBKR OFX work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)