### PR TITLE
Weigh an option leg by its contract size when balancing (0072)

### DIFF
--- a/docs/issues/0072-option-contract-size-in-balance.md
+++ b/docs/issues/0072-option-contract-size-in-balance.md
@@ -1,0 +1,47 @@
+---
+status: closed
+title: Weigh an option leg by its contract size when balancing
+milestone: M12
+dependencies: [0038]
+---
+
+`weightOf` converts a security leg at `quantity * unit_price`, which is the
+consideration for a share but a hundredth of it for an option. No option trade
+can balance, so its whole notional is routed to `IMBALANCE`.
+
+## Motivation
+
+An option is quoted per share and traded per contract. IBKR's QFX reports
+`<UNITS>8`, `<UNITPRICE>20.1105585` and `<TOTAL>-16095.867048`, which reconciles
+only as `8 x 20.1105585 x 100 + 7.420248` of commission. Weighing the leg without
+the contract size leaves 99% of the trade behind.
+
+On the IBKR sample export that is 391 of 659 groups and a residual of 175,279
+USD; with the contract size applied it falls to 9,398, which is commission plus
+the FX estimate error the export's own converter documents. The report from 0039
+is unreadable until this is fixed -- the missing-fee residuals it exists to find
+are two orders of magnitude smaller than the noise sitting on top of them.
+
+## Design
+
+- Shares per contract is `100 * contract_multiplier` for an `OPTION`, and 1 for
+  everything else. The 100 is the OCC standard deliverable and belongs to the
+  asset class; `contract_multiplier` records only the deviation from it, which is
+  what the column already means (`1 = standard (100 shares/contract)`, per
+  `server/migrations/001_initial.sql`). So there is nothing new to populate:
+  every standard contract already carries the right value.
+- It is a property of the instrument, not of the tx type, so it belongs on
+  `balanceInstrument` alongside `isCurrency` -- the same reason that field is
+  there rather than being inferred from the type.
+- A multiplier of zero is treated as 1. The column is `NOT NULL DEFAULT 1` so the
+  database cannot supply one, but a zero would silently weigh a whole trade to
+  nothing, which is the failure this issue is about.
+
+## Futures are not covered
+
+A future's contract size varies per contract -- 50 for ES, 1000 for CL -- and
+there is no standard for `contract_multiplier` to be a multiple of. Weighing one
+needs a contract size stored per instrument, which is a field the datamodel does
+not have and no plugin supplies. No future has ever been imported, so this is
+recorded rather than solved: a `BUYFUTURE` leg weighs as though its contract size
+were 1, exactly as it did before.

--- a/docs/spec/postings.md
+++ b/docs/spec/postings.md
@@ -143,6 +143,14 @@ cannot convert at all, so an exchange event whose source omitted a price leaves 
 residual in the security itself. See
 adr/0024-group-balance-is-checked-on-weight.md.
 
+A price is per underlying unit, so converting also multiplies by the instrument's
+**contract size**: `100 * contract_multiplier` for an option, and 1 for anything
+quoted in the units it trades in. The 100 is the OCC standard deliverable and
+belongs to the asset class, while `contract_multiplier` records only the deviation
+a corporate action can leave behind, so a standard contract needs nothing stored.
+A future's size varies per contract and is not held anywhere, so a future weighs as
+though its size were 1 (0072).
+
 Weights accumulate **per commodity**, so a group can produce more than one routed
 posting and the commodity is whatever is left over -- cash for a missing cash leg,
 the security for an unpaired `JRNLSEC`. A residual is routed only above a

--- a/server/service/ingestion/balance.go
+++ b/server/service/ingestion/balance.go
@@ -18,9 +18,12 @@ import (
 // meaningless: a buy is +10 AAPL and -1855 USD. Balance is checked on weight, as
 // in beancount, whose get_weight is cost > price > units. A posting converts at
 // its price when the units its counter-leg is expected in differ from its own;
-// otherwise it weighs its own quantity in its own commodity. Weights accumulate
-// per commodity, and whatever is left over is routed to an explicit posting
-// rather than rejected. See docs/adr/0024-group-balance-is-checked-on-weight.md.
+// otherwise it weighs its own quantity in its own commodity. A price is per
+// underlying unit, so converting also multiplies by the instrument's contract
+// size -- 100 for an option, 1 for anything quoted in the units it trades in.
+// Weights accumulate per commodity, and whatever is left over is routed to an
+// explicit posting rather than rejected. See
+// docs/adr/0024-group-balance-is-checked-on-weight.md.
 
 // exchangeTypes are the tx types whose counter-leg is money rather than the
 // commodity the posting is in: a security is exchanged for cash, so the security
@@ -75,7 +78,18 @@ const (
 type balanceInstrument struct {
 	isCurrency bool
 	currency   string
+	// Units of the underlying one unit of quantity delivers, which is what a
+	// price has to be multiplied by to reach the consideration. 1 for anything
+	// quoted in the units it trades in; 100 for a standard option contract.
+	contractSize float64
 }
+
+// optionContractSize is the OCC standard deliverable. It belongs to the asset
+// class rather than to the instrument: an OCC symbol exists only for a
+// standardised contract, and contract_multiplier records the deviation from this
+// that a corporate action can leave behind, not the size itself. See the column
+// comment in server/migrations/001_initial.sql.
+const optionContractSize = 100
 
 // commodity names what a weight is denominated in. A converted weight is named by
 // its currency and an unconverted one by its instrument, so both have to reduce to
@@ -142,7 +156,14 @@ func weightOf(tx *apiv1.Tx, instID string, inst balanceInstrument) (float64, com
 	own := ownCommodity(tx, instID, inst)
 	settle := settleCurrency(tx)
 	convert := func() (float64, commodity) {
-		return tx.GetQuantity() * tx.GetUnitPrice(), commodity{currency: settle}
+		// contractSize is 1 for every instrument quoted in the units it trades
+		// in, which includes every currency -- so this is a no-op on the FX case
+		// below and applies only where a price is per underlying unit.
+		size := inst.contractSize
+		if size <= 0 {
+			size = 1
+		}
+		return tx.GetQuantity() * tx.GetUnitPrice() * size, commodity{currency: settle}
 	}
 	switch {
 	// No price, so nothing to convert at. An exchange event with no price leaves a
@@ -282,12 +303,22 @@ func routedFor(first *apiv1.Tx, ref string, c commodity, desc string, amount flo
 func balanceInstruments(byID map[string]*db.InstrumentRow) map[string]balanceInstrument {
 	out := make(map[string]balanceInstrument, len(byID))
 	for id, r := range byID {
-		var inst balanceInstrument
+		inst := balanceInstrument{contractSize: 1}
 		if r.AssetClass != nil && *r.AssetClass == db.AssetClassCash {
 			inst.isCurrency = true
 			if r.Currency != nil {
 				inst.currency = strings.ToUpper(*r.Currency)
 			}
+		}
+		if r.AssetClass != nil && *r.AssetClass == db.AssetClassOption {
+			// A multiplier of zero would weigh a whole trade to nothing. The
+			// column is NOT NULL DEFAULT 1 so the database cannot supply one,
+			// but silently voiding a leg is too quiet a failure to risk.
+			multiplier := r.ContractMultiplier
+			if multiplier <= 0 {
+				multiplier = 1
+			}
+			inst.contractSize = optionContractSize * multiplier
 		}
 		out[id] = inst
 	}

--- a/server/service/ingestion/balance_test.go
+++ b/server/service/ingestion/balance_test.go
@@ -117,6 +117,33 @@ func TestRouteResiduals(t *testing.T) {
 		},
 		want: nil,
 	}, {
+		// An option is quoted per share and traded per contract, so its leg only
+		// reaches the cash it was exchanged for once the contract size is applied.
+		// Figures from local/masters/U7033034_20250107_20260107.qfx: 8 contracts at
+		// 20.1105585 settles at -16088.4468 before commission.
+		name: "option trade balances against the cash it settled for",
+		postings: []posting{
+			{desc: "OPT", typ: apiv1.TxType_BUYOPT, qty: 8, price: price(20.1105585), settle: "USD", instID: optID, groupRef: "t1"},
+			{desc: "USD", typ: apiv1.TxType_CASHFLOW, qty: -16088.4468, price: price(1), settle: "USD", trading: "USD", instID: usdID, groupRef: "t1"},
+		},
+		want: nil,
+	}, {
+		// The commission is what is left over, not the other 99% of the trade.
+		name: "option trade leaves only its netted commission",
+		postings: []posting{
+			{desc: "OPT", typ: apiv1.TxType_BUYOPT, qty: 8, price: price(20.1105585), settle: "USD", instID: optID, groupRef: "t1"},
+			{desc: "USD", typ: apiv1.TxType_CASHFLOW, qty: -16095.867048, price: price(1), settle: "USD", trading: "USD", instID: usdID, groupRef: "t1"},
+		},
+		want: []routed{{commodity: "USD", quantity: 7.420248, accountType: apiv1.AccountType_ACCOUNT_TYPE_IMBALANCE}},
+	}, {
+		// A share is quoted in the units it trades in, so nothing is multiplied.
+		name: "a share trade is unaffected by the contract size",
+		postings: []posting{
+			{desc: "AAPL", typ: apiv1.TxType_BUYSTOCK, qty: 8, price: price(20.1105585), settle: "USD", instID: aaplID, groupRef: "t1"},
+			{desc: "USD", typ: apiv1.TxType_CASHFLOW, qty: -160.884468, price: price(1), settle: "USD", trading: "USD", instID: usdID, groupRef: "t1"},
+		},
+		want: nil,
+	}, {
 		// 456.7872 against a cash row rounded to 456.79. The residual is real but
 		// is an artefact of the source being written to 2dp.
 		name: "sub-cent rounding is within tolerance",
@@ -317,4 +344,75 @@ func describeRouted(rs []routedPosting) string {
 		out += proto.CloneOf(r.tx).String() + " [" + commodity + "] "
 	}
 	return out
+}
+
+// The contract size a price is multiplied by to reach the consideration. The 100
+// belongs to the asset class -- an OCC symbol exists only for a standardised
+// contract -- while contract_multiplier records the deviation a corporate action
+// can leave behind. See the column comment in server/migrations/001_initial.sql.
+func TestBalanceInstruments_ContractSize(t *testing.T) {
+	cases := []struct {
+		name string
+		row  *db.InstrumentRow
+		want float64
+	}{{
+		name: "standard option contract delivers 100 shares",
+		row:  &db.InstrumentRow{AssetClass: strPtr(db.AssetClassOption), ContractMultiplier: 1},
+		want: 100,
+	}, {
+		name: "a 3:2 deliverable is recorded as 1.5, meaning 150",
+		row:  &db.InstrumentRow{AssetClass: strPtr(db.AssetClassOption), ContractMultiplier: 1.5},
+		want: 150,
+	}, {
+		// The column is NOT NULL DEFAULT 1 so the database cannot supply this,
+		// but a zero would weigh a whole trade to nothing.
+		name: "an absent multiplier falls back to the standard",
+		row:  &db.InstrumentRow{AssetClass: strPtr(db.AssetClassOption)},
+		want: 100,
+	}, {
+		name: "a share is quoted in the units it trades in",
+		row:  &db.InstrumentRow{AssetClass: strPtr(db.AssetClassStock), ContractMultiplier: 1},
+		want: 1,
+	}, {
+		name: "so is a currency",
+		row:  &db.InstrumentRow{AssetClass: strPtr(db.AssetClassCash), Currency: strPtr("USD")},
+		want: 1,
+	}, {
+		// A future's size varies per contract and nothing stores it, so one
+		// weighs as it always has. See docs/issues/0072.
+		name: "a future is left as it was",
+		row:  &db.InstrumentRow{AssetClass: strPtr(db.AssetClassFuture), ContractMultiplier: 1},
+		want: 1,
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := balanceInstruments(map[string]*db.InstrumentRow{"i": tc.row})["i"].contractSize
+			if got != tc.want {
+				t.Errorf("contract size = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// A non-standard deliverable balances against the cash it actually settled for,
+// which is what makes the multiplier worth reading rather than assuming 100.
+func TestRouteResiduals_NonStandardDeliverable(t *testing.T) {
+	at := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
+	price := func(v float64) *float64 { return &v }
+	instruments := balanceInstruments(map[string]*db.InstrumentRow{
+		optID: {ID: optID, AssetClass: strPtr(db.AssetClassOption), ContractMultiplier: 1.5},
+		usdID: {ID: usdID, AssetClass: strPtr(db.AssetClassCash), Currency: strPtr("USD")},
+	})
+
+	// 2 contracts of 150 shares at 3.00 is 900, not the 600 a standard one costs.
+	txs := []*apiv1.Tx{
+		posting{desc: "OPT", typ: apiv1.TxType_BUYOPT, qty: 2, price: price(3), settle: "USD", instID: optID, groupRef: "t1"}.tx(at),
+		posting{desc: "USD", typ: apiv1.TxType_CASHFLOW, qty: -900, price: price(1), settle: "USD", trading: "USD", instID: usdID, groupRef: "t1"}.tx(at),
+	}
+
+	got := routeResiduals(txs, []string{optID, usdID}, instruments)
+	if len(got) != 0 {
+		t.Fatalf("routed %d postings, want none: %s", len(got), describeRouted(got))
+	}
 }


### PR DESCRIPTION
Closes [0072](docs/issues/0072-option-contract-size-in-balance.md). Found while checking the 0040 converter work against the imbalance report. Independent of #309 and #310 -- server only.

## The bug

`weightOf` converts a security leg at `quantity * unit_price`. That is the consideration for a share, but a hundredth of it for an option: an option is quoted per share and traded per contract. No option trade can balance, so 99% of its notional is routed to `IMBALANCE`.

From `local/masters/U7033034_20250107_20260107.qfx`:

```
<UNITS>8  <UNITPRICE>20.1105585  <COMMISSION>7.420248  <TOTAL>-16095.867048
```

which reconciles only as `8 x 20.1105585 x 100 + 7.420248`.

On the IBKR sample export that is 391 of 659 groups and 175,279 USD of residual. With the contract size applied it falls to 9,398 -- commission plus the FX estimate error that export's own converter documents. The 0039 report is unreadable until this is fixed, because the missing-fee residuals it exists to find are two orders of magnitude smaller than the noise on top of them.

## Nothing new has to be stored

`contract_multiplier` is not the contract size. Its column comment says so:

```sql
-- Deliverable multiplier: 1 = standard (100 shares/contract). Non-standard
-- splits (e.g. 3:2) may set this to 1.5 meaning 150 shares/contract.
contract_multiplier NUMERIC NOT NULL DEFAULT 1,
```

The 100 belongs to the asset class -- an OCC symbol exists only for a standardised contract -- and the column records only the deviation a corporate action can leave behind. So shares per contract is `100 * contract_multiplier`, every standard contract already carries the right value, and nothing needs backfilling. That is also why nothing in the codebase writes the column, and why corporate-events.md can say it is never adjusted automatically.

Contract size is a property of the instrument rather than of the tx type, so it sits on `balanceInstrument` beside `isCurrency` -- the same reasoning that put `isCurrency` there. A multiplier of zero falls back to the standard: the column is `NOT NULL DEFAULT 1` so the database cannot supply one, but it would weigh a whole trade to nothing, which is exactly the failure being fixed.

The FX branch of `weightOf` also goes through `convert()`, and is unaffected: a currency instrument has a contract size of 1.

## Futures are not covered

A future's size varies per contract -- 50 for ES, 1000 for CL -- and there is no standard for the multiplier to be a multiple of. It needs a contract size stored per instrument, which the datamodel does not have and no plugin supplies. No future has ever been imported, so a `BUYFUTURE` leg weighs exactly as it did before. Recorded in the issue rather than solved.

## Testing

Three routing cases (option balances, option leaves only its commission, share unaffected) using the QFX figures, plus a table test over `balanceInstruments` covering the standard contract, a 3:2 deliverable, the zero fallback, shares, currencies and futures, and a routing case for the non-standard deliverable. Without the fix the first case is out by 15,927.

`make server-test`, `make check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)