### PR TITLE
Record the exact-decimal boundary in ADRs, issues and specs

### DIFF
--- a/.claude/skills/go/SKILL.md
+++ b/.claude/skills/go/SKILL.md
@@ -43,6 +43,18 @@ Prefer terse names for functions and variables. In particular, financial
 transactions are named `Tx` (not `Transaction`); reserve `Transaction` for database
 transactions. Use short receiver names and idiomatic interface names.
 
+## Decimals
+
+Quantities, prices and money are `shopspring/decimal`, not `float64`. It
+implements `sql.Scanner` and `driver.Valuer`, so it scans from and writes to
+`NUMERIC` columns through `lib/pq` directly. Use `float64` only past the
+exactness boundary -- valuations, FX-converted totals, return metrics -- per
+adr/0026-exact-decimals-bounded-by-closure.md. Plugin clients decoding provider
+JSON keep `float64`; the conversion belongs at the db and API layers.
+
+Never compare a `decimal.Decimal` with `==`. Use `.Equal` for equality and `.Cmp`
+for ordering. Arithmetic is method chaining: `a.Mul(b).Add(c)`.
+
 ## Testing idioms
 
 Go unit tests use the slice-of-test-cases (table-driven) approach:
@@ -86,6 +98,17 @@ Use matchers (`gomock.Any`, `gomock.AssignableToTypeOf`) and `DoAndReturn` to
 inspect arguments. Give shared assertion/context helpers a `t.Helper()` call; the
 canonical gRPC assertion is `testutil.RequireGRPCCode(t, err, codes.X)`. See the
 `unit-testing` skill for the rest.
+
+Comparing values containing a `decimal.Decimal` needs an explicit go-cmp option.
+`decimal.Decimal` holds a `big.Int` and an exponent, so `1.0` and `1.00` are
+`.Equal` but not `reflect.DeepEqual` -- the default comparison fails on a
+difference in scale that carries no difference in value:
+
+```go
+cmp.Diff(want, got, cmp.Comparer(func(a, b decimal.Decimal) bool { return a.Equal(b) }))
+```
+
+Put it in the shared comparer options rather than at each call site.
 
 ## Linting
 

--- a/.claude/skills/protobuf/SKILL.md
+++ b/.claude/skills/protobuf/SKILL.md
@@ -10,7 +10,8 @@ directories defined in docs/layout.md (Go beside the protos under `proto/`,
 TypeScript under `client/gen`, e2e TypeScript under `e2e/gen`) and are excluded from
 source control via `.gitignore`. Regenerate with `make generate`.
 
-Use proto version 3. Floating-point numerical values use the `double` type.
+Use proto version 3. See [Numeric values](#numeric-values) for choosing between
+`string` and `double`.
 
 ## Packages and versioning
 
@@ -32,6 +33,32 @@ Use proto version 3. Floating-point numerical values use the `double` type.
 - Fields are snake_case. Enums are PascalCase.
 - Reference messages across packages by their fully-qualified name
   (`portfoliodb.api.v1.Tx`).
+
+## Numeric values
+
+Quantities, prices and money are exact decimals and cross the wire as canonical
+decimal **strings**, not `double`. A `double` cannot carry an exact decimal, and
+a `NUMERIC` column exposed as one is lossy in both directions. Use plain `string`
+rather than `google.type.Decimal`, which is itself only a string wrapper -- with
+`optional string` where the value is nullable.
+
+Decide with the closure rule from adr/0026-exact-decimals-bounded-by-closure.md:
+a value is decimal if its expression tree, from source-recorded values, uses only
+`+`, `-` and `*`. That covers everything transcribed from a broker or a provider
+(quantities, prices, strikes, OHLC bars, index values) and everything summed or
+multiplied from them (holdings, posting weights, residual balances, realised
+gains). Past the first division or transcendental the value is an estimate, and
+`double` states that honestly -- portfolio valuations, FX-converted totals, and
+return metrics. Full reasoning in
+adr/0027-decimal-values-cross-the-wire-as-strings.md.
+
+A decimal `string` field carries two things a `double` did not need:
+
+- A trailing comment naming it as a decimal and giving units, since the type no
+  longer says so: `string quantity = 4; // decimal; signed, positive for buys`.
+- A protovalidate pattern. These fields were unconstrained as `double`, so this
+  is new coverage rather than a like-for-like replacement:
+  `[(buf.validate.field).string.pattern = "^-?[0-9]+(\\.[0-9]+)?$"]`.
 
 ## Enums
 

--- a/.claude/skills/typescript/SKILL.md
+++ b/.claude/skills/typescript/SKILL.md
@@ -36,10 +36,10 @@ adr/0027-decimal-values-cross-the-wire-as-strings.md.
   and is unnecessary on a value that never had any.
 - **Arithmetic: only in the converters.** Code under `client/lib/csv/` and
   `client/lib/ofx/` authors facts -- deriving counter-legs, splitting netted
-  totals -- and uses a decimal library (`big.js`) so the postings it emits
-  balance exactly. Nothing else on the client computes with these values. Keep
-  the dependency out of component code; the extension shares these modules and
-  carries the bundle cost.
+  totals -- and uses a decimal library so the postings it emits balance exactly.
+  Nothing else on the client computes with these values. Keep the dependency out
+  of component code; the extension shares these modules and carries the bundle
+  cost. The library is picked in 0042.
 - **Charts take `number`.** Series values (`ValuationPoint.total_value` and any
   later return metric) are `double` on the wire and feed Recharts directly.
 - Sorting and comparison need a numeric or decimal comparator; lexicographic

--- a/.claude/skills/typescript/SKILL.md
+++ b/.claude/skills/typescript/SKILL.md
@@ -25,6 +25,26 @@ Backend types come from generated protobuf-es v2 code (`@bufbuild/protobuf`) und
   `AssetClass.STOCK`, and `*_UNSPECIFIED` becomes `.UNSPECIFIED`. Enum label maps
   and string<->enum converters live in `client/lib/` (e.g. `asset-class.ts`).
 
+## Decimal fields
+
+Quantities, prices and money arrive as `string`, not `number` -- a TypeScript
+`number` is a float64 and cannot hold them exactly. See the `protobuf` skill and
+adr/0027-decimal-values-cross-the-wire-as-strings.md.
+
+- **Display: render the string.** Do not round-trip through `Number` to format
+  it. The `parseFloat(x.toFixed(n))` idiom exists only to hide float artifacts
+  and is unnecessary on a value that never had any.
+- **Arithmetic: only in the converters.** Code under `client/lib/csv/` and
+  `client/lib/ofx/` authors facts -- deriving counter-legs, splitting netted
+  totals -- and uses a decimal library (`big.js`) so the postings it emits
+  balance exactly. Nothing else on the client computes with these values. Keep
+  the dependency out of component code; the extension shares these modules and
+  carries the bundle cost.
+- **Charts take `number`.** Series values (`ValuationPoint.total_value` and any
+  later return metric) are `double` on the wire and feed Recharts directly.
+- Sorting and comparison need a numeric or decimal comparator; lexicographic
+  string ordering is wrong for these fields.
+
 ## Next.js / React
 
 - App Router (`client/app/`). Default to client components: interactive files

--- a/docs/adr/0020-double-entry-postings.md
+++ b/docs/adr/0020-double-entry-postings.md
@@ -33,12 +33,15 @@ session can leave an unbalanced group behind.
 
 An INITIALIZE row (see [0011](0011-synthetic-initialize-transactions.md)) is a pad
 with no counterparty, so it cannot satisfy the invariant until a reserved `Equity`
-account gives it one. The invariant is also not expressible while `quantity` and
+account gives it one. The invariant is also awkward to state while `quantity` and
 `unit_price` are `DOUBLE PRECISION`: summing float buys and sells does not land on
-exactly zero, which is why `qty_is_zero(q) := ABS(q) < 1e-9` already exists, and
-applying that epsilon to a balance check would let a genuine imbalance smaller than
-the tolerance pass silently. Both are prerequisites of turning the constraint on, so
-grouping lands first and the constraint follows.
+exactly zero, which is why `qty_is_zero(q) := ABS(q) < 1e-9` already exists. It can
+be written against floats with a relative tolerance, but that tolerance then has to
+be chosen and justified per call site, and an absolute one is silently
+scale-dependent. Exact decimals remove the question instead of answering it
+repeatedly; see [0026](0026-exact-decimals-bounded-by-closure.md). Both are
+prerequisites of turning the constraint on, so grouping lands first and the
+constraint follows.
 
 The read path is unaffected. Holdings, valuation, price coverage and holding
 declarations all aggregate `SUM(quantity)` grouped by instrument, and adding a

--- a/docs/adr/0022-typed-per-account-cash-flow-boundary.md
+++ b/docs/adr/0022-typed-per-account-cash-flow-boundary.md
@@ -81,6 +81,8 @@ both portfolio members, and excluded otherwise.
 
 0020's remaining consequences stand. An INITIALIZE row (see
 [0011](0011-synthetic-initialize-transactions.md)) is a pad with no counterparty
-and needs an `EQUITY` posting to satisfy the invariant, and the invariant is not
-expressible while `quantity` and `unit_price` are `DOUBLE PRECISION`, because
-summing float buys and sells does not land on exactly zero.
+and needs an `EQUITY` posting to satisfy the invariant, and the invariant is
+awkward to state while `quantity` and `unit_price` are `DOUBLE PRECISION`, because
+summing float buys and sells does not land on exactly zero and the tolerance that
+covers it has to be justified per call site (see
+[0026](0026-exact-decimals-bounded-by-closure.md)).

--- a/docs/adr/0024-group-balance-is-checked-on-weight.md
+++ b/docs/adr/0024-group-balance-is-checked-on-weight.md
@@ -63,6 +63,20 @@ the other side is money, and lets everything else show up as a residual. The kno
 cost is that a cross-currency movement whose broker supplies no FX rate leaves a
 residual rather than balancing.
 
+## Which columns are weighed
+
+Weight is computed from the raw `quantity` and `unit_price`, never from the
+`split_adjusted_*` pair. A split adjusts a security leg's quantity while leaving
+its cash counter-leg alone, and the pair only continues to balance because the
+price is adjusted inversely -- a 3:1 split turns `+10 AAPL @ 185.50` into
+`+30 @ 61.8333...` against the same `-1855 USD`. The product is preserved in
+exact arithmetic, but `61.8333...` is not exactly representable, so the adjusted
+weight misses by the rounding. An exact `SUM(...) = 0` over adjusted values would
+reject correct groups on any instrument that has had a split in an awkward ratio.
+The raw columns carry no such rounding; see
+[0028](0028-cumulative-split-factor-is-an-exact-rational.md) for why the adjusted
+ones do.
+
 ## Tolerance
 
 A residual is routed only above a tolerance: half a cent for money, `1e-6`

--- a/docs/adr/0026-exact-decimals-bounded-by-closure.md
+++ b/docs/adr/0026-exact-decimals-bounded-by-closure.md
@@ -1,0 +1,93 @@
+# Exact decimals are bounded by closure under + - *
+
+Quantities and prices are decimal, not binary floating point, and the schema has
+been moving that way: every numeric column except the four on `txs` is already
+`NUMERIC`. What was never settled is where exactness stops, because it has to
+stop somewhere.
+
+Decimals are closed under addition, subtraction and multiplication, and under
+nothing else. Those three are exact: a product's scale is the sum of its
+operands' scales, always finite. Division is not, and no storage type fixes it --
+`1/3` has no finite decimal representation, so Postgres picks a scale for you
+(`select_div_scale`, at least 16 significant digits) and rounds. The
+transcendentals are worse: `ln`, `exp`, `pow` and `sqrt` on `numeric` are
+software series expansions over digit arrays, so they are both slower than their
+`float8` counterparts and still approximate.
+
+So the boundary is algebraic, and it can be read off an expression rather than
+argued about: **a value is decimal if and only if its expression tree, from
+source-recorded values, contains only `+`, `-` and `*`. The first division or
+transcendental ends exactness, and past it `double` is the honest and much faster
+representation of an approximation.**
+
+Transcribed values are decimal because a source wrote them down in decimal:
+`quantity`, `unit_price`, `strike`, `contract_multiplier`, OHLC bars,
+`split_from`/`split_to`, `declared_qty`, inflation index values. Everything
+derived from them by the closed operations stays decimal, and that is where the
+useful invariants live: a posting's weight is `quantity * unit_price *
+contract_size`, a group's balance and a holding are sums, a realised gain is a
+difference. Exactness there is free, which is why it is worth having. Valuation
+divides by an FX rate, and performance metrics link returns geometrically and
+solve for an internal rate, so both are past the boundary.
+
+## Consequences
+
+**A stored column is not automatically a fact.** `split_adjusted_quantity` and
+`split_adjusted_unit_price` are a materialised cache of `quantity * factor`,
+recomputable from the quantity, the `share_count_basis` and the split chain.
+Being stored does not make them facts, and they are classified by their
+expression like anything else: the factor's division puts them past the boundary,
+so they carry a declared rounding scale (see
+[0028](0028-cumulative-split-factor-is-an-exact-rational.md)). The rounding is
+confined to the cache because the facts it derives from remain exact.
+
+**Balance is checked on raw values, never on the split-adjusted pair.** See
+[0024](0024-group-balance-is-checked-on-weight.md), which this is recorded
+against.
+
+**Queries cast operands, not results, at the boundary.** Valuation multiplies an
+exact quantity by a price and divides by an FX rate once per instrument per
+calendar day. Casting the result would have Postgres compute sixteen significant
+digits of `numeric` division for every one of those rows and then discard them;
+casting the operands keeps the day grid on hardware arithmetic, which is what it
+runs on today. The cast is also the only marker of where exactness ends in a
+query, so it is worth keeping in one place rather than spreading the conversion
+across the expression. See [spec/performance.md](../spec/performance.md).
+
+**A tolerance survives at ingest.** Exactness is not the same as agreement. A
+trade of 37 shares at 12.3456 costs 456.7872 against a broker cash row of
+-456.79, and that 0.0028 is exact, real, and entirely an artefact of the source
+having been written to 2dp. What exactness changes is that the tolerance can be
+inferred from the scale of the amounts rather than fixed as a constant, and that
+the floor against double rounding is no longer needed. Also in
+[0024](0024-group-balance-is-checked-on-weight.md).
+
+## Considered options
+
+- **Exact decimals everywhere.** Rejected on two grounds. It is not achievable:
+  the moment a value passes through an FX division or an average it is
+  approximate whatever type carries it, so "everywhere" means "decimal-typed
+  approximations", not exact ones. And it is misleading where it is achievable
+  in form only -- a decimal string for a portfolio valuation asserts that its
+  digits are meaningful when the FX division two layers down already destroyed
+  them. Encoding an estimate as an exact decimal misrepresents its provenance,
+  and that is the objection; the cost of numeric arithmetic on the valuation
+  day-grid is secondary.
+
+- **Floating point everywhere, with tolerances.** The status quo, and workable:
+  the balance invariant is expressible against `double precision` using a
+  relative epsilon. Rejected because every call site then has to choose and
+  justify one, and an absolute epsilon is silently scale-dependent -- `1e-9` in
+  the style of `qty_is_zero` is smaller than a double's ULP at the magnitude of
+  a large converted weight, so it emits spurious residuals on exactly the trades
+  that matter most. Exact decimals remove the question rather than answering it
+  repeatedly.
+
+- **Rational arithmetic throughout**, as GnuCash does with a numerator/
+  denominator pair. Fully exact, including under division. Rejected as
+  disproportionate: it is contagious through every layer and every client, and
+  the only place the repository actually needs it is the split factor, where it
+  is applied locally ([0028](0028-cumulative-split-factor-is-an-exact-rational.md)).
+
+The wire encoding that follows from this is recorded separately in
+[0027](0027-decimal-values-cross-the-wire-as-strings.md).

--- a/docs/adr/0026-exact-decimals-bounded-by-closure.md
+++ b/docs/adr/0026-exact-decimals-bounded-by-closure.md
@@ -45,8 +45,8 @@ confined to the cache because the facts it derives from remain exact.
 [0024](0024-group-balance-is-checked-on-weight.md), which this is recorded
 against.
 
-**Queries cast operands, not results, at the boundary.** Valuation multiplies an
-exact quantity by a price and divides by an FX rate once per instrument per
+**Queries cast operands, not results, at the boundary.** Valuation multiplies a
+decimal quantity by a price and divides by an FX rate once per instrument per
 calendar day. Casting the result would have Postgres compute sixteen significant
 digits of `numeric` division for every one of those rows and then discard them;
 casting the operands keeps the day grid on hardware arithmetic, which is what it

--- a/docs/adr/0027-decimal-values-cross-the-wire-as-strings.md
+++ b/docs/adr/0027-decimal-values-cross-the-wire-as-strings.md
@@ -1,0 +1,48 @@
+# Decimal values cross the wire as strings
+
+A protobuf `double` cannot carry an exact decimal, so the values
+[0026](0026-exact-decimals-bounded-by-closure.md) puts on the exact side of the
+boundary are encoded as canonical decimal strings in `api.proto` -- plain
+`string` fields, not `google.type.Decimal`. This is the convention Google's own
+API types follow (`google.type.Decimal` is itself a string; `google.type.Money`
+is an integer unit count) and that FIX and Stripe follow for the same reason.
+
+`google.type.Decimal` was the obvious alternative and was rejected because it is
+a message wrapping a single string field: it buys a self-documenting type name
+and nothing else, at the cost of `.value` indirection in Go and `{value: string}`
+in TypeScript on every access. `optional string` already gives the presence
+semantics the current `optional double` fields rely on. Since a bare `string`
+does not announce what it holds, two things stand in for the type name: a
+uniform field-comment convention, and protovalidate CEL patterns constraining
+the format. The validation is a net gain -- not one of the 26 `double` fields in
+`api.proto` today carries any constraint at all, so the string form is the first
+time these values are checked at the wire.
+
+A scaled integer pair (units plus scale, as `google.type.Money` uses) was also
+considered and rejected: it is compact but the scale is easy to mismatch across
+languages, and the compactness does not matter for the message sizes here.
+
+## Consequences
+
+Almost the whole API moves. Of the 26 `double` fields, 25 are on the exact side:
+the `txs` quantities and prices, `Holding` quantities, `Instrument.strike` and
+`contract_multiplier`, all three OHLC message variants,
+`InflationIndexProto.index_value` and `ResidualBalance.balance`. Two cases carry
+most of the weight. `ExportPriceRow` and `ImportPriceRow` are a round-trip pair,
+and an export that does not reimport identically is a bug -- today both sides
+downgrade a `NUMERIC` column through a `double`. And `strike` is denormalised
+from the OCC identifier, so it is a component of option identity; comparing
+identity components as floats is a latent bug that the option-identity work
+would eventually have found.
+
+`ValuationPoint.total_value` stays `double`, and any later performance metric
+joins it. It is the chart series, computed through an FX division, so by
+[0026](0026-exact-decimals-bounded-by-closure.md) it is an estimate before it
+reaches the wire and a decimal string would overstate it. Recharts consumes
+`number`, so a string would also be parsed back on arrival for no gain.
+
+Client display paths get simpler rather than harder: rendering a decimal string
+directly removes the `parseFloat(x.toFixed(n))` idiom that exists only to hide
+float artifacts. Arithmetic on the client is confined to the CSV and OFX
+converters, which author facts and need a decimal library; nothing else on the
+client computes with these values.

--- a/docs/adr/0028-cumulative-split-factor-is-an-exact-rational.md
+++ b/docs/adr/0028-cumulative-split-factor-is-an-exact-rational.md
@@ -1,0 +1,65 @@
+# The cumulative split factor is an exact rational
+
+`split_factor_at` returns the product of `split_to / split_from` over the splits
+between a row's `share_count_basis` and today, and computes it as
+`exp(sum(ln(...)))` on `double precision`. The function's own comment defends
+that: split factors are small rationals and the round trip is accurate to many
+decimal places for any realistic chain. It was a reasonable choice while the
+quantities it multiplied were themselves `double precision`.
+
+It stops being one once quantities are exact
+([0026](0026-exact-decimals-bounded-by-closure.md)), and the obvious repair --
+running the same expression in `numeric` -- is the worst available option.
+Postgres implements `ln` and `exp` on `numeric` as software series expansions
+over arbitrary-precision digit arrays, so it is far slower than the `float8`
+path and the result is still approximate. Paying that cost for an approximation
+makes no sense.
+
+The factor is a product, so it is computed as one. Postgres has no built-in
+product aggregate, but defining an exact one is a single statement, and
+multiplication over `numeric` is exact:
+
+```sql
+CREATE AGGREGATE mul(numeric) (SFUNC = numeric_mul, STYPE = numeric, INITCOND = '1');
+```
+
+The function returns the numerator and denominator separately -- `mul(split_to)`
+and `mul(split_from)` -- rather than their quotient, so callers compute
+`quantity * num / den` with all the multiplication first and a single division
+last. That ordering is the minimal-error form, and deferring the division is
+what keeps the exact part exact for as long as possible.
+
+## Considered options
+
+- **`exp(sum(ln(...)))` on `numeric`.** Rejected as above: slower and still
+  inexact.
+- **A recursive CTE walking the split chain.** Exact, but it re-expresses a
+  product as an ordered traversal for no benefit over an aggregate.
+- **Storing a cumulative factor per instrument.** Rejected: it is derived data
+  with a `CURRENT_DATE` dependency, so it needs invalidating every time a split's
+  ex-date passes, which is precisely the maintenance the function exists to
+  avoid.
+- **Computing the product in Go.** Rejected: the factor is applied inside the
+  recompute statements in `server/db/postgres/corporate_events.go`, so moving it
+  out of SQL would mean reading the split chain into the service and pushing the
+  adjusted values back, replacing a set-based update with a round trip.
+
+## Consequences
+
+The quotient is exact whenever the denominator divides `quantity * num`, which
+covers every forward split and every ratio whose denominator factors into 2s and
+5s -- 2:1, 3:2, 5:4. It is not exact for a genuine reverse `/3`: a 3:1 reverse
+split on 100 shares is 33.333..., and no representation fixes that. So the
+`split_adjusted_*` columns carry a declared rounding scale, chosen once and
+recorded in the schema.
+
+This is the boundary case that [0026](0026-exact-decimals-bounded-by-closure.md)
+classifies by expression rather than by storage. The rounding is confined to a
+derived cache: `quantity`, `share_count_basis` and the split chain are all exact
+and the adjusted values are recomputable from them at any time, which is already
+how the corporate-event recompute works. It also means an exact balance check
+must read the raw columns rather than the adjusted pair --
+[0024](0024-group-balance-is-checked-on-weight.md) records that.
+
+See [spec/bitemporality.md](../spec/bitemporality.md#share-count-basis) for what
+the share count basis is and which sources declare which.

--- a/docs/issues/0041-enable-balance-constraint.md
+++ b/docs/issues/0041-enable-balance-constraint.md
@@ -37,17 +37,42 @@ use `DEFERRABLE`.
 Balance is checked on weight -- quantity for same-commodity postings, and
 quantity times price for postings carrying a cost or conversion.
 
-## Blocker: quantity is DOUBLE PRECISION
+It is checked on the raw `quantity` and `unit_price`, never on the
+`split_adjusted_*` pair, which carries a rounding an exact check would reject.
+See adr/0024-group-balance-is-checked-on-weight.md.
 
-An exact `SUM(...) = 0` check cannot be written against
-`txs.quantity`/`unit_price`, which are `DOUBLE PRECISION`. Summing float buys
-and sells does not land on exactly zero -- this is already why
-`qty_is_zero(q) := ABS(q) < 1e-9` exists in 001_initial.sql. Applying the same
-epsilon to a balance check would defeat its purpose, since a genuine imbalance
-smaller than the tolerance would pass silently and a legitimate group could
-still fail as the number of legs grows.
+## Why exact decimals first
+
+A balance check is writable against `DOUBLE PRECISION` -- with a relative
+tolerance. What that costs is a tolerance that has to be chosen and defended in
+the one place whose whole purpose is to be unarguable, and an absolute epsilon
+in the style of `qty_is_zero` will not do: `1e-9` is below a double's ULP at the
+magnitude of a large converted weight, so it would fail on exactly the trades
+that matter most. Exact decimals make the check `SUM(...) = 0` with nothing to
+justify. See adr/0026-exact-decimals-bounded-by-closure.md.
+
+Note this is separate from the ingest tolerance, which stays either way: once
+residuals are routed above half a cent the group sums to zero by construction,
+and that is what makes an exact constraint satisfiable.
 
 Tracked as 0042.
+
+## Open question: where the weight function lives
+
+The constraint checks weight, so the trigger needs the weight rules --
+`exchangeTypes`, the settlement-currency guard, the contract-size multiplication
+in `server/service/ingestion/balance.go` -- available in SQL. Reimplementing
+them in PL/pgSQL means a second copy of the rules that must not drift from the
+Go one, which is a poor trade for a constraint whose value is that it cannot be
+bypassed.
+
+The alternative is to store each posting's computed weight on its row. The
+constraint then becomes a plain `SUM(weight) = 0` per group with no duplicated
+logic, and weight is `quantity * unit_price * contract_size`, closed under
+multiplication and so exact once 0042 lands. The cost is a stored derived column
+that recompute passes have to maintain.
+
+Settle this before implementing.
 
 ## Sequencing
 

--- a/docs/issues/0042-exact-decimal-quantities-prices.md
+++ b/docs/issues/0042-exact-decimal-quantities-prices.md
@@ -39,50 +39,69 @@ rather than only pads.
 
 ## Blocks
 
-0041. A balance constraint needs an exact `SUM(...) = 0`. With floats it would
-need an epsilon, which defeats the purpose: a genuine imbalance below the
-tolerance passes silently, while a legitimate group can still fail as the
-number of legs grows.
+0041. See that issue for what a balance constraint gains from exactness.
 
-## Scope: three layers, not one
+## Scope
 
-1. **Postgres** -- column types, `qty_is_zero`, `split_factor_at`.
-2. **Go** -- there is no decimal dependency today; `go.mod` has `lib/pq` and
-   nothing else relevant.
-3. **Wire and clients** -- proto and TypeScript.
+The boundary is set by adr/0026-exact-decimals-bounded-by-closure.md: exact
+decimals up to and including the last `+`, `-` or `*` from a recorded value, and
+`double` past the first division or transcendental. Applying it here:
 
-The API is already lossy for prices independently of `txs`: `eod_prices` stores
-`NUMERIC` but api.proto exposes `double open/high/low/close`, and `double
-quantity`, `double unit_price`, `double strike`, `double contract_multiplier`.
-TypeScript `number` is float64, so the browser is lossy too. This is not only a
-`txs` problem.
+**Postgres.** `NUMERIC` for the four columns. `qty_is_zero` becomes `q = 0` at
+its three call sites (`holdings.go`, `residual_balances.go`, `valuation.go`), or
+is dropped. The valuation query keeps its day-grid arithmetic on `float8` by
+casting the operands -- not the result -- at the point of FX conversion; see
+spec/performance.md.
 
-## Design
+**Go.** `shopspring/decimal` implements `sql.Scanner` and `driver.Valuer`, so it
+works with `lib/pq` without changing drivers. It stops at the db and API layers:
+the Massive and EODHD plugin clients parse JSON from providers that emit floats,
+and there is nothing to gain by converting them.
 
-**Postgres.** `NUMERIC` for the four columns. `qty_is_zero` becomes `q = 0`, or
-is dropped entirely.
+**Wire.** Decimal strings, per adr/0027-decimal-values-cross-the-wire-as-strings.md.
+25 of the 26 `double` fields in api.proto move; `ValuationPoint.total_value`
+stays `double`. `ExportPriceRow` and `ImportPriceRow` are the clearest case,
+being a round-trip pair that currently downgrades a `NUMERIC` column through a
+`double` in both directions. `Instrument.strike` is the next clearest: it is
+denormalised from the OCC identifier and so is a component of option identity.
+Add protovalidate patterns while the fields are being touched -- none of the 26
+carries a constraint today.
 
-**Go.** `shopspring/decimal` implements `sql.Scanner` and `driver.Valuer`, so
-it works with `lib/pq` without changing drivers.
+**Clients.** A decimal library (big.js, decimal.js) is needed only in the CSV and
+OFX converters under `client/lib/csv/` and `client/lib/ofx/`, which author facts
+and are shared with the extension. Display paths get simpler, not harder: the
+`parseFloat(tx.quantity.toFixed(4))` in `client/app/transactions/page.tsx` exists
+to hide float artifacts and deletes outright. Chart series stay `number`.
 
-**Wire.** A protobuf `double` cannot carry an exact decimal. Use canonical
-decimal strings: `google.type.Decimal` is already in the buf module cache, and
-a plain `string` field is equivalent and simpler. Client-side arithmetic needs
-a decimal library (decimal.js, big.js); display-only paths can parse the string
-directly.
+## split_factor_at
 
-## Sub-problem: split_factor_at
+Settled in adr/0028-cumulative-split-factor-is-an-exact-rational.md: a `mul`
+aggregate over `numeric`, returning numerator and denominator separately so the
+single division is deferred to the caller. The existing `exp(sum(ln(...)))`
+implementation and the comment defending it both go.
 
-`split_factor_at()` returns `DOUBLE PRECISION` and computes the cumulative
-factor as `exp(sum(ln(...)))`. Multiplying a `NUMERIC` quantity by a double
-factor returns to floating point, so this needs deciding as part of the work.
-Options: compute the product in Go; use a numeric custom aggregate or a
-recursive CTE in Postgres; or store the cumulative factor per instrument. The
-existing comment on the function documents why exp/ln was acceptable for
-realistic split chains -- that reasoning holds for the factor itself, but not
-once the result feeds an exact balance check.
+The `split_adjusted_*` columns then need a **declared rounding scale**, because a
+reverse `/3` has no exact decimal form. Pick a number as part of this work --
+more decimal places than any broker quotes fractional shares to -- and record it
+in the schema alongside the columns.
 
-## Note
+## Known costs
+
+`decimal.Decimal` wraps a `big.Int` and an exponent, so `1.0` and `1.00` are
+`.Equal` but neither `==` nor `reflect.DeepEqual`. The server tree has around 78
+`float64` references in tests and uses go-cmp throughout, so a
+`cmp.Comparer(decimal.Decimal.Equal)` needs threading through the test helpers,
+and it should land before the types change rather than after.
+
+## Sequencing
 
 Pre-release, so there is no migration or back-compat burden (CLAUDE.md). The
-change is wide but mechanical, and it will never be cheaper than now.
+change is wide but mechanical, and it will never be cheaper than now. Four PRs,
+to stay near the 500-800 line target:
+
+1. Postgres: column types, `qty_is_zero`, the `mul` aggregate and
+   `split_factor_at`.
+2. Go: the go-cmp comparer first, then decimal through the db layer, ingestion
+   and balancing.
+3. Proto: string fields, protovalidate patterns, regenerate.
+4. Client and extension.

--- a/docs/issues/0042-exact-decimal-quantities-prices.md
+++ b/docs/issues/0042-exact-decimal-quantities-prices.md
@@ -67,9 +67,13 @@ denormalised from the OCC identifier and so is a component of option identity.
 Add protovalidate patterns while the fields are being touched -- none of the 26
 carries a constraint today.
 
-**Clients.** A decimal library (big.js, decimal.js) is needed only in the CSV and
-OFX converters under `client/lib/csv/` and `client/lib/ofx/`, which author facts
-and are shared with the extension. Display paths get simpler, not harder: the
+**Clients.** A decimal library is needed only in the CSV and OFX converters under
+`client/lib/csv/` and `client/lib/ofx/`, which author facts and are shared with
+the extension. Pick it here: the converters need only the four operations and
+comparison, and the modules are shared with an MV3 extension where bundle size
+counts, so big.js (around 8KB minified) is the smaller fit and decimal.js (around
+32KB) buys arbitrary-precision functions nothing on the client uses. Display
+paths get simpler, not harder: the
 `parseFloat(tx.quantity.toFixed(4))` in `client/app/transactions/page.tsx` exists
 to hide float artifacts and deletes outright. Chart series stay `number`.
 

--- a/docs/issues/0043-holding-declarations-pad-assert.md
+++ b/docs/issues/0043-holding-declarations-pad-assert.md
@@ -79,4 +79,14 @@ server/service/api/declarations.go and server/service/api/recalc.go.
 `declared_qty` is `NUMERIC` but computed holdings sum `DOUBLE PRECISION`
 columns, so the comparison crosses a float boundary. 0042 removes that. This
 issue does not have to wait: an interim tolerance comparable to `qty_is_zero`
-is acceptable, and tightens to an exact comparison once 0042 lands.
+is acceptable, and tightens once 0042 lands.
+
+It does not tighten all the way to an exact comparison, though. The computed
+side is `SUM(split_adjusted_quantity)`, and those columns carry a declared
+rounding scale rather than being exact, because the split factor divides (see
+adr/0028-cumulative-split-factor-is-an-exact-rational.md and
+adr/0026-exact-decimals-bounded-by-closure.md). So the assertion keeps a
+tolerance derived from that scale and the number of contributing postings. That
+is a bound that can be stated, unlike the current epsilon, but it is not zero --
+which is a reason to settle the share count basis question above rather than
+hoping exactness resolves it.

--- a/docs/issues/0045-realised-gains-cost-basis-methods.md
+++ b/docs/issues/0045-realised-gains-cost-basis-methods.md
@@ -34,8 +34,22 @@ comes first.
   matching decisions visible so a user can check them.
 - Unrealised gain is the complement: current value less remaining basis.
 
+## Exactness
+
+The methods differ here too. Specific identification and FIFO only add, subtract
+and multiply, so a realised gain computed under either is exact once 0042 lands.
+Section 104 pooling averages, and an average divides: a pooled cost per share is
+not generally representable, so the pool carries a declared rounding scale and
+the rounding accumulates across acquisitions. That has to be decided with the
+pool's data model rather than discovered afterwards, because the pool is carried
+forward and a rounding policy applied to a running balance is not something a
+later change can revise cleanly. See
+adr/0026-exact-decimals-bounded-by-closure.md.
+
 ## Note
 
 This unlocks the performance work in the unscheduled milestone list (TWR and
 MWR). MWR additionally needs the external/internal cash flow boundary, which
-comes from double-entry (0036 onward), not from this issue.
+comes from double-entry (0036 onward), not from this issue. Both metrics are
+past the exactness boundary regardless of method -- geometric linking and an
+internal rate of return are division and root-finding.

--- a/docs/spec/bitemporality.md
+++ b/docs/spec/bitemporality.md
@@ -151,7 +151,17 @@ declaration is explicit -- `share_count_basis` on the row, and a declaration on
 the plugin interface and the ingestion request that sets it.
 
 `split_factor_at(instrument_id, share_count_basis)` converts a row from its own
-basis to today's. See [corporate-events.md](corporate-events.md#adjustment).
+basis to today's. It returns the factor as an exact rational -- a numerator and
+denominator, the products of `split_to` and `split_from` over the applicable
+splits -- so a caller multiplies before dividing and the division happens once.
+See [corporate-events.md](corporate-events.md#adjustment) and
+adr/0028-cumulative-split-factor-is-an-exact-rational.md.
+
+The `split_adjusted_quantity` and `split_adjusted_unit_price` columns are a
+derived cache of that conversion, not stored facts. A reverse split in an awkward
+ratio has no exact decimal form, so they carry a declared rounding scale while
+the values they derive from -- `quantity`, `unit_price`, `share_count_basis` and
+the split chain -- stay exact and can be recomputed from at any time.
 
 ## Rules
 

--- a/docs/spec/csv-format.md
+++ b/docs/spec/csv-format.md
@@ -27,6 +27,8 @@ Header names are case-insensitive. Supported column names:
 | `group_ref`              | No       | Opaque grouping key. Rows sharing a non-empty value are postings of one economic event. See [Transaction groups](#transaction-groups). |
 | `account_type`           | No       | What kind of leg the row is. Defaults to `USER`. See allowed values below. |
 
+`quantity` and `unit_price` are parsed as exact decimals and stored to the precision the file supplies, with no limit on decimal places. A converter deriving one leg from another must not round to reach a fixed scale. See adr/0026-exact-decimals-bounded-by-closure.md.
+
 ### Transaction groups
 
 Each row is a **posting**: a signed amount of one commodity in one account (see [postings.md](postings.md)). The postings of a single economic event -- a trade and the cash that paid for it -- are grouped by giving them the same `group_ref`. A row with no `group_ref` is its own single-posting group.
@@ -145,6 +147,8 @@ Header names are case-insensitive. Column order is not significant.
 | `currency` | No | ISO 4217 currency code, used as a validation hint. |
 
 Prices are stored as supplied. `split_adjusted_close` is derived by PortfolioDB from `close` and the known splits, and is what performance math uses.
+
+Price values are parsed and emitted as exact decimals, so a file written by `ExportPrices` reimports to the same stored values, to the digit. Trailing zeroes are the one thing not preserved: `1.50` and `1.5` are the same price. See adr/0026-exact-decimals-bounded-by-closure.md.
 
 ### Comment lines
 

--- a/docs/spec/performance.md
+++ b/docs/spec/performance.md
@@ -21,6 +21,23 @@ The final SELECT joins holdings with prices and aggregates
 `SUM(qty * close)` per date, where both sides are split-adjusted (see
 [Share count](#share-count) below).
 
+## Exact and approximate parts
+
+Holdings are accumulated from exact decimal quantities: the running position per
+instrument is a sum, so it stays exact. Valuing that position is not -- it
+multiplies by a market price and divides by an FX rate, and a division has no
+exact decimal result. The value is therefore an estimate from that point on, and
+the query says so by casting to `double precision` at the conversion, in the
+`valued` CTE.
+
+The cast is applied to the operands, not to the result, and is the single place
+this query crosses from exact to approximate.
+
+`ValuationPoint.total_value` is a `double` on the wire for the same reason, and
+so is any later return metric: geometric linking and an internal rate of return
+are past the boundary too. See adr/0026-exact-decimals-bounded-by-closure.md and
+adr/0027-decimal-values-cross-the-wire-as-strings.md.
+
 ## TimescaleDB usage
 
 `time_bucket_gapfill('1 day', price_date, dateFrom, dateTo)` generates a row

--- a/docs/spec/performance.md
+++ b/docs/spec/performance.md
@@ -23,15 +23,21 @@ The final SELECT joins holdings with prices and aggregates
 
 ## Exact and approximate parts
 
-Holdings are accumulated from exact decimal quantities: the running position per
-instrument is a sum, so it stays exact. Valuing that position is not -- it
-multiplies by a market price and divides by an FX rate, and a division has no
-exact decimal result. The value is therefore an estimate from that point on, and
-the query says so by casting to `double precision` at the conversion, in the
-`valued` CTE.
+The running position per instrument is a sum, so accumulating it introduces no
+error of its own. Its inputs are `split_adjusted_quantity`, though, which carries
+the split adjustment's declared rounding scale (see
+[Share count](#share-count) below), so the position is exact to that scale rather
+than exact outright, with the bound growing in the number of contributing
+postings. For valuation that rounding is immaterial and is tolerated rather than
+tracked; where it is not tolerable -- the balance constraint, a checked holding
+declaration -- the raw columns are read instead.
 
-The cast is applied to the operands, not to the result, and is the single place
-this query crosses from exact to approximate.
+Valuing the position is approximate for a stronger reason: it multiplies by a
+market price and divides by an FX rate, and a division has no exact decimal
+result. The value is an estimate from that point on, and the query says so by
+casting to `double precision` at the conversion, in the `valued` CTE. The cast is
+applied to the operands, not to the result, and is the single place this query
+crosses from exact to approximate.
 
 `ValuationPoint.total_value` is a `double` on the wire for the same reason, and
 so is any later return metric: geometric linking and an internal rate of return

--- a/docs/spec/postings.md
+++ b/docs/spec/postings.md
@@ -151,12 +151,18 @@ a corporate action can leave behind, so a standard contract needs nothing stored
 A future's size varies per contract and is not held anywhere, so a future weighs as
 though its size were 1 (0072).
 
+Weight is computed from the raw `quantity` and `unit_price`, never from the
+split-adjusted pair, which carries a rounding an exact check would reject (see
+adr/0028-cumulative-split-factor-is-an-exact-rational.md).
+
 Weights accumulate **per commodity**, so a group can produce more than one routed
 posting and the commodity is whatever is left over -- cash for a missing cash leg,
 the security for an unpaired `JRNLSEC`. A residual is routed only above a
-tolerance: half a cent for money, `1e-6` otherwise. The constants are interim, but
-the tolerance is not -- a group written to 2dp that balances to within half a cent
-is balanced.
+tolerance: half a cent for money, `1e-6` otherwise. The tolerance is not a
+floating-point fudge and does not go away when quantities become exact -- a group
+written to 2dp that balances to within half a cent is balanced. The constants are
+interim: once the amounts carry a scale, the tolerance is inferred from it rather
+than fixed. See adr/0026-exact-decimals-bounded-by-closure.md.
 
 The routed posting takes the `IMBALANCE` type, or `TRANSFER_CLEARING` when the
 group is a journal. It keeps the broker, account, date and `tx_type` of the group


### PR DESCRIPTION
Documentation only. No code changes.

Working through the consequences of [0042](docs/issues/0042-exact-decimal-quantities-prices.md) surfaced three things the existing documents got wrong or left open. This records the reasoning so 0042 and 0041 can be implemented against a settled design.

## The boundary is algebraic, not editorial

Decimals are closed under `+`, `-` and `*` and nothing else. Division and the transcendentals are inexact *whatever* the storage type -- `1/3` has no finite decimal representation, so Postgres picks a scale and rounds. That makes the rule syntactic rather than a judgement call: a value is decimal if its expression tree, from source-recorded values, uses only those three operations; the first division ends exactness.

Applied to `api.proto`, 25 of the 26 `double` fields sit on the exact side and only `ValuationPoint.total_value` does not.

- **New ADR 0026** -- the closure rule, and why "decimals everywhere" is both unachievable past a division and misleading where it is achievable in form only.
- **New ADR 0027** -- decimal values cross the wire as plain `string`, not `double`, not `google.type.Decimal`.

## split_factor_at needs replacing, not retyping

It computes `exp(sum(ln(...)))`. The `numeric` versions of `ln`/`exp` are software series expansions over digit arrays, so retyping would be slower *and* still approximate.

- **New ADR 0028** -- the factor becomes an exact rational pair from a `numeric` product aggregate, with the single division deferred to the caller.

Two consequences no document stated: `split_adjusted_*` are a derived cache carrying a declared rounding scale rather than facts, and therefore an exact balance check must read the raw columns -- a 3:1 split turns `+10 AAPL @ 185.50` into `+30 @ 61.8333...` against an untouched `-1855 USD`, and the rounding would reject a correct group. Added to **ADR 0024**.

## Three documents overstated the float problem

ADRs 0020 and 0022 and issue 0041 all said the balance invariant is "not expressible" while the columns are `DOUBLE PRECISION`. It is expressible, with a *relative* tolerance. Since ADR 0024 already accepts a half-cent routing tolerance at ingest, the correctness claim did not hold up. What exactness actually buys is that there is no tolerance to justify per call site and no scale-dependence to get wrong -- a stronger argument anyway. Corrected in all three.

## Also updated

- **0042** rewritten around the closure boundary, with the `split_factor_at` question now settled rather than left as four options, and two previously unstated costs: the go-cmp comparer `decimal.Decimal` needs, and that a decimal library is confined to the CSV/OFX converters.
- **0041** gains the raw-vs-split-adjusted requirement, and an open question it has to settle -- a constraint trigger duplicates the weight function from `balance.go` in PL/pgSQL unless the computed weight is stored on the posting row.
- **0043** and **0045** -- the declaration assertion does not tighten all the way to an exact comparison; Section 104 pooling averages and so lands past the boundary while FIFO and specific identification do not.
- **Specs** -- postings (tolerance and raw values), bitemporality (the rational return and the derived cache), performance (the exact/approximate split in the valuation query), csv-format (the round-trip guarantee).
- **Skills** -- the `protobuf` skill said "floating-point numerical values use the `double` type", which is the rule that would otherwise have added the next field wrongly. `go` gains `shopspring/decimal` and the go-cmp comparer (`1.0` and `1.00` are `.Equal` but not `DeepEqual`); `typescript` gains the string-field handling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)