### PR TITLE
Settle where the balance constraint's weight function lives (0041)

### DIFF
--- a/docs/adr/0024-group-balance-is-checked-on-weight.md
+++ b/docs/adr/0024-group-balance-is-checked-on-weight.md
@@ -54,6 +54,9 @@ posting with no price cannot convert at all.
 - **Adding an explicit annotation to the upload format.** Correct, and the option
   to keep open. Rejected for now because nothing balances until every converter
   has been taught to set it, whereas the tx type is already there.
+  [0029](0029-posting-weight-is-stored.md) stores the weight this rule computes
+  on the posting, which is the same annotation supplied by the server rather than
+  by the upload.
 
 The choice between these is decided by an asymmetry. **Failing to convert leaves a
 residual in some commodity: visible in the imbalance report, attributable to a

--- a/docs/adr/0029-posting-weight-is-stored.md
+++ b/docs/adr/0029-posting-weight-is-stored.md
@@ -1,0 +1,59 @@
+# Posting weight is stored, not re-derived
+
+[0041](../issues/0041-enable-balance-constraint.md) moves the group balance check
+into a deferred constraint trigger. Balance is checked on weight
+([0024](0024-group-balance-is-checked-on-weight.md)), whose rules -- the
+converting tx types, the settlement-currency guard, the contract-size
+multiplication -- live in Go, in `server/service/ingestion/balance.go`. The
+trigger needs them in SQL.
+
+Each posting **stores** the weight it contributes and the commodity it
+contributes in, and the constraint is a plain `SUM(weight) = 0` per
+`(group_id, weight_commodity)`. The weight rules stay in Go and are not
+reimplemented in PL/pgSQL.
+
+Two columns rather than one, because balance is per commodity: a group can leave
+a residual in cash and another in a security at the same time.
+`weight_commodity` is the currency code for a converted or cash leg, the
+instrument for an unconverted security leg, and the posting's description when
+its instrument never resolved. The fallback is a real value and never NULL, so an
+unresolved posting still balances against itself.
+
+## Considered options
+
+- **Reimplementing the weight rules in PL/pgSQL.** Rejected on two counts. It is
+  a second copy of the rules that must not drift from the Go one, which is a poor
+  trade for a constraint whose value is that it cannot be bypassed. More
+  decisively, it re-derives weight at COMMIT from the *current* `instruments`
+  row, and instrument state moves under a posting after ingest: a merge rewrites
+  `txs.instrument_id` wholesale, and `contract_multiplier` records the deviation
+  a corporate action leaves behind. A re-derived check could therefore reject a
+  group that was balanced when it was written, on an update that has nothing to
+  do with it. A stored weight is fixed at the fact's own time, which is the same
+  reason `split_adjusted_*` are stored rather than computed on read.
+
+## Consequences
+
+The constraint proves that the *declared* weights of a group sum to zero, not
+that its postings balance. A writer that computes weight wrongly writes a
+self-consistent lie, which is weaker than the unbypassable check 0041 set out to
+add.
+
+That is accepted, because it is beancount's contract as well: there, weight comes
+from a `{}` or `@` annotation that whoever wrote the entry supplied. 0024 already
+records the explicit annotation as correct and worth keeping open, rejected only
+because nothing would balance until every converter had been taught to set it.
+Storing the computed weight is that annotation arriving from the server instead
+of the upload -- it buys the property without the converter work, and leaves the
+door open for a converter to supply its own later.
+
+The PL/pgSQL alternative does not deliver the stronger property either. A second
+copy that has drifted checks the wrong rule while looking authoritative, which is
+worse than a declared value, because the divergence is invisible.
+
+Weight is computed from the raw `quantity` and `unit_price`, which the corporate
+event recompute does not touch -- it writes only the `split_adjusted_*` pair --
+so weight is written once at ingest and no recompute pass has to maintain it. The
+one exception is the instrument merge, which must rewrite `weight_commodity`
+alongside `instrument_id` in the same statement. Both legs of a same-instrument
+group move together there, so the group stays balanced across the merge.

--- a/docs/issues/0041-enable-balance-constraint.md
+++ b/docs/issues/0041-enable-balance-constraint.md
@@ -57,22 +57,30 @@ and that is what makes an exact constraint satisfiable.
 
 Tracked as 0042.
 
-## Open question: where the weight function lives
+## Where the weight function lives
 
-The constraint checks weight, so the trigger needs the weight rules --
-`exchangeTypes`, the settlement-currency guard, the contract-size multiplication
-in `server/service/ingestion/balance.go` -- available in SQL. Reimplementing
-them in PL/pgSQL means a second copy of the rules that must not drift from the
-Go one, which is a poor trade for a constraint whose value is that it cannot be
-bypassed.
+Settled in adr/0029-posting-weight-is-stored.md: each posting stores the weight
+it contributes, and the weight rules are not reimplemented in PL/pgSQL. Two
+columns on `txs`, because balance is per commodity:
 
-The alternative is to store each posting's computed weight on its row. The
-constraint then becomes a plain `SUM(weight) = 0` per group with no duplicated
-logic, and weight is `quantity * unit_price * contract_size`, closed under
-multiplication and so exact once 0042 lands. The cost is a stored derived column
-that recompute passes have to maintain.
+- `weight` -- `quantity`, or `quantity * unit_price * contract_size` for a
+  converting leg. Closed under multiplication, so exact once 0042 lands.
+- `weight_commodity` -- the currency code for a converted or cash leg, the
+  instrument for an unconverted security leg, and the posting's description when
+  its instrument never resolved. Never NULL, so an unresolved posting still
+  balances against itself.
 
-Settle this before implementing.
+The trigger then groups on `(group_id, weight_commodity)` and checks
+`SUM(weight) = 0`.
+
+The instrument merge in `server/db/postgres/instruments.go` rewrites
+`txs.instrument_id`, so it has to rewrite `weight_commodity` in the same
+statement. Nothing else maintains the columns: weight is on the raw `quantity`
+and `unit_price`, which the corporate event recompute leaves alone.
+
+Note what this costs. The constraint proves that the declared weights of a group
+sum to zero, not that its postings balance, so the motivation above is stronger
+than what lands. 0029 records why that is the right trade anyway.
 
 ## Sequencing
 

--- a/docs/spec/postings.md
+++ b/docs/spec/postings.md
@@ -120,7 +120,9 @@ unset.
 Every group is balanced at ingest. Whatever its postings leave over is routed to an
 explicit counterparty rather than rejected, so the invariant holds by construction
 from day one and a residual becomes measurable instead of being absorbed into a cash
-balance. The database constraint that enforces it is not switched on yet.
+balance. The database constraint that enforces it is not switched on yet; when it
+is, it checks a weight stored on each posting rather than one re-derived in SQL
+(see adr/0029-posting-weight-is-stored.md).
 
 A group's postings are in different commodities, so a plain `SUM(quantity)` cannot
 say whether it balances: a buy is `+10 AAPL` and `-1855 USD`. Balance is checked on


### PR DESCRIPTION
Documentation only. Closes the open question in
[0041](docs/issues/0041-enable-balance-constraint.md): whether the deferred
balance constraint should reimplement the weight rules in PL/pgSQL, or read a
weight stored on each posting.

## Decision

Store the weight. Recorded in
[adr/0029-posting-weight-is-stored.md](docs/adr/0029-posting-weight-is-stored.md).

Two columns on `txs` rather than one, because balance is per commodity:
`weight` and `weight_commodity`. The trigger groups on
`(group_id, weight_commodity)` and checks `SUM(weight) = 0`.

The decisive argument against re-deriving in PL/pgSQL is not the duplicated
rules -- it is that a COMMIT-time re-derivation reads *current* instrument
state, which moves under a posting after ingest. An instrument merge rewrites
`txs.instrument_id` wholesale, and `contract_multiplier` records the deviation a
corporate action leaves behind. A re-derived check could therefore reject a
group that was balanced when it was written, on an update unrelated to it. A
stored weight is fixed at the fact's own time, for the same reason
`split_adjusted_*` are stored rather than computed on read.

## What it costs

The constraint then proves that a group's *declared* weights sum to zero, not
that its postings balance, which is weaker than the unbypassable check 0041 set
out to add. 0029 records why that is accepted: it is beancount's contract as
well, and 0024 already had the explicit annotation down as correct and worth
keeping open, rejected only because every converter would need teaching first.
This is that annotation arriving from the server rather than the upload. The
PL/pgSQL alternative does not deliver the stronger property either -- a drifted
second copy checks the wrong rule while looking authoritative.

## Changes

- `docs/adr/0029-posting-weight-is-stored.md` (new) -- the decision, the rejected
  alternative, and the consequences.
- `docs/adr/0024-...` -- the "explicit annotation to the upload format" bullet now
  points at 0029 as the same annotation supplied by the server.
- `docs/issues/0041-...` -- open question replaced with the settled design, including
  the instrument merge that must rewrite `weight_commodity` alongside `instrument_id`.
- `docs/spec/postings.md` -- terse pointer on the sentence that already notes the
  constraint is not switched on.

No code or schema changes; the columns land with 0041 itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)