### PR TITLE
Move quantities and prices to NUMERIC (0042)

### DIFF
--- a/docs/spec/corporate-events.md
+++ b/docs/spec/corporate-events.md
@@ -100,15 +100,22 @@ For why these are excluded, see adr/0005-corporate-events-design.md.
 
 The `eod_prices` and `txs` tables carry `split_adjusted_*` columns alongside the raw values. The columns are populated at insert time (defaulting to the raw counterpart via a BEFORE trigger) and recomputed by `RecomputeSplitAdjustments` whenever new splits arrive.
 
-The adjustment factor for a row with reference date `R` and instrument `I` is:
+The adjustment factor for a row with reference date `R` and instrument `I` is a
+rational, returned as a numerator and a denominator rather than as their quotient:
 
 ```
-factor = product over splits where
+over splits where
   split.instrument_id = I
   AND split.ex_date > R
   AND split.ex_date <= current_date
-  of (split.split_to / split.split_from)
+
+num = product of split.split_to
+den = product of split.split_from
 ```
+
+Both products are exact, and callers multiply by `num` before dividing by `den` so
+the single division comes last. That ordering is what keeps the exact part exact
+for as long as possible; see adr/0028-cumulative-split-factor-is-an-exact-rational.md.
 
 The reference date `R` is the row's **share count basis** -- the date at which the share count its raw values are denominated in was current. It is declared by whoever supplied the row and stored on the row itself, not inferred from when the row was fetched; see [bitemporality.md](bitemporality.md#share-count-basis).
 
@@ -116,14 +123,17 @@ The `ex_date <= current_date` clause is the future-date guard: without it a futu
 
 Because the guard is evaluated against the wall clock, the `split_adjusted_*` columns are as-of now rather than as-of any stored date. Arithmetic must never mix the two share counts: raw quantity multiplies raw price, split-adjusted quantity multiplies split-adjusted price. Mixing them across a split scales the result by the split factor.
 
-Adjustment math:
+Adjustment math. A quantity adjusts by the factor and a price by its reciprocal,
+so `num` and `den` swap places between the two:
 
-- `split_adjusted_close = close / factor` (and same for open / high / low)
-- `split_adjusted_volume = round(volume * factor)` (more shares trade in adjusted-share terms)
-- `split_adjusted_quantity = quantity * factor` (more shares held)
-- `split_adjusted_unit_price = unit_price / factor` (per-share price drops)
+- `split_adjusted_close = close * den / num` (and same for open / high / low)
+- `split_adjusted_volume = round(volume * num / den)` (more shares trade in adjusted-share terms)
+- `split_adjusted_quantity = quantity * num / den` (more shares held)
+- `split_adjusted_unit_price = unit_price * den / num` (per-share price drops)
 
 The cost-basis invariant `qty × price == split_adjusted_quantity × split_adjusted_unit_price` is preserved by construction.
+
+The quotient is exact whenever `den` divides the product -- every forward split, and every ratio whose denominator factors into 2s and 5s (2:1, 3:2, 5:4). It is not exact for a genuine reverse `/3`, so the `split_adjusted_*` columns declare a rounding scale of 12 decimal places, recorded in the schema alongside them. The rounding is confined to that derived cache: the raw columns stay exact and the adjusted pair is recomputable from them at any time. An exact check -- a group balance, a checked holding declaration -- reads the raw columns instead.
 
 ### Option contracts
 

--- a/server/db/postgres/corporate_events.go
+++ b/server/db/postgres/corporate_events.go
@@ -688,25 +688,31 @@ func (p *Postgres) RecomputeSplitAdjustments(ctx context.Context, instrumentID s
 	}
 
 	return p.runInTx(ctx, func(exec queryable) error {
-		// Prices: compute the factor once per (instrument, date) in a
-		// FROM-subquery, then reference f.factor in all SET clauses.
-		// open/high/low/close are NUMERIC; volume is BIGINT (multiplied).
+		// Prices: compute the factor once per (instrument, date) in a LATERAL,
+		// then reference f.num and f.den in all SET clauses. LATERAL rather than
+		// a plain subquery selecting (split_factor_at(...)).*, which would call
+		// the function once per output column.
+		//
+		// The factor is a rational and divides last: a price adjusts by its
+		// reciprocal, so the multiplication is by den and the division by num.
+		// open/high/low/close are NUMERIC; volume is BIGINT and adjusts the other
+		// way (more shares trade in adjusted-share terms).
 		priceSQL := fmt.Sprintf(`
 			UPDATE eod_prices ep SET
 				split_adjusted_open    = CASE WHEN ep.open   IS NULL THEN NULL
-					ELSE ep.open   / f.factor::numeric END,
+					ELSE ep.open   * f.den / f.num END,
 				split_adjusted_high    = CASE WHEN ep.high   IS NULL THEN NULL
-					ELSE ep.high   / f.factor::numeric END,
+					ELSE ep.high   * f.den / f.num END,
 				split_adjusted_low     = CASE WHEN ep.low    IS NULL THEN NULL
-					ELSE ep.low    / f.factor::numeric END,
-				split_adjusted_close   = ep.close / f.factor::numeric,
+					ELSE ep.low    * f.den / f.num END,
+				split_adjusted_close   = ep.close * f.den / f.num,
 				split_adjusted_volume  = CASE WHEN ep.volume IS NULL THEN NULL
-					ELSE round(ep.volume::numeric * f.factor::numeric)::bigint END
+					ELSE round(ep.volume::numeric * f.num / f.den)::bigint END
 			FROM (
-				SELECT instrument_id, price_date,
-					split_factor_at(instrument_id, share_count_basis) AS factor
-				FROM eod_prices
-				WHERE instrument_id %s
+				SELECT p.instrument_id, p.price_date, f.num, f.den
+				FROM eod_prices p,
+					LATERAL split_factor_at(p.instrument_id, p.share_count_basis) f
+				WHERE p.instrument_id %s
 			) f
 			WHERE ep.instrument_id = f.instrument_id
 			  AND ep.price_date = f.price_date
@@ -715,17 +721,22 @@ func (p *Postgres) RecomputeSplitAdjustments(ctx context.Context, instrumentID s
 			return fmt.Errorf("recompute split adjustments (prices): %w", err)
 		}
 
-		// Txs: factor is already double precision so no cast is needed.
+		// Txs: a quantity adjusts by the factor and a price by its reciprocal, so
+		// the two invert each other and the cost-basis invariant
+		// quantity * unit_price == split_adjusted_quantity * split_adjusted_unit_price
+		// holds. Both multiply before the single division; the result rounds to
+		// the columns' declared scale, which is where a reverse /3 lands.
 		txSQL := fmt.Sprintf(`
 			UPDATE txs t SET
-				split_adjusted_quantity   = t.quantity * f.factor,
+				split_adjusted_quantity   = t.quantity * f.num / f.den,
 				split_adjusted_unit_price = CASE WHEN t.unit_price IS NULL THEN NULL
-					ELSE t.unit_price / f.factor END
+					ELSE t.unit_price * f.den / f.num END
 			FROM (
-				SELECT id, split_factor_at(instrument_id, share_count_basis) AS factor
-				FROM txs
-				WHERE instrument_id IS NOT NULL
-				  AND instrument_id %s
+				SELECT x.id, f.num, f.den
+				FROM txs x,
+					LATERAL split_factor_at(x.instrument_id, x.share_count_basis) f
+				WHERE x.instrument_id IS NOT NULL
+				  AND x.instrument_id %s
 			) f
 			WHERE t.id = f.id
 		`, instFilter)

--- a/server/db/postgres/corporate_events_test.go
+++ b/server/db/postgres/corporate_events_test.go
@@ -702,6 +702,94 @@ func TestRecomputeSplitAdjustments_NoSplits(t *testing.T) {
 	}
 }
 
+// TestRecomputeSplitAdjustments_ForwardSplitIsExact asserts on the stored text of
+// the adjusted columns rather than on a float64, because the point of the num/den
+// factor is that a forward split leaves no rounding at all. A 7:1 then 4:1 chain
+// on 100 shares at 280 is 2800 shares at 10 exactly -- the old exp(sum(ln(...)))
+// factor reached 27.999999999999996 and both adjusted values inherited it.
+func TestRecomputeSplitAdjustments_ForwardSplitIsExact(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID := setupUser(t, p)
+	instID := setupInstrument(t, p, "AAPL")
+
+	insertTxs(t, p, userID, instID, []*apiv1.Tx{{
+		Type:                  apiv1.TxType_BUYSTOCK,
+		Timestamp:             ts(2010, 6, 1),
+		Quantity:              100,
+		UnitPrice:             proto.Float64(280),
+		InstrumentDescription: "AAPL",
+	}})
+	if err := p.UpsertStockSplits(ctx, []db.StockSplit{
+		{InstrumentID: instID, ExDate: d(2014, 6, 9), SplitFrom: "1", SplitTo: "7", DataProvider: "test"},
+		{InstrumentID: instID, ExDate: d(2020, 8, 31), SplitFrom: "1", SplitTo: "4", DataProvider: "test"},
+	}); err != nil {
+		t.Fatalf("upsert splits: %v", err)
+	}
+	if err := p.RecomputeSplitAdjustments(ctx, instID); err != nil {
+		t.Fatalf("recompute: %v", err)
+	}
+
+	// Read as text so the assertion is on the stored decimal, not on a value the
+	// driver has already rounded into a float64.
+	var saQty, saUnitPrice string
+	if err := p.q.QueryRowContext(ctx, `
+		SELECT trim_scale(split_adjusted_quantity)::text,
+		       trim_scale(split_adjusted_unit_price)::text
+		FROM txs WHERE instrument_id = $1::uuid
+	`, instID).Scan(&saQty, &saUnitPrice); err != nil {
+		t.Fatalf("read tx: %v", err)
+	}
+	if saQty != "2800" {
+		t.Errorf("split_adjusted_quantity: got %q want %q", saQty, "2800")
+	}
+	if saUnitPrice != "10" {
+		t.Errorf("split_adjusted_unit_price: got %q want %q", saUnitPrice, "10")
+	}
+}
+
+// TestRecomputeSplitAdjustments_ReverseSplitRoundsToDeclaredScale covers the case
+// the declared scale exists for. A 1:3 reverse split on 100 shares is 33.333...,
+// which has no finite decimal form, so the column rounds it at 12 places. The
+// price moves the other way and 280 * 3 is exact, so only one side of the pair
+// rounds -- which is why the cost-basis invariant is checked on the raw columns.
+func TestRecomputeSplitAdjustments_ReverseSplitRoundsToDeclaredScale(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID := setupUser(t, p)
+	instID := setupInstrument(t, p, "RVRS")
+
+	insertTxs(t, p, userID, instID, []*apiv1.Tx{{
+		Type:                  apiv1.TxType_BUYSTOCK,
+		Timestamp:             ts(2020, 1, 2),
+		Quantity:              100,
+		UnitPrice:             proto.Float64(280),
+		InstrumentDescription: "RVRS",
+	}})
+	if err := p.UpsertStockSplits(ctx, []db.StockSplit{
+		{InstrumentID: instID, ExDate: d(2021, 3, 1), SplitFrom: "3", SplitTo: "1", DataProvider: "test"},
+	}); err != nil {
+		t.Fatalf("upsert splits: %v", err)
+	}
+	if err := p.RecomputeSplitAdjustments(ctx, instID); err != nil {
+		t.Fatalf("recompute: %v", err)
+	}
+
+	var saQty, saUnitPrice string
+	if err := p.q.QueryRowContext(ctx, `
+		SELECT split_adjusted_quantity::text, trim_scale(split_adjusted_unit_price)::text
+		FROM txs WHERE instrument_id = $1::uuid
+	`, instID).Scan(&saQty, &saUnitPrice); err != nil {
+		t.Fatalf("read tx: %v", err)
+	}
+	if saQty != "33.333333333333" {
+		t.Errorf("split_adjusted_quantity: got %q want %q (12dp)", saQty, "33.333333333333")
+	}
+	if saUnitPrice != "840" {
+		t.Errorf("split_adjusted_unit_price: got %q want %q", saUnitPrice, "840")
+	}
+}
+
 // TestListStockSplitsForExport_BestIdentifier verifies that the export query
 // joins each split with the highest-priority identifier for the instrument.
 // MIC_TICKER beats ISIN beats BROKER_DESCRIPTION.

--- a/server/db/postgres/holdings_test.go
+++ b/server/db/postgres/holdings_test.go
@@ -95,6 +95,56 @@ func TestComputeHoldings_signedQuantity(t *testing.T) {
 	}
 }
 
+// TestComputeHoldings_fractionalQuantitiesSumExactly pins the reason the quantity
+// columns are NUMERIC. Ten buys of 0.1 sum to exactly 1 in decimal; in binary
+// floating point they sum to 0.9999999999999999, and that residual reached the
+// user as the holding quantity. qty_is_zero's old epsilon hid the closed-position
+// case but nothing guarded the open one.
+func TestComputeHoldings_fractionalQuantitiesSumExactly(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|exact", "U", "u@u.com")
+	now := time.Now()
+	from := timestamppb.New(now.Add(-1 * time.Hour))
+	to := timestamppb.New(now)
+	at := timestamppb.New(now.Add(-30 * time.Minute))
+
+	txs := make([]*apiv1.Tx, 0, 10)
+	instIDs := make([]string, 0, 10)
+	instID, err := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{
+		{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "FRAC", Canonical: false},
+	}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+	for i := 0; i < 10; i++ {
+		txs = append(txs, &apiv1.Tx{
+			Timestamp: at, InstrumentDescription: "FRAC",
+			Type: apiv1.TxType_BUYSTOCK, Quantity: 0.1,
+		})
+		instIDs = append(instIDs, instID)
+	}
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, instIDs, nil); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+
+	holdings, _, err := p.ComputeHoldings(ctx, userID, nil, "", nil)
+	if err != nil {
+		t.Fatalf("holdings: %v", err)
+	}
+	var got float64
+	for _, h := range holdings {
+		if h.InstrumentDescription == "FRAC" {
+			got = h.Quantity
+			break
+		}
+	}
+	// Exact equality, not approxEq: that is the whole point.
+	if got != 1 {
+		t.Fatalf("ten buys of 0.1: got %v want exactly 1", got)
+	}
+}
+
 // TestComputeHoldings_excludesNonUserAccountTypes verifies the counterparty leg of a
 // one-sided event does not net against the holding it balances. The EQUITY leg here is
 // what an INITIALIZE pad's counterparty looks like: same instrument, same broker

--- a/server/db/postgres/postgres.go
+++ b/server/db/postgres/postgres.go
@@ -27,8 +27,11 @@ type queryable interface {
 	GetContext(ctx context.Context, dest interface{}, query string, args ...interface{}) error
 }
 
-// qtyIsZero mirrors the SQL qty_is_zero function: true when a quantity is
-// effectively zero, absorbing floating-point residuals from summed buys/sells.
+// qtyIsZero is true when a running position is closed. Its SQL counterpart no
+// longer needs an epsilon -- the quantity columns are NUMERIC and buys sum
+// against sells exactly -- but this one still reads a float64 position out of the
+// HeldRanges window, so it keeps absorbing that sum's residual until the scan
+// type follows the column.
 func qtyIsZero(q float64) bool {
 	return q > -1e-9 && q < 1e-9
 }

--- a/server/db/postgres/valuation.go
+++ b/server/db/postgres/valuation.go
@@ -220,32 +220,49 @@ valued AS (
         inst.asset_class,
         dh.qty,
         gp.close,
+        -- This CASE is the single place the query crosses from exact to
+        -- approximate. Quantities and prices are exact decimals, but valuing a
+        -- position divides by an FX rate and a division has no exact decimal
+        -- result, so the value is an estimate from here on. The cast says so, and
+        -- it is applied to the operands rather than to the result: casting the
+        -- result would have Postgres compute sixteen significant digits of numeric
+        -- division for every instrument on every calendar day and then discard
+        -- them. See docs/spec/performance.md and
+        -- docs/adr/0026-exact-decimals-bounded-by-closure.md.
         CASE
             -- Unidentified instrument: always unpriced.
             WHEN dh.instrument_id IS NULL THEN NULL
             -- Cash in display currency: implicit price 1.0, no FX needed.
             WHEN inst.asset_class = 'CASH' AND COALESCE(inst.currency, $4) = $4
-                THEN dh.qty
+                THEN dh.qty::double precision
             -- Cash in foreign currency: implicit price 1.0, convert via FX rate.
             WHEN inst.asset_class = 'CASH' THEN
                 CASE
                     WHEN $4 = 'USD' THEN
-                        CASE WHEN fr.rate IS NOT NULL THEN dh.qty * fr.rate ELSE NULL END
+                        CASE WHEN fr.rate IS NOT NULL
+                            THEN dh.qty::double precision * fr.rate::double precision
+                            ELSE NULL
+                        END
                     ELSE
                         CASE WHEN dfr.rate IS NOT NULL
                                 AND (COALESCE(inst.currency, 'USD') = 'USD' OR fr.rate IS NOT NULL)
-                            THEN dh.qty * COALESCE(fr.rate, 1.0) / dfr.rate
+                            THEN dh.qty::double precision
+                                * COALESCE(fr.rate::double precision, 1.0)
+                                / dfr.rate::double precision
                             ELSE NULL
                         END
                 END
             -- Non-cash with no price: unpriced.
             WHEN gp.close IS NULL THEN NULL
             -- Instrument currency IS the display currency (or NULL): no conversion.
-            WHEN COALESCE(inst.currency, $4) = $4 THEN dh.qty * gp.close
+            WHEN COALESCE(inst.currency, $4) = $4
+                THEN dh.qty::double precision * gp.close::double precision
             -- Display = USD: fx_rate = BASEUSD_rate.
             WHEN $4 = 'USD' THEN
                 CASE WHEN fr.rate IS NOT NULL
-                    THEN dh.qty * gp.close * fr.rate
+                    THEN dh.qty::double precision
+                        * gp.close::double precision
+                        * fr.rate::double precision
                     ELSE NULL  -- missing FX rate -> unpriced
                 END
             -- Display != USD: fx_rate = BASEUSD_rate / DISPLAYUSD_rate.
@@ -253,7 +270,10 @@ valued AS (
             ELSE
                 CASE WHEN dfr.rate IS NOT NULL
                         AND (COALESCE(inst.currency, 'USD') = 'USD' OR fr.rate IS NOT NULL)
-                    THEN dh.qty * gp.close * COALESCE(fr.rate, 1.0) / dfr.rate
+                    THEN dh.qty::double precision
+                        * gp.close::double precision
+                        * COALESCE(fr.rate::double precision, 1.0)
+                        / dfr.rate::double precision
                     ELSE NULL  -- missing base or display FX rate -> unpriced
                 END
         END AS converted_value,

--- a/server/db/postgres/valuation_test.go
+++ b/server/db/postgres/valuation_test.go
@@ -1200,3 +1200,66 @@ func unpricedOn(t *testing.T, points []db.ValuationPoint, want time.Time) bool {
 	t.Fatalf("no valuation point for %s", want.Format("2006-01-02"))
 	return false
 }
+
+// TestGetUserValuation_ExcludesDatesBeforeFirstTx covers qty_is_zero's NULL
+// branch, which is the only reason the function still exists now that quantities
+// are exact and there is no residual to absorb. daily_holdings forward-fills the
+// last known position with a LIMIT 1 correlated subquery, so on every grid day
+// before an instrument's first tx the position is NULL rather than zero. The NULL
+// branch classifies that as "not held", so the row leaves the valued CTE and the
+// day drops out of the series entirely -- priced days before the first purchase
+// are absent rather than zero, and the instrument is never reported as unpriced
+// on them.
+func TestGetUserValuation_ExcludesDatesBeforeFirstTx(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+
+	userID, _ := p.GetOrCreateUser(ctx, "sub|nullqty", "U", "u@nullqty.com")
+	instID, err := p.EnsureInstrument(ctx, "STOCK", "", "USD", "NULLQ", "", "", []db.IdentifierInput{
+		{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "NULLQ", Canonical: false},
+	}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+
+	// Bought on Jan 3, but the valuation window opens on Jan 1.
+	buyDate := time.Date(2025, 1, 3, 12, 0, 0, 0, time.UTC)
+	txs := []*apiv1.Tx{
+		{Timestamp: timestamppb.New(buyDate), InstrumentDescription: "NULLQ", Type: apiv1.TxType_BUYSTOCK, Quantity: 10, Account: "main"},
+	}
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "",
+		timestamppb.New(buyDate.Add(-time.Hour)), timestamppb.New(buyDate.Add(time.Hour)),
+		txs, []string{instID}, nil); err != nil {
+		t.Fatalf("replace txs: %v", err)
+	}
+	prices := []db.EODPrice{
+		{InstrumentID: instID, PriceDate: time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), Close: 100.0, DataProvider: "test"},
+		{InstrumentID: instID, PriceDate: time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC), Close: 100.0, DataProvider: "test"},
+		{InstrumentID: instID, PriceDate: time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC), Close: 150.0, DataProvider: "test"},
+	}
+	if err := p.UpsertPrices(ctx, prices); err != nil {
+		t.Fatalf("upsert prices: %v", err)
+	}
+
+	points, err := p.GetUserValuation(ctx, userID,
+		time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		time.Date(2025, 1, 4, 0, 0, 0, 0, time.UTC), "USD")
+	if err != nil {
+		t.Fatalf("get user valuation: %v", err)
+	}
+	// Jan 1 and Jan 2 are priced but not held, so they are not in the series at
+	// all. Only Jan 3 survives.
+	if len(points) != 1 {
+		t.Fatalf("expected 1 point, got %d", len(points))
+	}
+	if got := points[0].Date.Format("2006-01-02"); got != "2025-01-03" {
+		t.Errorf("point date: got %s want 2025-01-03", got)
+	}
+	if points[0].TotalValue != 1500 {
+		t.Errorf("total value: got %v want 1500", points[0].TotalValue)
+	}
+	// A NULL position is not an unpriced one: the instrument simply was not held.
+	if len(points[0].UnpricedInstruments) != 0 {
+		t.Errorf("expected no unpriced instruments, got %v", points[0].UnpricedInstruments)
+	}
+}

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -78,6 +78,15 @@ CREATE INDEX idx_tx_groups_job_id ON tx_groups (job_id);
 -- instrument. They equal the raw quantity/unit_price when no later split exists.
 -- They are recomputed idempotently from the raw columns whenever splits change
 -- (see RecomputeTxSplitAdjustments).
+-- quantity and unit_price are transcribed decimals and are exact, so they are
+-- bare NUMERIC. The split-adjusted pair is not: the cumulative split factor is a
+-- rational and a reverse /3 has no finite decimal form, so the pair declares a
+-- rounding scale of 12 -- more places than any broker quotes fractional shares or
+-- prices to. The rounding is confined to this derived cache; the raw columns it
+-- is computed from stay exact and it is recomputable from them at any time. An
+-- exact check (a group balance, a checked declaration) reads the raw columns.
+-- See docs/adr/0026-exact-decimals-bounded-by-closure.md and
+-- docs/adr/0028-cumulative-split-factor-is-an-exact-rational.md.
 CREATE TABLE txs (
   id                        UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id                   UUID NOT NULL REFERENCES users (id) ON DELETE CASCADE,
@@ -86,12 +95,12 @@ CREATE TABLE txs (
   timestamp                 TIMESTAMPTZ NOT NULL,
   instrument_description    TEXT NOT NULL,
   tx_type                   TEXT NOT NULL,
-  quantity                  DOUBLE PRECISION NOT NULL,
-  split_adjusted_quantity   DOUBLE PRECISION NOT NULL,
+  quantity                  NUMERIC NOT NULL,
+  split_adjusted_quantity   NUMERIC(38, 12) NOT NULL,
   trading_currency          TEXT,
   settlement_currency       TEXT,
-  unit_price                DOUBLE PRECISION,
-  split_adjusted_unit_price DOUBLE PRECISION,
+  unit_price                NUMERIC,
+  split_adjusted_unit_price NUMERIC(38, 12),
   share_count_basis         DATE NOT NULL,
   synthetic_purpose         TEXT CHECK (synthetic_purpose IS NULL OR synthetic_purpose = 'INITIALIZE'),
   account_type              TEXT NOT NULL DEFAULT 'USER'
@@ -405,6 +414,11 @@ WHERE
 -- no later split exists. close (NOT NULL) implies split_adjusted_close (NOT NULL);
 -- the others are NULL iff their raw counterpart is NULL. Volume is adjusted in
 -- the opposite direction (more shares trade in adjusted-share terms).
+-- The raw OHLC are transcribed decimals and are exact, so they are bare NUMERIC.
+-- The split_adjusted_* pair is not: the cumulative split factor is a rational and
+-- a reverse /3 has no finite decimal form, so they declare a rounding scale of 12,
+-- matching txs.split_adjusted_*. The rounding is confined to this derived cache.
+-- See docs/adr/0028-cumulative-split-factor-is-an-exact-rational.md.
 -- adjusted_close is preserved as-supplied by the data provider on the provider's
 -- own basis (typically including dividend adjustment as well as splits). It is
 -- never an input to valuation and exists to cross-check split_adjusted_close,
@@ -413,13 +427,13 @@ CREATE TABLE eod_prices (
   instrument_id          UUID        NOT NULL REFERENCES instruments (id) ON DELETE CASCADE,
   price_date             DATE        NOT NULL,
   open                   NUMERIC,
-  split_adjusted_open    NUMERIC,
+  split_adjusted_open    NUMERIC(38, 12),
   high                   NUMERIC,
-  split_adjusted_high    NUMERIC,
+  split_adjusted_high    NUMERIC(38, 12),
   low                    NUMERIC,
-  split_adjusted_low     NUMERIC,
+  split_adjusted_low     NUMERIC(38, 12),
   close                  NUMERIC     NOT NULL,
-  split_adjusted_close   NUMERIC     NOT NULL,
+  split_adjusted_close   NUMERIC(38, 12) NOT NULL,
   adjusted_close         NUMERIC,
   volume                 BIGINT,
   split_adjusted_volume  BIGINT,
@@ -656,10 +670,22 @@ CREATE TRIGGER trg_default_split_adjusted_eod_price
   BEFORE INSERT OR UPDATE ON eod_prices
   FOR EACH ROW EXECUTE FUNCTION default_split_adjusted_eod_price();
 
+-- mul is the product aggregate Postgres does not ship. Multiplication over
+-- numeric is exact, so a cumulative split factor built from it is exact.
+-- numeric_mul is strict and the initcond is non-null, so a NULL input is skipped
+-- rather than poisoning the product, and zero input rows return 1.
+CREATE AGGREGATE mul(numeric) (SFUNC = numeric_mul, STYPE = numeric, INITCOND = '1');
+
 -- split_factor_at returns the cumulative split adjustment factor for the
--- given instrument as of the given reference date. The factor is the product
--- of (split_to / split_from) over every stock split with ex_date strictly
--- greater than reference_date AND less than or equal to the current date.
+-- given instrument as of the given reference date, as an exact rational: the
+-- numerator is the product of split_to and the denominator the product of
+-- split_from, over every stock split with ex_date strictly greater than
+-- reference_date AND less than or equal to the current date.
+--
+-- The quotient is returned unevaluated so that callers multiply first and divide
+-- once -- quantity * num / den rather than quantity * (num / den) -- which is the
+-- minimal-error ordering and keeps the exact part exact for as long as possible.
+-- See docs/adr/0028-cumulative-split-factor-is-an-exact-rational.md.
 --
 -- For derivative instruments (options, futures) that have an underlying_id,
 -- the function also includes splits on the underlying instrument. This
@@ -677,17 +703,15 @@ CREATE TRIGGER trg_default_split_adjusted_eod_price
 -- daily scheduler (see docs/spec/corporate-events.md) is responsible for
 -- triggering that recompute when ex_dates cross.
 --
--- Returns 1 when no effective future splits are known, so a row with no
--- later splits is unchanged by adjustment. Implemented via exp(sum(ln(...)))
--- on double precision: split factors are small rationals (typically 2, 3,
--- 4, 0.5) and the round-trip is accurate to many decimal places for any
--- realistic chain of splits.
-CREATE OR REPLACE FUNCTION split_factor_at(p_instrument_id UUID, p_reference DATE)
-RETURNS DOUBLE PRECISION LANGUAGE sql STABLE AS $$
-  SELECT COALESCE(
-    exp(sum(ln(s.split_to::double precision / s.split_from::double precision))),
-    1::double precision
-  )
+-- Returns 1/1 when no effective future splits are known, so a row with no
+-- later splits is unchanged by adjustment.
+CREATE OR REPLACE FUNCTION split_factor_at(
+  p_instrument_id UUID,
+  p_reference DATE,
+  OUT num NUMERIC,
+  OUT den NUMERIC
+) LANGUAGE sql STABLE AS $$
+  SELECT mul(s.split_to), mul(s.split_from)
   FROM stock_splits s
   WHERE s.instrument_id IN (
       p_instrument_id,
@@ -724,9 +748,12 @@ CREATE TABLE ignored_asset_classes (
 
 CREATE INDEX idx_ignored_asset_classes_user ON ignored_asset_classes (user_id);
 
--- qty_is_zero returns true when a double precision quantity is effectively zero,
--- absorbing floating-point residuals from SUM aggregation over buys/sells.
-CREATE FUNCTION qty_is_zero(q double precision) RETURNS boolean
+-- qty_is_zero is a null-safe test for a closed position. Quantities are exact
+-- decimals, so summing buys against sells lands on zero and there is no residual
+-- to absorb -- what the function still carries is the NULL branch, which the
+-- valuation day grid depends on: a holding has no position on a date before its
+-- instrument's first tx, and that reads as closed rather than as unknown.
+CREATE FUNCTION qty_is_zero(q numeric) RETURNS boolean
     LANGUAGE sql IMMUTABLE PARALLEL SAFE AS $$
-    SELECT q IS NULL OR ABS(q) < 1e-9
+    SELECT q IS NULL OR q = 0
 $$;


### PR DESCRIPTION
First of six PRs for 0042. Postgres only -- no Go type changes, no proto change.

## What moves

The four quantity and price columns on `txs` go from `DOUBLE PRECISION` to
`NUMERIC`. They were the only numeric columns in the schema not already
`NUMERIC`.

The raw `quantity` and `unit_price` stay bare, like every other transcribed
fact. The `split_adjusted_*` pair declares `NUMERIC(38, 12)` -- in `eod_prices`
as well as `txs`, since both are the same division-derived cache -- because the
cumulative split factor is a rational and a reverse `/3` has no finite decimal
form. Twelve places is more than any broker quotes fractional shares or prices
to. The rounding is confined to the cache; the raw columns it is recomputed from
stay exact, which is why an exact check reads those instead.

## split_factor_at

Now returns the factor as an exact rational -- `OUT num`, `OUT den` -- built from
a new `mul(numeric)` aggregate, replacing `exp(sum(ln(...)))` on `double
precision`. Callers multiply by the numerator before dividing by the
denominator, so the single division comes last (adr/0028). A quantity adjusts by
the factor and a price by its reciprocal, so `num` and `den` swap places between
the two, and the cost-basis invariant still holds by construction.

The recompute statements use `LATERAL` rather than a subquery selecting
`(split_factor_at(...)).*`, which would call the function once per output column.

The `CURRENT_DATE` future-date guard and its rationale are unchanged.

## qty_is_zero

Redefined over `numeric` as `q IS NULL OR q = 0`. Exactness removes the residual
it was absorbing, but the `NULL` branch is load-bearing and stays: the valuation
day grid forward-fills a position with a `LIMIT 1` correlated subquery that is
`NULL` on every date before an instrument's first tx, and that has to read as
not-held rather than as unknown.

The Go mirror `qtyIsZero` keeps its epsilon for now -- it still reads a
`float64` out of the `HeldRanges` window. It goes when that scan type follows
the column, in the `Tx` PR.

## Valuation

`daily_holdings.qty` becomes `numeric`, which would otherwise turn six branches
of the `valued` CTE into `numeric` division at `select_div_scale`. The query
casts its **operands** to `double precision` at the FX conversion -- the single
place it crosses from exact to approximate (adr/0026, spec/performance.md).

Measured at **866ms** mean for 50 instruments over 5 years, against the 860ms
baseline recorded in `valuation_bench_test.go`. No numeric cliff.

## Why this lands alone

Scanning a `NUMERIC` column into a Go `float64` works: `lib/pq` has no
`T_numeric` case and returns the raw text, and `database/sql`'s reflection
fallback `ParseFloat`s a string into a `Float64` destination. On write it emits
`strconv.AppendFloat(..., 'f', -1, 64)`, which Postgres parses into `numeric`.
So the Go layer compiles and passes untouched, and the decimal types follow in
later PRs.

One trap worth naming: `numeric -> float8` is an implicit cast in `pg_cast`, so
`qty_is_zero(SUM(t.quantity))` would still have resolved against the old
`double precision` signature. It was redefined deliberately, not left to that.

## Tests

- `TestComputeHoldings_fractionalQuantitiesSumExactly` -- ten buys of 0.1 sum to
  exactly 1. In float they summed to 0.9999999999999999 and that reached the
  user as the holding quantity.
- `TestRecomputeSplitAdjustments_ForwardSplitIsExact` -- asserts on the stored
  decimal text, not a float64. A 7:1 then 4:1 chain lands on exactly 2800 at 10;
  the old factor reached 27.999999999999996.
- `TestRecomputeSplitAdjustments_ReverseSplitRoundsToDeclaredScale` -- a 1:3
  reverse lands at 33.333333333333, pinning the declared scale, while the price
  side stays exact.
- `TestGetUserValuation_ExcludesDatesBeforeFirstTx` -- covers the `NULL` branch.

## Verification

`make db-test`, `make server-test`, `make check` and `make e2e-test` (33 passed,
including both stock-split specs) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)