### PR TITLE
Classify sub-tolerance residuals as SOURCE_ROUNDING (0041)

### DIFF
--- a/client/app/admin/imbalance/page.tsx
+++ b/client/app/admin/imbalance/page.tsx
@@ -13,7 +13,7 @@ import { listResidualBalances, type ResidualBalance } from "@/lib/portfolio-api"
 import { ageInDays, groupByBroker, isMoney, transferAgeBucket } from "@/lib/residual-balance";
 import { AccountType, AssetClass, TxType, type Broker } from "@/gen/api/v1/api_pb";
 
-type Tab = "imbalance" | "transfers";
+type Tab = "imbalance" | "transfers" | "rounding";
 
 function TabButton({
   active,
@@ -76,6 +76,7 @@ export default function AdminImbalancePage() {
 
   const error = loadError ? errorMessage(loadError, "Failed to load residual balances") : null;
   const imbalances = balances.filter((b) => b.accountType === AccountType.IMBALANCE);
+  const rounding = balances.filter((b) => b.accountType === AccountType.SOURCE_ROUNDING);
   const transfers = balances
     .filter((b) => b.accountType === AccountType.TRANSFER_CLEARING)
     .sort((a, b) => (a.oldestTimestamp?.getTime() ?? Infinity) - (b.oldestTimestamp?.getTime() ?? Infinity));
@@ -87,7 +88,9 @@ export default function AdminImbalancePage() {
         What each broker converter failed to capture. A group whose postings do not sum
         to zero has its residual routed to {ACCOUNT_TYPE_LABEL[AccountType.IMBALANCE]},
         so the size of these balances is a direct measure of how lossy each converter
-        is. Balances are per commodity and are never converted between them.
+        is -- unless it is small enough to be the source rounding its own figures, which
+        is separated out under {ACCOUNT_TYPE_LABEL[AccountType.SOURCE_ROUNDING]}.
+        Balances are per commodity and are never converted between them.
       </p>
 
       {error && <ErrorAlert>{error}</ErrorAlert>}
@@ -132,43 +135,79 @@ export default function AdminImbalancePage() {
         <TabButton active={tab === "transfers"} onClick={() => setTab("transfers")}>
           Unmatched transfers
         </TabButton>
+        <TabButton active={tab === "rounding"} onClick={() => setTab("rounding")}>
+          Source rounding
+        </TabButton>
       </div>
 
       {tab === "imbalance" && (
-        <ImbalanceTab rows={imbalances} loading={loading} hasError={error !== null} />
+        <ResidualTab
+          rows={imbalances}
+          loading={loading}
+          hasError={error !== null}
+          empty="No imbalances. Every group balances."
+          blurb={
+            <>
+              Expect uncategorised income to dominate until each converter emits the income
+              and expense legs of its single-row dividends and charges. The tx type separates
+              the two: an {TX_TYPE_LABEL[TxType.INCOME]} balance is a dividend we do not
+              categorise yet, a trade balance is a fee the broker did not report. A negative
+              balance is value arriving from outside the ledger, which is what an
+              uncategorised dividend looks like.
+            </>
+          }
+        />
       )}
       {tab === "transfers" && (
         <TransfersTab rows={transfers} loading={loading} hasError={error !== null} />
+      )}
+      {tab === "rounding" && (
+        <ResidualTab
+          rows={rounding}
+          loading={loading}
+          hasError={error !== null}
+          empty="No rounding residuals. Every source agrees with itself."
+          blurb={
+            <>
+              What each source&apos;s own rounding costs. A broker quoting a price to four
+              places and a cash amount to two disagrees with itself by a fraction of a cent
+              per trade; the difference is exact and real, but it is an artefact of how the
+              statement was written rather than a leg the converter missed. One posting here
+              is noise -- the total and the posting count are the point.
+            </>
+          }
+        />
       )}
     </div>
   );
 }
 
-function ImbalanceTab({
+// ResidualTab renders one account type's balances, grouped by broker with per-commodity
+// subtotals. Imbalance and source rounding differ only in what they mean, not in shape:
+// both are a signed total per (account, commodity, event) with a posting count, so they
+// share a table and take their own blurb and empty message.
+function ResidualTab({
   rows,
   loading,
   hasError,
+  blurb,
+  empty,
 }: {
   rows: ResidualBalance[];
   loading: boolean;
   hasError: boolean;
+  blurb: React.ReactNode;
+  empty: string;
 }) {
   if (loading && rows.length === 0) return <p className="text-text-muted">Loading balances...</p>;
   if (rows.length === 0 && !hasError) {
-    return <p className="text-text-muted">No imbalances. Every group balances.</p>;
+    return <p className="text-text-muted">{empty}</p>;
   }
 
   const groups = groupByBroker(rows);
   return (
     <div className="space-y-3">
-      <p className="max-w-3xl text-xs text-text-muted">
-        Expect uncategorised income to dominate until each converter emits the income
-        and expense legs of its single-row dividends and charges. The tx type separates
-        the two: an {TX_TYPE_LABEL[TxType.INCOME]} balance is a dividend we do not categorise yet,
-        a trade balance is a fee the broker did not report. A negative balance is value
-        arriving from outside the ledger, which is what an uncategorised dividend looks
-        like.
-      </p>
+      <p className="max-w-3xl text-xs text-text-muted">{blurb}</p>
       <table data-testid="imbalance-table" className="w-full text-left text-sm">
         <thead>
           <tr className="border-b border-border text-text-muted">

--- a/client/lib/csv/group-balance.test-utils.ts
+++ b/client/lib/csv/group-balance.test-utils.ts
@@ -40,8 +40,10 @@ const EXCHANGE_TYPES = new Set<TxType>([
  *
  * The weights below are exact now, so a group written to full precision balances
  * to exactly zero. The tolerance stays because it is not a floating-point fudge:
- * a source written to 2dp that balances to within half a cent is balanced, and
- * the server routes nothing below this either.
+ * a source written to 2dp that balances to within half a cent is balanced. The
+ * server does post the difference, to SOURCE_ROUNDING rather than to IMBALANCE,
+ * but that is the server classifying its own residual and says nothing about
+ * whether the converter did its job -- which is what this file checks.
  */
 const TOLERANCE = new Big("0.005");
 

--- a/client/lib/tx-type.ts
+++ b/client/lib/tx-type.ts
@@ -36,4 +36,5 @@ export const ACCOUNT_TYPE_LABEL: Record<number, string> = {
   [AccountType.EXPENSE]: "Expense",
   [AccountType.IMBALANCE]: "Imbalance",
   [AccountType.TRANSFER_CLEARING]: "In Flight",
+  [AccountType.SOURCE_ROUNDING]: "Rounding",
 };

--- a/docs/adr/0024-group-balance-is-checked-on-weight.md
+++ b/docs/adr/0024-group-balance-is-checked-on-weight.md
@@ -82,7 +82,7 @@ ones do.
 
 ## Tolerance
 
-A residual is routed only above a tolerance: half a cent for money, `1e-6`
+A residual is classified by a tolerance: half a cent for money, `1e-6`
 otherwise. This is not a floating-point fudge and it does not disappear when
 [0042](../issues/0042-exact-decimal-quantities-prices.md) makes quantities exact.
 A trade of 37 shares at 12.3456 costs 456.7872 against a broker cash row of
@@ -102,3 +102,32 @@ The balance constraint in
 [0041](../issues/0041-enable-balance-constraint.md) needs no tolerance of its own
 either way. Once residuals are routed the group sums to zero by construction,
 which is what lets that constraint be an exact `SUM(...) = 0`.
+
+### What the tolerance decides
+
+**Amended by [0041](../issues/0041-enable-balance-constraint.md).** The paragraph
+above was true only of residuals at or above the tolerance. A residual *below* it
+was originally suppressed rather than routed, which left the group summing to a
+small non-zero value -- so the ordinary, well-formed, 2dp-rounded trade groups were
+exactly the ones an exact `SUM(...) = 0` would have rejected.
+
+The tolerance therefore decides the **account type** a residual is routed to, not
+whether it is routed. Every non-zero residual gets a posting: `IMBALANCE` or
+`TRANSFER_CLEARING` at or above the tolerance, and `SOURCE_ROUNDING` below it. A
+sub-tolerance residual on a journal is rounding too, so `SOURCE_ROUNDING` beats the
+transfer classification rather than the other way round.
+
+Two alternatives were considered and rejected. **Absorbing the sub-tolerance
+residual into the weight of the group's converting leg** would have needed no new
+type and written no extra rows, but it makes a leg's stored weight something other
+than `quantity * unit_price * contract_size`, so a reader comparing the two sees a
+discrepancy with nothing to explain it. **Folding the small residuals into
+`IMBALANCE`** would have been simpler still and is what dropping the tolerance
+outright amounts to, but the whole point of a typed residual account is to classify
+what is left over: an `IMBALANCE` balance is converter work to be done, and a
+rounding difference is not, so merging them costs the one thing already known about
+the residual and makes the imbalance figure permanently non-zero for every broker
+that rounds.
+
+The tolerance still keeps its original job of not treating a rounded source as a
+data-quality problem. It just says so in the account type rather than by omission.

--- a/docs/spec/csv-format.md
+++ b/docs/spec/csv-format.md
@@ -39,7 +39,7 @@ Grouping is the converter's job. The server persists what it is given: it does n
 
 **Fees are postings, not a column.** A commission, levy or duty is a row with `type=INVEXPENSE` and a negative `quantity` in the settlement currency, paired with an `account_type=EXPENSE` row for the same money. Put the pair in the trade's group when the broker charges it as part of the trade; give it a group of its own when the broker reports it as a separate cash event on its own date. Where a broker folds the commission into a single cash total, the converter splits that total into a consideration row and a fee row rather than posting it as one (see adr/0025-netted-cash-totals-are-split-into-legs.md).
 
-A group whose postings do not sum to zero is accepted, not rejected. The server routes whatever is left over to an `IMBALANCE` posting -- or `TRANSFER_CLEARING` for a journal -- so the residual is made visible rather than silently absorbed. See [postings.md](postings.md#balancing).
+A group whose postings do not sum to zero is accepted, not rejected. The server routes whatever is left over to an `IMBALANCE` posting -- `TRANSFER_CLEARING` for a journal, or `SOURCE_ROUNDING` when the difference is small enough to be the source rounding its own figures -- so the residual is made visible rather than silently absorbed. See [postings.md](postings.md#balancing).
 
 ### Transaction types (type column)
 
@@ -52,7 +52,7 @@ Allowed values for `type` (OFX-style):
 ### Account types (account_type column)
 
 Allowed values for `account_type`:
-`USER`, `EQUITY`, `INCOME`, `EXPENSE`, `IMBALANCE`, `TRANSFER_CLEARING`.
+`USER`, `EQUITY`, `INCOME`, `EXPENSE`, `IMBALANCE`, `TRANSFER_CLEARING`, `SOURCE_ROUNDING`.
 
 An absent column or an empty cell means `USER`, so an ordinary export needs no such
 column. An unrecognised value is a row error rather than a silent fall back to `USER`.

--- a/docs/spec/postings.md
+++ b/docs/spec/postings.md
@@ -38,6 +38,7 @@ to the account that produced it.
 | `EXPENSE`           | Commissions, levies, custody and service charges, taxes.   |
 | `IMBALANCE`         | The residual of a group that does not sum to zero.         |
 | `TRANSFER_CLEARING` | One side of a transfer whose other side is not yet known.  |
+| `SOURCE_ROUNDING`   | A residual small enough to be the source rounding its own figures. |
 
 Opening balances are `EQUITY` postings rather than a type of their own. An opening
 balance is one use of equity, and a withdrawal to a bank is an equity posting too; an
@@ -159,18 +160,12 @@ adr/0028-cumulative-split-factor-is-an-exact-rational.md).
 
 Weights accumulate **per commodity**, so a group can produce more than one routed
 posting and the commodity is whatever is left over -- cash for a missing cash leg,
-the security for an unpaired `JRNLSEC`. A residual is routed only above a
-tolerance: half a cent for money, `1e-6` otherwise. The tolerance is not a
-floating-point fudge and did not go away when quantities became exact -- a group
-written to 2dp that balances to within half a cent is balanced, and that is a
-disagreement between two rounded figures rather than arithmetic error. Inferring
-the tolerance from the scale of the contributing amounts, rather than fixing it,
-would change which residuals get routed and has not been done. See
-adr/0026-exact-decimals-bounded-by-closure.md.
+the security for an unpaired `JRNLSEC`.
 
 Weights are exact: a posting's weight is `quantity * unit_price * contract_size`,
 which is closed under multiplication, so a group's balance is a plain sum with
-nothing to absorb.
+nothing to absorb. Every non-zero residual is routed, and only a group that sums to
+exactly zero produces no posting at all.
 
 The routed posting takes the `IMBALANCE` type, or `TRANSFER_CLEARING` when the
 group is a journal. It keeps the broker, account, date and `tx_type` of the group
@@ -178,6 +173,30 @@ it balances, so the residual stays attributable to the account and the kind of
 event that produced it. Its commodity is carried by `instrument_id`, never encoded
 in a name. It is written into the group it balances, so replace-by-period takes it
 with the cascade.
+
+### Source rounding
+
+A residual below a **tolerance** -- half a cent for money, `1e-6` otherwise -- takes
+the `SOURCE_ROUNDING` type instead. The tolerance is not a floating-point fudge and
+did not go away when quantities became exact: a broker quoting a price to 4dp and a
+cash amount to 2dp disagrees with itself by a fraction of a cent per trade, and that
+difference is exact and real but is an artefact of how the statement was written
+rather than a leg the converter missed. Inferring the tolerance from the scale of the
+contributing amounts, rather than fixing it, would change which residuals are
+classified this way and has not been done. See
+adr/0026-exact-decimals-bounded-by-closure.md.
+
+The tolerance decides the **type** of the routed posting, not whether one is written.
+Suppressing the small residuals would leave the group summing to a small non-zero
+value, which is what the balance constraint rejects; folding them into `IMBALANCE`
+alongside genuinely missing legs would throw away the one thing already known about
+them. A sub-tolerance residual on a journal is rounding too, so `SOURCE_ROUNDING`
+beats `TRANSFER_CLEARING` rather than the other way round.
+
+Rounding balances appear in the imbalance report under their own tab -- one posting
+is noise, but the per-broker total and posting count are the only place the cost of a
+source's rounding is visible -- and are deliberately absent from the dashboard
+counts, which ask whether something is wrong.
 
 An INITIALIZE pad is balanced by an `EQUITY` counterparty instead; see
 [fixed-point.md](fixed-point.md#the-equity-counterparty).

--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -62,6 +62,7 @@ enum AccountType {
   ACCOUNT_TYPE_EXPENSE = 4;           // Commissions, levies, custody and service charges, taxes.
   ACCOUNT_TYPE_IMBALANCE = 5;         // The residual of a group that does not sum to zero.
   ACCOUNT_TYPE_TRANSFER_CLEARING = 6; // One side of a transfer whose other side is not yet known.
+  ACCOUNT_TYPE_SOURCE_ROUNDING = 7;   // A residual small enough to be the source rounding, not missing data.
 }
 
 // IdentifierType is the controlled vocabulary for instrument identifier types.
@@ -330,9 +331,10 @@ service ApiService {
   rpc CountUnhandledCorporateEvents(CountUnhandledCorporateEventsRequest) returns (CountUnhandledCorporateEventsResponse);
   rpc ResolveUnhandledCorporateEvent(ResolveUnhandledCorporateEventRequest) returns (ResolveUnhandledCorporateEventResponse);
 
-  // Residual balances (admin-only). The net IMBALANCE and TRANSFER_CLEARING value
-  // left in each broker account: a direct measure of how lossy each broker
-  // converter is, and of which transfers are missing a side.
+  // Residual balances (admin-only). The net IMBALANCE, TRANSFER_CLEARING and
+  // SOURCE_ROUNDING value left in each broker account: a direct measure of how lossy
+  // each broker converter is, of which transfers are missing a side, and of what the
+  // source's own rounding costs.
   rpc ListResidualBalances(ListResidualBalancesRequest) returns (ListResidualBalancesResponse);
   rpc CountResidualBalances(CountResidualBalancesRequest) returns (CountResidualBalancesResponse);
 }
@@ -1247,13 +1249,15 @@ message ResolveUnhandledCorporateEventResponse {}
 // uncategorised dividend whose income leg the converter does not yet emit. A
 // TRANSFER_CLEARING balance is one side of a journal. Nothing pairs the two
 // sides until transfers are matched, so a transfer balance means a transfer was
-// imported rather than that its second side is missing.
+// imported rather than that its second side is missing. A SOURCE_ROUNDING balance
+// is the accumulated difference between figures the source rounded to different
+// scales: not a fault, but worth measuring per broker.
 //
 // Balances are per commodity and are never converted: one in a currency is money,
 // one in a security is a quantity of shares, and the two are not summed. See
 // docs/spec/postings.md.
 message ResidualBalance {
-  AccountType account_type = 1;  // IMBALANCE or TRANSFER_CLEARING
+  AccountType account_type = 1;  // IMBALANCE, TRANSFER_CLEARING or SOURCE_ROUNDING
   Broker broker = 2;
   string account = 3;
   string instrument_id = 4;
@@ -1278,8 +1282,8 @@ message ListResidualBalancesRequest {
   // bound is open-ended.
   google.protobuf.Timestamp period_from = 1;    // inclusive
   google.protobuf.Timestamp period_before = 2;  // exclusive
-  // Restrict to one account type. ACCOUNT_TYPE_UNSPECIFIED returns both IMBALANCE
-  // and TRANSFER_CLEARING.
+  // Restrict to one account type. ACCOUNT_TYPE_UNSPECIFIED returns IMBALANCE,
+  // TRANSFER_CLEARING and SOURCE_ROUNDING alike.
   AccountType account_type = 3 [(buf.validate.field).enum.defined_only = true];
 }
 

--- a/server/db/postgres/residual_balances.go
+++ b/server/db/postgres/residual_balances.go
@@ -10,11 +10,17 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-// residualBalanceAgg aggregates the residual postings -- the IMBALANCE and
-// TRANSFER_CLEARING legs routed to balance groups whose source data was one-sided
-// -- across every user. $1/$2 are a half-open [from, before) window over the
-// posting timestamp, either of which may be NULL for an open bound; $3 restricts to
-// one account type, or is the empty string for both.
+// residualBalanceAgg aggregates the residual postings -- the IMBALANCE,
+// TRANSFER_CLEARING and SOURCE_ROUNDING legs routed to balance groups whose source
+// data was one-sided or disagreed with itself -- across every user. $1/$2 are a
+// half-open [from, before) window over the posting timestamp, either of which may be
+// NULL for an open bound; $3 restricts to one account type, or is the empty string
+// for all of them.
+//
+// SOURCE_ROUNDING is reported rather than hidden: one such posting is noise, but the
+// aggregate says how much a broker's rounding costs and over how many postings, which
+// is the only place that is visible. It is deliberately absent from the dashboard
+// counts below, which ask whether something is wrong.
 //
 // The commodity is the instrument's name, not its currency: for money the two
 // agree, but a residual left by an unpaired JRNLSEC is a quantity of shares whose
@@ -37,7 +43,7 @@ const residualBalanceAgg = `
 		MAX(t.timestamp)  AS newest
 	FROM txs t
 	LEFT JOIN instruments i ON i.id = t.instrument_id
-	WHERE t.account_type IN ('IMBALANCE', 'TRANSFER_CLEARING')
+	WHERE t.account_type IN ('IMBALANCE', 'TRANSFER_CLEARING', 'SOURCE_ROUNDING')
 		-- Routing drops a residual it cannot resolve an instrument for, so this
 		-- excludes nothing in practice; it is here so a NULL commodity cannot
 		-- reach the scan.
@@ -107,7 +113,8 @@ func (p *Postgres) ListResidualBalances(ctx context.Context, opts db.ResidualBal
 
 // CountResidualBalances implements db.ResidualBalanceDB. It counts over all of
 // history: the dashboard asks whether anything is wrong, not what was wrong during
-// some window.
+// some window. SOURCE_ROUNDING is not counted -- the source rounding its own cash
+// figures is not a fault, and counting it would make the dashboard permanently red.
 func (p *Postgres) CountResidualBalances(ctx context.Context, staleBefore time.Time) (int32, int32, error) {
 	q := "WITH r AS (" + residualBalanceAgg + `
 		)

--- a/server/db/postgres/residual_balances_test.go
+++ b/server/db/postgres/residual_balances_test.go
@@ -281,6 +281,44 @@ func TestListResidualBalances_AccountTypeFilter(t *testing.T) {
 	}
 }
 
+// TestResidualBalances_SourceRoundingIsReportedNotCounted verifies where a rounding
+// residual lands: aggregated in the report, where the per-broker total and posting
+// count are the only place its cost is visible, and absent from the dashboard counts,
+// which ask whether something is wrong. A source rounding its own cash figures is not.
+func TestResidualBalances_SourceRoundingIsReportedNotCounted(t *testing.T) {
+	p := testDBTx(t)
+	userID := newUser(t, p, "sub|rounding")
+	usd := usdInstrument(t, p)
+
+	seedResiduals(t, p, userID,
+		residualSeed{"IBKR", "A1", usd, apiv1.TxType_BUYSTOCK, apiv1.AccountType_ACCOUNT_TYPE_SOURCE_ROUNDING, "0.0028", 1},
+		residualSeed{"IBKR", "A1", usd, apiv1.TxType_BUYSTOCK, apiv1.AccountType_ACCOUNT_TYPE_SOURCE_ROUNDING, "-0.0011", 2},
+	)
+
+	ctx := context.Background()
+	rows, err := p.ListResidualBalances(ctx, db.ResidualBalanceOpts{AccountType: apiv1.AccountType_ACCOUNT_TYPE_SOURCE_ROUNDING})
+	if err != nil {
+		t.Fatalf("list rounding: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("expected the two postings to aggregate to 1 row, got %+v", rows)
+	}
+	if rows[0].Balance.String() != "0.0017" {
+		t.Errorf("balance = %v, want 0.0017", rows[0].Balance)
+	}
+	if rows[0].PostingCount != 2 {
+		t.Errorf("posting count = %d, want 2", rows[0].PostingCount)
+	}
+
+	imbalances, stale, err := p.CountResidualBalances(ctx, time.Now().UTC().AddDate(0, 0, -7))
+	if err != nil {
+		t.Fatalf("count: %v", err)
+	}
+	if imbalances != 0 || stale != 0 {
+		t.Errorf("counts = (%d, %d), want (0, 0): rounding is not a fault", imbalances, stale)
+	}
+}
+
 // TestCountResidualBalances_StalenessBoundary verifies a recently imported transfer
 // is quiet and an old one is loud. Every imbalance counts whatever its age.
 func TestCountResidualBalances_StalenessBoundary(t *testing.T) {

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -105,7 +105,8 @@ CREATE TABLE txs (
   synthetic_purpose         TEXT CHECK (synthetic_purpose IS NULL OR synthetic_purpose = 'INITIALIZE'),
   account_type              TEXT NOT NULL DEFAULT 'USER'
                               CHECK (account_type IN ('USER', 'EQUITY', 'INCOME', 'EXPENSE',
-                                                      'IMBALANCE', 'TRANSFER_CLEARING')),
+                                                      'IMBALANCE', 'TRANSFER_CLEARING',
+                                                      'SOURCE_ROUNDING')),
   group_id                  UUID REFERENCES tx_groups (id) ON DELETE CASCADE,
   created_at                TIMESTAMPTZ NOT NULL DEFAULT now()
 );
@@ -364,14 +365,14 @@ ALTER TABLE txs ADD COLUMN instrument_id UUID REFERENCES instruments (id);
 
 CREATE INDEX idx_txs_instrument_id ON txs (instrument_id);
 
--- Residual postings -- the IMBALANCE and TRANSFER_CLEARING legs routed to balance a
--- group its source data left one-sided -- are a small minority of txs, and the report
--- that aggregates them reads every one across all users. A partial index over just
--- those rows answers it without carrying the USER postings that dominate the table.
--- Column order follows the report's GROUP BY.
+-- Residual postings -- the IMBALANCE, TRANSFER_CLEARING and SOURCE_ROUNDING legs
+-- routed to balance a group its source data left one-sided -- are a small minority of
+-- txs, and the report that aggregates them reads every one across all users. A partial
+-- index over just those rows answers it without carrying the USER postings that
+-- dominate the table. Column order follows the report's GROUP BY.
 CREATE INDEX idx_txs_residual_postings
   ON txs (account_type, user_id, broker, account, instrument_id, tx_type)
-  WHERE account_type IN ('IMBALANCE', 'TRANSFER_CLEARING');
+  WHERE account_type IN ('IMBALANCE', 'TRANSFER_CLEARING', 'SOURCE_ROUNDING');
 
 -- At most one INITIALIZE posting per holding per account type. account_type is part of
 -- the key because the pad's counterparty is an equal-and-opposite posting of the same

--- a/server/service/ingestion/balance.go
+++ b/server/service/ingestion/balance.go
@@ -59,18 +59,26 @@ var transferTypes = map[apiv1.TxType]bool{
 	apiv1.TxType_JRNLSEC:  true,
 }
 
-// Tolerances below which a residual is not worth a posting. A trade of 37 shares
-// at 12.3456 costs 456.7872 against a broker cash row of -456.79: the 0.0028 is
-// an artefact of the source being written to 2dp, not a real discrepancy.
-// Beancount infers half the last significant digit for exactly this case, and
-// half a cent is what it would infer for 2dp money.
+// Tolerances below which a residual is the source disagreeing with itself rather
+// than a leg it left out. A trade of 37 shares at 12.3456 costs 456.7872 against a
+// broker cash row of -456.79: the 0.0028 is an artefact of the source being
+// written to 2dp, not a real discrepancy. Beancount infers half the last
+// significant digit for exactly this case, and half a cent is what it would infer
+// for 2dp money.
 //
 // Quantities are exact decimals now, so this is no longer absorbing arithmetic
 // error -- it is the disagreement between two figures the source rounded
 // differently, which exactness does not remove. Both beancount and ledger keep a
 // tolerance for the same reason. Inferring it from the scale of the contributing
-// amounts, rather than fixing it, is a change to which residuals get routed and
+// amounts, rather than fixing it, is a change to how residuals get classified and
 // is deliberately not made here.
+//
+// The tolerance decides the account type a residual is routed to, not whether it
+// is routed at all. Suppressing the small ones would leave the group summing to a
+// small non-zero value, which is exactly what the balance constraint rejects; and
+// dropping them into IMBALANCE alongside genuinely missing legs would throw away
+// the one thing already known about them. See
+// docs/adr/0024-group-balance-is-checked-on-weight.md.
 var (
 	moneyTolerance     = decimal.RequireFromString("0.005")
 	commodityTolerance = decimal.New(1, -6)
@@ -131,7 +139,8 @@ func (c commodity) key() string {
 	}
 }
 
-// tolerance returns the residual below which this commodity counts as balanced.
+// tolerance returns the residual below which a difference in this commodity reads
+// as the source's own rounding rather than as a leg it omitted.
 func (c commodity) tolerance() decimal.Decimal {
 	if c.currency != "" {
 		return moneyTolerance
@@ -244,9 +253,12 @@ func groupPostings(txs []*apiv1.Tx) ([]string, map[string][]int) {
 }
 
 // routeResiduals returns the counterparty postings that make every group balance.
-// Groups that already balance produce none. A group can produce more than one when
-// its residual spans commodities, as beancount's residual inventory and ledger's
-// Imbalance:<CUR> both can.
+// Only a group that already sums to exactly zero produces none. A group can produce
+// more than one when its residual spans commodities, as beancount's residual
+// inventory and ledger's Imbalance:<CUR> both can. The account type says which kind
+// of residual it is: IMBALANCE for a leg the source omitted, TRANSFER_CLEARING for
+// the unmatched side of a journal, and SOURCE_ROUNDING for a difference small
+// enough to be the source's own rounding.
 //
 // It assigns a synthetic group_ref to any posting that has none, so that a routed
 // counterparty is stored in the same group as the posting it balances.
@@ -296,14 +308,24 @@ func routeResiduals(txs []*apiv1.Tx, instrumentIDs []string, instruments map[str
 		// the map iteration gave.
 		sort.Strings(keys)
 		first := txs[idxs[0]]
-		accountType := apiv1.AccountType_ACCOUNT_TYPE_IMBALANCE
+		residual := apiv1.AccountType_ACCOUNT_TYPE_IMBALANCE
 		if transfer {
-			accountType = apiv1.AccountType_ACCOUNT_TYPE_TRANSFER_CLEARING
+			residual = apiv1.AccountType_ACCOUNT_TYPE_TRANSFER_CLEARING
 		}
 		for _, k := range keys {
 			c := commodities[k]
-			if sums[k].Abs().LessThan(c.tolerance()) {
+			if sums[k].IsZero() {
 				continue
+			}
+			// Below tolerance the residual is the source disagreeing with itself
+			// rather than a leg the source left out, and saying so is worth more
+			// than leaving it unposted: it keeps the group summing to exactly zero
+			// while classifying the difference as what it is. A sub-tolerance
+			// residual on a journal is rounding too, so this beats the transfer
+			// case rather than the other way round.
+			accountType := residual
+			if sums[k].Abs().LessThan(c.tolerance()) {
+				accountType = apiv1.AccountType_ACCOUNT_TYPE_SOURCE_ROUNDING
 			}
 			out = append(out, routedFor(first, ref, c, descs[k], sums[k].Neg(), accountType))
 		}

--- a/server/service/ingestion/balance_test.go
+++ b/server/service/ingestion/balance_test.go
@@ -145,14 +145,36 @@ func TestRouteResiduals(t *testing.T) {
 		},
 		want: nil,
 	}, {
-		// 456.7872 against a cash row rounded to 456.79. The residual is real but
-		// is an artefact of the source being written to 2dp.
-		name: "sub-cent rounding is within tolerance",
+		// 456.7872 against a cash row rounded to 456.79. The residual is real but is
+		// an artefact of the source being written to 2dp, so it is routed as rounding
+		// rather than as a leg the converter missed. It is still routed: leaving it
+		// unposted is what would stop the group summing to exactly zero.
+		name: "sub-cent difference routes as source rounding",
 		postings: []posting{
 			{desc: "AAPL", typ: apiv1.TxType_BUYSTOCK, qty: "37", price: price("12.3456"), settle: "USD", instID: aaplID, groupRef: "t1"},
 			{desc: "USD", typ: apiv1.TxType_BUYSTOCK, qty: "-456.79", settle: "USD", trading: "USD", instID: usdID, groupRef: "t1"},
 		},
-		want: nil,
+		want: []routed{{commodity: "USD", quantity: "0.0028", accountType: apiv1.AccountType_ACCOUNT_TYPE_SOURCE_ROUNDING}},
+	}, {
+		// Half a cent is the boundary and the tolerance is exclusive, so this is a
+		// missing leg rather than rounding. The pair of cases either side of it is
+		// what pins the comparison down.
+		name: "a residual at the tolerance is an imbalance, not rounding",
+		postings: []posting{
+			{desc: "AAPL", typ: apiv1.TxType_BUYSTOCK, qty: "1", price: price("100"), settle: "USD", instID: aaplID, groupRef: "t1"},
+			{desc: "USD", typ: apiv1.TxType_BUYSTOCK, qty: "-99.995", settle: "USD", trading: "USD", instID: usdID, groupRef: "t1"},
+		},
+		want: []routed{{commodity: "USD", quantity: "-0.005", accountType: apiv1.AccountType_ACCOUNT_TYPE_IMBALANCE}},
+	}, {
+		// A journal whose two sides disagree by a fraction of a cent disagrees because
+		// one statement rounded, not because a side is missing, so rounding beats the
+		// transfer classification rather than the other way round.
+		name: "sub-cent difference on a journal routes as rounding, not clearing",
+		postings: []posting{
+			{desc: "USD", typ: apiv1.TxType_JRNLFUND, qty: "1000.001", settle: "USD", trading: "USD", instID: usdID, groupRef: "j1"},
+			{desc: "USD", typ: apiv1.TxType_JRNLFUND, qty: "-1000", settle: "USD", trading: "USD", instID: usdID, groupRef: "j1"},
+		},
+		want: []routed{{commodity: "USD", quantity: "-0.001", accountType: apiv1.AccountType_ACCOUNT_TYPE_SOURCE_ROUNDING}},
 	}, {
 		name: "dividend with its income leg routes nothing",
 		postings: []posting{


### PR DESCRIPTION
First of four PRs for [0041](docs/issues/0041-enable-balance-constraint.md), which enforces posting balance with a deferred constraint trigger.

## Why

adr/0024 claims "once residuals are routed the group sums to zero by construction", which is what lets 0041's constraint be an exact `SUM(weight) = 0`. That holds only for residuals **at or above** the routing tolerance. A residual below half a cent was suppressed rather than routed (`sums[k].Abs().LessThan(c.tolerance())` -> `continue`), so the group was declared balanced while its weights summed to a small non-zero value.

Those are not edge cases. A broker quoting a price to 4dp and a cash amount to 2dp disagrees with itself by a fraction of a cent on every trade: 37 shares at 12.3456 costs 456.7872 against a cash row of -456.79. An exact constraint would reject precisely the ordinary, well-formed trade groups.

## What changes

The tolerance now decides the **account type** a residual is routed to, not whether it is routed. Every non-zero residual gets a posting:

| Residual | Account type |
| --- | --- |
| >= tolerance, ordinary group | `IMBALANCE` |
| >= tolerance, journal | `TRANSFER_CLEARING` |
| < tolerance, any group | `SOURCE_ROUNDING` |

A sub-tolerance residual on a journal is rounding too, so `SOURCE_ROUNDING` beats the transfer classification rather than the other way round.

## Alternatives rejected

- **Absorbing the residual into the converting leg's stored weight.** No new type, no extra rows, but it makes a leg's weight something other than `quantity * unit_price * contract_size`, so a reader comparing the two sees a discrepancy with nothing to explain it.
- **Folding the small residuals into `IMBALANCE`.** Simplest, but the point of a typed residual account is to classify what is left over. An `IMBALANCE` balance is converter work to be done; a rounding difference is not. Merging them costs the one thing already known about the residual and makes the imbalance figure permanently non-zero for every broker that rounds.

Both are recorded in the amendment to adr/0024.

## Reporting

Rounding balances are aggregated in the residual report under their own tab -- one posting is noise, but the per-broker total and posting count are the only place the cost of a source's rounding is visible. They are deliberately absent from the dashboard counts, which ask whether something is wrong; a source rounding its own cash figures is not.

Holdings and valuation read `account_type = 'USER'` only, so nothing here reaches a position or a valuation.

## Notes for review

- `accountTypeToStr` / `strToAccountType` and the client's `parseAccountType` all derive from the generated enum names, so none of them needed touching -- the new value is accepted on upload for the same reason `IMBALANCE` already is.
- The client-side `group-balance.test-utils.ts` mirror is unchanged in behaviour: it checks whether a *converter* balanced a group, which this does not change.

## Test plan

- `make check`, `make server-test`, `make db-test`, `make client-test` all pass.
- New `balance_test.go` cases: a sub-cent difference routes as `SOURCE_ROUNDING`; a residual exactly at the tolerance is an `IMBALANCE` (the tolerance is exclusive, and the pair either side of the boundary pins the comparison down); a sub-cent difference on a journal routes as rounding rather than clearing.
- New `TestResidualBalances_SourceRoundingIsReportedNotCounted`: two rounding postings aggregate into one reported row with a posting count, and the dashboard counts stay at zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)