### PR TITLE
Require every posting to belong to a group (0041)

### DIFF
--- a/docs/spec/postings.md
+++ b/docs/spec/postings.md
@@ -112,9 +112,10 @@ lossiness measurable.
 ever pruned by age the id still distinguishes one creation from another and still
 groups everything written by the same upload.
 
-Every posting belongs to exactly one group. `txs.group_id` is nullable only so that
-raw fixtures can write a posting without one; no production write path leaves it
-unset.
+Every posting belongs to exactly one group, and `txs.group_id` is `NOT NULL` so that
+none can be written without one. A lone posting is a group of one. The balance
+invariant is stated per group, so a posting outside every group would be a row it
+could not reach.
 
 ## Balancing
 

--- a/e2e/fixtures/instruments.sql
+++ b/e2e/fixtures/instruments.sql
@@ -20,12 +20,21 @@ VALUES
   ('e2e00000-0000-0000-0000-000000000103', 'MIC_TICKER', 'TSLA', true)
 ON CONFLICT DO NOTHING;
 
--- Transactions referencing the instruments (for holdings/valuation).
-INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type, quantity, trading_currency, unit_price, instrument_id)
+-- Transactions referencing the instruments (for holdings/valuation). Every posting
+-- belongs to a group, so each trade gets one; the ids are explicit because the
+-- postings reference them.
+INSERT INTO tx_groups (id, user_id, timestamp)
 VALUES
-  ('e2e00000-0000-0000-0000-000000000001', 'FIDELITY', 'ACC-1', '2024-01-15', 'AMZN - Amazon.com Inc.', 'BUYSTOCK', 8, 'USD', 155.20, 'e2e00000-0000-0000-0000-000000000101'),
-  ('e2e00000-0000-0000-0000-000000000001', 'FIDELITY', 'ACC-1', '2024-01-16', 'NVDA - NVIDIA Corp.', 'BUYSTOCK', 15, 'USD', 560.50, 'e2e00000-0000-0000-0000-000000000102'),
-  ('e2e00000-0000-0000-0000-000000000001', 'FIDELITY', 'ACC-1', '2024-01-17', 'TSLA - Tesla Inc.', 'BUYSTOCK', 12, 'USD', 218.90, 'e2e00000-0000-0000-0000-000000000103')
+  ('e2e00000-0000-0000-0000-000000000201', 'e2e00000-0000-0000-0000-000000000001', '2024-01-15'),
+  ('e2e00000-0000-0000-0000-000000000202', 'e2e00000-0000-0000-0000-000000000001', '2024-01-16'),
+  ('e2e00000-0000-0000-0000-000000000203', 'e2e00000-0000-0000-0000-000000000001', '2024-01-17')
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type, quantity, trading_currency, unit_price, instrument_id, group_id)
+VALUES
+  ('e2e00000-0000-0000-0000-000000000001', 'FIDELITY', 'ACC-1', '2024-01-15', 'AMZN - Amazon.com Inc.', 'BUYSTOCK', 8, 'USD', 155.20, 'e2e00000-0000-0000-0000-000000000101', 'e2e00000-0000-0000-0000-000000000201'),
+  ('e2e00000-0000-0000-0000-000000000001', 'FIDELITY', 'ACC-1', '2024-01-16', 'NVDA - NVIDIA Corp.', 'BUYSTOCK', 15, 'USD', 560.50, 'e2e00000-0000-0000-0000-000000000102', 'e2e00000-0000-0000-0000-000000000202'),
+  ('e2e00000-0000-0000-0000-000000000001', 'FIDELITY', 'ACC-1', '2024-01-17', 'TSLA - Tesla Inc.', 'BUYSTOCK', 12, 'USD', 218.90, 'e2e00000-0000-0000-0000-000000000103', 'e2e00000-0000-0000-0000-000000000203')
 ON CONFLICT DO NOTHING;
 
 -- EOD prices: a few days of data for each instrument.

--- a/e2e/fixtures/residual-balances.sql
+++ b/e2e/fixtures/residual-balances.sql
@@ -5,53 +5,72 @@
 -- TRANSFER_CLEARING. Seeding them directly keeps the fixture about the report
 -- rather than about the converters.
 --
+-- Every posting belongs to a group, so each residual gets one. The ids are explicit
+-- because the postings reference them.
+--
 -- Timestamps are relative to now() so the age assertions do not rot.
+
+INSERT INTO tx_groups (id, user_id, timestamp)
+VALUES
+  ('e2e00000-0000-0000-0000-000000000301', 'e2e00000-0000-0000-0000-000000000001', now() - INTERVAL '5 days'),
+  ('e2e00000-0000-0000-0000-000000000302', 'e2e00000-0000-0000-0000-000000000001', now() - INTERVAL '6 days'),
+  ('e2e00000-0000-0000-0000-000000000303', 'e2e00000-0000-0000-0000-000000000001', now() - INTERVAL '60 days'),
+  ('e2e00000-0000-0000-0000-000000000304', 'e2e00000-0000-0000-0000-000000000001', now() - INTERVAL '59 days'),
+  ('e2e00000-0000-0000-0000-000000000305', 'e2e00000-0000-0000-0000-000000000001', now() - INTERVAL '40 days'),
+  ('e2e00000-0000-0000-0000-000000000306', 'e2e00000-0000-0000-0000-000000000001', now() - INTERVAL '2 days')
+ON CONFLICT (id) DO NOTHING;
 
 -- A dividend the converter reported as cash only, so its income leg is missing and
 -- the whole value lands in Imbalance. Negative: value arriving from outside the
 -- ledger.
 INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type,
-                 quantity, trading_currency, settlement_currency, instrument_id, account_type)
+                 quantity, trading_currency, settlement_currency, instrument_id, account_type, group_id)
 SELECT 'e2e00000-0000-0000-0000-000000000001', 'FIDELITY', 'ACC-1',
-       now() - INTERVAL '5 days', 'USD', 'INCOME', -137.08, 'USD', 'USD', i.instrument_id, 'IMBALANCE'
+       now() - INTERVAL '5 days', 'USD', 'INCOME', -137.08, 'USD', 'USD', i.instrument_id, 'IMBALANCE',
+       'e2e00000-0000-0000-0000-000000000301'
 FROM (SELECT instrument_id FROM instrument_identifiers
       WHERE identifier_type = 'CURRENCY' AND value = 'USD' LIMIT 1) i;
 
 -- A trade whose price and cash total disagree: the commission the broker netted
 -- into the total and did not report separately.
 INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type,
-                 quantity, trading_currency, settlement_currency, instrument_id, account_type)
+                 quantity, trading_currency, settlement_currency, instrument_id, account_type, group_id)
 SELECT 'e2e00000-0000-0000-0000-000000000001', 'FIDELITY', 'ACC-1',
-       now() - INTERVAL '6 days', 'USD', 'BUYSTOCK', 4.95, 'USD', 'USD', i.instrument_id, 'IMBALANCE'
+       now() - INTERVAL '6 days', 'USD', 'BUYSTOCK', 4.95, 'USD', 'USD', i.instrument_id, 'IMBALANCE',
+       'e2e00000-0000-0000-0000-000000000302'
 FROM (SELECT instrument_id FROM instrument_identifiers
       WHERE identifier_type = 'CURRENCY' AND value = 'USD' LIMIT 1) i;
 
 -- A journal between two Schwab accounts whose second side did arrive. Both sides
 -- are TRANSFER_CLEARING postings, so the report has to consume them against each
--- other; neither should appear.
+-- other; neither should appear. They arrive in separate statements, so they are
+-- separate groups -- pairing them is 0068.
 INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type,
-                 quantity, trading_currency, settlement_currency, instrument_id, account_type)
+                 quantity, trading_currency, settlement_currency, instrument_id, account_type, group_id)
 SELECT 'e2e00000-0000-0000-0000-000000000001', 'SCHB', v.account,
        now() - (v.days || ' days')::INTERVAL, 'USD', 'JRNLFUND', v.qty, 'USD', 'USD',
-       i.instrument_id, 'TRANSFER_CLEARING'
-FROM (VALUES ('SCH-1', 1000.00, '60'), ('SCH-2', -1000.00, '59')) AS v(account, qty, days),
+       i.instrument_id, 'TRANSFER_CLEARING', v.group_id::uuid
+FROM (VALUES ('SCH-1', 1000.00, '60', 'e2e00000-0000-0000-0000-000000000303'),
+             ('SCH-2', -1000.00, '59', 'e2e00000-0000-0000-0000-000000000304')) AS v(account, qty, days, group_id),
      (SELECT instrument_id FROM instrument_identifiers
       WHERE identifier_type = 'CURRENCY' AND value = 'USD' LIMIT 1) i;
 
 -- One side of a transfer out of an IBKR account, long enough ago that the other
 -- side is not coming.
 INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type,
-                 quantity, trading_currency, settlement_currency, instrument_id, account_type)
+                 quantity, trading_currency, settlement_currency, instrument_id, account_type, group_id)
 SELECT 'e2e00000-0000-0000-0000-000000000001', 'IBKR', 'U-OLD',
-       now() - INTERVAL '40 days', 'USD', 'JRNLFUND', 500.00, 'USD', 'USD', i.instrument_id, 'TRANSFER_CLEARING'
+       now() - INTERVAL '40 days', 'USD', 'JRNLFUND', 500.00, 'USD', 'USD', i.instrument_id, 'TRANSFER_CLEARING',
+       'e2e00000-0000-0000-0000-000000000305'
 FROM (SELECT instrument_id FROM instrument_identifiers
       WHERE identifier_type = 'CURRENCY' AND value = 'USD' LIMIT 1) i;
 
 -- A transfer imported two days ago whose other side may still be on its way. It
 -- must stay quiet.
 INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type,
-                 quantity, trading_currency, settlement_currency, instrument_id, account_type)
+                 quantity, trading_currency, settlement_currency, instrument_id, account_type, group_id)
 SELECT 'e2e00000-0000-0000-0000-000000000001', 'IBKR', 'U-NEW',
-       now() - INTERVAL '2 days', 'USD', 'JRNLFUND', 250.00, 'USD', 'USD', i.instrument_id, 'TRANSFER_CLEARING'
+       now() - INTERVAL '2 days', 'USD', 'JRNLFUND', 250.00, 'USD', 'USD', i.instrument_id, 'TRANSFER_CLEARING',
+       'e2e00000-0000-0000-0000-000000000306'
 FROM (SELECT instrument_id FROM instrument_identifiers
       WHERE identifier_type = 'CURRENCY' AND value = 'USD' LIMIT 1) i;

--- a/server/db/postgres/corporate_events_test.go
+++ b/server/db/postgres/corporate_events_test.go
@@ -1395,10 +1395,10 @@ func insertTxWithBasis(t *testing.T, p *Postgres, userID, instID string, ts time
 	var id string
 	err := p.q.QueryRowContext(context.Background(), `
 		INSERT INTO txs (user_id, broker, account, timestamp, instrument_description,
-			tx_type, quantity, instrument_id, share_count_basis)
-		VALUES ($1::uuid, 'IBKR', '', $2, 'AAPL', 'BUYSTOCK', $3, $4::uuid, $5::date)
+			tx_type, quantity, instrument_id, share_count_basis, group_id)
+		VALUES ($1::uuid, 'IBKR', '', $2, 'AAPL', 'BUYSTOCK', $3, $4::uuid, $5::date, $6::uuid)
 		RETURNING id
-	`, userID, ts, qty, instID, basis).Scan(&id)
+	`, userID, ts, qty, instID, basis, newTxGroup(t, p, userID)).Scan(&id)
 	if err != nil {
 		t.Fatalf("insert tx: %v", err)
 	}

--- a/server/db/postgres/declarations.go
+++ b/server/db/postgres/declarations.go
@@ -195,7 +195,7 @@ func (p *Postgres) UpsertInitializeTx(ctx context.Context, userID, broker, accou
 	// from the other. See docs/spec/postings.md and
 	// docs/adr/0022-typed-per-account-cash-flow-boundary.md.
 	return p.runInTx(ctx, func(exec queryable) error {
-		var groupID uuid.NullUUID
+		var groupID uuid.UUID
 		err := exec.QueryRowContext(ctx, `
 			SELECT group_id FROM txs
 			WHERE user_id = $1 AND broker = $2 AND account = $3 AND instrument_id = $4
@@ -204,13 +204,11 @@ func (p *Postgres) UpsertInitializeTx(ctx context.Context, userID, broker, accou
 		`, userUUID, broker, account, instUUID).Scan(&groupID)
 		switch {
 		case err == sql.ErrNoRows:
-			var newGroupID uuid.UUID
 			if err := exec.QueryRowContext(ctx, `
 				INSERT INTO tx_groups (user_id, timestamp) VALUES ($1, $2) RETURNING id
-			`, userUUID, timestamp).Scan(&newGroupID); err != nil {
+			`, userUUID, timestamp).Scan(&groupID); err != nil {
 				return fmt.Errorf("insert initialize tx group: %w", err)
 			}
-			groupID = uuid.NullUUID{UUID: newGroupID, Valid: true}
 		case err != nil:
 			return fmt.Errorf("find initialize tx: %w", err)
 		}
@@ -240,12 +238,9 @@ func (p *Postgres) UpsertInitializeTx(ctx context.Context, userID, broker, accou
 				return fmt.Errorf("upsert initialize %s posting: %w", leg.accountType, err)
 			}
 		}
-		if !groupID.Valid {
-			return nil
-		}
 		if _, err := exec.ExecContext(ctx, `
 			UPDATE tx_groups SET timestamp = $2 WHERE id = $1
-		`, groupID.UUID, timestamp); err != nil {
+		`, groupID, timestamp); err != nil {
 			return fmt.Errorf("update initialize tx group: %w", err)
 		}
 		return nil
@@ -262,8 +257,8 @@ func (p *Postgres) DeleteInitializeTx(ctx context.Context, userID, broker, accou
 	if err != nil {
 		return fmt.Errorf("invalid instrument id: %w", err)
 	}
-	// Delete the group and let the FK cascade take the posting, so no empty group
-	// is left behind. Postings written without a group are cleared directly.
+	// Delete the group and let the FK cascade take both legs of the pad, so neither
+	// an empty group nor a lone counterparty is left behind.
 	return p.runInTx(ctx, func(exec queryable) error {
 		_, err := exec.ExecContext(ctx, `
 			DELETE FROM tx_groups g
@@ -277,15 +272,6 @@ func (p *Postgres) DeleteInitializeTx(ctx context.Context, userID, broker, accou
 		`, userUUID, broker, account, instUUID)
 		if err != nil {
 			return fmt.Errorf("delete initialize tx group: %w", err)
-		}
-		_, err = exec.ExecContext(ctx, `
-			DELETE FROM txs
-			WHERE user_id = $1 AND broker = $2 AND account = $3 AND instrument_id = $4
-			  AND synthetic_purpose = 'INITIALIZE'
-			  AND group_id IS NULL
-		`, userUUID, broker, account, instUUID)
-		if err != nil {
-			return fmt.Errorf("delete initialize tx: %w", err)
 		}
 		return nil
 	})

--- a/server/db/postgres/portfolios_test.go
+++ b/server/db/postgres/portfolios_test.go
@@ -102,10 +102,11 @@ func TestListBrokersAndAccounts_excludesNonUser(t *testing.T) {
 	userID, _ := p.GetOrCreateUser(ctx, "sub|ba-acct-type", "U", "u@ba.com")
 	if _, err := p.q.ExecContext(ctx, `
 		INSERT INTO txs (user_id, broker, account, timestamp, instrument_description,
-		                 tx_type, quantity, split_adjusted_quantity, share_count_basis, account_type)
-		VALUES ($1, 'IBKR', 'A', now(), 'X', 'BUYSTOCK', 1, 1, current_date, 'USER'),
-		       ($1, 'IBKR', 'CLEARING', now(), 'X', 'TRANSFER', 1, 1, current_date, 'TRANSFER_CLEARING')
-	`, userID); err != nil {
+		                 tx_type, quantity, split_adjusted_quantity, share_count_basis,
+		                 account_type, group_id)
+		VALUES ($1, 'IBKR', 'A', now(), 'X', 'BUYSTOCK', 1, 1, current_date, 'USER', $2::uuid),
+		       ($1, 'IBKR', 'CLEARING', now(), 'X', 'TRANSFER', 1, 1, current_date, 'TRANSFER_CLEARING', $2::uuid)
+	`, userID, newTxGroup(t, p, userID)); err != nil {
 		t.Fatalf("insert txs: %v", err)
 	}
 	got, err := p.ListBrokersAndAccounts(ctx, userID)

--- a/server/db/postgres/postgres_test.go
+++ b/server/db/postgres/postgres_test.go
@@ -69,6 +69,22 @@ func createTx(ctx context.Context, p *Postgres, userID, broker, account, jobID s
 	return p.CreateTxGroup(ctx, userID, broker, account, jobID, []*apiv1.Tx{tx}, []string{instrumentID}, shareCountBasis)
 }
 
+// newTxGroup creates an empty tx group and returns its id, for the fixtures that
+// write a posting with raw SQL because the normal path cannot produce it -- an
+// account_type outside the vocabulary, or a NULL instrument_id. Every posting
+// belongs to a group, so those fixtures need one too.
+func newTxGroup(t *testing.T, p *Postgres, userID string) string {
+	t.Helper()
+	var id string
+	err := p.q.QueryRowContext(context.Background(), `
+		INSERT INTO tx_groups (user_id, timestamp) VALUES ($1::uuid, now()) RETURNING id
+	`, userID).Scan(&id)
+	if err != nil {
+		t.Fatalf("create tx group: %v", err)
+	}
+	return id
+}
+
 // decf builds a decimal from a float literal, which is what a price test fixture
 // is naturally written as. Production code never converts this way -- the
 // provider seam in server/pricefetcher does it once, deliberately.

--- a/server/db/postgres/price_cache_test.go
+++ b/server/db/postgres/price_cache_test.go
@@ -222,9 +222,9 @@ func TestHeldRanges_UnidentifiedExcluded(t *testing.T) {
 
 	// Insert a tx with NULL instrument_id directly via SQL.
 	_, err := p.q.ExecContext(ctx, `
-		INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type, quantity)
-		VALUES ($1::uuid, 'TEST', 'A', $2, 'UNKNOWN', 'BUYSTOCK', 100)
-	`, userID, d(2024, 6, 1))
+		INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type, quantity, group_id)
+		VALUES ($1::uuid, 'TEST', 'A', $2, 'UNKNOWN', 'BUYSTOCK', 100, $3::uuid)
+	`, userID, d(2024, 6, 1), newTxGroup(t, p, userID))
 	if err != nil {
 		t.Fatalf("insert tx: %v", err)
 	}

--- a/server/db/postgres/txs.go
+++ b/server/db/postgres/txs.go
@@ -111,18 +111,6 @@ func (p *Postgres) ReplaceTxsInPeriod(ctx context.Context, userID, broker, jobID
 		if err != nil {
 			return fmt.Errorf("delete tx groups in period: %w", err)
 		}
-		// Postings written without a group (raw-SQL test fixtures) have no group to
-		// cascade from and are cleared directly.
-		_, err = exec.ExecContext(ctx, `
-			DELETE FROM txs
-			WHERE user_id = $1 AND broker = $2
-			  AND timestamp >= $3 AND timestamp < $4
-			  AND synthetic_purpose IS NULL
-			  AND group_id IS NULL
-		`, userUUID, broker, fromT, beforeT)
-		if err != nil {
-			return fmt.Errorf("delete ungrouped txs in period: %w", err)
-		}
 		return insertPostings(ctx, exec, userUUID, broker, jobUUID, txs, instrumentIDs, shareCountBasis, "")
 	})
 }

--- a/server/db/postgres/txs_test.go
+++ b/server/db/postgres/txs_test.go
@@ -888,9 +888,10 @@ func TestTxs_AccountTypeCheckConstraint(t *testing.T) {
 	userID, _ := p.GetOrCreateUser(ctx, "sub|acct-check", "U", "u@check.com")
 	_, err := p.q.ExecContext(ctx, `
 		INSERT INTO txs (user_id, broker, account, timestamp, instrument_description,
-		                 tx_type, quantity, split_adjusted_quantity, share_count_basis, account_type)
-		VALUES ($1, 'IBKR', 'A', now(), 'X', 'BUYSTOCK', 1, 1, current_date, 'Imbalance.USD')
-	`, userID)
+		                 tx_type, quantity, split_adjusted_quantity, share_count_basis,
+		                 account_type, group_id)
+		VALUES ($1, 'IBKR', 'A', now(), 'X', 'BUYSTOCK', 1, 1, current_date, 'Imbalance.USD', $2::uuid)
+	`, userID, newTxGroup(t, p, userID))
 	if err == nil {
 		t.Fatal("insert with an account_type outside the vocabulary: want error, got none")
 	}

--- a/server/db/postgres/valuation_test.go
+++ b/server/db/postgres/valuation_test.go
@@ -84,9 +84,9 @@ func TestGetPortfolioValuation_UnpricedInstruments(t *testing.T) {
 	// Insert tx with NULL instrument_id directly (unidentified instrument).
 	buyDate := time.Date(2025, 1, 2, 12, 0, 0, 0, time.UTC)
 	_, err := p.q.ExecContext(ctx, `
-		INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type, quantity, instrument_id)
-		VALUES ($1, 'IBKR', 'main', $2, 'MYSTERY CORP', 'BUYSTOCK', 5, NULL)
-	`, userID, buyDate)
+		INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type, quantity, instrument_id, group_id)
+		VALUES ($1, 'IBKR', 'main', $2, 'MYSTERY CORP', 'BUYSTOCK', 5, NULL, $3::uuid)
+	`, userID, buyDate, newTxGroup(t, p, userID))
 	if err != nil {
 		t.Fatalf("insert tx: %v", err)
 	}

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -60,8 +60,10 @@ CREATE INDEX idx_tx_groups_job_id ON tx_groups (job_id);
 
 -- Transactions. No natural key (broker statements often supply date only). Bulk idempotency
 -- by replace-by-period (user_id, broker, period). Single-tx ingestion is append-only.
--- group_id is the economic event this row is a posting of. Deleting a group deletes
--- its postings, which makes the group the unit of deletion for replace-by-period.
+-- group_id is the economic event this row is a posting of. Every posting belongs to
+-- exactly one group -- a lone posting is a group of one -- so that the balance
+-- invariant has no rows it cannot reach. Deleting a group deletes its postings, which
+-- makes the group the unit of deletion for replace-by-period.
 -- account_type classifies the account this row lands in. USER is an ordinary broker
 -- account posting; the others are the non-asset side of an event that is one-sided in
 -- the source data and keep the broker and account of the event they belong to, so a
@@ -107,7 +109,7 @@ CREATE TABLE txs (
                               CHECK (account_type IN ('USER', 'EQUITY', 'INCOME', 'EXPENSE',
                                                       'IMBALANCE', 'TRANSFER_CLEARING',
                                                       'SOURCE_ROUNDING')),
-  group_id                  UUID REFERENCES tx_groups (id) ON DELETE CASCADE,
+  group_id                  UUID NOT NULL REFERENCES tx_groups (id) ON DELETE CASCADE,
   created_at                TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 


### PR DESCRIPTION
Second of four PRs for [0041](docs/issues/0041-enable-balance-constraint.md). Independent of #320 -- both branch from main.

## Why

`docs/spec/postings.md` already claimed "every posting belongs to exactly one group", and then immediately conceded that `txs.group_id` was nullable so raw fixtures could write one without.

0041 states the balance invariant per group. A posting outside every group is a row the constraint cannot reach, which is a hole in an invariant whose whole value is that it cannot be bypassed. Cheaper to close it now, separately, than to discover it alongside the trigger.

## What changes

- `txs.group_id` is `NOT NULL`.
- The five Go fixtures that write a posting with raw SQL create a group first, via a new `newTxGroup` helper in `postgres_test.go`. They use raw SQL because the normal path cannot produce what they need -- an `account_type` outside the vocabulary, or a `NULL instrument_id` -- so they are not going away.
- The two e2e SQL fixtures do the same with explicit group ids, which read better than a CTE here since the postings reference them.
- Two delete paths existed only to clean up group-less postings and are removed: the second `DELETE` in `ReplaceTxsInPeriod` and the equivalent in `DeleteInitializeTx`. The group cascade is now the only path, which is what makes a replace unable to leave half an economic event behind.
- `UpsertInitializeTx` reads its group id into a plain `uuid.UUID` rather than a `uuid.NullUUID`. The column cannot be NULL, so neither the null case nor the guard that skipped the group timestamp update can arise.

## Test plan

- `make check`, `make server-test`, `make db-test` pass.
- `make e2e-test`: 33/33 pass. This is the suite that matters here -- it is the only one that commits, so it is the only one that would have caught a fixture writing a posting without a group.

🤖 Generated with [Claude Code](https://claude.com/claude-code)