### PR TITLE
Store the weight each posting contributes to its group (0041)

### DIFF
--- a/docs/adr/0029-posting-weight-is-stored.md
+++ b/docs/adr/0029-posting-weight-is-stored.md
@@ -19,6 +19,34 @@ instrument for an unconverted security leg, and the posting's description when
 its instrument never resolved. The fallback is a real value and never NULL, so an
 unresolved posting still balances against itself.
 
+## The encoding
+
+The three kinds are not the same kind of thing, so they are prefixed rather than
+stored bare: `cur:USD`, `inst:<uuid>`, `desc:<description>`. Without a prefix a
+description that happened to read `USD` would be the same commodity as the currency,
+and the merge would have no way to rewrite instrument names without also matching a
+description that looked like a uuid. It is the same string `commodity.key()` in
+`server/service/ingestion/balance.go` already produced to accumulate the sums, so the
+stored value is the key the residual was computed against rather than a second
+spelling of it.
+
+A uuid column referencing `instruments` was considered and rejected. Currencies are
+instruments, so `cur:USD` could have been the currency instrument's id -- but that
+means resolving the settlement currency to an instrument for every converted posting
+rather than only for the routed ones, and it leaves the `desc:` fallback with nowhere
+to go on a posting whose instrument never resolved. A nullable commodity would then
+be a group the constraint cannot check.
+
+## Weights the caller does not supply
+
+`db.TxDB` takes weights as a slice parallel to the postings, and a nil slice means
+the caller has none. Each posting then weighs its own quantity in its own instrument,
+which is not a placeholder: it is exactly what the weight rule returns for a posting
+with no price. The fixtures that write postings directly are therefore writing a
+defensible weight rather than a filler value, and a caller that forgets to supply
+weights produces a group that fails the constraint rather than one that silently
+passes.
+
 ## Considered options
 
 - **Reimplementing the weight rules in PL/pgSQL.** Rejected on two counts. It is

--- a/docs/spec/postings.md
+++ b/docs/spec/postings.md
@@ -122,9 +122,27 @@ could not reach.
 Every group is balanced at ingest. Whatever its postings leave over is routed to an
 explicit counterparty rather than rejected, so the invariant holds by construction
 from day one and a residual becomes measurable instead of being absorbed into a cash
-balance. The database constraint that enforces it is not switched on yet; when it
-is, it checks a weight stored on each posting rather than one re-derived in SQL
-(see adr/0029-posting-weight-is-stored.md).
+balance.
+
+Each posting **stores** what it contributes to that balance, in two columns:
+
+| Column             | Notes                                                              |
+| ------------------ | ------------------------------------------------------------------ |
+| `weight`           | The amount contributed. `NUMERIC`, exact.                           |
+| `weight_commodity` | What it is contributed in: `cur:<code>`, `inst:<uuid>` or `desc:<text>`. Never empty. |
+
+A group balances when `SUM(weight)` is zero for each `weight_commodity`. The database
+constraint that enforces it is not switched on yet, but the columns it reads are
+written now.
+
+The weight is stored rather than re-derived on read because instrument state moves
+under a posting after ingest: a merge rewrites `instrument_id` wholesale and
+`contract_multiplier` records what a corporate action left behind, so a re-derived
+weight could disagree with the one the group was balanced on. The cost is that the
+constraint proves the *declared* weights of a group sum to zero rather than that its
+postings balance; see adr/0029-posting-weight-is-stored.md for why that is the right
+trade. Nothing maintains the columns after ingest except the instrument merge, which
+rewrites `weight_commodity` alongside `instrument_id` in the same statement.
 
 A group's postings are in different commodities, so a plain `SUM(quantity)` cannot
 say whether it balances: a buy is `+10 AAPL` and `-1855 USD`. Balance is checked on

--- a/e2e/fixtures/instruments.sql
+++ b/e2e/fixtures/instruments.sql
@@ -22,7 +22,8 @@ ON CONFLICT DO NOTHING;
 
 -- Transactions referencing the instruments (for holdings/valuation). Every posting
 -- belongs to a group, so each trade gets one; the ids are explicit because the
--- postings reference them.
+-- postings reference them. A priced BUYSTOCK converts, so it weighs its
+-- consideration in the settlement currency: quantity * unit_price.
 INSERT INTO tx_groups (id, user_id, timestamp)
 VALUES
   ('e2e00000-0000-0000-0000-000000000201', 'e2e00000-0000-0000-0000-000000000001', '2024-01-15'),
@@ -30,11 +31,11 @@ VALUES
   ('e2e00000-0000-0000-0000-000000000203', 'e2e00000-0000-0000-0000-000000000001', '2024-01-17')
 ON CONFLICT (id) DO NOTHING;
 
-INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type, quantity, trading_currency, unit_price, instrument_id, group_id)
+INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type, quantity, trading_currency, unit_price, instrument_id, weight, weight_commodity, group_id)
 VALUES
-  ('e2e00000-0000-0000-0000-000000000001', 'FIDELITY', 'ACC-1', '2024-01-15', 'AMZN - Amazon.com Inc.', 'BUYSTOCK', 8, 'USD', 155.20, 'e2e00000-0000-0000-0000-000000000101', 'e2e00000-0000-0000-0000-000000000201'),
-  ('e2e00000-0000-0000-0000-000000000001', 'FIDELITY', 'ACC-1', '2024-01-16', 'NVDA - NVIDIA Corp.', 'BUYSTOCK', 15, 'USD', 560.50, 'e2e00000-0000-0000-0000-000000000102', 'e2e00000-0000-0000-0000-000000000202'),
-  ('e2e00000-0000-0000-0000-000000000001', 'FIDELITY', 'ACC-1', '2024-01-17', 'TSLA - Tesla Inc.', 'BUYSTOCK', 12, 'USD', 218.90, 'e2e00000-0000-0000-0000-000000000103', 'e2e00000-0000-0000-0000-000000000203')
+  ('e2e00000-0000-0000-0000-000000000001', 'FIDELITY', 'ACC-1', '2024-01-15', 'AMZN - Amazon.com Inc.', 'BUYSTOCK', 8, 'USD', 155.20, 'e2e00000-0000-0000-0000-000000000101', 1241.60, 'cur:USD', 'e2e00000-0000-0000-0000-000000000201'),
+  ('e2e00000-0000-0000-0000-000000000001', 'FIDELITY', 'ACC-1', '2024-01-16', 'NVDA - NVIDIA Corp.', 'BUYSTOCK', 15, 'USD', 560.50, 'e2e00000-0000-0000-0000-000000000102', 8407.50, 'cur:USD', 'e2e00000-0000-0000-0000-000000000202'),
+  ('e2e00000-0000-0000-0000-000000000001', 'FIDELITY', 'ACC-1', '2024-01-17', 'TSLA - Tesla Inc.', 'BUYSTOCK', 12, 'USD', 218.90, 'e2e00000-0000-0000-0000-000000000103', 2626.80, 'cur:USD', 'e2e00000-0000-0000-0000-000000000203')
 ON CONFLICT DO NOTHING;
 
 -- EOD prices: a few days of data for each instrument.

--- a/e2e/fixtures/residual-balances.sql
+++ b/e2e/fixtures/residual-balances.sql
@@ -6,7 +6,8 @@
 -- rather than about the converters.
 --
 -- Every posting belongs to a group, so each residual gets one. The ids are explicit
--- because the postings reference them.
+-- because the postings reference them. Every residual here is a cash posting with no
+-- price, so it weighs its own quantity in the currency it is denominated in.
 --
 -- Timestamps are relative to now() so the age assertions do not rot.
 
@@ -24,20 +25,22 @@ ON CONFLICT (id) DO NOTHING;
 -- the whole value lands in Imbalance. Negative: value arriving from outside the
 -- ledger.
 INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type,
-                 quantity, trading_currency, settlement_currency, instrument_id, account_type, group_id)
+                 quantity, trading_currency, settlement_currency, instrument_id, account_type,
+                 weight, weight_commodity, group_id)
 SELECT 'e2e00000-0000-0000-0000-000000000001', 'FIDELITY', 'ACC-1',
        now() - INTERVAL '5 days', 'USD', 'INCOME', -137.08, 'USD', 'USD', i.instrument_id, 'IMBALANCE',
-       'e2e00000-0000-0000-0000-000000000301'
+       -137.08, 'cur:USD', 'e2e00000-0000-0000-0000-000000000301'
 FROM (SELECT instrument_id FROM instrument_identifiers
       WHERE identifier_type = 'CURRENCY' AND value = 'USD' LIMIT 1) i;
 
 -- A trade whose price and cash total disagree: the commission the broker netted
 -- into the total and did not report separately.
 INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type,
-                 quantity, trading_currency, settlement_currency, instrument_id, account_type, group_id)
+                 quantity, trading_currency, settlement_currency, instrument_id, account_type,
+                 weight, weight_commodity, group_id)
 SELECT 'e2e00000-0000-0000-0000-000000000001', 'FIDELITY', 'ACC-1',
        now() - INTERVAL '6 days', 'USD', 'BUYSTOCK', 4.95, 'USD', 'USD', i.instrument_id, 'IMBALANCE',
-       'e2e00000-0000-0000-0000-000000000302'
+       4.95, 'cur:USD', 'e2e00000-0000-0000-0000-000000000302'
 FROM (SELECT instrument_id FROM instrument_identifiers
       WHERE identifier_type = 'CURRENCY' AND value = 'USD' LIMIT 1) i;
 
@@ -46,10 +49,11 @@ FROM (SELECT instrument_id FROM instrument_identifiers
 -- other; neither should appear. They arrive in separate statements, so they are
 -- separate groups -- pairing them is 0068.
 INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type,
-                 quantity, trading_currency, settlement_currency, instrument_id, account_type, group_id)
+                 quantity, trading_currency, settlement_currency, instrument_id, account_type,
+                 weight, weight_commodity, group_id)
 SELECT 'e2e00000-0000-0000-0000-000000000001', 'SCHB', v.account,
        now() - (v.days || ' days')::INTERVAL, 'USD', 'JRNLFUND', v.qty, 'USD', 'USD',
-       i.instrument_id, 'TRANSFER_CLEARING', v.group_id::uuid
+       i.instrument_id, 'TRANSFER_CLEARING', v.qty, 'cur:USD', v.group_id::uuid
 FROM (VALUES ('SCH-1', 1000.00, '60', 'e2e00000-0000-0000-0000-000000000303'),
              ('SCH-2', -1000.00, '59', 'e2e00000-0000-0000-0000-000000000304')) AS v(account, qty, days, group_id),
      (SELECT instrument_id FROM instrument_identifiers
@@ -58,19 +62,21 @@ FROM (VALUES ('SCH-1', 1000.00, '60', 'e2e00000-0000-0000-0000-000000000303'),
 -- One side of a transfer out of an IBKR account, long enough ago that the other
 -- side is not coming.
 INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type,
-                 quantity, trading_currency, settlement_currency, instrument_id, account_type, group_id)
+                 quantity, trading_currency, settlement_currency, instrument_id, account_type,
+                 weight, weight_commodity, group_id)
 SELECT 'e2e00000-0000-0000-0000-000000000001', 'IBKR', 'U-OLD',
        now() - INTERVAL '40 days', 'USD', 'JRNLFUND', 500.00, 'USD', 'USD', i.instrument_id, 'TRANSFER_CLEARING',
-       'e2e00000-0000-0000-0000-000000000305'
+       500.00, 'cur:USD', 'e2e00000-0000-0000-0000-000000000305'
 FROM (SELECT instrument_id FROM instrument_identifiers
       WHERE identifier_type = 'CURRENCY' AND value = 'USD' LIMIT 1) i;
 
 -- A transfer imported two days ago whose other side may still be on its way. It
 -- must stay quiet.
 INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type,
-                 quantity, trading_currency, settlement_currency, instrument_id, account_type, group_id)
+                 quantity, trading_currency, settlement_currency, instrument_id, account_type,
+                 weight, weight_commodity, group_id)
 SELECT 'e2e00000-0000-0000-0000-000000000001', 'IBKR', 'U-NEW',
        now() - INTERVAL '2 days', 'USD', 'JRNLFUND', 250.00, 'USD', 'USD', i.instrument_id, 'TRANSFER_CLEARING',
-       'e2e00000-0000-0000-0000-000000000306'
+       250.00, 'cur:USD', 'e2e00000-0000-0000-0000-000000000306'
 FROM (SELECT instrument_id FROM instrument_identifiers
       WHERE identifier_type = 'CURRENCY' AND value = 'USD' LIMIT 1) i;

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -217,17 +217,44 @@ type PortfolioDB interface {
 	ListBrokersAndAccounts(ctx context.Context, userID string) ([]BrokerAccount, error)
 }
 
+// Weight is what a posting contributes to its group's balance, and the commodity it
+// contributes in. A group balances when its postings' weights sum to zero in every
+// commodity.
+//
+// The weight rules -- which tx types convert, the settlement-currency guard, the
+// contract-size multiplication -- live in server/service/ingestion/balance.go and are
+// evaluated once, at ingest. The value is then stored on the posting rather than
+// re-derived on read, because instrument state moves under a posting afterwards: a
+// merge rewrites instrument_id wholesale and contract_multiplier records what a
+// corporate action left behind, so a re-derived weight could disagree with the one
+// the group was balanced on. See docs/adr/0029-posting-weight-is-stored.md.
+//
+// Commodity is a prefixed name rather than an id, because the three kinds of
+// commodity a weight can be in are not the same kind of thing: "cur:USD" for money,
+// "inst:<uuid>" for a security, and "desc:<description>" for a posting whose
+// instrument never resolved. It is never empty, so an unresolved posting still
+// balances against itself.
+type Weight struct {
+	Amount    decimal.Decimal
+	Commodity string
+}
+
 // TxDB provides transaction write and list.
 type TxDB interface {
 	// Txs sharing a group_ref are written as postings of one tx group; the rest get
 	// a group each. Every group is stamped with the ingestion job that created it.
 	// shareCountBasis is the date the uploaded quantities and unit prices are
 	// denominated in. nil means as-traded: each row uses its own timestamp.
-	ReplaceTxsInPeriod(ctx context.Context, userID, broker, jobID string, periodFrom, periodBefore *timestamppb.Timestamp, txs []*apiv1.Tx, instrumentIDs []string, shareCountBasis *time.Time) error
+	//
+	// weights is parallel to txs and carries what each posting contributes to its
+	// group's balance. A nil slice means the caller has none, and each posting then
+	// weighs its own quantity in its own instrument -- which is what the weight rule
+	// returns for a posting with no price.
+	ReplaceTxsInPeriod(ctx context.Context, userID, broker, jobID string, periodFrom, periodBefore *timestamppb.Timestamp, txs []*apiv1.Tx, instrumentIDs []string, weights []Weight, shareCountBasis *time.Time) error
 	// CreateTxGroup appends the postings of one economic event as a single group.
 	// It takes a slice rather than a tx so that the append path can carry a routed
 	// counterparty, without which its groups could never balance.
-	CreateTxGroup(ctx context.Context, userID, broker, account, jobID string, txs []*apiv1.Tx, instrumentIDs []string, shareCountBasis *time.Time) error
+	CreateTxGroup(ctx context.Context, userID, broker, account, jobID string, txs []*apiv1.Tx, instrumentIDs []string, weights []Weight, shareCountBasis *time.Time) error
 	ListTxs(ctx context.Context, userID string, broker *apiv1.Broker, account string, periodFrom, periodBefore *timestamppb.Timestamp, descending bool, pageSize int32, pageToken string) ([]*apiv1.PortfolioTx, string, error)
 	ListTxsByPortfolio(ctx context.Context, portfolioID string, broker *apiv1.Broker, periodFrom, periodBefore *timestamppb.Timestamp, descending bool, pageSize int32, pageToken string) ([]*apiv1.PortfolioTx, string, error)
 }

--- a/server/db/postgres/corporate_events_test.go
+++ b/server/db/postgres/corporate_events_test.go
@@ -1395,8 +1395,9 @@ func insertTxWithBasis(t *testing.T, p *Postgres, userID, instID string, ts time
 	var id string
 	err := p.q.QueryRowContext(context.Background(), `
 		INSERT INTO txs (user_id, broker, account, timestamp, instrument_description,
-			tx_type, quantity, instrument_id, share_count_basis, group_id)
-		VALUES ($1::uuid, 'IBKR', '', $2, 'AAPL', 'BUYSTOCK', $3, $4::uuid, $5::date, $6::uuid)
+			tx_type, quantity, instrument_id, share_count_basis, weight, weight_commodity, group_id)
+		VALUES ($1::uuid, 'IBKR', '', $2, 'AAPL', 'BUYSTOCK', $3, $4::uuid, $5::date,
+			$3, 'inst:' || $4, $6::uuid)
 		RETURNING id
 	`, userID, ts, qty, instID, basis, newTxGroup(t, p, userID)).Scan(&id)
 	if err != nil {

--- a/server/db/postgres/declarations.go
+++ b/server/db/postgres/declarations.go
@@ -224,16 +224,30 @@ func (p *Postgres) UpsertInitializeTx(ctx context.Context, userID, broker, accou
 			{"USER", quantity},
 			{"EQUITY", quantity.Neg()},
 		} {
+			// A pad has no price, so each leg weighs its own quantity in its own
+			// commodity and the two cancel. The commodity is named the way
+			// ownCommodity in server/service/ingestion/balance.go names it, so a
+			// cash pad reads as the same commodity an ingested cash leg does.
+			// weight is in the DO UPDATE list for the same reason quantity is:
+			// otherwise a recalculation moves the quantity and leaves the weight
+			// behind, and the group stops balancing.
 			if _, err := exec.ExecContext(ctx, `
 				INSERT INTO txs (user_id, broker, account, timestamp, instrument_description,
 				                 tx_type, quantity, instrument_id, synthetic_purpose,
-				                 account_type, group_id)
-				VALUES ($1, $2, $3, $4, 'INITIALIZE', $7, $5, $6, 'INITIALIZE', $8, $9)
+				                 account_type, weight, weight_commodity, group_id)
+				SELECT $1, $2, $3, $4, 'INITIALIZE', $7, $5, $6, 'INITIALIZE', $8, $5,
+				       CASE WHEN i.asset_class = 'CASH' AND i.currency IS NOT NULL
+				            THEN 'cur:' || upper(i.currency)
+				            ELSE 'inst:' || i.id::text END,
+				       $9
+				FROM instruments i WHERE i.id = $6
 				ON CONFLICT (user_id, broker, account, instrument_id, account_type)
 				  WHERE synthetic_purpose = 'INITIALIZE'
 				DO UPDATE SET timestamp = EXCLUDED.timestamp,
 				              quantity = EXCLUDED.quantity,
-				              tx_type = EXCLUDED.tx_type
+				              tx_type = EXCLUDED.tx_type,
+				              weight = EXCLUDED.weight,
+				              weight_commodity = EXCLUDED.weight_commodity
 			`, userUUID, broker, account, timestamp, leg.quantity, instUUID, txType, leg.accountType, groupID); err != nil {
 				return fmt.Errorf("upsert initialize %s posting: %w", leg.accountType, err)
 			}

--- a/server/db/postgres/holdings_test.go
+++ b/server/db/postgres/holdings_test.go
@@ -39,7 +39,7 @@ func TestComputeHoldings_instrumentNameOverTxDescription(t *testing.T) {
 	txs := []*apiv1.Tx{
 		{Timestamp: ts, InstrumentDescription: "MSFT MICROSOFT CORP", Type: apiv1.TxType_INCOME, Quantity: "137.08", Account: ""},
 	}
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{cashID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{cashID}, nil, nil); err != nil {
 		t.Fatalf("replace: %v", err)
 	}
 
@@ -75,7 +75,7 @@ func TestComputeHoldings_signedQuantity(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ensure instrument: %v", err)
 	}
-	err = p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID}, nil)
+	err = p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID}, nil, nil)
 	if err != nil {
 		t.Fatalf("replace: %v", err)
 	}
@@ -124,7 +124,7 @@ func TestComputeHoldings_fractionalQuantitiesSumExactly(t *testing.T) {
 		})
 		instIDs = append(instIDs, instID)
 	}
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, instIDs, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, instIDs, nil, nil); err != nil {
 		t.Fatalf("replace: %v", err)
 	}
 
@@ -167,7 +167,7 @@ func TestComputeHoldings_excludesNonUserAccountTypes(t *testing.T) {
 		{Timestamp: ts, InstrumentDescription: "TSCO", Type: apiv1.TxType_BUYSTOCK, Quantity: "40", Account: "A", GroupRef: "pad"},
 		{Timestamp: ts, InstrumentDescription: "TSCO", Type: apiv1.TxType_BUYSTOCK, Quantity: "-40", Account: "A", GroupRef: "pad", AccountType: apiv1.AccountType_ACCOUNT_TYPE_EQUITY},
 	}
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID, instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID, instID}, nil, nil); err != nil {
 		t.Fatalf("replace: %v", err)
 	}
 

--- a/server/db/postgres/instruments.go
+++ b/server/db/postgres/instruments.go
@@ -24,7 +24,21 @@ func mergeInstruments(ctx context.Context, exec queryable, survivor, mergedAway 
 	if survivor == mergedAway {
 		return nil
 	}
-	if _, err := exec.ExecContext(ctx, `UPDATE txs SET instrument_id = $1 WHERE instrument_id = $2`, survivor, mergedAway); err != nil {
+	// weight_commodity moves with instrument_id, in the same statement: a posting
+	// weighing in its own security names it by instrument, so leaving the name behind
+	// would split one commodity into two and unbalance the group. Only the 'inst:'
+	// form needs rewriting -- a converted or cash leg is named by its currency code,
+	// which the merge does not change. Both legs of a same-instrument group move
+	// together, so the group stays balanced across the merge. See
+	// docs/adr/0029-posting-weight-is-stored.md.
+	if _, err := exec.ExecContext(ctx, `
+		UPDATE txs
+		SET instrument_id = $1::uuid,
+		    weight_commodity = CASE WHEN weight_commodity = 'inst:' || $2::uuid::text
+		                            THEN 'inst:' || $1::uuid::text
+		                            ELSE weight_commodity END
+		WHERE instrument_id = $2::uuid
+	`, survivor, mergedAway); err != nil {
 		return fmt.Errorf("update txs: %w", err)
 	}
 	rows, err := exec.QueryContext(ctx, `SELECT identifier_type, domain, value, canonical FROM instrument_identifiers WHERE instrument_id = $1`, mergedAway)

--- a/server/db/postgres/instruments_test.go
+++ b/server/db/postgres/instruments_test.go
@@ -41,7 +41,7 @@ func TestEnsureInstrument_mergeWhenMultipleInstrumentsMatch(t *testing.T) {
 		{Timestamp: ts1, InstrumentDescription: "StockA", Type: apiv1.TxType_BUYSTOCK, Quantity: "10", Account: ""},
 		{Timestamp: ts2, InstrumentDescription: "StockB", Type: apiv1.TxType_BUYSTOCK, Quantity: "5", Account: ""},
 	}
-	err = p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{idA, idB}, nil)
+	err = p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{idA, idB}, nil, nil)
 	if err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
@@ -780,5 +780,69 @@ func TestInsertInstrumentIdentifier_NormalizesSegmentMIC(t *testing.T) {
 		if id.Type == "MIC_TICKER" && id.Domain != "XNAS" {
 			t.Fatalf("expected MIC_TICKER domain XNAS, got %s", id.Domain)
 		}
+	}
+}
+
+// TestMergeInstruments_RewritesWeightCommodity verifies the one thing a merge has to
+// do to keep the balance invariant: a posting weighing in its own security names that
+// commodity by instrument, so leaving the name behind would split one commodity into
+// two and unbalance a group that was balanced when it was written. Both legs of an
+// unpaired securities journal move together, so the group stays balanced.
+func TestMergeInstruments_RewritesWeightCommodity(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	idA, err := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "ISIN", Value: "W1", Canonical: true}}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure A: %v", err)
+	}
+	idB, err := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "CUSIP", Value: "W1", Canonical: true}}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure B: %v", err)
+	}
+	userID, _ := p.GetOrCreateUser(ctx, "sub|weight-merge", "U", "u@wm.com")
+	now := time.Now()
+	from, to := timestamppb.New(now.Add(-time.Hour)), timestamppb.New(now.Add(time.Hour))
+
+	// A journal leg against A and its clearing counterparty against B: two names for
+	// what the merge is about to decide is one commodity.
+	txs := []*apiv1.Tx{
+		{Timestamp: timestamppb.New(now), InstrumentDescription: "StockA", Type: apiv1.TxType_JRNLSEC, Quantity: "-10", GroupRef: "j1"},
+		{Timestamp: timestamppb.New(now), InstrumentDescription: "StockB", Type: apiv1.TxType_JRNLSEC, Quantity: "10", GroupRef: "j1"},
+	}
+	ws := []db.Weight{
+		{Amount: decf(-10), Commodity: "inst:" + idA},
+		{Amount: decf(10), Commodity: "inst:" + idB},
+	}
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{idA, idB}, ws, nil); err != nil {
+		t.Fatalf("replace txs: %v", err)
+	}
+
+	survivor, err := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{
+		{Type: "ISIN", Value: "W1", Canonical: true},
+		{Type: "CUSIP", Value: "W1", Canonical: true},
+	}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+
+	rows, err := p.q.QueryContext(ctx, `SELECT weight_commodity FROM txs WHERE user_id = $1`, userID)
+	if err != nil {
+		t.Fatalf("read commodities: %v", err)
+	}
+	defer rows.Close()
+	want := "inst:" + survivor
+	n := 0
+	for rows.Next() {
+		var got string
+		if err := rows.Scan(&got); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		if got != want {
+			t.Errorf("weight_commodity = %q, want %q (the survivor)", got, want)
+		}
+		n++
+	}
+	if n != 2 {
+		t.Fatalf("expected 2 postings, got %d", n)
 	}
 }

--- a/server/db/postgres/portfolios_test.go
+++ b/server/db/postgres/portfolios_test.go
@@ -103,9 +103,9 @@ func TestListBrokersAndAccounts_excludesNonUser(t *testing.T) {
 	if _, err := p.q.ExecContext(ctx, `
 		INSERT INTO txs (user_id, broker, account, timestamp, instrument_description,
 		                 tx_type, quantity, split_adjusted_quantity, share_count_basis,
-		                 account_type, group_id)
-		VALUES ($1, 'IBKR', 'A', now(), 'X', 'BUYSTOCK', 1, 1, current_date, 'USER', $2::uuid),
-		       ($1, 'IBKR', 'CLEARING', now(), 'X', 'TRANSFER', 1, 1, current_date, 'TRANSFER_CLEARING', $2::uuid)
+		                 account_type, weight, weight_commodity, group_id)
+		VALUES ($1, 'IBKR', 'A', now(), 'X', 'BUYSTOCK', 1, 1, current_date, 'USER', 1, 'desc:X', $2::uuid),
+		       ($1, 'IBKR', 'CLEARING', now(), 'X', 'TRANSFER', 1, 1, current_date, 'TRANSFER_CLEARING', 1, 'desc:X', $2::uuid)
 	`, userID, newTxGroup(t, p, userID)); err != nil {
 		t.Fatalf("insert txs: %v", err)
 	}

--- a/server/db/postgres/postgres_test.go
+++ b/server/db/postgres/postgres_test.go
@@ -66,7 +66,7 @@ func testDBTx(t *testing.T) *Postgres {
 // seed row, and CreateTxGroup takes a slice so that the append path can carry a
 // routed counterparty alongside the posting it balances.
 func createTx(ctx context.Context, p *Postgres, userID, broker, account, jobID string, tx *apiv1.Tx, instrumentID string, shareCountBasis *time.Time) error {
-	return p.CreateTxGroup(ctx, userID, broker, account, jobID, []*apiv1.Tx{tx}, []string{instrumentID}, shareCountBasis)
+	return p.CreateTxGroup(ctx, userID, broker, account, jobID, []*apiv1.Tx{tx}, []string{instrumentID}, nil, shareCountBasis)
 }
 
 // newTxGroup creates an empty tx group and returns its id, for the fixtures that

--- a/server/db/postgres/price_cache_test.go
+++ b/server/db/postgres/price_cache_test.go
@@ -54,7 +54,7 @@ func insertTxs(t *testing.T, p *Postgres, userID, instID string, txs []*apiv1.Tx
 	}
 	from := timestamppb.New(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC))
 	to := timestamppb.New(time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "TEST", "", from, to, txs, ids, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "TEST", "", from, to, txs, ids, nil, nil); err != nil {
 		t.Fatalf("insert txs: %v", err)
 	}
 }
@@ -222,8 +222,9 @@ func TestHeldRanges_UnidentifiedExcluded(t *testing.T) {
 
 	// Insert a tx with NULL instrument_id directly via SQL.
 	_, err := p.q.ExecContext(ctx, `
-		INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type, quantity, group_id)
-		VALUES ($1::uuid, 'TEST', 'A', $2, 'UNKNOWN', 'BUYSTOCK', 100, $3::uuid)
+		INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type, quantity,
+		                 weight, weight_commodity, group_id)
+		VALUES ($1::uuid, 'TEST', 'A', $2, 'UNKNOWN', 'BUYSTOCK', 100, 100, 'desc:UNKNOWN', $3::uuid)
 	`, userID, d(2024, 6, 1), newTxGroup(t, p, userID))
 	if err != nil {
 		t.Fatalf("insert tx: %v", err)

--- a/server/db/postgres/txs.go
+++ b/server/db/postgres/txs.go
@@ -8,6 +8,7 @@ import (
 	sq "github.com/Masterminds/squirrel"
 	"github.com/google/uuid"
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	"github.com/leedenison/portfoliodb/server/db"
 	"github.com/shopspring/decimal"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -22,13 +23,14 @@ var psql = sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
 const insertPostingSQL = `
 	WITH g AS (
 		INSERT INTO tx_groups (user_id, timestamp, job_id)
-		VALUES ($1, $4, $14)
+		VALUES ($1, $4, $16)
 		RETURNING id
 	)
 	INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type,
 	                 quantity, trading_currency, settlement_currency, unit_price,
-	                 instrument_id, share_count_basis, account_type, group_id)
-	SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::date, $13, g.id FROM g
+	                 instrument_id, share_count_basis, account_type,
+	                 weight, weight_commodity, group_id)
+	SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::date, $13, $14, $15, g.id FROM g
 	RETURNING group_id
 `
 
@@ -37,8 +39,9 @@ const insertPostingSQL = `
 const insertPostingInGroupSQL = `
 	INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type,
 	                 quantity, trading_currency, settlement_currency, unit_price,
-	                 instrument_id, share_count_basis, account_type, group_id)
-	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::date, $13, $14)
+	                 instrument_id, share_count_basis, account_type,
+	                 weight, weight_commodity, group_id)
+	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::date, $13, $14, $15, $16)
 `
 
 // groupResolver hands out the tx group for a tx's group_ref. An empty group_ref
@@ -71,7 +74,7 @@ func (r *groupResolver) record(ref string, id uuid.UUID) {
 }
 
 // ReplaceTxsInPeriod implements db.TxDB.
-func (p *Postgres) ReplaceTxsInPeriod(ctx context.Context, userID, broker, jobID string, periodFrom, periodBefore *timestamppb.Timestamp, txs []*apiv1.Tx, instrumentIDs []string, shareCountBasis *time.Time) error {
+func (p *Postgres) ReplaceTxsInPeriod(ctx context.Context, userID, broker, jobID string, periodFrom, periodBefore *timestamppb.Timestamp, txs []*apiv1.Tx, instrumentIDs []string, weights []db.Weight, shareCountBasis *time.Time) error {
 	userUUID, err := uuid.Parse(userID)
 	if err != nil {
 		return fmt.Errorf("invalid user id: %w", err)
@@ -111,7 +114,7 @@ func (p *Postgres) ReplaceTxsInPeriod(ctx context.Context, userID, broker, jobID
 		if err != nil {
 			return fmt.Errorf("delete tx groups in period: %w", err)
 		}
-		return insertPostings(ctx, exec, userUUID, broker, jobUUID, txs, instrumentIDs, shareCountBasis, "")
+		return insertPostings(ctx, exec, userUUID, broker, jobUUID, txs, instrumentIDs, weights, shareCountBasis, "")
 	})
 }
 
@@ -119,7 +122,10 @@ func (p *Postgres) ReplaceTxsInPeriod(ctx context.Context, userID, broker, jobID
 // group_ref and reusing it for that ref's later legs. account overrides the
 // account on every posting when non-empty, for the append path where the whole
 // group belongs to one named account.
-func insertPostings(ctx context.Context, exec queryable, userUUID uuid.UUID, broker string, jobUUID interface{}, txs []*apiv1.Tx, instrumentIDs []string, shareCountBasis *time.Time, account string) error {
+//
+// weights is parallel to txs, or nil when the caller has none. See db.TxDB for what
+// a missing weight means.
+func insertPostings(ctx context.Context, exec queryable, userUUID uuid.UUID, broker string, jobUUID interface{}, txs []*apiv1.Tx, instrumentIDs []string, weights []db.Weight, shareCountBasis *time.Time, account string) error {
 	resolver := newGroupResolver()
 	for i, t := range txs {
 		instUUID, err := uuid.Parse(instrumentIDs[i])
@@ -155,10 +161,14 @@ func insertPostings(ctx context.Context, exec queryable, userUUID uuid.UUID, bro
 		if err != nil {
 			return fmt.Errorf("invalid unit price %q: %w", t.GetUnitPrice(), err)
 		}
+		w := db.Weight{Amount: qty, Commodity: "inst:" + instUUID.String()}
+		if i < len(weights) {
+			w = weights[i]
+		}
 		args := []interface{}{
 			userUUID, broker, acc, ts, t.InstrumentDescription, txTypeStr, qty,
 			nullStr(t.TradingCurrency), nullStr(t.SettlementCurrency), nullDecimal(price),
-			instUUID, shareCountBasis, acctTypeStr,
+			instUUID, shareCountBasis, acctTypeStr, w.Amount, w.Commodity,
 		}
 		ref := t.GetGroupRef()
 		if groupID, ok := resolver.group(ref); ok {
@@ -183,7 +193,7 @@ func insertPostings(ctx context.Context, exec queryable, userUUID uuid.UUID, bro
 // group that could never be balanced would put the balance invariant permanently
 // out of reach. The postings share the named account. group_ref is ignored -- the
 // whole call is one group -- so the resolver never splits it.
-func (p *Postgres) CreateTxGroup(ctx context.Context, userID, broker, account, jobID string, txs []*apiv1.Tx, instrumentIDs []string, shareCountBasis *time.Time) error {
+func (p *Postgres) CreateTxGroup(ctx context.Context, userID, broker, account, jobID string, txs []*apiv1.Tx, instrumentIDs []string, weights []db.Weight, shareCountBasis *time.Time) error {
 	userUUID, err := uuid.Parse(userID)
 	if err != nil {
 		return fmt.Errorf("invalid user id: %w", err)
@@ -198,7 +208,7 @@ func (p *Postgres) CreateTxGroup(ctx context.Context, userID, broker, account, j
 		grouped[i].GroupRef = "one-group"
 	}
 	return p.runInTx(ctx, func(exec queryable) error {
-		if err := insertPostings(ctx, exec, userUUID, broker, jobUUID, grouped, instrumentIDs, shareCountBasis, account); err != nil {
+		if err := insertPostings(ctx, exec, userUUID, broker, jobUUID, grouped, instrumentIDs, weights, shareCountBasis, account); err != nil {
 			return fmt.Errorf("create tx group: %w", err)
 		}
 		return nil

--- a/server/db/postgres/txs_test.go
+++ b/server/db/postgres/txs_test.go
@@ -8,6 +8,7 @@ import (
 
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
 	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/shopspring/decimal"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -31,7 +32,7 @@ func TestReplaceTxsInPeriod_and_ComputeHoldings(t *testing.T) {
 		t.Fatalf("ensure instrument: %v", err)
 	}
 	instrumentIDs := []string{instID, instID}
-	err = p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, instrumentIDs, nil)
+	err = p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, instrumentIDs, nil, nil)
 	if err != nil {
 		t.Fatalf("replace: %v", err)
 	}
@@ -82,7 +83,7 @@ func TestReplaceTxsInPeriod_PeriodBeforeIsExclusive(t *testing.T) {
 	// a window abutting the next one must not reach into it.
 	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "",
 		timestamppb.New(time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)), timestamppb.New(boundary),
-		nil, nil, nil); err != nil {
+		nil, nil, nil, nil); err != nil {
 		t.Fatalf("replace: %v", err)
 	}
 
@@ -119,7 +120,7 @@ func TestReplaceTxsInPeriod_PreservesSyntheticInitializeTx(t *testing.T) {
 	oldTx := []*apiv1.Tx{
 		{Timestamp: timestamppb.New(now.Add(-80 * time.Minute)), InstrumentDescription: "MSFT", Type: apiv1.TxType_BUYSTOCK, Quantity: "5", Account: ""},
 	}
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, oldTx, []string{instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, oldTx, []string{instID}, nil, nil); err != nil {
 		t.Fatalf("seed real tx: %v", err)
 	}
 
@@ -128,7 +129,7 @@ func TestReplaceTxsInPeriod_PreservesSyntheticInitializeTx(t *testing.T) {
 		{Timestamp: timestamppb.New(now.Add(-60 * time.Minute)), InstrumentDescription: "MSFT", Type: apiv1.TxType_BUYSTOCK, Quantity: "7", Account: ""},
 		{Timestamp: timestamppb.New(now.Add(-20 * time.Minute)), InstrumentDescription: "MSFT", Type: apiv1.TxType_SELLSTOCK, Quantity: "-2", Account: ""},
 	}
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, newTxs, []string{instID, instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, newTxs, []string{instID, instID}, nil, nil); err != nil {
 		t.Fatalf("replace: %v", err)
 	}
 
@@ -260,7 +261,7 @@ func TestCreateTxGroup_PutsEveryPostingInOneGroup(t *testing.T) {
 		{Timestamp: timestamppb.New(at), InstrumentDescription: "NFLX", Type: apiv1.TxType_BUYSTOCK, Quantity: "4", Account: "A", GroupRef: "a"},
 		{Timestamp: timestamppb.New(at), InstrumentDescription: "NFLX", Type: apiv1.TxType_BUYSTOCK, Quantity: "-4", Account: "A", GroupRef: "b", AccountType: apiv1.AccountType_ACCOUNT_TYPE_IMBALANCE},
 	}
-	if err := p.CreateTxGroup(ctx, userID, "IBKR", "A", "", txs, []string{instID, instID}, nil); err != nil {
+	if err := p.CreateTxGroup(ctx, userID, "IBKR", "A", "", txs, []string{instID, instID}, nil, nil); err != nil {
 		t.Fatalf("create tx group: %v", err)
 	}
 	if got := countGroups(t, p, userID); got != 1 {
@@ -298,10 +299,10 @@ func TestReplaceTxsInPeriod_DeletesRoutedPostingsWithTheirGroup(t *testing.T) {
 		{Timestamp: timestamppb.New(base.Add(time.Hour)), InstrumentDescription: "IMB", Type: apiv1.TxType_BUYSTOCK, Quantity: "10", Account: "A", GroupRef: "t1"},
 		{Timestamp: timestamppb.New(base.Add(time.Hour)), InstrumentDescription: "IMB", Type: apiv1.TxType_BUYSTOCK, Quantity: "-10", Account: "A", GroupRef: "t1", AccountType: apiv1.AccountType_ACCOUNT_TYPE_IMBALANCE},
 	}
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID, instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID, instID}, nil, nil); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, nil, nil, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, nil, nil, nil, nil); err != nil {
 		t.Fatalf("replace with nothing: %v", err)
 	}
 	var remaining int
@@ -331,7 +332,7 @@ func TestReplaceTxsInPeriod_CreatesGroupPerTx(t *testing.T) {
 		{Timestamp: timestamppb.New(base.Add(3 * time.Hour)), InstrumentDescription: "TSLA", Type: apiv1.TxType_SELLSTOCK, Quantity: "-1", Account: ""},
 	}
 	from, to := timestamppb.New(base), timestamppb.New(base.Add(24*time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID, instID, instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID, instID, instID}, nil, nil); err != nil {
 		t.Fatalf("replace: %v", err)
 	}
 
@@ -366,7 +367,7 @@ func TestReplaceTxsInPeriod_GroupsByGroupRef(t *testing.T) {
 	}
 	from, to := timestamppb.New(base), timestamppb.New(base.Add(24*time.Hour))
 	ids := []string{instID, instID, instID}
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, ids, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, ids, nil, nil); err != nil {
 		t.Fatalf("replace: %v", err)
 	}
 
@@ -409,7 +410,7 @@ func TestReplaceTxsInPeriod_GroupRefScopedToUpload(t *testing.T) {
 			{Timestamp: timestamppb.New(period.Add(time.Hour)), InstrumentDescription: "BP", Type: apiv1.TxType_CASHFLOW, Quantity: "-50", Account: "", GroupRef: "same-ref"},
 		}
 		from, to := timestamppb.New(period), timestamppb.New(period.Add(24*time.Hour))
-		if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID, instID}, nil); err != nil {
+		if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID, instID}, nil, nil); err != nil {
 			t.Fatalf("replace: %v", err)
 		}
 	}
@@ -445,10 +446,10 @@ func TestReplaceTxsInPeriod_DeletesWholeGroups(t *testing.T) {
 		{Timestamp: timestamppb.New(base.Add(time.Hour)), InstrumentDescription: "GSK", Type: apiv1.TxType_BUYSTOCK, Quantity: "10", Account: "", GroupRef: "r"},
 		{Timestamp: timestamppb.New(base.Add(time.Hour)), InstrumentDescription: "GSK", Type: apiv1.TxType_CASHFLOW, Quantity: "-50", Account: "", GroupRef: "r"},
 	}
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, seed, []string{instID, instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, seed, []string{instID, instID}, nil, nil); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, nil, nil, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, nil, nil, nil, nil); err != nil {
 		t.Fatalf("replace with nothing: %v", err)
 	}
 
@@ -480,13 +481,13 @@ func TestReplaceTxsInPeriod_DeletesGroupsInPeriod(t *testing.T) {
 		{Timestamp: timestamppb.New(base.Add(time.Hour)), InstrumentDescription: "AMD", Type: apiv1.TxType_BUYSTOCK, Quantity: "1", Account: ""},
 		{Timestamp: timestamppb.New(base.Add(2 * time.Hour)), InstrumentDescription: "AMD", Type: apiv1.TxType_BUYSTOCK, Quantity: "2", Account: ""},
 	}
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, seed, []string{instID, instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, seed, []string{instID, instID}, nil, nil); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 	replacement := []*apiv1.Tx{
 		{Timestamp: timestamppb.New(base.Add(3 * time.Hour)), InstrumentDescription: "AMD", Type: apiv1.TxType_BUYSTOCK, Quantity: "9", Account: ""},
 	}
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, replacement, []string{instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, replacement, []string{instID}, nil, nil); err != nil {
 		t.Fatalf("replace: %v", err)
 	}
 
@@ -740,7 +741,7 @@ func TestListTxsByPortfolio_ComputeHoldingsForPortfolio(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ensure instrument: %v", err)
 	}
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txList, []string{instID, instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txList, []string{instID, instID}, nil, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 	txs, tok, err = p.ListTxsByPortfolio(ctx, port.GetId(), nil, nil, nil, false, 50, "")
@@ -846,7 +847,7 @@ func TestReplaceTxsInPeriod_RoundTripsAccountType(t *testing.T) {
 		{Timestamp: timestamppb.New(base.Add(time.Hour)), InstrumentDescription: "USD", Type: apiv1.TxType_INCOME, Quantity: "-23.4", Account: "A", GroupRef: "div-1", AccountType: apiv1.AccountType_ACCOUNT_TYPE_INCOME},
 	}
 	from, to := timestamppb.New(base), timestamppb.New(base.Add(24*time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID, instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID, instID}, nil, nil); err != nil {
 		t.Fatalf("replace: %v", err)
 	}
 
@@ -889,8 +890,8 @@ func TestTxs_AccountTypeCheckConstraint(t *testing.T) {
 	_, err := p.q.ExecContext(ctx, `
 		INSERT INTO txs (user_id, broker, account, timestamp, instrument_description,
 		                 tx_type, quantity, split_adjusted_quantity, share_count_basis,
-		                 account_type, group_id)
-		VALUES ($1, 'IBKR', 'A', now(), 'X', 'BUYSTOCK', 1, 1, current_date, 'Imbalance.USD', $2::uuid)
+		                 account_type, weight, weight_commodity, group_id)
+		VALUES ($1, 'IBKR', 'A', now(), 'X', 'BUYSTOCK', 1, 1, current_date, 'Imbalance.USD', 1, 'desc:X', $2::uuid)
 	`, userID, newTxGroup(t, p, userID))
 	if err == nil {
 		t.Fatal("insert with an account_type outside the vocabulary: want error, got none")
@@ -917,7 +918,7 @@ func TestReplaceTxsInPeriod_RoundTripsZeroUnitPrice(t *testing.T) {
 		{Timestamp: timestamppb.New(base.Add(2 * time.Hour)), InstrumentDescription: "OPT", Type: apiv1.TxType_BUYOPT, Quantity: "1", Account: "A"},
 	}
 	from, to := timestamppb.New(base), timestamppb.New(base.Add(24*time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID, instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID, instID}, nil, nil); err != nil {
 		t.Fatalf("replace: %v", err)
 	}
 
@@ -953,5 +954,85 @@ func TestReplaceTxsInPeriod_RoundTripsZeroUnitPrice(t *testing.T) {
 	}
 	if p := byType[apiv1.TxType_BUYOPT].UnitPrice; p != nil {
 		t.Errorf("unpriced buy unit_price: want absent, got %v", *p)
+	}
+}
+
+// TestReplaceTxsInPeriod_StoresWeight verifies the weight the caller supplies reaches
+// the columns the balance constraint reads, rather than being recomputed or dropped.
+// A converting leg and its cash counter-leg are both written, because a group balances
+// only when the two agree on the commodity they weigh in.
+func TestReplaceTxsInPeriod_StoresWeight(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|weight", "U", "u@w.com")
+	instID, err := p.EnsureInstrument(ctx, "STOCK", "", "USD", "", "", "",
+		[]db.IdentifierInput{{Type: "MIC_TICKER", Domain: "XNAS", Value: "AAPL", Canonical: true}}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+	price := "185.50"
+	now := time.Now()
+	from, to := timestamppb.New(now.Add(-time.Hour)), timestamppb.New(now.Add(time.Hour))
+	txs := []*apiv1.Tx{
+		{Timestamp: timestamppb.New(now), InstrumentDescription: "AAPL", Type: apiv1.TxType_BUYSTOCK,
+			Quantity: "10", UnitPrice: &price, SettlementCurrency: "USD", GroupRef: "g1"},
+		{Timestamp: timestamppb.New(now), InstrumentDescription: "USD", Type: apiv1.TxType_BUYSTOCK,
+			Quantity: "-1855", SettlementCurrency: "USD", TradingCurrency: "USD", GroupRef: "g1"},
+	}
+	ws := []db.Weight{
+		{Amount: decf(1855), Commodity: "cur:USD"},
+		{Amount: decf(-1855), Commodity: "cur:USD"},
+	}
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID, instID}, ws, nil); err != nil {
+		t.Fatalf("replace txs: %v", err)
+	}
+
+	var residual decimal.Decimal
+	err = p.q.QueryRowContext(ctx, `
+		SELECT SUM(weight) FROM txs WHERE user_id = $1 AND weight_commodity = 'cur:USD'
+	`, userID).Scan(&residual)
+	if err != nil {
+		t.Fatalf("sum weights: %v", err)
+	}
+	if !residual.IsZero() {
+		t.Errorf("group weights sum to %v in cur:USD, want exactly 0", residual)
+	}
+}
+
+// TestReplaceTxsInPeriod_DefaultsWeightWhenAbsent verifies what a nil weights slice
+// means: each posting weighs its own quantity in its own instrument, which is what the
+// weight rule returns for a posting with no price. The fixtures that pass nil are then
+// writing a defensible weight rather than a placeholder.
+func TestReplaceTxsInPeriod_DefaultsWeightWhenAbsent(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|weight-default", "U", "u@wd.com")
+	instID, err := p.EnsureInstrument(ctx, "STOCK", "", "USD", "", "", "",
+		[]db.IdentifierInput{{Type: "MIC_TICKER", Domain: "XNAS", Value: "MSFT", Canonical: true}}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+	now := time.Now()
+	from, to := timestamppb.New(now.Add(-time.Hour)), timestamppb.New(now.Add(time.Hour))
+	txs := []*apiv1.Tx{
+		{Timestamp: timestamppb.New(now), InstrumentDescription: "MSFT", Type: apiv1.TxType_BUYSTOCK, Quantity: "7"},
+	}
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID}, nil, nil); err != nil {
+		t.Fatalf("replace txs: %v", err)
+	}
+
+	var weight decimal.Decimal
+	var commodity string
+	err = p.q.QueryRowContext(ctx, `
+		SELECT weight, weight_commodity FROM txs WHERE user_id = $1
+	`, userID).Scan(&weight, &commodity)
+	if err != nil {
+		t.Fatalf("read weight: %v", err)
+	}
+	if weight.String() != "7" {
+		t.Errorf("weight = %v, want 7 (the posting's own quantity)", weight)
+	}
+	if want := "inst:" + instID; commodity != want {
+		t.Errorf("weight_commodity = %q, want %q", commodity, want)
 	}
 }

--- a/server/db/postgres/valuation_bench_test.go
+++ b/server/db/postgres/valuation_bench_test.go
@@ -49,7 +49,7 @@ func seedValuationLoad(t testing.TB, p *Postgres, instruments, years int) (strin
 	}
 	if err := p.ReplaceTxsInPeriod(ctx, userID, "BENCH", "",
 		timestamppb.New(buy.Add(-time.Hour)), timestamppb.New(buy.Add(time.Hour)),
-		txs, instIDs, nil); err != nil {
+		txs, instIDs, nil, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 

--- a/server/db/postgres/valuation_test.go
+++ b/server/db/postgres/valuation_test.go
@@ -34,7 +34,7 @@ func TestGetPortfolioValuation_Basic(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID}, nil, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -84,8 +84,9 @@ func TestGetPortfolioValuation_UnpricedInstruments(t *testing.T) {
 	// Insert tx with NULL instrument_id directly (unidentified instrument).
 	buyDate := time.Date(2025, 1, 2, 12, 0, 0, 0, time.UTC)
 	_, err := p.q.ExecContext(ctx, `
-		INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type, quantity, instrument_id, group_id)
-		VALUES ($1, 'IBKR', 'main', $2, 'MYSTERY CORP', 'BUYSTOCK', 5, NULL, $3::uuid)
+		INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type, quantity, instrument_id,
+		                 weight, weight_commodity, group_id)
+		VALUES ($1, 'IBKR', 'main', $2, 'MYSTERY CORP', 'BUYSTOCK', 5, NULL, 5, 'desc:MYSTERY CORP', $3::uuid)
 	`, userID, buyDate, newTxGroup(t, p, userID))
 	if err != nil {
 		t.Fatalf("insert tx: %v", err)
@@ -139,7 +140,7 @@ func TestGetPortfolioValuation_DifferentDescriptionsNetToZero(t *testing.T) {
 	}
 	from := timestamppb.New(transferDate.Add(-1 * time.Hour))
 	to := timestamppb.New(sellDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID, instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID, instID}, nil, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -208,7 +209,7 @@ func TestGetPortfolioValuation_UnpricedDeduplication(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID, instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID, instID}, nil, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -255,7 +256,7 @@ func TestGetPortfolioValuation_MultipleInstruments(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instA, instB}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instA, instB}, nil, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -303,7 +304,7 @@ func TestGetUserValuation_Basic(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID}, nil, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -380,7 +381,7 @@ func TestGetPortfolioValuation_ExcludesDateBefore(t *testing.T) {
 	txs := []*apiv1.Tx{
 		{Timestamp: timestamppb.New(buyDate), InstrumentDescription: "AAPL Corp", Type: apiv1.TxType_BUYSTOCK, Quantity: "10", Account: "main"},
 	}
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", timestamppb.New(buyDate.Add(-time.Hour)), timestamppb.New(buyDate.Add(time.Hour)), txs, []string{instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", timestamppb.New(buyDate.Add(-time.Hour)), timestamppb.New(buyDate.Add(time.Hour)), txs, []string{instID}, nil, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 	prices := []db.EODPrice{
@@ -424,7 +425,7 @@ func TestGetPortfolioValuation_FromEqualsBeforeReturnsNothing(t *testing.T) {
 	txs := []*apiv1.Tx{
 		{Timestamp: timestamppb.New(buyDate), InstrumentDescription: "AAPL Corp", Type: apiv1.TxType_BUYSTOCK, Quantity: "10", Account: "main"},
 	}
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", timestamppb.New(buyDate.Add(-time.Hour)), timestamppb.New(buyDate.Add(time.Hour)), txs, []string{instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", timestamppb.New(buyDate.Add(-time.Hour)), timestamppb.New(buyDate.Add(time.Hour)), txs, []string{instID}, nil, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 	if err := p.UpsertPrices(ctx, []db.EODPrice{
@@ -474,7 +475,7 @@ func TestGetUserValuation_FXConversion_DisplayUSD(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID}, nil, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -529,7 +530,7 @@ func TestGetUserValuation_FXConversion_CrossRate(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID}, nil, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -583,7 +584,7 @@ func TestGetUserValuation_FXConversion_MissingRate(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID}, nil, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -635,7 +636,7 @@ func TestGetUserValuation_FXConversion_USDDisplayNonUSD(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID}, nil, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -688,7 +689,7 @@ func TestGetUserValuation_FXConversion_MissingBaseRate(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID}, nil, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -752,7 +753,7 @@ func TestGetUserValuation_CashInDisplayCurrency(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{usdInstID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{usdInstID}, nil, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -804,7 +805,7 @@ func TestGetUserValuation_CashInForeignCurrency(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{gbpInstID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{gbpInstID}, nil, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -845,7 +846,7 @@ func TestGetUserValuation_CashForeignMissingFXRate(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{gbpInstID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{gbpInstID}, nil, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -906,7 +907,7 @@ func TestGetUserValuation_CashForeignCurrency_NonUSDDisplay(t *testing.T) {
 	}
 	from := timestamppb.New(buyDate.Add(-1 * time.Hour))
 	to := timestamppb.New(buyDate.Add(1 * time.Hour))
-	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{eurInstID}, nil); err != nil {
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{eurInstID}, nil, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -958,7 +959,7 @@ func TestGetUserValuation_ContinuousAcrossSplit(t *testing.T) {
 	}
 	if err := p.ReplaceTxsInPeriod(ctx, userID,
 		"IBKR", "", timestamppb.New(buyDate.Add(-time.Hour)), timestamppb.New(buyDate.Add(time.Hour)),
-		txs, []string{instID}, nil); err != nil {
+		txs, []string{instID}, nil, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -1021,7 +1022,7 @@ func TestGetUserValuation_FXUnaffectedByASplit(t *testing.T) {
 	}
 	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "",
 		timestamppb.New(buyDate.Add(-time.Hour)), timestamppb.New(buyDate.Add(time.Hour)),
-		txs, []string{instID}, nil); err != nil {
+		txs, []string{instID}, nil, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 
@@ -1073,7 +1074,7 @@ func setupHeldInstrument(t *testing.T, p *Postgres, sub, desc string, qty string
 	}
 	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "",
 		timestamppb.New(ts.Add(-time.Hour)), timestamppb.New(ts.Add(time.Hour)),
-		txs, []string{instID}, nil); err != nil {
+		txs, []string{instID}, nil, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 	return userID, instID
@@ -1229,7 +1230,7 @@ func TestGetUserValuation_ExcludesDatesBeforeFirstTx(t *testing.T) {
 	}
 	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "",
 		timestamppb.New(buyDate.Add(-time.Hour)), timestamppb.New(buyDate.Add(time.Hour)),
-		txs, []string{instID}, nil); err != nil {
+		txs, []string{instID}, nil, nil); err != nil {
 		t.Fatalf("replace txs: %v", err)
 	}
 	prices := []db.EODPrice{

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -80,6 +80,20 @@ CREATE INDEX idx_tx_groups_job_id ON tx_groups (job_id);
 -- instrument. They equal the raw quantity/unit_price when no later split exists.
 -- They are recomputed idempotently from the raw columns whenever splits change
 -- (see RecomputeTxSplitAdjustments).
+-- weight is what this posting contributes to its group's balance and weight_commodity
+-- names what that contribution is denominated in: 'cur:<code>' for money,
+-- 'inst:<uuid>' for a security, 'desc:<text>' when the instrument never resolved. A
+-- group balances when SUM(weight) is zero for each weight_commodity. The weight rules
+-- live in server/service/ingestion/balance.go and are evaluated once at ingest; the
+-- result is stored rather than re-derived here, because instrument state moves under a
+-- posting afterwards -- a merge rewrites instrument_id and contract_multiplier records
+-- what a corporate action left behind -- so a re-derived weight could disagree with the
+-- one the group was balanced on. Computed from the raw quantity and unit_price, never
+-- from the split-adjusted pair, which carries a rounding an exact check would reject.
+-- The merge in server/db/postgres/instruments.go is the only thing that maintains
+-- these after ingest, and it rewrites weight_commodity alongside instrument_id.
+-- See docs/adr/0029-posting-weight-is-stored.md and
+-- docs/adr/0024-group-balance-is-checked-on-weight.md.
 -- quantity and unit_price are transcribed decimals and are exact, so they are
 -- bare NUMERIC. The split-adjusted pair is not: the cumulative split factor is a
 -- rational and a reverse /3 has no finite decimal form, so the pair declares a
@@ -109,6 +123,8 @@ CREATE TABLE txs (
                               CHECK (account_type IN ('USER', 'EQUITY', 'INCOME', 'EXPENSE',
                                                       'IMBALANCE', 'TRANSFER_CLEARING',
                                                       'SOURCE_ROUNDING')),
+  weight                    NUMERIC NOT NULL,
+  weight_commodity          TEXT NOT NULL,
   group_id                  UUID NOT NULL REFERENCES tx_groups (id) ON DELETE CASCADE,
   created_at                TIMESTAMPTZ NOT NULL DEFAULT now()
 );

--- a/server/service/ingestion/balance.go
+++ b/server/service/ingestion/balance.go
@@ -151,10 +151,16 @@ func (c commodity) tolerance() decimal.Decimal {
 // routedPosting is a counterparty the server writes to make a group balance.
 // currency is set when the commodity is money and its instrument still has to be
 // looked up; instrumentID is set when it is carried over from the leg balanced.
+//
+// weight is carried rather than recomputed from the finished tx. Weighing it again
+// would give the same answer -- a routed posting has no price, so it weighs its own
+// quantity in its own commodity -- but the residual it negates is the value the group
+// has to be balanced against, and carrying it means the two cannot drift.
 type routedPosting struct {
 	tx           *apiv1.Tx
 	currency     string
 	instrumentID string
+	weight       db.Weight
 }
 
 // settleCurrency is the currency a converted weight is denominated in. Settlement
@@ -225,6 +231,40 @@ func weightOf(tx *apiv1.Tx, qty decimal.Decimal, price *decimal.Decimal, instID 
 	}
 }
 
+// weighPosting parses a posting's decimals and applies the weight rule. ok is false
+// when either is malformed, which leaves the posting out of its group's sums rather
+// than failing the batch -- routing exists so imperfect source data still lands, and
+// the group is then left unbalanced, the same state it was in before routing existed.
+// The protovalidate patterns reject a malformed value at the interceptor for every
+// unary RPC, so this is reachable only from an internal caller.
+func weighPosting(tx *apiv1.Tx, instID string, inst balanceInstrument) (decimal.Decimal, commodity, bool) {
+	qty, err := decimal.NewFromString(tx.GetQuantity())
+	if err != nil {
+		return decimal.Decimal{}, ownCommodity(tx, instID, inst), false
+	}
+	price, err := parseOptDec(tx.UnitPrice)
+	if err != nil {
+		return decimal.Decimal{}, ownCommodity(tx, instID, inst), false
+	}
+	amount, c := weightOf(tx, qty, price, instID, inst)
+	return amount, c, true
+}
+
+// weights returns what each posting contributes to its group's balance, parallel to
+// txs, for storing alongside them. It applies the same rule routeResiduals sums on,
+// so a stored weight and the residual routed against it cannot disagree.
+//
+// A posting the rule cannot weigh contributes zero in its own commodity, which is the
+// stored form of routeResiduals leaving it out of the sums.
+func weights(txs []*apiv1.Tx, instrumentIDs []string, instruments map[string]balanceInstrument) []db.Weight {
+	out := make([]db.Weight, len(txs))
+	for i, t := range txs {
+		amount, c, _ := weighPosting(t, instrumentIDs[i], instruments[instrumentIDs[i]])
+		out[i] = db.Weight{Amount: amount, Commodity: c.key()}
+	}
+	return out
+}
+
 // groupPostings returns the indices of each group's postings in input order,
 // and the group refs in a stable order. Postings with no ref are each their own
 // group, and are given a synthetic ref so a routed counterparty can join them.
@@ -286,15 +326,10 @@ func routeResiduals(txs []*apiv1.Tx, instrumentIDs []string, instruments map[str
 			if transferTypes[t.GetType()] {
 				transfer = true
 			}
-			qty, err := decimal.NewFromString(t.GetQuantity())
-			if err != nil {
+			amount, c, ok := weighPosting(t, instrumentIDs[i], instruments[instrumentIDs[i]])
+			if !ok {
 				continue
 			}
-			price, err := parseOptDec(t.UnitPrice)
-			if err != nil {
-				continue
-			}
-			amount, c := weightOf(t, qty, price, instrumentIDs[i], instruments[instrumentIDs[i]])
 			k := c.key()
 			if _, seen := sums[k]; !seen {
 				keys = append(keys, k)
@@ -346,18 +381,21 @@ func routedFor(first *apiv1.Tx, ref string, c commodity, desc string, amount dec
 		GroupRef:    ref,
 		AccountType: accountType,
 	}
+	// The routed posting weighs the residual it negates, in the commodity that
+	// residual accumulated in. That is what makes the group sum to zero.
+	weight := db.Weight{Amount: amount, Commodity: c.key()}
 	if c.currency != "" {
 		// A currency posting's description is the code, matching how an ordinary
 		// cash row arrives, so nothing downstream has to treat it specially.
 		tx.InstrumentDescription = c.currency
 		tx.TradingCurrency = c.currency
 		tx.SettlementCurrency = c.currency
-		return routedPosting{tx: tx, currency: c.currency}
+		return routedPosting{tx: tx, currency: c.currency, weight: weight}
 	}
 	tx.InstrumentDescription = desc
 	tx.TradingCurrency = first.GetTradingCurrency()
 	tx.SettlementCurrency = first.GetSettlementCurrency()
-	return routedPosting{tx: tx, instrumentID: c.instrumentID}
+	return routedPosting{tx: tx, instrumentID: c.instrumentID, weight: weight}
 }
 
 // balanceInstruments reduces the resolved instruments to what balancing needs:
@@ -392,16 +430,18 @@ func balanceInstruments(byID map[string]*db.InstrumentRow) map[string]balanceIns
 // resolveRouted turns the routed postings into txs with a resolved instrument,
 // ready to store alongside the postings they balance. A residual in a currency
 // resolves through the seeded currency instruments; one in a security carries the
-// instrument of the leg it balances. The third return names the commodities whose
-// residual could not be given an instrument.
+// instrument of the leg it balances. It returns the txs, their instruments and their
+// weights in step, and last the commodities whose residual could not be given an
+// instrument.
 //
 // A residual with nowhere to go is dropped rather than failed: routing exists so
 // that imperfect source data still lands, and refusing an import because its
 // residual has no instrument would defeat that. The group is then left unbalanced,
 // which is the same state it was in before routing existed.
-func resolveRouted(ctx context.Context, database db.InstrumentDB, routed []routedPosting) ([]*apiv1.Tx, []string, []string) {
+func resolveRouted(ctx context.Context, database db.InstrumentDB, routed []routedPosting) ([]*apiv1.Tx, []string, []db.Weight, []string) {
 	var txs []*apiv1.Tx
 	var ids []string
+	var ws []db.Weight
 	var unresolved []string
 	byCurrency := map[string]string{}
 	for _, r := range routed {
@@ -431,6 +471,7 @@ func resolveRouted(ctx context.Context, database db.InstrumentDB, routed []route
 		}
 		txs = append(txs, r.tx)
 		ids = append(ids, id)
+		ws = append(ws, r.weight)
 	}
-	return txs, ids, unresolved
+	return txs, ids, ws, unresolved
 }

--- a/server/service/ingestion/balance_test.go
+++ b/server/service/ingestion/balance_test.go
@@ -444,3 +444,125 @@ func TestRouteResiduals_NonStandardDeliverable(t *testing.T) {
 		t.Fatalf("routed %d postings, want none: %s", len(got), describeRouted(got))
 	}
 }
+
+// TestWeights covers the stored form of each branch of the weight rule. The values
+// are the ones routeResiduals sums on, so what is asserted here is what a group's
+// balance is checked against.
+func TestWeights(t *testing.T) {
+	at := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
+	price := func(v string) *string { return &v }
+	instruments := balanceFixtures()
+
+	cases := []struct {
+		name      string
+		posting   posting
+		instID    string
+		amount    string
+		commodity string
+	}{{
+		// The converting branch: a security leg reaches its counter-leg's units at
+		// its price, so it weighs money rather than shares.
+		name:      "a priced buy weighs its consideration in the settlement currency",
+		posting:   posting{desc: "AAPL", typ: apiv1.TxType_BUYSTOCK, qty: "10", price: price("185.50"), settle: "USD"},
+		instID:    aaplID,
+		amount:    "1855",
+		commodity: "cur:USD",
+	}, {
+		// A price is per underlying unit, so the contract size is part of the
+		// consideration rather than a correction applied to it.
+		name:      "an option leg weighs by its contract size",
+		posting:   posting{desc: "OPT", typ: apiv1.TxType_BUYOPT, qty: "8", price: price("20.1105585"), settle: "USD"},
+		instID:    optID,
+		amount:    "16088.4468",
+		commodity: "cur:USD",
+	}, {
+		// The settlement-currency guard: a cash row is already in the units the
+		// group balances in, so its price is not a conversion rate whatever the
+		// broker typed in the tx type column.
+		name:      "a cash row typed as a sale weighs its own quantity",
+		posting:   posting{desc: "USD", typ: apiv1.TxType_SELLSTOCK, qty: "-1855", price: price("185.50"), settle: "USD", trading: "USD"},
+		instID:    usdID,
+		amount:    "-1855",
+		commodity: "cur:USD",
+	}, {
+		// No price is not a price of zero: there is nothing to convert at, so the
+		// weight stays in the security and the missing price shows up as a
+		// share-denominated residual.
+		name:      "an unpriced buy weighs shares in its instrument",
+		posting:   posting{desc: "AAPL", typ: apiv1.TxType_BUYSTOCK, qty: "10", settle: "USD"},
+		instID:    aaplID,
+		amount:    "10",
+		commodity: "inst:" + aaplID,
+	}, {
+		// A movement across currencies does have its counter-leg in other units,
+		// and the price is the FX rate.
+		name:      "a cross-currency dividend converts at the FX rate",
+		posting:   posting{desc: "EUR", typ: apiv1.TxType_INCOME, qty: "100", price: price("1.35"), settle: "USD", trading: "EUR"},
+		instID:    eurID,
+		amount:    "135",
+		commodity: "cur:USD",
+	}, {
+		// A journal moves a commodity without converting it, so the weight holds
+		// the shares rather than a frozen cash value.
+		name:      "a securities journal weighs shares even with a price",
+		posting:   posting{desc: "AAPL", typ: apiv1.TxType_JRNLSEC, qty: "-10", price: price("185.50"), settle: "USD"},
+		instID:    aaplID,
+		amount:    "-10",
+		commodity: "inst:" + aaplID,
+	}, {
+		// The fallback that keeps weight_commodity non-empty: a posting whose
+		// instrument never resolved still balances against itself.
+		name:      "an unresolved posting falls back to its description",
+		posting:   posting{desc: "MYSTERY CORP", typ: apiv1.TxType_BUYSTOCK, qty: "5"},
+		instID:    "",
+		amount:    "5",
+		commodity: "desc:MYSTERY CORP",
+	}}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := weights([]*apiv1.Tx{tc.posting.tx(at)}, []string{tc.instID}, instruments)
+			if len(got) != 1 {
+				t.Fatalf("weights returned %d entries, want 1", len(got))
+			}
+			if got[0].Amount.String() != tc.amount {
+				t.Errorf("amount = %v, want %v", got[0].Amount, tc.amount)
+			}
+			if got[0].Commodity != tc.commodity {
+				t.Errorf("commodity = %q, want %q", got[0].Commodity, tc.commodity)
+			}
+		})
+	}
+}
+
+// TestWeights_GroupSumsToZeroOnceRouted is the property the balance constraint will
+// check: the stored weights of a group, including the routed counterparty, sum to
+// exactly zero in every commodity. The netted fee makes it non-trivial -- the group
+// as supplied does not balance, and it is the routed posting that closes it.
+func TestWeights_GroupSumsToZeroOnceRouted(t *testing.T) {
+	at := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
+	price := func(v string) *string { return &v }
+	instruments := balanceFixtures()
+
+	txs := []*apiv1.Tx{
+		posting{desc: "AAPL", typ: apiv1.TxType_BUYSTOCK, qty: "10", price: price("185.50"), settle: "USD", instID: aaplID, groupRef: "t1"}.tx(at),
+		posting{desc: "USD", typ: apiv1.TxType_BUYSTOCK, qty: "-1866.95", settle: "USD", trading: "USD", instID: usdID, groupRef: "t1"}.tx(at),
+	}
+	ids := []string{aaplID, usdID}
+
+	routed := routeResiduals(txs, ids, instruments)
+	if len(routed) != 1 {
+		t.Fatalf("routed %d postings, want 1: %s", len(routed), describeRouted(routed))
+	}
+
+	all := append(weights(txs, ids, instruments), routed[0].weight)
+	sums := map[string]decimal.Decimal{}
+	for _, w := range all {
+		sums[w.Commodity] = sums[w.Commodity].Add(w.Amount)
+	}
+	for commodity, sum := range sums {
+		if !sum.IsZero() {
+			t.Errorf("weights sum to %v in %s, want exactly 0", sum, commodity)
+		}
+	}
+}

--- a/server/service/ingestion/worker.go
+++ b/server/service/ingestion/worker.go
@@ -239,20 +239,26 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 	// explicit counterparty. This runs after filtering, so a dropped SPLIT leg
 	// cannot contribute a residual, and after resolution, because telling a
 	// currency commodity from a security one is a property of the instrument.
-	routed := routeResiduals(txsToProcess, instrumentIDs, balanceInstruments(instByID))
-	routedTxs, routedIDs, unresolved := resolveRouted(ctx, database, routed)
+	balanceInsts := balanceInstruments(instByID)
+	routed := routeResiduals(txsToProcess, instrumentIDs, balanceInsts)
+	routedTxs, routedIDs, routedWeights, unresolved := resolveRouted(ctx, database, routed)
 	for _, cur := range unresolved {
 		log.Printf("ingestion job %s: no currency instrument for %q; residual left unrouted", j.JobID, cur)
 	}
+	// Weighed after routing, which is what assigns a synthetic group_ref to a posting
+	// that had none, and before the routed postings are appended, since those carry
+	// the weight of the residual they negate rather than one derived from the tx.
+	txWeights := weights(txsToProcess, instrumentIDs, balanceInsts)
 	txsToProcess = append(txsToProcess, routedTxs...)
 	instrumentIDs = append(instrumentIDs, routedIDs...)
+	txWeights = append(txWeights, routedWeights...)
 
 	// Store transactions.
 	var storeErr error
 	if bulk {
-		storeErr = database.ReplaceTxsInPeriod(ctx, userID, broker, j.JobID, req.PeriodFrom, req.PeriodBefore, txsToProcess, instrumentIDs, shareCountBasis)
+		storeErr = database.ReplaceTxsInPeriod(ctx, userID, broker, j.JobID, req.PeriodFrom, req.PeriodBefore, txsToProcess, instrumentIDs, txWeights, shareCountBasis)
 	} else {
-		storeErr = database.CreateTxGroup(ctx, userID, broker, txsToProcess[0].GetAccount(), j.JobID, txsToProcess, instrumentIDs, shareCountBasis)
+		storeErr = database.CreateTxGroup(ctx, userID, broker, txsToProcess[0].GetAccount(), j.JobID, txsToProcess, instrumentIDs, txWeights, shareCountBasis)
 	}
 	if storeErr != nil {
 		log.Printf("ingestion job %s: %v", j.JobID, storeErr)

--- a/server/service/ingestion/worker_test.go
+++ b/server/service/ingestion/worker_test.go
@@ -94,7 +94,7 @@ func TestProcessBulk_AppendsIdentificationErrorsWhenBrokerDescriptionOnly(t *tes
 		ListInstrumentsByIDs(gomock.Any(), []string{"broker-only-id"}).
 		Return([]*db.InstrumentRow{{ID: "broker-only-id"}}, nil)
 	database.EXPECT().
-		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", "job-1", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", "job-1", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil)
 	database.EXPECT().
 		InstrumentsWithSplits(gomock.Any(), gomock.Any()).
@@ -156,7 +156,7 @@ func TestProcessBulk_BatchCache_ResolvesSameDescriptionOnce(t *testing.T) {
 		ListInstrumentsByIDs(gomock.Any(), []string{"cached-inst-id"}).
 		Return([]*db.InstrumentRow{{ID: "cached-inst-id"}}, nil)
 	database.EXPECT().
-		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", "job-2", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", "job-2", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil)
 	database.EXPECT().
 		InstrumentsWithSplits(gomock.Any(), gomock.Any()).
@@ -218,8 +218,8 @@ func TestProcessBulk_DropsTxTypeSplitTransactions(t *testing.T) {
 		ListInstrumentsByIDs(gomock.Any(), []string{"aapl-id"}).
 		Return([]*db.InstrumentRow{{ID: "aapl-id"}}, nil)
 	database.EXPECT().
-		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", "job-split", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, _, _, _ string, _, _ *timestamppb.Timestamp, storedTxs []*apiv1.Tx, ids []string, _ *time.Time) error {
+		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", "job-split", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _ string, _, _ *timestamppb.Timestamp, storedTxs []*apiv1.Tx, ids []string, ws []db.Weight, _ *time.Time) error {
 			supplied := userPostings(storedTxs)
 			if len(supplied) != 1 || supplied[0].InstrumentDescription != "AAPL" || supplied[0].Type != apiv1.TxType_BUYSTOCK {
 				t.Errorf("ReplaceTxsInPeriod called with %d supplied txs, expected 1 (AAPL BUYSTOCK)", len(supplied))
@@ -230,6 +230,12 @@ func TestProcessBulk_DropsTxTypeSplitTransactions(t *testing.T) {
 			}
 			if len(ids) != len(storedTxs) {
 				t.Errorf("instrument ids (%d) and txs (%d) must stay parallel", len(ids), len(storedTxs))
+			}
+			// Weights are appended in two steps -- the supplied postings, then the
+			// routed ones -- so a slice that has fallen out of step is the failure
+			// mode worth pinning.
+			if len(ws) != len(storedTxs) {
+				t.Errorf("weights (%d) and txs (%d) must stay parallel", len(ws), len(storedTxs))
 			}
 			return nil
 		})
@@ -379,7 +385,7 @@ func TestProcessBulk_StockEtfEquivalence(t *testing.T) {
 		ListInstrumentsByIDs(gomock.Any(), []string{"spy-etf-id"}).
 		Return([]*db.InstrumentRow{{ID: "spy-etf-id", AssetClass: strPtr(db.AssetClassETF)}}, nil)
 	database.EXPECT().
-		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", "job-etf", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", "job-etf", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil)
 	database.EXPECT().
 		InstrumentsWithSplits(gomock.Any(), gomock.Any()).
@@ -553,7 +559,7 @@ func TestProcessBulk_TransferToStockAllowed(t *testing.T) {
 		ListInstrumentsByIDs(gomock.Any(), []string{"msft-id"}).
 		Return([]*db.InstrumentRow{{ID: "msft-id", AssetClass: strPtr(db.AssetClassStock)}}, nil)
 	database.EXPECT().
-		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", "job-transfer-stock", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", "job-transfer-stock", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil)
 	database.EXPECT().
 		InstrumentsWithSplits(gomock.Any(), gomock.Any()).


### PR DESCRIPTION
Third of four PRs for [0041](docs/issues/0041-enable-balance-constraint.md). **Stacked on #320** (both change `balance.go`); review that one first.

## Why

0041's constraint checks `SUM(weight) = 0` per `(group_id, weight_commodity)`. The weight rules -- which tx types convert, the settlement-currency guard, the contract-size multiplication -- live in Go, and adr/0029 settled that they stay there. A second copy in PL/pgSQL would drift, and re-deriving at COMMIT would read instrument state that has moved under the posting since it was written: a merge rewrites `instrument_id` wholesale and `contract_multiplier` records what a corporate action left behind, so a re-derived weight could reject a group that was balanced when it was written.

So each posting stores what it contributed. This PR writes the columns; nothing reads them yet.

## The columns

| Column | Notes |
| --- | --- |
| `weight` | `NUMERIC NOT NULL`. `quantity * unit_price * contract_size` is closed under multiplication, so it is exact. Not `NUMERIC(38,12)` -- that scale exists for `split_adjusted_*`, which carries a declared rounding, and weight carries none. |
| `weight_commodity` | `TEXT NOT NULL`. `cur:USD`, `inst:<uuid>`, `desc:<text>`. |

Two columns because balance is per commodity: a group can leave a residual in cash and another in a security at the same time.

The prefix is what makes the three kinds unambiguous -- without it a description reading `USD` would be the same commodity as the currency, and the merge could not rewrite instrument names without also matching a description that looked like a uuid. It is the string `commodity.key()` already produced to accumulate the sums, so the stored value is the key the residual was computed against rather than a second spelling of it. A uuid column referencing `instruments` was considered and rejected in the adr/0029 amendment: it would mean resolving the settlement currency to an instrument for every converted posting, and leaves the `desc:` fallback nowhere to go.

## The boundary

`weights []db.Weight` is a slice parallel to the existing `instrumentIDs` on `ReplaceTxsInPeriod` and `CreateTxGroup`. Weight stays off the wire, so no client can declare one. Most of the diff is the ~50 mechanical `nil` arguments this adds at existing call sites.

A nil slice means the caller has none, and each posting then weighs its own quantity in its own instrument -- which is what the weight rule returns for a posting with no price. So the fixtures that pass nil write a defensible weight rather than a filler value, and a caller that forgets produces a group that fails the constraint rather than one that silently passes.

## The two writers outside ingestion

- **`UpsertInitializeTx`**: a pad has no price, so each leg weighs its own quantity and the two cancel. It names the commodity the way `ownCommodity` does, so a cash pad reads as the same commodity an ingested cash leg does. `weight` is in the `DO UPDATE` list for the same reason `quantity` is -- otherwise a recalculation moves the quantity and leaves the weight behind.
- **`mergeInstruments`**: rewrites `weight_commodity` alongside `instrument_id` in the same statement, which is the one maintenance obligation adr/0029 names. Only the `inst:` form needs rewriting; a converted or cash leg is named by its currency code, which a merge does not change.

Nothing else maintains the columns: weight is on the raw `quantity` and `unit_price`, which `RecomputeSplitAdjustments` leaves alone.

## Test plan

- `make check`, `make server-test`, `make db-test`, `make e2e-test` (33/33) all pass.
- `TestWeights`: one case per branch of the rule -- the converting branch, the contract-size multiplication, the settlement-currency guard, an unpriced leg staying in its security, a cross-currency FX conversion, a securities journal not converting despite a price, and the `desc:` fallback.
- `TestWeights_GroupSumsToZeroOnceRouted`: the property the constraint will check. A netted-fee group does not balance as supplied, and the routed posting closes it to exactly zero.
- `TestReplaceTxsInPeriod_StoresWeight` / `_DefaultsWeightWhenAbsent`: the columns round-trip, and nil means the documented default.
- `TestMergeInstruments_RewritesWeightCommodity`: an unpaired securities journal across two instruments stays balanced across the merge that unifies them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)