### PR TITLE
Enforce posting balance with a deferred constraint trigger (0041)

### DIFF
--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -38,6 +38,11 @@ services:
       GOCACHE: /app/.cache/go-build
       GOMODCACHE: /app/.gomodcache
       TEST_DATABASE_URL: postgres://portfoliodb:portfoliodb@postgres:5432/portfoliodb_test?sslmode=disable
+      # Opt-in performance tests. Passed through from the host with no default so
+      # that `BENCH_BALANCE=1 make db-test` reaches the container, and an unset one
+      # leaves the test skipped.
+      BENCH_BALANCE: "${BENCH_BALANCE:-}"
+      BENCH_VALUATION: "${BENCH_VALUATION:-}"
     volumes:
       - ..:/app
     working_dir: /app

--- a/docs/issues/0041-enable-balance-constraint.md
+++ b/docs/issues/0041-enable-balance-constraint.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Enforce posting balance with a deferred constraint trigger
 milestone: M12
 dependencies: [0038, 0042]
@@ -86,3 +86,41 @@ than what lands. 0029 records why that is the right trade anyway.
 
 Requires 0038 and 0042. Best landed after 0040, when residuals are small and
 the `Imbalance` postings being written are few and explainable.
+
+## What landed
+
+Ahead of 0040 after all. Nothing in the constraint depends on residuals being
+small: it rejects a group that does not sum to zero, not one whose residual is
+large, and routing makes every group sum to zero whatever the source data looks
+like. Landing it earlier means the invariant holds while 0040 is being written
+rather than after.
+
+**The tolerance was a gap in the design.** adr/0024 claimed routing leaves a
+group summing to zero by construction, and that held only for residuals at or
+above the routing tolerance. A residual below half a cent was suppressed rather
+than routed, so the group summed to a small non-zero value -- which is exactly
+what an exact check rejects, on exactly the ordinary 2dp-rounded trade groups.
+The tolerance now selects the account type rather than deciding whether to route,
+and a sub-tolerance residual becomes a `SOURCE_ROUNDING` posting. adr/0024 records
+the two rejected alternatives.
+
+**`txs.group_id` became `NOT NULL`.** The invariant is stated per group, so a
+posting outside every group was a row the constraint could not reach. The spec
+already claimed every posting belongs to one.
+
+**`weight_commodity` is prefixed** -- `cur:USD`, `inst:<uuid>`, `desc:<text>` --
+which is the string `commodity.key()` already produced to accumulate the sums.
+Recorded in adr/0029 along with why a uuid column referencing `instruments` does
+not work.
+
+**An unresolvable residual now fails the job.** It used to be dropped with a log
+line, leaving the group unbalanced; the constraint turns that into an aborted
+upload, so the failure has to name the commodity to say anything useful.
+
+**Cost, measured** (`server/db/postgres/balance_bench_test.go`, 10,000 postings):
+21us per posting at COMMIT against 413us to insert one -- about 5%. The row-level
+trigger is affordable and needs no per-transaction deduplication. The `WHEN` guard
+on the update trigger is worth 170ms on a whole-table split recompute at that size.
+
+Landed as four PRs: `SOURCE_ROUNDING`, `group_id NOT NULL`, the stored weight, and
+the trigger.

--- a/docs/spec/postings.md
+++ b/docs/spec/postings.md
@@ -131,9 +131,24 @@ Each posting **stores** what it contributes to that balance, in two columns:
 | `weight`           | The amount contributed. `NUMERIC`, exact.                           |
 | `weight_commodity` | What it is contributed in: `cur:<code>`, `inst:<uuid>` or `desc:<text>`. Never empty. |
 
-A group balances when `SUM(weight)` is zero for each `weight_commodity`. The database
-constraint that enforces it is not switched on yet, but the columns it reads are
-written now.
+A group balances when `SUM(weight)` is zero for each `weight_commodity`, and a
+`DEFERRABLE INITIALLY DEFERRED` constraint trigger enforces exactly that. Enforcing it
+in the database rather than the application makes it unbypassable: no code path, no bad
+import and no manual psql session can leave an unbalanced group behind.
+
+The check is deferred to COMMIT because the legs of a group can be written in any
+order, and each leg on its own leaves the group unbalanced. A group deleted whole
+matches no rows and passes vacuously, which is what lets replace-by-period delete
+groups and let the cascade take their postings; deleting a single leg does not.
+
+The exactness is what makes the check arguable-free. There is no tolerance in it,
+because every non-zero residual is routed at ingest -- including the sub-tolerance ones,
+which go to `SOURCE_ROUNDING` -- so a group sums to zero by construction. It reads the
+raw `quantity` and `unit_price`, never the split-adjusted pair, which carries a rounding
+an exact check would reject.
+
+It costs about 5% of an import: 21us per posting at COMMIT against 413us to insert one
+(see `server/db/postgres/balance_bench_test.go`).
 
 The weight is stored rather than re-derived on read because instrument state moves
 under a posting after ingest: a merge rewrites `instrument_id` wholesale and

--- a/e2e/fixtures/instruments.sql
+++ b/e2e/fixtures/instruments.sql
@@ -23,7 +23,9 @@ ON CONFLICT DO NOTHING;
 -- Transactions referencing the instruments (for holdings/valuation). Every posting
 -- belongs to a group, so each trade gets one; the ids are explicit because the
 -- postings reference them. A priced BUYSTOCK converts, so it weighs its
--- consideration in the settlement currency: quantity * unit_price.
+-- consideration in the settlement currency: quantity * unit_price, against an
+-- equal and opposite counterparty. The group has to balance -- the constraint is
+-- on.
 INSERT INTO tx_groups (id, user_id, timestamp)
 VALUES
   ('e2e00000-0000-0000-0000-000000000201', 'e2e00000-0000-0000-0000-000000000001', '2024-01-15'),
@@ -36,6 +38,21 @@ VALUES
   ('e2e00000-0000-0000-0000-000000000001', 'FIDELITY', 'ACC-1', '2024-01-15', 'AMZN - Amazon.com Inc.', 'BUYSTOCK', 8, 'USD', 155.20, 'e2e00000-0000-0000-0000-000000000101', 1241.60, 'cur:USD', 'e2e00000-0000-0000-0000-000000000201'),
   ('e2e00000-0000-0000-0000-000000000001', 'FIDELITY', 'ACC-1', '2024-01-16', 'NVDA - NVIDIA Corp.', 'BUYSTOCK', 15, 'USD', 560.50, 'e2e00000-0000-0000-0000-000000000102', 8407.50, 'cur:USD', 'e2e00000-0000-0000-0000-000000000202'),
   ('e2e00000-0000-0000-0000-000000000001', 'FIDELITY', 'ACC-1', '2024-01-17', 'TSLA - Tesla Inc.', 'BUYSTOCK', 12, 'USD', 218.90, 'e2e00000-0000-0000-0000-000000000103', 2626.80, 'cur:USD', 'e2e00000-0000-0000-0000-000000000203')
+ON CONFLICT DO NOTHING;
+
+-- The counterparty that makes each trade balance. EQUITY rather than a USER cash
+-- row, because this fixture seeds an opening position rather than a cash trail: an
+-- EQUITY leg is value entering the holdings from outside the ledger, and only USER
+-- postings reach holdings and valuation, so the counterparty cannot show up as a
+-- negative cash balance in the specs that read them.
+INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type, quantity, trading_currency, settlement_currency, instrument_id, account_type, weight, weight_commodity, group_id)
+SELECT 'e2e00000-0000-0000-0000-000000000001', 'FIDELITY', 'ACC-1', v.at::timestamptz, 'USD', 'BUYSTOCK',
+       v.qty, 'USD', 'USD', i.instrument_id, 'EQUITY', v.qty, 'cur:USD', v.group_id::uuid
+FROM (VALUES ('2024-01-15', -1241.60, 'e2e00000-0000-0000-0000-000000000201'),
+             ('2024-01-16', -8407.50, 'e2e00000-0000-0000-0000-000000000202'),
+             ('2024-01-17', -2626.80, 'e2e00000-0000-0000-0000-000000000203')) AS v(at, qty, group_id),
+     (SELECT instrument_id FROM instrument_identifiers
+      WHERE identifier_type = 'CURRENCY' AND value = 'USD' LIMIT 1) i
 ON CONFLICT DO NOTHING;
 
 -- EOD prices: a few days of data for each instrument.

--- a/e2e/fixtures/residual-balances.sql
+++ b/e2e/fixtures/residual-balances.sql
@@ -9,6 +9,11 @@
 -- because the postings reference them. Every residual here is a cash posting with no
 -- price, so it weighs its own quantity in the currency it is denominated in.
 --
+-- Each residual gets an equal and opposite EQUITY counterparty, because the balance
+-- constraint is on and a residual alone in its group does not sum to zero. In
+-- production that counterparty is the posting the residual was routed against;
+-- EQUITY keeps it out of holdings and valuation, which this fixture is not about.
+--
 -- Timestamps are relative to now() so the age assertions do not rot.
 
 INSERT INTO tx_groups (id, user_id, timestamp)
@@ -79,4 +84,23 @@ SELECT 'e2e00000-0000-0000-0000-000000000001', 'IBKR', 'U-NEW',
        now() - INTERVAL '2 days', 'USD', 'JRNLFUND', 250.00, 'USD', 'USD', i.instrument_id, 'TRANSFER_CLEARING',
        250.00, 'cur:USD', 'e2e00000-0000-0000-0000-000000000306'
 FROM (SELECT instrument_id FROM instrument_identifiers
+      WHERE identifier_type = 'CURRENCY' AND value = 'USD' LIMIT 1) i;
+
+-- The counterparties. One per group, equal and opposite, so every group above sums
+-- to zero in cur:USD. The report reads only the residual account types, so these are
+-- invisible to it.
+INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type,
+                 quantity, trading_currency, settlement_currency, instrument_id, account_type,
+                 weight, weight_commodity, group_id)
+SELECT 'e2e00000-0000-0000-0000-000000000001', v.broker, v.account,
+       now() - (v.days || ' days')::INTERVAL, 'USD', v.tx_type, v.qty, 'USD', 'USD',
+       i.instrument_id, 'EQUITY', v.qty, 'cur:USD', v.group_id::uuid
+FROM (VALUES ('FIDELITY', 'ACC-1', '5',  'INCOME',   137.08,   'e2e00000-0000-0000-0000-000000000301'),
+             ('FIDELITY', 'ACC-1', '6',  'BUYSTOCK', -4.95,    'e2e00000-0000-0000-0000-000000000302'),
+             ('SCHB',     'SCH-1', '60', 'JRNLFUND', -1000.00, 'e2e00000-0000-0000-0000-000000000303'),
+             ('SCHB',     'SCH-2', '59', 'JRNLFUND', 1000.00,  'e2e00000-0000-0000-0000-000000000304'),
+             ('IBKR',     'U-OLD', '40', 'JRNLFUND', -500.00,  'e2e00000-0000-0000-0000-000000000305'),
+             ('IBKR',     'U-NEW', '2',  'JRNLFUND', -250.00,  'e2e00000-0000-0000-0000-000000000306'))
+     AS v(broker, account, days, tx_type, qty, group_id),
+     (SELECT instrument_id FROM instrument_identifiers
       WHERE identifier_type = 'CURRENCY' AND value = 'USD' LIMIT 1) i;

--- a/server/db/postgres/balance_bench_test.go
+++ b/server/db/postgres/balance_bench_test.go
@@ -1,0 +1,253 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// seedBalancedGroups writes groups balanced two-leg trades, the shape a broker export
+// lands as: a converting security leg and the cash it settled for. It returns the user
+// and the instrument the security legs point at.
+//
+// One ReplaceTxsInPeriod call for all of them, inside the test's transaction, so the
+// insert cost measured is the one a real import pays.
+func seedBalancedGroups(t testing.TB, p *Postgres, groups int) (string, string) {
+	t.Helper()
+	ctx := context.Background()
+
+	userID, err := p.GetOrCreateUser(ctx, "sub|balance-bench", "Bench", "bench@balance.com")
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	instID, err := p.EnsureInstrument(ctx, "STOCK", "", "USD", "BENCH", "", "",
+		[]db.IdentifierInput{{Type: "MIC_TICKER", Domain: "XNAS", Value: "BENCH", Canonical: true}}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+	usd, err := p.EnsureInstrument(ctx, "CASH", "", "USD", "USD", "", "",
+		[]db.IdentifierInput{{Type: "CURRENCY", Value: "USD", Canonical: true}}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure USD: %v", err)
+	}
+
+	base := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	price := "100"
+	var txs []*apiv1.Tx
+	var ids []string
+	var ws []db.Weight
+	for i := range groups {
+		ref := fmt.Sprintf("g%d", i)
+		at := timestamppb.New(base.Add(time.Duration(i) * time.Minute))
+		txs = append(txs,
+			&apiv1.Tx{Timestamp: at, InstrumentDescription: "BENCH", Type: apiv1.TxType_BUYSTOCK,
+				Quantity: "10", UnitPrice: &price, SettlementCurrency: "USD", GroupRef: ref},
+			&apiv1.Tx{Timestamp: at, InstrumentDescription: "USD", Type: apiv1.TxType_BUYSTOCK,
+				Quantity: "-1000", SettlementCurrency: "USD", TradingCurrency: "USD", GroupRef: ref})
+		ids = append(ids, instID, usd)
+		ws = append(ws,
+			db.Weight{Amount: decf(1000), Commodity: "cur:USD"},
+			db.Weight{Amount: decf(-1000), Commodity: "cur:USD"})
+	}
+	from := timestamppb.New(base.Add(-time.Hour))
+	before := timestamppb.New(base.Add(time.Duration(groups+60) * time.Minute))
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "BENCH", "", from, before, txs, ids, ws, nil); err != nil {
+		t.Fatalf("seed groups: %v", err)
+	}
+	return userID, instID
+}
+
+// seedPairedJournals writes groups of two journal legs that both weigh in the same
+// security, which is the shape a merge has to keep balanced: both legs name the
+// commodity by instrument, so both move when the instrument does. It returns the user,
+// the instrument the postings point at, and a second instrument to merge it into.
+func seedPairedJournals(t testing.TB, p *Postgres, groups int) (string, string, string) {
+	t.Helper()
+	ctx := context.Background()
+
+	userID, err := p.GetOrCreateUser(ctx, "sub|merge-bench", "Bench", "bench@merge.com")
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	mergedAway, err := p.EnsureInstrument(ctx, "STOCK", "", "USD", "MRGA", "", "",
+		[]db.IdentifierInput{{Type: "MIC_TICKER", Domain: "XNAS", Value: "MRGA", Canonical: true}}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure merged-away: %v", err)
+	}
+	survivor, err := p.EnsureInstrument(ctx, "STOCK", "", "USD", "MRGB", "", "",
+		[]db.IdentifierInput{{Type: "MIC_TICKER", Domain: "XNAS", Value: "MRGB", Canonical: true}}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure survivor: %v", err)
+	}
+
+	base := time.Date(2024, 1, 1, 12, 0, 0, 0, time.UTC)
+	commodity := "inst:" + mergedAway
+	var txs []*apiv1.Tx
+	var ids []string
+	var ws []db.Weight
+	for i := range groups {
+		ref := fmt.Sprintf("j%d", i)
+		at := timestamppb.New(base.Add(time.Duration(i) * time.Minute))
+		txs = append(txs,
+			&apiv1.Tx{Timestamp: at, InstrumentDescription: "MRGA", Type: apiv1.TxType_JRNLSEC, Quantity: "-10", GroupRef: ref},
+			&apiv1.Tx{Timestamp: at, InstrumentDescription: "MRGA", Type: apiv1.TxType_JRNLSEC, Quantity: "10", GroupRef: ref})
+		ids = append(ids, mergedAway, mergedAway)
+		ws = append(ws,
+			db.Weight{Amount: decf(-10), Commodity: commodity},
+			db.Weight{Amount: decf(10), Commodity: commodity})
+	}
+	from := timestamppb.New(base.Add(-time.Hour))
+	before := timestamppb.New(base.Add(time.Duration(groups+60) * time.Minute))
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "MERGE", "", from, before, txs, ids, ws, nil); err != nil {
+		t.Fatalf("seed journals: %v", err)
+	}
+	return userID, mergedAway, survivor
+}
+
+// TestBalanceConstraintPerformance times what the deferred balance constraint costs an
+// import. It reports rather than asserts: a threshold here would only be flaky.
+//
+// The constraint is DEFERRABLE INITIALLY DEFERRED, so its work happens at COMMIT. This
+// runs under testDBTx, which rolls back -- but SET CONSTRAINTS ... IMMEDIATE drains the
+// queued checks at exactly the point COMMIT would have run them, so the drain time is
+// the COMMIT-time cost, measurable separately from the insert.
+//
+// Postgres requires AFTER ... FOR EACH ROW for a constraint trigger, so a
+// statement-level check over transition tables is not available: every posting queues
+// its own event and each group is therefore checked once per leg.
+//
+// Measured on a 10,000-posting import (5,000 two-leg groups) against
+// timescale/timescaledb:latest-pg16 in docker:
+//
+//	insert                      4.1s   (413us per posting)
+//	deferred check drain        208ms  (21us per posting)
+//	split recompute, guarded    630ms
+//	split recompute, unguarded  800ms
+//
+// So the constraint costs about 5% of an import it makes unbypassable, which settles
+// the question the row-level trigger raised: Postgres requires AFTER ... FOR EACH ROW
+// for a constraint trigger, so a statement-level check over transition tables is not
+// available and each group is checked once per leg. At 21us a check that is
+// affordable, and deduplicating the checks within a transaction is not worth the
+// machinery.
+//
+// The guarded/unguarded pair is the WHEN clause on the UPDATE trigger. The recompute
+// rewrites split_adjusted_* for every posting in the table and leaves weight alone, so
+// the guard turns 10,000 queued checks into none for 170ms on this size -- growing
+// with the table, since the recompute is whole-table and the import is not.
+//
+// Run with: BENCH_BALANCE=1 make db-test
+func TestBalanceConstraintPerformance(t *testing.T) {
+	if os.Getenv("BENCH_BALANCE") == "" {
+		t.Skip("set BENCH_BALANCE=1 to run")
+	}
+	ctx := context.Background()
+	const groups = 5000
+
+	// Constrained: seed, then drain the queue COMMIT would have drained.
+	p := testDBTx(t)
+	start := time.Now()
+	_, instID := seedBalancedGroups(t, p, groups)
+	insert := time.Since(start)
+
+	start = time.Now()
+	if err := drainBalanceChecks(t, p); err != nil {
+		t.Fatalf("drain: %v", err)
+	}
+	drain := time.Since(start)
+
+	t.Logf("constrained: insert %s, deferred check drain %s (%d postings in %d groups)",
+		insert.Round(time.Millisecond), drain.Round(time.Millisecond), groups*2, groups)
+	t.Logf("per posting: insert %s, check %s",
+		(insert / time.Duration(groups*2)).Round(time.Microsecond),
+		(drain / time.Duration(groups*2)).Round(time.Microsecond))
+
+	// The split-adjustment recompute over the whole table: the worst case in the
+	// schema for the UPDATE trigger, and what its WHEN guard exists for.
+	if _, err := p.q.ExecContext(ctx, `
+		INSERT INTO stock_splits (instrument_id, ex_date, split_from, split_to, data_provider)
+		VALUES ($1::uuid, '2025-01-01'::date, 1, 3, 'bench')
+	`, instID); err != nil {
+		t.Fatalf("insert split: %v", err)
+	}
+	start = time.Now()
+	if err := p.RecomputeSplitAdjustments(ctx, ""); err != nil {
+		t.Fatalf("recompute: %v", err)
+	}
+	recompute := time.Since(start)
+	if err := drainBalanceChecks(t, p); err != nil {
+		t.Fatalf("drain after recompute: %v", err)
+	}
+	t.Logf("whole-table split recompute, guarded (touches every posting, weight untouched): %s",
+		recompute.Round(time.Millisecond))
+
+	// The same recompute with the WHEN guard removed, so the guard's value is a
+	// measured delta rather than an assumption. Dropping and recreating a trigger
+	// inside the test transaction is safe: the rollback takes it with everything else.
+	if _, err := p.q.ExecContext(ctx, `
+		DROP TRIGGER trg_tx_group_balance_update ON txs;
+		CREATE CONSTRAINT TRIGGER trg_tx_group_balance_update
+		  AFTER UPDATE ON txs
+		  DEFERRABLE INITIALLY DEFERRED
+		  FOR EACH ROW EXECUTE FUNCTION check_tx_group_balance();
+	`); err != nil {
+		t.Fatalf("replace the update trigger: %v", err)
+	}
+	start = time.Now()
+	if err := p.RecomputeSplitAdjustments(ctx, ""); err != nil {
+		t.Fatalf("unguarded recompute: %v", err)
+	}
+	if err := drainBalanceChecks(t, p); err != nil {
+		t.Fatalf("drain after unguarded recompute: %v", err)
+	}
+	unguarded := time.Since(start)
+	t.Logf("whole-table split recompute, unguarded (one queued check per posting): %s -- the WHEN guard saves %s",
+		unguarded.Round(time.Millisecond), (unguarded - recompute).Round(time.Millisecond))
+
+	t.Log("all figures are one run against a docker postgres and are indicative, not a threshold")
+}
+
+// TestBalanceConstraintMergePerformance times the one path that legitimately fires the
+// UPDATE trigger for every posting it touches. It is a separate test because the
+// DROP TRIGGER above takes an ACCESS EXCLUSIVE lock on txs for the rest of that
+// transaction, which would block the connection this one opens.
+//
+// Measured on 10,000 postings: 950ms, 95us per posting. Dearer than the deferred
+// check because each row is checked as it is updated rather than once at the end,
+// and it is the price of the merge keeping weight_commodity in step with
+// instrument_id. A merge touching this many postings is not a routine event.
+//
+// Run with: BENCH_BALANCE=1 make db-test
+func TestBalanceConstraintMergePerformance(t *testing.T) {
+	if os.Getenv("BENCH_BALANCE") == "" {
+		t.Skip("set BENCH_BALANCE=1 to run")
+	}
+	ctx := context.Background()
+	const groups = 5000
+
+	// Paired journals: both legs weigh in the instrument being merged, so both move
+	// together, which is the case the merge has to keep balanced.
+	p := testDBTx(t)
+	_, mergedAway, survivor := seedPairedJournals(t, p, groups)
+	if err := drainBalanceChecks(t, p); err != nil {
+		t.Fatalf("seeded journals do not balance: %v", err)
+	}
+
+	start := time.Now()
+	if err := p.runInTx(ctx, func(exec queryable) error {
+		return mergeInstruments(ctx, exec, uuid.MustParse(survivor), uuid.MustParse(mergedAway))
+	}); err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+	merge := time.Since(start)
+	t.Logf("merge rewriting weight_commodity on %d postings, each checked: %s (%s per posting)",
+		groups*2, merge.Round(time.Millisecond),
+		(merge / time.Duration(groups*2)).Round(time.Microsecond))
+}

--- a/server/db/postgres/balance_constraint_test.go
+++ b/server/db/postgres/balance_constraint_test.go
@@ -1,0 +1,222 @@
+package postgres
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// The balance constraint is DEFERRABLE INITIALLY DEFERRED, so it fires at COMMIT --
+// and testDBTx rolls back and never commits, which would leave every test here
+// vacuous. SET CONSTRAINTS ... IMMEDIATE drains the queued checks at the point COMMIT
+// would have run them, and makes every later statement in the transaction check as it
+// goes. That is what these tests assert against.
+//
+// Because it also switches later statements to immediate checking, a test that wants
+// to write a group leg by leg must write it all first and drain afterwards, which is
+// the same order a real transaction uses.
+func drainBalanceChecks(t *testing.T, p *Postgres) error {
+	t.Helper()
+	_, err := p.q.ExecContext(context.Background(),
+		`SET CONSTRAINTS trg_tx_group_balance, trg_tx_group_balance_update IMMEDIATE`)
+	return err
+}
+
+// balanceSeed creates a user and the USD currency instrument the postings below weigh
+// in, and returns both.
+func balanceSeed(t *testing.T, p *Postgres, sub string) (string, string) {
+	t.Helper()
+	ctx := context.Background()
+	userID, err := p.GetOrCreateUser(ctx, sub, "U", sub+"@b.com")
+	if err != nil {
+		t.Fatalf("create user: %v", err)
+	}
+	usd, err := p.EnsureInstrument(ctx, "CASH", "", "USD", "USD", "", "",
+		[]db.IdentifierInput{{Type: "CURRENCY", Value: "USD", Canonical: true}}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure USD: %v", err)
+	}
+	return userID, usd
+}
+
+// insertRawPosting writes one posting with a declared weight, bypassing the balancing
+// path, which is the only way to construct the states these tests are about.
+func insertRawPosting(t *testing.T, p *Postgres, userID, instID, groupID, qty, weight, commodity string) {
+	t.Helper()
+	_, err := p.q.ExecContext(context.Background(), `
+		INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type,
+		                 quantity, instrument_id, weight, weight_commodity, group_id)
+		VALUES ($1::uuid, 'IBKR', 'A', now(), 'USD', 'JRNLFUND', $2::numeric, $3::uuid,
+		        $4::numeric, $5, $6::uuid)
+	`, userID, qty, instID, weight, commodity, groupID)
+	if err != nil {
+		t.Fatalf("insert posting: %v", err)
+	}
+}
+
+// TestTxGroupBalance_LegsMayArriveInAnyOrder is the reason the constraint is deferred.
+// Each leg on its own leaves the group unbalanced, so an immediate check would reject
+// whichever arrived first however the writer ordered them.
+func TestTxGroupBalance_LegsMayArriveInAnyOrder(t *testing.T) {
+	p := testDBTx(t)
+	userID, usd := balanceSeed(t, p, "sub|balance-order")
+	groupID := newTxGroup(t, p, userID)
+
+	// Negative leg first: the group is -1000 USD until the second arrives.
+	insertRawPosting(t, p, userID, usd, groupID, "-1000", "-1000", "cur:USD")
+	insertRawPosting(t, p, userID, usd, groupID, "1000", "1000", "cur:USD")
+
+	if err := drainBalanceChecks(t, p); err != nil {
+		t.Fatalf("balanced group rejected: %v", err)
+	}
+}
+
+// TestTxGroupBalance_UnbalancedGroupIsRejected is the invariant itself. The message
+// has to name the group and the commodity, because a rejection that says only "does
+// not balance" leaves whoever hits it nowhere to start.
+func TestTxGroupBalance_UnbalancedGroupIsRejected(t *testing.T) {
+	p := testDBTx(t)
+	userID, usd := balanceSeed(t, p, "sub|balance-reject")
+	groupID := newTxGroup(t, p, userID)
+
+	insertRawPosting(t, p, userID, usd, groupID, "-1000", "-1000", "cur:USD")
+
+	err := drainBalanceChecks(t, p)
+	if err == nil {
+		t.Fatal("unbalanced group accepted: want a constraint violation")
+	}
+	for _, want := range []string{groupID, "-1000", "cur:USD"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("violation message %q does not name %q", err.Error(), want)
+		}
+	}
+}
+
+// TestTxGroupBalance_PerCommodity verifies the check is per commodity rather than over
+// the group as a whole. A buy is +10 AAPL and -1855 USD, and a group whose two
+// commodities happen to cancel numerically has not balanced in either of them.
+func TestTxGroupBalance_PerCommodity(t *testing.T) {
+	p := testDBTx(t)
+	userID, usd := balanceSeed(t, p, "sub|balance-commodity")
+	groupID := newTxGroup(t, p, userID)
+
+	insertRawPosting(t, p, userID, usd, groupID, "10", "10", "cur:USD")
+	insertRawPosting(t, p, userID, usd, groupID, "-10", "-10", "inst:"+usd)
+
+	if err := drainBalanceChecks(t, p); err == nil {
+		t.Fatal("a group summing to zero only across commodities was accepted")
+	}
+}
+
+// TestTxGroupBalance_DeletingAWholeGroupPasses verifies the cascade replace-by-period
+// depends on. Deleting the group takes its postings with it, and each deleted posting
+// queues a check against a group that no longer has any -- which has to pass
+// vacuously rather than read as an unbalanced group.
+func TestTxGroupBalance_DeletingAWholeGroupPasses(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, usd := balanceSeed(t, p, "sub|balance-delete")
+	groupID := newTxGroup(t, p, userID)
+
+	insertRawPosting(t, p, userID, usd, groupID, "-1000", "-1000", "cur:USD")
+	insertRawPosting(t, p, userID, usd, groupID, "1000", "1000", "cur:USD")
+
+	if _, err := p.q.ExecContext(ctx, `DELETE FROM tx_groups WHERE id = $1::uuid`, groupID); err != nil {
+		t.Fatalf("delete group: %v", err)
+	}
+	if err := drainBalanceChecks(t, p); err != nil {
+		t.Fatalf("deleting a whole group was rejected: %v", err)
+	}
+}
+
+// TestTxGroupBalance_DeletingOneLegIsRejected is the other half of the delete case:
+// the cascade is safe, but removing a single posting is not, and the constraint has to
+// tell them apart.
+func TestTxGroupBalance_DeletingOneLegIsRejected(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, usd := balanceSeed(t, p, "sub|balance-delete-leg")
+	groupID := newTxGroup(t, p, userID)
+
+	insertRawPosting(t, p, userID, usd, groupID, "-1000", "-1000", "cur:USD")
+	insertRawPosting(t, p, userID, usd, groupID, "1000", "1000", "cur:USD")
+	if err := drainBalanceChecks(t, p); err != nil {
+		t.Fatalf("balanced group rejected: %v", err)
+	}
+
+	_, err := p.q.ExecContext(ctx, `DELETE FROM txs WHERE group_id = $1::uuid AND weight > 0`, groupID)
+	if err == nil {
+		t.Fatal("deleting one leg of a balanced group was accepted")
+	}
+}
+
+// TestTxGroupBalance_UpdatingAWeightIsChecked verifies the UPDATE trigger's WHEN guard
+// lets through the thing it must: a change to weight itself. The guard exists so that
+// the split-adjustment recompute does not queue a check per row, and a guard that was
+// too broad would stop the constraint noticing an edit to the value it reads.
+func TestTxGroupBalance_UpdatingAWeightIsChecked(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, usd := balanceSeed(t, p, "sub|balance-update")
+	groupID := newTxGroup(t, p, userID)
+
+	insertRawPosting(t, p, userID, usd, groupID, "-1000", "-1000", "cur:USD")
+	insertRawPosting(t, p, userID, usd, groupID, "1000", "1000", "cur:USD")
+	if err := drainBalanceChecks(t, p); err != nil {
+		t.Fatalf("balanced group rejected: %v", err)
+	}
+
+	_, err := p.q.ExecContext(ctx,
+		`UPDATE txs SET weight = 999 WHERE group_id = $1::uuid AND weight > 0`, groupID)
+	if err == nil {
+		t.Fatal("editing a weight out of balance was accepted")
+	}
+}
+
+// TestTxGroupBalance_SplitRecomputeIsNotAffected verifies the recompute the WHEN guard
+// exists for. It rewrites split_adjusted_* for every posting of an instrument and
+// leaves weight alone, so it must neither fail nor be checked -- weight is computed
+// from the raw columns the recompute does not touch.
+func TestTxGroupBalance_SplitRecomputeIsNotAffected(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, usd := balanceSeed(t, p, "sub|balance-recompute")
+	instID, err := p.EnsureInstrument(ctx, "STOCK", "", "USD", "", "", "",
+		[]db.IdentifierInput{{Type: "MIC_TICKER", Domain: "XNAS", Value: "SPLT", Canonical: true}}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+	price := "100"
+	now := time.Now()
+	from, to := timestamppb.New(now.Add(-time.Hour)), timestamppb.New(now.Add(time.Hour))
+	txs := []*apiv1.Tx{
+		{Timestamp: timestamppb.New(now), InstrumentDescription: "SPLT", Type: apiv1.TxType_BUYSTOCK,
+			Quantity: "10", UnitPrice: &price, SettlementCurrency: "USD", GroupRef: "g1"},
+		{Timestamp: timestamppb.New(now), InstrumentDescription: "USD", Type: apiv1.TxType_BUYSTOCK,
+			Quantity: "-1000", SettlementCurrency: "USD", TradingCurrency: "USD", GroupRef: "g1"},
+	}
+	ws := []db.Weight{{Amount: decf(1000), Commodity: "cur:USD"}, {Amount: decf(-1000), Commodity: "cur:USD"}}
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "IBKR", "", from, to, txs, []string{instID, usd}, ws, nil); err != nil {
+		t.Fatalf("replace txs: %v", err)
+	}
+	if _, err := p.q.ExecContext(ctx, `
+		INSERT INTO stock_splits (instrument_id, ex_date, split_from, split_to, data_provider)
+		VALUES ($1::uuid, $2::date, 1, 3, 'test')
+	`, instID, now.Add(24*time.Hour)); err != nil {
+		t.Fatalf("insert split: %v", err)
+	}
+	if err := drainBalanceChecks(t, p); err != nil {
+		t.Fatalf("balanced group rejected before the recompute: %v", err)
+	}
+
+	// A 3:1 split triples the security leg's quantity and thirds its price, which
+	// does not divide exactly -- the point of weighing the raw columns.
+	if err := p.RecomputeSplitAdjustments(ctx, instID); err != nil {
+		t.Fatalf("recompute rejected by the balance constraint: %v", err)
+	}
+}

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -44,8 +44,8 @@ CREATE INDEX idx_portfolio_filters_portfolio ON portfolio_filters (portfolio_id)
 -- It is deliberately not a foreign key: a group must outlive its job, and if job
 -- rows are ever pruned by age the id still distinguishes one creation from another
 -- and still groups everything written by the same upload.
--- Groups hold a single posting until ingestion emits grouped legs, at which point
--- the postings of a group are required to sum to zero.
+-- The postings of a group are required to sum to zero in every commodity they weigh
+-- in, enforced by check_tx_group_balance() at COMMIT.
 -- See docs/spec/postings.md.
 CREATE TABLE tx_groups (
   id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
@@ -632,6 +632,76 @@ $$ LANGUAGE plpgsql;
 CREATE TRIGGER trg_default_split_adjusted_tx
   BEFORE INSERT OR UPDATE ON txs
   FOR EACH ROW EXECUTE FUNCTION default_split_adjusted_tx();
+
+-- The postings of a tx group must sum to zero in every commodity they weigh in.
+--
+-- Enforcing this here rather than in the application makes it unbypassable: no code
+-- path, no bad import and no manual psql session can leave an unbalanced group
+-- behind. It is affordable because ingestion routes every non-zero residual to an
+-- explicit counterparty, so balance is satisfiable by construction and turning the
+-- check on cannot reject otherwise-valid data.
+--
+-- It reads the stored weight rather than re-deriving one. The weight rules live in
+-- server/service/ingestion/balance.go, and a second copy in PL/pgSQL would both drift
+-- from the Go one and re-derive at COMMIT from instrument state that has moved under
+-- the posting since it was written -- which could reject a group that was balanced
+-- when it was written, on an update that has nothing to do with it. See
+-- docs/adr/0029-posting-weight-is-stored.md.
+--
+-- TG_OP branching rather than a CASE over NEW/OLD, because referencing NEW in a
+-- DELETE raises whether or not the branch is taken. A wholly deleted group matches no
+-- rows and passes vacuously, which is what lets replace-by-period delete groups and
+-- let the cascade take their postings.
+CREATE OR REPLACE FUNCTION check_tx_group_balance() RETURNS TRIGGER AS $$
+DECLARE
+  gids UUID[] := ARRAY[]::UUID[];
+  gid  UUID;
+  bad  RECORD;
+BEGIN
+  IF TG_OP <> 'INSERT' THEN
+    gids := gids || OLD.group_id;
+  END IF;
+  IF TG_OP <> 'DELETE' THEN
+    gids := gids || NEW.group_id;
+  END IF;
+  FOREACH gid IN ARRAY gids LOOP
+    SELECT weight_commodity, SUM(weight) AS residual INTO bad
+    FROM txs
+    WHERE group_id = gid
+    GROUP BY weight_commodity
+    HAVING SUM(weight) <> 0
+    LIMIT 1;
+    IF FOUND THEN
+      RAISE EXCEPTION 'tx group % does not balance: % left over in %',
+        gid, bad.residual, bad.weight_commodity
+        USING ERRCODE = 'check_violation';
+    END IF;
+  END LOOP;
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Deferred to COMMIT so the legs of a group can be inserted in any order within one
+-- transaction: a group is only ever balanced once all of it is written. There is
+-- precedent for DEFERRABLE in this schema -- exchanges.operating_mic and the
+-- plugin_config precedence uniqueness both use it.
+CREATE CONSTRAINT TRIGGER trg_tx_group_balance
+  AFTER INSERT OR DELETE ON txs
+  DEFERRABLE INITIALLY DEFERRED
+  FOR EACH ROW EXECUTE FUNCTION check_tx_group_balance();
+
+-- Split into a second trigger because WHEN cannot reference OLD on an INSERT. The
+-- guard is what keeps the split-adjustment recompute cheap: with no instrument filter
+-- it rewrites split_adjusted_* for every posting in the table and leaves weight alone,
+-- so without this every such row would queue a deferred check.
+CREATE CONSTRAINT TRIGGER trg_tx_group_balance_update
+  AFTER UPDATE ON txs
+  DEFERRABLE INITIALLY DEFERRED
+  FOR EACH ROW
+  WHEN (OLD.weight IS DISTINCT FROM NEW.weight
+     OR OLD.weight_commodity IS DISTINCT FROM NEW.weight_commodity
+     OR OLD.group_id IS DISTINCT FROM NEW.group_id)
+  EXECUTE FUNCTION check_tx_group_balance();
 
 -- Same defaulting trigger for eod_prices. close (NOT NULL) implies
 -- split_adjusted_close (NOT NULL); the OHLV columns are nullable on both

--- a/server/service/ingestion/balance.go
+++ b/server/service/ingestion/balance.go
@@ -434,10 +434,11 @@ func balanceInstruments(byID map[string]*db.InstrumentRow) map[string]balanceIns
 // weights in step, and last the commodities whose residual could not be given an
 // instrument.
 //
-// A residual with nowhere to go is dropped rather than failed: routing exists so
-// that imperfect source data still lands, and refusing an import because its
-// residual has no instrument would defeat that. The group is then left unbalanced,
-// which is the same state it was in before routing existed.
+// A residual with nowhere to go is left out and named in the last return. The
+// caller fails the job on it: the group would otherwise be stored unbalanced, and
+// the balance constraint rejects that at COMMIT, taking the whole upload with it.
+// Naming the commodity is the only way the failure says anything useful. Currencies
+// are seeded, so this is a safety net rather than a live path.
 func resolveRouted(ctx context.Context, database db.InstrumentDB, routed []routedPosting) ([]*apiv1.Tx, []string, []db.Weight, []string) {
 	var txs []*apiv1.Tx
 	var ids []string

--- a/server/service/ingestion/worker.go
+++ b/server/service/ingestion/worker.go
@@ -242,8 +242,24 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 	balanceInsts := balanceInstruments(instByID)
 	routed := routeResiduals(txsToProcess, instrumentIDs, balanceInsts)
 	routedTxs, routedIDs, routedWeights, unresolved := resolveRouted(ctx, database, routed)
-	for _, cur := range unresolved {
-		log.Printf("ingestion job %s: no currency instrument for %q; residual left unrouted", j.JobID, cur)
+	// A residual with no instrument to post it against used to be dropped with a log
+	// line, leaving its group unbalanced. The balance constraint now rejects that
+	// group at COMMIT, taking the whole upload with it, so failing the job here names
+	// the commodity instead of surfacing a constraint violation that does not.
+	// Currencies are seeded, so this is a safety net rather than a live path.
+	if len(unresolved) > 0 {
+		errs := make([]*apiv1.ValidationError, len(unresolved))
+		for i, cur := range unresolved {
+			log.Printf("ingestion job %s: no instrument for residual commodity %q", j.JobID, cur)
+			errs[i] = &apiv1.ValidationError{
+				RowIndex: -1,
+				Field:    "instrument_description",
+				Message:  fmt.Sprintf("no instrument for residual commodity %q; the group it balances cannot be stored", cur),
+			}
+		}
+		_ = database.AppendValidationErrors(ctx, j.JobID, errs)
+		_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_FAILED)
+		return false, ""
 	}
 	// Weighed after routing, which is what assigns a synthetic group_ref to a posting
 	// that had none, and before the routed postings are appended, since those carry


### PR DESCRIPTION
Last of four PRs for [0041](docs/issues/0041-enable-balance-constraint.md). **Stacked on #322** -> #321 -> #320; review those first.

## Why

A tx group's postings sum to zero in every commodity they weigh in. That has been true since 0038 routed residuals, but only because the ingestion path chooses to hold it -- any other writer, a bad import or a manual psql session, could leave an unbalanced group behind. This makes it unbypassable.

## The trigger

`DEFERRABLE INITIALLY DEFERRED`, because the legs of a group are written in any order and each on its own leaves the group unbalanced. It reads the stored weight rather than re-deriving one, per adr/0029.

Two triggers rather than one, because `WHEN` cannot reference `OLD` on an `INSERT`. The guard on the UPDATE trigger is what keeps `RecomputeSplitAdjustments` cheap: with no instrument filter it rewrites `split_adjusted_*` for every posting in the table and leaves `weight` alone, so without it every such row would queue a deferred check.

The check is a plain `SUM(weight) = 0` with no tolerance to defend, which is only possible because #320 made every non-zero residual routed.

## The cost, measured

You asked for this rather than the guess the plan carried. `server/db/postgres/balance_bench_test.go`, gated on `BENCH_BALANCE=1 make db-test`, reporting rather than asserting. 10,000 postings (5,000 two-leg groups) against `timescale/timescaledb:latest-pg16` in docker:

| | |
| --- | --- |
| insert | 4.1s (413us/posting) |
| deferred check drain | **208ms (21us/posting)** |
| split recompute, guarded | 630ms |
| split recompute, unguarded | 800ms |
| merge rewriting `weight_commodity` on 10k postings | 950ms |

So the constraint costs about **5%** of the import it makes unbypassable. That settles the question the row-level trigger raised: Postgres requires `AFTER ... FOR EACH ROW` for a constraint trigger, so a statement-level check over transition tables is not available and each group is checked once per leg. At 21us that is affordable, and deduplicating the checks within a transaction is not worth the machinery.

The guarded/unguarded pair makes the `WHEN` clause's value a measured delta rather than an assumption -- the benchmark drops and recreates the trigger without it and reruns the same recompute.

The benchmark runs under `testDBTx`, which rolls back and never commits, so a deferred trigger would never fire. `SET CONSTRAINTS ... IMMEDIATE` drains the queued checks at exactly the point COMMIT would have run them, which is what makes the drain time the COMMIT-time cost and separable from the insert.

## Other changes

- **An unresolvable residual now fails the job.** It used to be dropped with a log line, leaving its group unbalanced -- which the constraint turns into an aborted upload, so the failure has to name the commodity to say anything useful. Currencies are seeded, so this is a safety net rather than a live path.
- **e2e fixtures.** They seed residual postings directly, which is the point of them, so each now gets the equal and opposite counterparty its group needs. `EQUITY` rather than a `USER` cash row: only `USER` postings reach holdings and valuation, and these fixtures are not about either, so the counterparty must not show up as a negative cash balance in the specs that read them.
- **`docker-compose.test.yml`** passes `BENCH_BALANCE` / `BENCH_VALUATION` through to the test container. `BENCH_VALUATION=1 make db-test` did not previously reach it, so the existing valuation benchmark could only be run by hand.

## Landed ahead of 0040

The issue said "best landed after 0040, when residuals are small". Nothing in the constraint depends on that: it rejects a group that does not sum to zero, not one whose residual is large, and routing makes every group sum to zero whatever the source data looks like. Landing it now means the invariant holds while 0040 is being written rather than after.

## Test plan

- `make check`, `make server-test`, `make db-test` pass. `make e2e-test`: 33/33 -- the only suite that commits, and so the only one that runs the deferred trigger through the real upload path.
- Seven new trigger tests in `balance_constraint_test.go`: legs in either order pass (the reason for deferring); an unbalanced group is rejected with the group and commodity named; a group summing to zero only across commodities is rejected; deleting a whole group passes and deleting one leg does not; editing a weight out of balance is caught (proving the `WHEN` guard is not too broad); a split recompute is unaffected.
- `BENCH_BALANCE=1 make db-test` for the figures above.

Closes 0041.

🤖 Generated with [Claude Code](https://claude.com/claude-code)