### PR TITLE
Close 0040: split netted commission into fee postings

### DIFF
--- a/client/lib/csv/converters/brokers.ts
+++ b/client/lib/csv/converters/brokers.ts
@@ -1,8 +1,10 @@
 /**
- * Register brokers that have no converter yet (display only in holdings/portfolios).
+ * Register brokers that have no converter yet (display only in holdings and
+ * portfolios).
  *
- * Schwab is registered in ./schwab.ts because it now contributes a
- * split extractor for the admin Corporate Events page.
+ * Empty: every broker in the Broker enum that has data to convert has its own
+ * module. SCHB does not -- see docs/issues/0073-schwab-client-converter.md --
+ * so a Schwab upload has only the standard format to go through.
  */
 
 export {};

--- a/client/lib/csv/converters/ibkr-ofx.test.ts
+++ b/client/lib/csv/converters/ibkr-ofx.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { convertIbkrOfx } from "./ibkr-ofx";
+import { AccountType, IdentifierType, TxType } from "@/gen/api/v1/api_pb";
+import { expectGroupsBalance } from "@/lib/csv/group-balance.test-utils";
+
+/**
+ * An option trade taken verbatim from local/masters/U7033034_20250107_20260107.qfx,
+ * with the OPTINFO that names it. It is here because it is the arithmetic the
+ * contract size has to reproduce: 8 x 20.1105585 x 100 = 16088.4468, and only
+ * with the multiplier does that plus the 7.420248 commission reach the
+ * -16095.867048 the broker reported. Weighed at one share per contract the
+ * group would be short the other 99%.
+ */
+const OPT_BUY = `<BUYOPT>
+  <INVBUY>
+    <INVTRAN><FITID>20250123U70330347171218488</FITID><DTTRADE>20250123030529.000[-5:EST]</DTTRADE></INVTRAN>
+    <SECID><UNIQUEID>731401093</UNIQUEID><UNIQUEIDTYPE>CONID</UNIQUEIDTYPE></SECID>
+    <UNITS>8
+    <UNITPRICE>20.1105585
+    <COMMISSION>7.420248
+    <TAXES>0
+    <TOTAL>-16095.867048
+    <CURRENCY><CURRATE>0.8432</CURRATE><CURSYM>EUR</CURSYM></CURRENCY>
+  </INVBUY>
+  <OPTBUYTYPE>BUYTOCLOSE
+</BUYOPT>`;
+
+const OPT_SEC_LIST = `<OPTINFO><SECINFO>
+  <SECID><UNIQUEID>731401093</UNIQUEID><UNIQUEIDTYPE>CONID</UNIQUEIDTYPE></SECID>
+  <SECNAME>P RHM  20250919 560 M RHM 19SEP25 560 P</SECNAME>
+  <TICKER>P RHM  20250919 560 M</TICKER>
+</SECINFO><OPTTYPE>PUT</OPTTYPE><STRIKEPRICE>560</STRIKEPRICE><SHPERCTRCT>100</SHPERCTRCT></OPTINFO>`;
+
+function buildOfx(transactions: string, secList: string): string {
+  return `OFXHEADER:100
+DATA:OFXSGML
+VERSION:102
+
+<OFX>
+  <SIGNONMSGSRSV1><SONRS><STATUS><CODE>0</CODE></STATUS></SONRS></SIGNONMSGSRSV1>
+  <INVSTMTMSGSRSV1>
+    <INVSTMTTRNRS>
+      <INVSTMTRS>
+        <CURDEF>GBP
+        <INVACCTFROM><BROKERID>4705</BROKERID><ACCTID>U7033034</ACCTID></INVACCTFROM>
+        <INVTRANLIST>
+          <DTSTART>20250101
+          <DTEND>20250401
+          ${transactions}
+        </INVTRANLIST>
+      </INVSTMTRS>
+    </INVSTMTTRNRS>
+  </INVSTMTMSGSRSV1>
+  <SECLISTMSGSRSV1><SECLIST>${secList}</SECLIST></SECLISTMSGSRSV1>
+</OFX>`;
+}
+
+describe("convertIbkrOfx", () => {
+  it("resolves an option's CONID to its OCC symbol through the SECLIST", () => {
+    const result = convertIbkrOfx(buildOfx(OPT_BUY, OPT_SEC_LIST));
+    expect(result.errors).toEqual([]);
+
+    const security = result.txs.find((t) => t.type === TxType.BUYOPT)!;
+    expect(security.identifierHints).toHaveLength(1);
+    expect(security.identifierHints[0]!.type).toBe(IdentifierType.OCC);
+    expect(security.identifierHints[0]!.value).toBe("P RHM  20250919 560 M");
+  });
+
+  it("weighs the option leg by its contract size, so the trade balances", () => {
+    // The assertion that matters: expectGroupsBalance mirrors weightOf in
+    // balance.go, so a group that balances here is one the server will not route
+    // to IMBALANCE. Without the 100x it is out by 15927.56 EUR.
+    expectGroupsBalance(convertIbkrOfx(buildOfx(OPT_BUY, OPT_SEC_LIST)).txs);
+  });
+
+  it("splits the commission out of the option's netted total", () => {
+    const result = convertIbkrOfx(buildOfx(OPT_BUY, OPT_SEC_LIST));
+
+    const cash = result.txs.find((t) => t.type === TxType.CASHFLOW)!;
+    expect(cash.quantity).toBe("-16088.4468");
+
+    const fees = result.txs.filter((t) => t.type === TxType.INVEXPENSE);
+    expect(fees).toHaveLength(2);
+    expect(fees.find((t) => t.accountType === AccountType.USER)!.quantity).toBe("-7.420248");
+    expect(fees.find((t) => t.accountType === AccountType.EXPENSE)!.quantity).toBe("7.420248");
+  });
+
+  it("leaves an option with no SECLIST entry unhinted rather than guessing", () => {
+    const security = convertIbkrOfx(buildOfx(OPT_BUY, "")).txs.find(
+      (t) => t.type === TxType.BUYOPT,
+    )!;
+    expect(security.identifierHints).toHaveLength(0);
+  });
+});

--- a/client/lib/csv/converters/ibkr-ofx.ts
+++ b/client/lib/csv/converters/ibkr-ofx.ts
@@ -13,7 +13,7 @@ import type { StandardParseResult } from "@/lib/csv/standard";
 import { parseOfxStatement } from "@/lib/ofx/parser";
 import { register } from "./registry";
 
-function convertIbkrOfx(text: string): StandardParseResult {
+export function convertIbkrOfx(text: string): StandardParseResult {
   const result = parseOfxStatement(text);
 
   // IBKR uses CONID (internal contract ID) for options. The SECLIST

--- a/client/lib/csv/group-balance.test-utils.ts
+++ b/client/lib/csv/group-balance.test-utils.ts
@@ -5,9 +5,9 @@
  * A group's postings are in different commodities, so a plain sum says nothing
  * -- a buy is +10 AAPL and -1855 USD. This mirrors weightOf in
  * server/service/ingestion/balance.go, reduced to the cases a converter can
- * produce: a security leg converts to money at its price, and everything else
- * weighs its own quantity in the settlement currency. It does not model a
- * securities journal, whose commodity is neither.
+ * produce: a security leg converts to money at its price times its contract
+ * size, and everything else weighs its own quantity in the settlement currency.
+ * It does not model a securities journal, whose commodity is neither.
  *
  * Not a test file itself -- the name keeps it out of vitest's include glob.
  */
@@ -15,7 +15,7 @@
 import { expect } from "vitest";
 import type { Tx } from "@/gen/api/v1/api_pb";
 import { Big } from "@/lib/decimal";
-import { TxType } from "@/gen/api/v1/api_pb";
+import { IdentifierType, TxType } from "@/gen/api/v1/api_pb";
 
 /** Types whose counter-leg is money, so the posting converts at its price. */
 const EXCHANGE_TYPES = new Set<TxType>([
@@ -47,6 +47,23 @@ const EXCHANGE_TYPES = new Set<TxType>([
  */
 const TOLERANCE = new Big("0.005");
 
+/**
+ * The OCC standard deliverable, matching optionContractSize in balance.go.
+ *
+ * balance.go reads the size off the resolved instrument's asset class; a
+ * converter has resolved nothing yet, so an OCC hint stands in for one. The
+ * symbology exists only for a standardised contract, so the hint and the asset
+ * class agree. A contract_multiplier left behind by a corporate action does not,
+ * but a converter cannot know one either.
+ */
+const OPTION_CONTRACT_SIZE = new Big(100);
+
+/** What one unit of quantity delivers: 100 for an option contract, else 1. */
+function contractSize(tx: Tx): Big {
+  const isOption = tx.identifierHints.some((h) => h.type === IdentifierType.OCC);
+  return isOption ? OPTION_CONTRACT_SIZE : new Big(1);
+}
+
 /** What a posting contributes to its group's balance, and in what commodity. */
 export function weigh(tx: Tx): { amount: Big; commodity: string } {
   const settle = (tx.settlementCurrency || tx.tradingCurrency).toUpperCase();
@@ -57,7 +74,7 @@ export function weigh(tx: Tx): { amount: Big; commodity: string } {
     if (tx.unitPrice === undefined || !settle) {
       return { amount: qty, commodity: tx.instrumentDescription };
     }
-    return { amount: qty.times(tx.unitPrice), commodity: settle };
+    return { amount: qty.times(tx.unitPrice).times(contractSize(tx)), commodity: settle };
   }
   return { amount: qty, commodity: settle || tx.instrumentDescription };
 }

--- a/docs/issues/0040-csv-fees-net-amount.md
+++ b/docs/issues/0040-csv-fees-net-amount.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Emit fee and cash postings from brokers that net commission
 milestone: M12
 dependencies: [0039, 0063]
@@ -13,7 +13,7 @@ standard CSV. It no longer does. A fee is a posting with `type=INVEXPENSE`, not 
 column: that is already how Fidelity's separately-reported charges arrive, and
 columns would express the same money twice. See
 adr/0021-converters-own-transaction-grouping.md. What remains is the converter-side
-work for brokers that do not report charges separately.
+work for brokers that fold the charge into one cash total.
 
 ## Motivation
 
@@ -24,38 +24,76 @@ in `Imbalance` (0038) whenever the price and the cash total disagree.
 
 ## Design
 
-- The converter derives the fee as `|Amount| - quantity * price` and emits it as an
-  `INVEXPENSE` posting in the same group as the trade.
+- The converter takes the fee from what the broker reported separately -- `<COMMISSION>`
+  and `<TAXES>` in OFX, `Fees & Comm` in a Schwab CSV -- and emits it as an
+  `INVEXPENSE` posting in the same group as the trade, paired with its `EXPENSE`
+  mirror. The consideration leg is then `total + commission`, so the two cash legs
+  add back up to the total the broker reported. See
+  adr/0025-netted-cash-totals-are-split-into-legs.md.
 - Where a broker reports charges as their own rows on their own dates (Fidelity),
   they stay separate single-posting groups. Do not fold them into the trade group;
   they are separate cash events and grouping them would misdate them.
-- The currency qualifier matters. Derive the fee only after the price and the cash
-  total are in the same currency.
+- Deriving the fee as `|Amount| - quantity * price` was the original design and was
+  rejected -- see the measurement below. It is only the commission when the price
+  and the cash total are already in the same currency and the price is exact.
 
-## Sequencing
+## Delivered
 
-Prioritise converter updates using the imbalance report from 0039 -- fix the
-broker with the largest residual first. The Fidelity converter (0013) is the
-existing worked example.
+Shared helpers in `client/lib/csv/postings.ts` (`counterLeg`, `feeLeg`,
+`counterLegs`, `refPrefix`), the Fidelity CSV and JSON converters emitting income
+and expense counter-legs, and the OFX parser splitting IBKR's netted `<TOTAL>`.
+Then the manual test data under `local/scripts`, which had four defects that made
+the 0039 report unusable as the sequencing evidence this issue asks for:
 
-## Manual test data
+- `check-balance.py` did not weigh an option leg by its 100x contract size, which
+  `balance.go` has applied since 0072. It reported IBKR option residuals about 100x
+  too large, which pointed the report at options rather than at the FX bug below.
+  `client/lib/csv/group-balance.test-utils.ts` had the same omission.
+- `convert-ibkr.py` parsed `Amount` without stripping thousands separators, so 87
+  trades were silently dropped from both the FX rate sample and the price
+  conversion and kept a base-currency price against an instrument-currency cash
+  total. This was the dominant IBKR residual.
+- `convert-ibkr.py` dropped 44 rows outright: 20 `Withholding Tax`, 13 `Broker
+  Interest Received`, 11 `Broker Interest Paid`. These are the `EXPENSE` and
+  `INCOME` postings 0071 exists to report.
+- `convert-ibkr.py` typed `Deposits/Withdrawals` as `CASHFLOW`, so 3,779,387 of
+  external funding routed to `IMBALANCE` rather than `TRANSFER_CLEARING`.
+  `convert-fidelity.py` types the same events as `JRNLFUND`.
 
-The broker CSVs under `local/standard-format` carry no fee postings, so every
-conflated fee shows up as `Imbalance` until they are regenerated. Doing that is part
-of this work: the scripts that produce them live in `local/scripts` and have to emit
-the fee postings alongside the client converters.
+IBKR's residual after the four: 320.97 USD across 250 trade groups, from 1.35m
+before.
 
-Whether the source data supports it varies by broker, so check before assuming a
-regeneration is mechanical. The IBKR master (`local/masters/Lee-IBKR-CWSY.csv`)
-has no commission column at all -- only `Amount`, the cash total with commission
-already in it. Two ways round that:
+## Why IBKR's CSV keeps its commission in the residual
 
-- Take fees from the OFX/QFX export of the same account, which does carry
-  `<COMMISSION>` per transaction alongside `UNITPRICE` and `TOTAL`.
-- Derive them as `|Amount| - quantity * multiplier * unit_price`, which is what
-  the residual is once the price is in the instrument's currency.
+`local/masters/Lee-IBKR-CWSY.csv` has no commission column, and its `Price` is
+IBKR's own intraday conversion into the account's base currency while `Amount` is
+in the instrument's. Both candidate rates for the conversion were measured against
+the 599 trades in that master, and neither yields a commission:
 
-That currency qualifier matters. The IBKR export quotes `Price` in the account's
-base currency while `Amount` is in the instrument's, so the conversion has to
-happen before any fee is derived from the difference. `convert-ibkr.py` already
-does it and documents why.
+- The rate `convert-ibkr.py` estimates from `|Amount| / (quantity * multiplier *
+  Price)` is solved from the trade itself on any row at or above its threshold, so
+  the subtraction is zero by construction -- for 333 of 599 trades. The whole
+  master leaves -318.47 USD, which is not a plausible commission bill for 383
+  option trades.
+- A real daily `USDGBP` close, which the price master carries, leaves 235 of 599
+  derived fees negative -- a commission that pays you -- with a tail to 1901% of
+  notional.
+
+So the number is not weakly-attributed commission, it is unattributable, and it
+stays in the residual where it is honest about being unexplained. This costs
+nothing in the product: there is no client-side IBKR CSV converter, and the
+shipped IBKR path is OFX/QFX, which reports `<COMMISSION>` on 326 of 326 trades
+and is split properly. The QFX cannot backfill the CSV's history either -- the two
+masters are disjoint, the CSV ending 2025-01-06 and the QFX starting 2025-01-23.
+
+## Residuals left behind, and where they belong
+
+- Fidelity `JRNLFUND` and `TRANSFER` single-posting groups, about 636k and 200k --
+  external transfers, matched by 0068.
+- Helen-Fidelity's 23 unpaired `BUYSTOCK` groups and one `SELLSTOCK` -- trade and
+  cash pairing failures, 0065 and 0069.
+- Schwab's three groups worth 667,750 -- the export's quantities are split adjusted
+  while its prices are as traded, so pre-split GOOG and TSLA rows cannot balance.
+  That is 0057.
+- Schwab has no client-side converter to update, only `local/scripts/convert-schwab.py`,
+  which already splits `Fees & Comm`. Writing one is 0073.

--- a/docs/issues/0073-schwab-client-converter.md
+++ b/docs/issues/0073-schwab-client-converter.md
@@ -1,0 +1,47 @@
+---
+status: open
+title: Client-side Schwab transaction converter
+dependencies: [0040]
+---
+
+Add a Schwab CSV converter to `client/lib/csv/converters/`, so a Schwab export can
+be uploaded through the web client as Fidelity and IBKR already can.
+
+## Motivation
+
+`SCHB` is in the `Broker` enum but has no converter, so a Schwab user has only the
+standard format to go through -- which means converting by hand. Schwab is also the
+third shape of the fee problem: it nets commission into `Amount` while reporting it
+separately in `Fees & Comm`, so under
+adr/0025-netted-cash-totals-are-split-into-legs.md its converter splits the total
+into a consideration leg and a fee leg. That is the case 0040 covered for IBKR's
+OFX and Fidelity's own rows, and left for Schwab only because no converter existed
+to update.
+
+## Design
+
+- Consideration is `Amount + fee`, not `quantity * unit_price`. The broker's own
+  arithmetic is what the two cash legs have to add back up to, and here the export
+  makes the point twice over: its quantities are split adjusted while its prices
+  are as traded, so the product is wrong on any row predating a split.
+- The fee leg comes from `feeLeg` in `client/lib/csv/postings.ts`, and its expense
+  mirror from `counterLegs`, called last so a derived fee gets one too.
+- `local/scripts/convert-schwab.py` is a working reference for the `Action` to
+  `TxType` map and for the group and cash-leg construction. It is not a
+  translation target: it reads a CWSY-preprocessed master, and the converter has
+  to read what Schwab actually exports.
+
+## Blocked on sample data
+
+No genuine Schwab export is in the repo. `local/masters/Helen-Schwab-CWSY.csv` has
+been through CWSY pre-processing: columns 0-7 are the raw Schwab view and 8-13 are
+added. Writing the converter against those first eight columns would leave every
+real-export quirk unverified -- the preamble and total rows, `"02/08/2022 as of
+02/07/2022"` dates, quoted dollar amounts, the account line. Get a real export
+first.
+
+## Out of scope
+
+The mixed share count basis noted above is 0057, not this issue. It is what leaves
+three groups in `Helen-Schwab.csv` unbalanced by 667,750 USD, and no fee handling
+will close that gap.


### PR DESCRIPTION
Closes 0040. The two converter PRs for this issue landed already (#309 Fidelity
counter-legs, #310 the OFX split of IBKR's netted `<TOTAL>`). What remained was
the manual test data under `local/`, which is gitignored -- so most of the work
in this issue is not in this diff. The issue file records what was done and
measured.

## The test data

Four defects in `local/scripts` made the 0039 imbalance report unusable as the
sequencing evidence 0040 asks for:

- `check-balance.py` did not weigh an option leg by its 100x contract size, which
  `balance.go` has applied since 0072. It reported IBKR option residuals about
  100x too large, pointing the report at options rather than at the FX bug below.
- `convert-ibkr.py` parsed `Amount` without stripping thousands separators, so 87
  trades were silently dropped from both the FX rate sample and the price
  conversion and kept a base-currency price against an instrument-currency cash
  total. The dominant IBKR residual.
- `convert-ibkr.py` dropped 44 rows outright -- 20 `Withholding Tax`, 13 `Broker
  Interest Received`, 11 `Broker Interest Paid`. These are the `EXPENSE` and
  `INCOME` postings 0071 exists to report.
- `convert-ibkr.py` typed `Deposits/Withdrawals` as `CASHFLOW`, routing 3,779,387
  of external funding to `IMBALANCE` instead of `TRANSFER_CLEARING`.
  `convert-fidelity.py` types the same events as `JRNLFUND`.

IBKR's imbalance residual after the four: **320.97 USD across 250 trade groups,
from 1.35m before**.

## What is in this diff

`group-balance.test-utils.ts` had the same contract-size omission as
`check-balance.py`, so a converter could emit an option trade short 99% of its
consideration and the helper would call the group balanced. No test exercised an
option, so `ibkr-ofx.test.ts` is new -- `ibkr-ofx.ts` had no tests at all. Its
fixture is a trade taken verbatim from the QFX master, where
`8 x 20.1105585 x 100` plus `7.420248` of commission is what reaches the reported
`-16095.867048`. Reverting the multiplier fails that test by exactly
`-15927.562332 EUR`.

`brokers.ts` stops claiming a `./schwab.ts` that never existed, and 0073 opens
for the client-side Schwab converter -- Schwab nets commission and reports
`Fees & Comm`, but there was no converter to update, only the offline script
(which already splits it). It is blocked on a genuine Schwab export; the only
sample in the repo has been through CWSY pre-processing.

## Why IBKR's CSV keeps its commission in the residual

The issue originally proposed deriving the fee as `|Amount| - quantity * price`.
Measured against the 599 trades in the CSV master, neither candidate rate yields
a commission:

| Rate | Result |
|---|---|
| The script's own estimate | Solved from the trade itself above its threshold, so the subtraction is **zero by construction on 333 of 599 trades**. The whole master leaves -318.47 USD, not a plausible bill for 383 option trades. |
| A real daily `USDGBP` close | **235 of 599 derived fees come out negative** -- a commission that pays you -- with a tail to 1901% of notional. |

`Price` is IBKR's own intraday base-currency conversion, so no independent rate
reproduces it. The number is unattributable, not weakly attributed, which is what
adr/0025 already says. It costs nothing in the product: there is no client-side
IBKR CSV converter, and the shipped IBKR path is OFX/QFX, which reports
`<COMMISSION>` on 326 of 326 trades. The QFX cannot backfill the CSV either --
the masters are disjoint (CSV ends 2025-01-06, QFX starts 2025-01-23).

## Testing

`make client-test extension-test` (280 + 86 pass), `make lint-ts
client-typecheck` clean. `check-balance.py` re-run over all four regenerated
files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)