### PR TITLE
Denominate holding declarations and fix the pad's share count (0043)

### DIFF
--- a/client/app/holdings/declaration-form.tsx
+++ b/client/app/holdings/declaration-form.tsx
@@ -20,6 +20,20 @@ function todayStr(): string {
   return new Date().toISOString().slice(0, 10);
 }
 
+/**
+ * Which share count a declared quantity is denominated in. The wire carries a date;
+ * the form offers the two readings that date can have, because a raw date picker
+ * asks a question users cannot answer.
+ */
+type ShareCountBasis = "as-of" | "today";
+
+/** The stored basis read back as one of the two choices the form offers. */
+function initialBasis(decl: HoldingDeclaration): ShareCountBasis {
+  const stored = decl.shareCountBasis ? protoDateToStr(decl.shareCountBasis) : "";
+  const asOf = decl.asOfDate ? protoDateToStr(decl.asOfDate) : "";
+  return stored && stored !== asOf ? "today" : "as-of";
+}
+
 /** Ticker if the instrument has one, else its name, else the bare id. */
 function instrumentDisplayLabel(decl: HoldingDeclaration): string {
   const ticker = decl.instrument?.identifiers?.find(
@@ -45,6 +59,13 @@ export function DeclarationForm({
   const [picked, setPicked] = useState<{ id: string; label: string } | null>(null);
   const [declaredQty, setDeclaredQty] = useState(editing?.declaredQty ?? "");
   const [asOfDate, setAsOfDate] = useState(editing?.asOfDate ? protoDateToStr(editing.asOfDate) : todayStr());
+  // Which share count the quantity is in. A number copied off a statement of the
+  // as-of date is in the share count current then; one copied off today's holdings
+  // screen is in today's. A split between the two dates makes them differ by the
+  // split factor, so the user says which rather than the system guessing.
+  const [basis, setBasis] = useState<ShareCountBasis>(
+    editing ? initialBasis(editing) : "as-of"
+  );
   const [error, setError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
 
@@ -80,12 +101,14 @@ export function DeclarationForm({
       return;
     }
     setSubmitting(true);
+    const shareCountBasis = basis === "today" ? todayStr() : asOfDate;
     try {
       if (editing) {
         await updateHoldingDeclaration({
           id: editing.id,
           declaredQty,
           asOfDate,
+          shareCountBasis,
         });
       } else {
         await createHoldingDeclaration({
@@ -94,6 +117,7 @@ export function DeclarationForm({
           instrumentId,
           declaredQty,
           asOfDate,
+          shareCountBasis,
         });
       }
       onDone();
@@ -252,6 +276,36 @@ export function DeclarationForm({
           />
         </div>
       </div>
+
+      <fieldset>
+        <legend className="mb-1 block text-xs font-semibold uppercase tracking-wider text-text-muted">
+          Share Count
+        </legend>
+        <p className="mb-2 text-sm text-text-muted">
+          If the instrument has split since the as of date, the same holding is a
+          different number of shares before and after. Tell us which one you counted.
+        </p>
+        <div className="space-y-1">
+          {(
+            [
+              ["as-of", "The share count on the as of date (from a statement or contract note)"],
+              ["today", "Today's share count (from a current holdings screen)"],
+            ] as const
+          ).map(([value, label]) => (
+            <label key={value} className="flex items-start gap-2 text-sm text-text-primary">
+              <input
+                type="radio"
+                name="share-count-basis"
+                value={value}
+                checked={basis === value}
+                onChange={() => setBasis(value)}
+                className="mt-0.5"
+              />
+              <span>{label}</span>
+            </label>
+          ))}
+        </div>
+      </fieldset>
 
       <div className="flex gap-3">
         <button

--- a/client/app/holdings/opening-balances.tsx
+++ b/client/app/holdings/opening-balances.tsx
@@ -16,6 +16,18 @@ import { IdentifierType } from "@/gen/api/v1/api_pb";
 import type { HoldingDeclaration } from "@/gen/api/v1/api_pb";
 import { DeclarationForm } from "./declaration-form";
 
+/**
+ * Which share count the declared quantity is in, said the way the form asks it. The
+ * denomination only matters once it differs from the as of date, so a declaration on
+ * the as-traded default reads as the date itself rather than as jargon.
+ */
+function shareCountLabel(decl: HoldingDeclaration): string {
+  const basis = decl.shareCountBasis ? protoDateToStr(decl.shareCountBasis) : "";
+  const asOf = decl.asOfDate ? protoDateToStr(decl.asOfDate) : "";
+  if (!basis || basis === asOf) return "As of date";
+  return `As of ${basis}`;
+}
+
 export function OpeningBalances() {
   const queryClient = useQueryClient();
   const [deleteError, setDeleteError] = useState<string | null>(null);
@@ -119,6 +131,9 @@ export function OpeningBalances() {
                   <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-text-muted">
                     As Of Date
                   </th>
+                  <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-text-muted">
+                    Share Count
+                  </th>
                   <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wider text-text-muted">
                     Actions
                   </th>
@@ -128,7 +143,7 @@ export function OpeningBalances() {
                 {declarations.length === 0 ? (
                   <tr>
                     <td
-                      colSpan={6}
+                      colSpan={7}
                       className="px-4 py-8 text-center text-text-muted"
                     >
                       No opening balance checkpoints.
@@ -158,6 +173,9 @@ export function OpeningBalances() {
                         </td>
                         <td className="px-4 py-3 text-text-muted">
                           {protoDateToStr(d.asOfDate)}
+                        </td>
+                        <td className="px-4 py-3 text-text-muted">
+                          {shareCountLabel(d)}
                         </td>
                         <td className="px-4 py-3 text-right">
                           <button

--- a/client/lib/portfolio-api.ts
+++ b/client/lib/portfolio-api.ts
@@ -795,6 +795,7 @@ export async function createHoldingDeclaration(params: {
   instrumentId: string;
   declaredQty: string;
   asOfDate: string;
+  shareCountBasis: string;
 }): Promise<HoldingDeclaration> {
   const base = getBaseUrl();
   const req = create(CreateHoldingDeclarationRequestSchema, {
@@ -803,6 +804,7 @@ export async function createHoldingDeclaration(params: {
     instrumentId: params.instrumentId,
     declaredQty: params.declaredQty,
     asOfDate: strToProtoDate(params.asOfDate),
+    shareCountBasis: strToProtoDate(params.shareCountBasis),
   });
   const resBytes = await unaryFetch(base, ApiServicePrefix + "CreateHoldingDeclaration", toBinary(CreateHoldingDeclarationRequestSchema, req), {
     credentials: "include",
@@ -815,12 +817,14 @@ export async function updateHoldingDeclaration(params: {
   id: string;
   declaredQty: string;
   asOfDate: string;
+  shareCountBasis: string;
 }): Promise<HoldingDeclaration> {
   const base = getBaseUrl();
   const req = create(UpdateHoldingDeclarationRequestSchema, {
     id: params.id,
     declaredQty: params.declaredQty,
     asOfDate: strToProtoDate(params.asOfDate),
+    shareCountBasis: strToProtoDate(params.shareCountBasis),
   });
   const resBytes = await unaryFetch(base, ApiServicePrefix + "UpdateHoldingDeclaration", toBinary(UpdateHoldingDeclarationRequestSchema, req), {
     credentials: "include",

--- a/docs/spec/bitemporality.md
+++ b/docs/spec/bitemporality.md
@@ -142,6 +142,7 @@ Every source declares its own. The storage layer assumes nothing.
 | Price plugin returning as-traded bars | each bar's `price_date` | The bar is the market as it printed that day. |
 | Price plugin returning back-adjusted bars | the fetch date | The provider restated the whole series to the share count current when it answered. |
 | Price import file | `price_date`, unless the row declares otherwise | Matches PortfolioDB's own export, which emits raw close. |
+| Holding declaration | `as_of_date`, unless the user says otherwise | A quantity read off a record of some date is in the share count current then. A quantity read off today's holdings screen is not, and the form asks which. |
 
 Both defaults are inferrable, and both are wrong for a source that restates. Two
 sources here can: the browser extension scrapes the broker's live web UI, which

--- a/docs/spec/fixed-point.md
+++ b/docs/spec/fixed-point.md
@@ -26,22 +26,43 @@ All transactions carry a `synthetic_purpose` field. This is `NULL` for real tran
 
 Holdings are computed aggregates (there is no holdings table), so a holding is identified by the composite key `(broker, account, instrument_id)`.
 
-| Column         | Type                     | Notes                                                    |
-|----------------|--------------------------|----------------------------------------------------------|
-| id             | uuid, PK                 |                                                          |
-| user_id        | uuid, FK -> users        |                                                          |
-| broker         | text                     | Broker for the holding                                   |
-| account        | text                     | Account for the holding                                  |
-| instrument_id  | uuid, FK -> instruments  | Instrument for the holding                               |
-| declared_qty   | numeric                  | The number of units the user held at `as_of_date`        |
-| as_of_date     | date                     | The date the user's declaration refers to                |
-| created_at     | timestamptz              |                                                          |
-| updated_at     | timestamptz              |                                                          |
+| Column            | Type                     | Notes                                                    |
+|-------------------|--------------------------|----------------------------------------------------------|
+| id                | uuid, PK                 |                                                          |
+| user_id           | uuid, FK -> users        |                                                          |
+| broker            | text                     | Broker for the holding                                   |
+| account           | text                     | Account for the holding                                  |
+| instrument_id     | uuid, FK -> instruments  | Instrument for the holding                               |
+| declared_qty      | numeric                  | The number of units the user held at `as_of_date`        |
+| as_of_date        | date                     | The date the user's declaration refers to                |
+| share_count_basis | date                     | Which share count `declared_qty` is in. Defaults to `as_of_date`. |
+| created_at        | timestamptz              |                                                          |
+| updated_at        | timestamptz              |                                                          |
 
 **Constraints:**
 
 - `UNIQUE (user_id, broker, account, instrument_id)` -- one declaration per holding per user.
 - `as_of_date` must be on or after the user's portfolio start date (enforced in application logic, since the portfolio start date is dynamic).
+
+### Denomination
+
+A quantity of shares means nothing without the share count it is expressed in. A
+user reading "500 shares" off a statement dated 2021-01-01 means the share count
+current then; a user reading it off today's holdings screen means today's. Both
+are ordinary, and a split between the two dates makes them differ by the split
+factor -- so the declaration states which rather than the system guessing.
+
+`share_count_basis` is that statement, and it defaults to `as_of_date`: the
+as-traded assumption, the same default `txs` and `eod_prices` carry. The default
+is applied by a trigger on the table, so every path in lands on it. It is an
+insert-time decision -- moving `as_of_date` afterwards does not restate a
+denomination the user already gave.
+
+The balance the pad is computed against is converted into the declaration's basis
+before the subtraction (`holding_qty_in_basis`), so both sides of it are in one
+share count. Summing raw quantities instead would add postings recorded either
+side of a split, giving a number in no share count at all. See
+[bitemporality.md](bitemporality.md#share-count-basis).
 
 ### transactions (existing table, amended)
 
@@ -74,15 +95,18 @@ It is excluded from holdings and from every other quantity aggregation, along wi
 
 **Procedure:**
 
-1. Store the holding declaration record (`user_id`, `broker`, `account`, `instrument_id`, `declared_qty`, `as_of_date`).
+1. Store the holding declaration record (`user_id`, `broker`, `account`, `instrument_id`, `declared_qty`, `as_of_date`, `share_count_basis`).
 2. Determine the portfolio start date: the date of the earliest real transaction for this user across all holdings.
-3. Compute the running unit balance for this holding from all real transactions (excluding any existing INITIALIZE) for the same `(broker, account, instrument_id)` that fall on or between the portfolio start date and `as_of_date` inclusive.
+3. Compute the running unit balance for this holding from all real transactions (excluding any existing INITIALIZE) for the same `(broker, account, instrument_id)` that fall on or between the portfolio start date and `as_of_date` inclusive, converting each posting from its own `share_count_basis` into the declaration's.
 4. Calculate the INITIALIZE quantity: `declared_qty - running_balance`. Both are
    exact decimals and subtraction is closed, so the pad reconciles the holding to
    the declaration exactly rather than to within a rounding of it.
 5. Create (or replace) the INITIALIZE transaction for this holding with:
    - `date` = portfolio start date, at `00:00:00` (midnight, start of day)
    - `quantity` = the value computed in step 4
+   - `share_count_basis` = the declaration's. The pad is dated where the history
+     begins but denominated where the declaration is; the two are unrelated, and
+     inferring the basis from the timestamp made the pad wrong by a split factor.
    - `broker`, `account`, `instrument_id` = copied from the declaration
    - `synthetic_purpose` = `'INITIALIZE'`
 6. Create (or replace) its `EQUITY` counterparty in the same group, identical but for `account_type` and a negated `quantity`.

--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -882,6 +882,11 @@ message HoldingDeclaration {
   Instrument instrument = 5;  // optional; populated when listing
   string declared_qty = 6;           // numeric string to preserve precision
   google.type.Date as_of_date = 7;
+  // The date at which the share count declared_qty is denominated in was current.
+  // as_of_date means the quantity was read off a record of that date; today means it
+  // was read off a current holdings view. Always populated on read.
+  // See docs/spec/bitemporality.md.
+  google.type.Date share_count_basis = 8;
 }
 
 message ListHoldingDeclarationsRequest {}
@@ -896,6 +901,8 @@ message CreateHoldingDeclarationRequest {
   string instrument_id = 3 [(buf.validate.field).string.min_len = 1];
   string declared_qty = 4 [(buf.validate.field).string.min_len = 1];    // numeric string
   google.type.Date as_of_date = 5 [(buf.validate.field).required = true];
+  // Optional; unset means as_of_date, the as-traded assumption.
+  google.type.Date share_count_basis = 6;
 }
 
 message CreateHoldingDeclarationResponse {
@@ -906,6 +913,8 @@ message UpdateHoldingDeclarationRequest {
   string id = 1 [(buf.validate.field).string.min_len = 1];
   string declared_qty = 2 [(buf.validate.field).string.min_len = 1];    // numeric string
   google.type.Date as_of_date = 3 [(buf.validate.field).required = true];
+  // Optional; unset means as_of_date, the as-traded assumption.
+  google.type.Date share_count_basis = 4;
 }
 
 message UpdateHoldingDeclarationResponse {

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -612,27 +612,45 @@ type HoldingDeclarationRow struct {
 	InstrumentID string
 	DeclaredQty  string // numeric as string to preserve precision
 	AsOfDate     time.Time
+	// ShareCountBasis is the date at which the share count DeclaredQty is
+	// denominated in was current. Defaults to AsOfDate. See docs/spec/bitemporality.md.
+	ShareCountBasis time.Time
+}
+
+// InitializeTx is the derived pad for a holding declaration: the synthetic posting
+// that makes the declared quantity true, and the EQUITY counterparty that balances
+// it. Timestamp is the portfolio start date and ShareCountBasis is the declaration's,
+// which are independent -- the pad is dated when the history begins but denominated
+// where the declaration is. TxType is the OFX type string (e.g. "BUYSTOCK", "SELLOPT").
+type InitializeTx struct {
+	TxType          string
+	Timestamp       time.Time
+	Quantity        decimal.Decimal
+	ShareCountBasis time.Time
 }
 
 // HoldingDeclarationDB provides holding declaration CRUD and INITIALIZE tx helpers.
 type HoldingDeclarationDB interface {
-	CreateHoldingDeclaration(ctx context.Context, userID, broker, account, instrumentID, declaredQty string, asOfDate time.Time) (*HoldingDeclarationRow, error)
-	UpdateHoldingDeclaration(ctx context.Context, id, declaredQty string, asOfDate time.Time) (*HoldingDeclarationRow, error)
+	CreateHoldingDeclaration(ctx context.Context, userID, broker, account, instrumentID, declaredQty string, asOfDate, shareCountBasis time.Time) (*HoldingDeclarationRow, error)
+	UpdateHoldingDeclaration(ctx context.Context, id, declaredQty string, asOfDate, shareCountBasis time.Time) (*HoldingDeclarationRow, error)
 	DeleteHoldingDeclaration(ctx context.Context, id string) error
 	GetHoldingDeclaration(ctx context.Context, id string) (*HoldingDeclarationRow, error)
 	ListHoldingDeclarations(ctx context.Context, userID string) ([]*HoldingDeclarationRow, error)
 	// GetPortfolioStartDate returns the earliest real tx timestamp for the user, or nil if none exist.
 	GetPortfolioStartDate(ctx context.Context, userID string) (*time.Time, error)
-	// ComputeRunningBalance sums quantity of real (non-synthetic) txs for the given holding where timestamp >= from and timestamp < to.
-	ComputeRunningBalance(ctx context.Context, userID, broker, account, instrumentID string, from, to time.Time) (decimal.Decimal, error)
-	// UpsertInitializeTx creates or updates the INITIALIZE synthetic tx for the given holding. txType is the OFX type string (e.g. "BUYSTOCK", "SELLOPT").
-	UpsertInitializeTx(ctx context.Context, userID, broker, account, instrumentID, txType string, timestamp time.Time, quantity decimal.Decimal) error
+	// ComputeRunningBalance sums the real (non-synthetic) txs for the given holding
+	// where timestamp >= from and timestamp < to, expressed in the share count
+	// current at basis. Quantities are converted from each posting's own
+	// share_count_basis, so the sum is in one denomination rather than a mixture.
+	ComputeRunningBalance(ctx context.Context, userID, broker, account, instrumentID string, from, to, basis time.Time) (decimal.Decimal, error)
+	// UpsertInitializeTx creates or updates the INITIALIZE synthetic tx for the given holding.
+	UpsertInitializeTx(ctx context.Context, userID, broker, account, instrumentID string, init InitializeTx) error
 	// DeleteInitializeTx deletes the INITIALIZE synthetic tx for the given holding, if it exists.
 	DeleteInitializeTx(ctx context.Context, userID, broker, account, instrumentID string) error
 	// CreateDeclarationWithInitializeTx atomically creates a declaration and upserts its INITIALIZE tx.
-	CreateDeclarationWithInitializeTx(ctx context.Context, userID, broker, account, instrumentID, declaredQty string, asOfDate time.Time, initTxType string, initTimestamp time.Time, initQty decimal.Decimal) (*HoldingDeclarationRow, error)
+	CreateDeclarationWithInitializeTx(ctx context.Context, userID, broker, account, instrumentID, declaredQty string, asOfDate, shareCountBasis time.Time, init InitializeTx) (*HoldingDeclarationRow, error)
 	// UpdateDeclarationWithInitializeTx atomically updates a declaration and upserts its INITIALIZE tx.
-	UpdateDeclarationWithInitializeTx(ctx context.Context, id, declaredQty string, asOfDate time.Time, userID, broker, account, instrumentID, initTxType string, initTimestamp time.Time, initQty decimal.Decimal) (*HoldingDeclarationRow, error)
+	UpdateDeclarationWithInitializeTx(ctx context.Context, id, declaredQty string, asOfDate, shareCountBasis time.Time, userID, broker, account, instrumentID string, init InitializeTx) (*HoldingDeclarationRow, error)
 	// DeleteDeclarationWithInitializeTx atomically deletes a declaration and its INITIALIZE tx.
 	DeleteDeclarationWithInitializeTx(ctx context.Context, id, userID, broker, account, instrumentID string) error
 }

--- a/server/db/postgres/declarations.go
+++ b/server/db/postgres/declarations.go
@@ -11,30 +11,38 @@ import (
 	"github.com/shopspring/decimal"
 )
 
+// declarationCols is the projection every declaration read shares, so a column added
+// to the table reaches all of them at once.
+const declarationCols = `id, user_id, broker, account, instrument_id, declared_qty, as_of_date, share_count_basis`
+
 type declarationRow struct {
-	ID           uuid.UUID `db:"id"`
-	UserID       uuid.UUID `db:"user_id"`
-	Broker       string    `db:"broker"`
-	Account      string    `db:"account"`
-	InstrumentID uuid.UUID `db:"instrument_id"`
-	DeclaredQty  string    `db:"declared_qty"`
-	AsOfDate     time.Time `db:"as_of_date"`
+	ID              uuid.UUID `db:"id"`
+	UserID          uuid.UUID `db:"user_id"`
+	Broker          string    `db:"broker"`
+	Account         string    `db:"account"`
+	InstrumentID    uuid.UUID `db:"instrument_id"`
+	DeclaredQty     string    `db:"declared_qty"`
+	AsOfDate        time.Time `db:"as_of_date"`
+	ShareCountBasis time.Time `db:"share_count_basis"`
 }
 
 func (r *declarationRow) toRow() *db.HoldingDeclarationRow {
 	return &db.HoldingDeclarationRow{
-		ID:           r.ID.String(),
-		UserID:       r.UserID.String(),
-		Broker:       r.Broker,
-		Account:      r.Account,
-		InstrumentID: r.InstrumentID.String(),
-		DeclaredQty:  r.DeclaredQty,
-		AsOfDate:     r.AsOfDate,
+		ID:              r.ID.String(),
+		UserID:          r.UserID.String(),
+		Broker:          r.Broker,
+		Account:         r.Account,
+		InstrumentID:    r.InstrumentID.String(),
+		DeclaredQty:     r.DeclaredQty,
+		AsOfDate:        r.AsOfDate,
+		ShareCountBasis: r.ShareCountBasis,
 	}
 }
 
-// CreateHoldingDeclaration implements db.HoldingDeclarationDB.
-func (p *Postgres) CreateHoldingDeclaration(ctx context.Context, userID, broker, account, instrumentID, declaredQty string, asOfDate time.Time) (*db.HoldingDeclarationRow, error) {
+// CreateHoldingDeclaration implements db.HoldingDeclarationDB. A zero
+// shareCountBasis leaves the column NULL so the table's trigger applies the
+// as_of_date default, keeping the rule in one place.
+func (p *Postgres) CreateHoldingDeclaration(ctx context.Context, userID, broker, account, instrumentID, declaredQty string, asOfDate, shareCountBasis time.Time) (*db.HoldingDeclarationRow, error) {
 	userUUID, err := uuid.Parse(userID)
 	if err != nil {
 		return nil, fmt.Errorf("invalid user id: %w", err)
@@ -43,31 +51,43 @@ func (p *Postgres) CreateHoldingDeclaration(ctx context.Context, userID, broker,
 	if err != nil {
 		return nil, fmt.Errorf("invalid instrument id: %w", err)
 	}
+	var basis *time.Time
+	if !shareCountBasis.IsZero() {
+		basis = &shareCountBasis
+	}
 	var row declarationRow
 	err = p.q.QueryRowxContext(ctx, `
-		INSERT INTO holding_declarations (user_id, broker, account, instrument_id, declared_qty, as_of_date)
-		VALUES ($1, $2, $3, $4, $5, $6)
-		RETURNING id, user_id, broker, account, instrument_id, declared_qty, as_of_date
-	`, userUUID, broker, account, instUUID, declaredQty, asOfDate).StructScan(&row)
+		INSERT INTO holding_declarations (user_id, broker, account, instrument_id, declared_qty, as_of_date, share_count_basis)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		RETURNING `+declarationCols,
+		userUUID, broker, account, instUUID, declaredQty, asOfDate, basis).StructScan(&row)
 	if err != nil {
 		return nil, fmt.Errorf("create holding declaration: %w", err)
 	}
 	return row.toRow(), nil
 }
 
-// UpdateHoldingDeclaration implements db.HoldingDeclarationDB.
-func (p *Postgres) UpdateHoldingDeclaration(ctx context.Context, id, declaredQty string, asOfDate time.Time) (*db.HoldingDeclarationRow, error) {
+// UpdateHoldingDeclaration implements db.HoldingDeclarationDB. The trigger that
+// defaults share_count_basis fires on insert only, so a zero shareCountBasis here
+// leaves the stored denomination alone rather than restating it from as_of_date.
+func (p *Postgres) UpdateHoldingDeclaration(ctx context.Context, id, declaredQty string, asOfDate, shareCountBasis time.Time) (*db.HoldingDeclarationRow, error) {
 	declID, err := uuid.Parse(id)
 	if err != nil {
 		return nil, fmt.Errorf("invalid declaration id: %w", err)
 	}
+	var basis *time.Time
+	if !shareCountBasis.IsZero() {
+		basis = &shareCountBasis
+	}
 	var row declarationRow
 	err = p.q.QueryRowxContext(ctx, `
 		UPDATE holding_declarations
-		SET declared_qty = $1, as_of_date = $2, updated_at = now()
-		WHERE id = $3
-		RETURNING id, user_id, broker, account, instrument_id, declared_qty, as_of_date
-	`, declaredQty, asOfDate, declID).StructScan(&row)
+		SET declared_qty = $1, as_of_date = $2,
+		    share_count_basis = COALESCE($3, share_count_basis),
+		    updated_at = now()
+		WHERE id = $4
+		RETURNING `+declarationCols,
+		declaredQty, asOfDate, basis, declID).StructScan(&row)
 	if err != nil {
 		return nil, fmt.Errorf("update holding declaration: %w", err)
 	}
@@ -99,7 +119,7 @@ func (p *Postgres) GetHoldingDeclaration(ctx context.Context, id string) (*db.Ho
 	}
 	var row declarationRow
 	err = p.q.QueryRowxContext(ctx, `
-		SELECT id, user_id, broker, account, instrument_id, declared_qty, as_of_date
+		SELECT `+declarationCols+`
 		FROM holding_declarations WHERE id = $1
 	`, declID).StructScan(&row)
 	if err != nil {
@@ -116,7 +136,7 @@ func (p *Postgres) ListHoldingDeclarations(ctx context.Context, userID string) (
 	}
 	var rows []declarationRow
 	err = p.q.SelectContext(ctx, &rows, `
-		SELECT id, user_id, broker, account, instrument_id, declared_qty, as_of_date
+		SELECT `+declarationCols+`
 		FROM holding_declarations WHERE user_id = $1
 		ORDER BY broker, account, as_of_date
 	`, userUUID)
@@ -150,8 +170,14 @@ func (p *Postgres) GetPortfolioStartDate(ctx context.Context, userID string) (*t
 	return &t.Time, nil
 }
 
-// ComputeRunningBalance implements db.HoldingDeclarationDB.
-func (p *Postgres) ComputeRunningBalance(ctx context.Context, userID, broker, account, instrumentID string, from, to time.Time) (decimal.Decimal, error) {
+// ComputeRunningBalance implements db.HoldingDeclarationDB. Summing the raw
+// quantities would mix share counts: a posting recorded before a split and one
+// recorded after are in different units, and adding them scales the total by some
+// part of the split factor. holding_qty_in_basis converts each posting into the
+// declaration's basis first, so the pad reconciles a holding to a declaration
+// denominated the same way. Synthetics are excluded -- a pad must not feed back
+// into its own recomputation.
+func (p *Postgres) ComputeRunningBalance(ctx context.Context, userID, broker, account, instrumentID string, from, to, basis time.Time) (decimal.Decimal, error) {
 	userUUID, err := uuid.Parse(userID)
 	if err != nil {
 		return decimal.Decimal{}, fmt.Errorf("invalid user id: %w", err)
@@ -162,12 +188,8 @@ func (p *Postgres) ComputeRunningBalance(ctx context.Context, userID, broker, ac
 	}
 	var balance decimal.NullDecimal
 	err = p.q.QueryRowContext(ctx, `
-		SELECT COALESCE(SUM(quantity), 0) FROM txs
-		WHERE user_id = $1 AND broker = $2 AND account = $3 AND instrument_id = $4
-		  AND timestamp >= $5 AND timestamp < $6
-		  AND synthetic_purpose IS NULL
-		  AND account_type = 'USER'
-	`, userUUID, broker, account, instUUID, from, to).Scan(&balance)
+		SELECT qty FROM holding_qty_in_basis($1, $2, $3, $4, $5, $6, $7, false)
+	`, userUUID, broker, account, instUUID, from, to, basis).Scan(&balance)
 	if err != nil {
 		return decimal.Decimal{}, fmt.Errorf("compute running balance: %w", err)
 	}
@@ -175,7 +197,7 @@ func (p *Postgres) ComputeRunningBalance(ctx context.Context, userID, broker, ac
 }
 
 // UpsertInitializeTx implements db.HoldingDeclarationDB.
-func (p *Postgres) UpsertInitializeTx(ctx context.Context, userID, broker, account, instrumentID, txType string, timestamp time.Time, quantity decimal.Decimal) error {
+func (p *Postgres) UpsertInitializeTx(ctx context.Context, userID, broker, account, instrumentID string, init db.InitializeTx) error {
 	userUUID, err := uuid.Parse(userID)
 	if err != nil {
 		return fmt.Errorf("invalid user id: %w", err)
@@ -206,7 +228,7 @@ func (p *Postgres) UpsertInitializeTx(ctx context.Context, userID, broker, accou
 		case err == sql.ErrNoRows:
 			if err := exec.QueryRowContext(ctx, `
 				INSERT INTO tx_groups (user_id, timestamp) VALUES ($1, $2) RETURNING id
-			`, userUUID, timestamp).Scan(&groupID); err != nil {
+			`, userUUID, init.Timestamp).Scan(&groupID); err != nil {
 				return fmt.Errorf("insert initialize tx group: %w", err)
 			}
 		case err != nil:
@@ -221,8 +243,8 @@ func (p *Postgres) UpsertInitializeTx(ctx context.Context, userID, broker, accou
 			accountType string
 			quantity    decimal.Decimal
 		}{
-			{"USER", quantity},
-			{"EQUITY", quantity.Neg()},
+			{"USER", init.Quantity},
+			{"EQUITY", init.Quantity.Neg()},
 		} {
 			// A pad has no price, so each leg weighs its own quantity in its own
 			// commodity and the two cancel. The commodity is named the way
@@ -231,15 +253,22 @@ func (p *Postgres) UpsertInitializeTx(ctx context.Context, userID, broker, accou
 			// weight is in the DO UPDATE list for the same reason quantity is:
 			// otherwise a recalculation moves the quantity and leaves the weight
 			// behind, and the group stops balancing.
+			//
+			// share_count_basis is written rather than left to the txs trigger, which
+			// would seed it from the timestamp. The pad is dated at the portfolio
+			// start date but denominated where its declaration is, and the two have no
+			// reason to agree; letting the trigger decide also left the basis behind
+			// whenever a recalculation moved the timestamp. It is in the DO UPDATE
+			// list so both legs keep the same denomination as the declaration moves.
 			if _, err := exec.ExecContext(ctx, `
 				INSERT INTO txs (user_id, broker, account, timestamp, instrument_description,
 				                 tx_type, quantity, instrument_id, synthetic_purpose,
-				                 account_type, weight, weight_commodity, group_id)
+				                 account_type, weight, weight_commodity, share_count_basis, group_id)
 				SELECT $1, $2, $3, $4, 'INITIALIZE', $7, $5, $6, 'INITIALIZE', $8, $5,
 				       CASE WHEN i.asset_class = 'CASH' AND i.currency IS NOT NULL
 				            THEN 'cur:' || upper(i.currency)
 				            ELSE 'inst:' || i.id::text END,
-				       $9
+				       $9, $10
 				FROM instruments i WHERE i.id = $6
 				ON CONFLICT (user_id, broker, account, instrument_id, account_type)
 				  WHERE synthetic_purpose = 'INITIALIZE'
@@ -247,14 +276,15 @@ func (p *Postgres) UpsertInitializeTx(ctx context.Context, userID, broker, accou
 				              quantity = EXCLUDED.quantity,
 				              tx_type = EXCLUDED.tx_type,
 				              weight = EXCLUDED.weight,
-				              weight_commodity = EXCLUDED.weight_commodity
-			`, userUUID, broker, account, timestamp, leg.quantity, instUUID, txType, leg.accountType, groupID); err != nil {
+				              weight_commodity = EXCLUDED.weight_commodity,
+				              share_count_basis = EXCLUDED.share_count_basis
+			`, userUUID, broker, account, init.Timestamp, leg.quantity, instUUID, init.TxType, leg.accountType, init.ShareCountBasis, groupID); err != nil {
 				return fmt.Errorf("upsert initialize %s posting: %w", leg.accountType, err)
 			}
 		}
 		if _, err := exec.ExecContext(ctx, `
 			UPDATE tx_groups SET timestamp = $2 WHERE id = $1
-		`, groupID, timestamp); err != nil {
+		`, groupID, init.Timestamp); err != nil {
 			return fmt.Errorf("update initialize tx group: %w", err)
 		}
 		return nil
@@ -292,31 +322,31 @@ func (p *Postgres) DeleteInitializeTx(ctx context.Context, userID, broker, accou
 }
 
 // CreateDeclarationWithInitializeTx implements db.HoldingDeclarationDB.
-func (p *Postgres) CreateDeclarationWithInitializeTx(ctx context.Context, userID, broker, account, instrumentID, declaredQty string, asOfDate time.Time, initTxType string, initTimestamp time.Time, initQty decimal.Decimal) (*db.HoldingDeclarationRow, error) {
+func (p *Postgres) CreateDeclarationWithInitializeTx(ctx context.Context, userID, broker, account, instrumentID, declaredQty string, asOfDate, shareCountBasis time.Time, init db.InitializeTx) (*db.HoldingDeclarationRow, error) {
 	var row *db.HoldingDeclarationRow
 	err := p.runInTx(ctx, func(tx queryable) error {
 		txp := &Postgres{q: tx}
-		r, err := txp.CreateHoldingDeclaration(ctx, userID, broker, account, instrumentID, declaredQty, asOfDate)
+		r, err := txp.CreateHoldingDeclaration(ctx, userID, broker, account, instrumentID, declaredQty, asOfDate, shareCountBasis)
 		if err != nil {
 			return err
 		}
 		row = r
-		return txp.UpsertInitializeTx(ctx, userID, broker, account, instrumentID, initTxType, initTimestamp, initQty)
+		return txp.UpsertInitializeTx(ctx, userID, broker, account, instrumentID, init)
 	})
 	return row, err
 }
 
 // UpdateDeclarationWithInitializeTx implements db.HoldingDeclarationDB.
-func (p *Postgres) UpdateDeclarationWithInitializeTx(ctx context.Context, id, declaredQty string, asOfDate time.Time, userID, broker, account, instrumentID, initTxType string, initTimestamp time.Time, initQty decimal.Decimal) (*db.HoldingDeclarationRow, error) {
+func (p *Postgres) UpdateDeclarationWithInitializeTx(ctx context.Context, id, declaredQty string, asOfDate, shareCountBasis time.Time, userID, broker, account, instrumentID string, init db.InitializeTx) (*db.HoldingDeclarationRow, error) {
 	var row *db.HoldingDeclarationRow
 	err := p.runInTx(ctx, func(tx queryable) error {
 		txp := &Postgres{q: tx}
-		r, err := txp.UpdateHoldingDeclaration(ctx, id, declaredQty, asOfDate)
+		r, err := txp.UpdateHoldingDeclaration(ctx, id, declaredQty, asOfDate, shareCountBasis)
 		if err != nil {
 			return err
 		}
 		row = r
-		return txp.UpsertInitializeTx(ctx, userID, broker, account, instrumentID, initTxType, initTimestamp, initQty)
+		return txp.UpsertInitializeTx(ctx, userID, broker, account, instrumentID, init)
 	})
 	return row, err
 }

--- a/server/db/postgres/declarations_test.go
+++ b/server/db/postgres/declarations_test.go
@@ -12,6 +12,25 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+// initTx builds a pad denominated in the share count current on its own date, which
+// is what the tests that are not about denomination want.
+func initTx(at time.Time, qty float64) db.InitializeTx {
+	return db.InitializeTx{TxType: "BUYSTOCK", Timestamp: at, Quantity: decf(qty), ShareCountBasis: at}
+}
+
+// addSplit records a stock split. Splits are written by the corporate event path in
+// production; these tests need one to exist, not to arrive.
+func addSplit(t *testing.T, p *Postgres, instID string, exDate time.Time, from, to int) {
+	t.Helper()
+	_, err := p.q.ExecContext(context.Background(), `
+		INSERT INTO stock_splits (instrument_id, ex_date, split_from, split_to, data_provider)
+		VALUES ($1, $2, $3, $4, 'test')
+	`, instID, exDate, from, to)
+	if err != nil {
+		t.Fatalf("insert split: %v", err)
+	}
+}
+
 func TestCreateHoldingDeclaration(t *testing.T) {
 	p := testDBTx(t)
 	ctx := context.Background()
@@ -19,7 +38,7 @@ func TestCreateHoldingDeclaration(t *testing.T) {
 	instID, _ := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "AAPL", Canonical: false}}, "", nil, nil, nil)
 
 	asOf := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
-	row, err := p.CreateHoldingDeclaration(ctx, userID, "IBKR", "acct1", instID, "150.5", asOf)
+	row, err := p.CreateHoldingDeclaration(ctx, userID, "IBKR", "acct1", instID, "150.5", asOf, time.Time{})
 	if err != nil {
 		t.Fatalf("create: %v", err)
 	}
@@ -38,11 +57,11 @@ func TestCreateHoldingDeclaration_DuplicateRejected(t *testing.T) {
 	instID, _ := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "GOOG", Canonical: false}}, "", nil, nil, nil)
 
 	asOf := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
-	_, err := p.CreateHoldingDeclaration(ctx, userID, "IBKR", "acct1", instID, "100", asOf)
+	_, err := p.CreateHoldingDeclaration(ctx, userID, "IBKR", "acct1", instID, "100", asOf, time.Time{})
 	if err != nil {
 		t.Fatalf("first create: %v", err)
 	}
-	_, err = p.CreateHoldingDeclaration(ctx, userID, "IBKR", "acct1", instID, "200", asOf)
+	_, err = p.CreateHoldingDeclaration(ctx, userID, "IBKR", "acct1", instID, "200", asOf, time.Time{})
 	if err == nil {
 		t.Fatal("expected duplicate error")
 	}
@@ -55,10 +74,10 @@ func TestUpdateHoldingDeclaration(t *testing.T) {
 	instID, _ := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "MSFT", Canonical: false}}, "", nil, nil, nil)
 
 	asOf := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
-	row, _ := p.CreateHoldingDeclaration(ctx, userID, "IBKR", "acct1", instID, "100", asOf)
+	row, _ := p.CreateHoldingDeclaration(ctx, userID, "IBKR", "acct1", instID, "100", asOf, time.Time{})
 
 	newDate := time.Date(2025, 7, 1, 0, 0, 0, 0, time.UTC)
-	updated, err := p.UpdateHoldingDeclaration(ctx, row.ID, "200", newDate)
+	updated, err := p.UpdateHoldingDeclaration(ctx, row.ID, "200", newDate, time.Time{})
 	if err != nil {
 		t.Fatalf("update: %v", err)
 	}
@@ -77,7 +96,7 @@ func TestDeleteHoldingDeclaration(t *testing.T) {
 	instID, _ := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "TSLA", Canonical: false}}, "", nil, nil, nil)
 
 	asOf := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
-	row, _ := p.CreateHoldingDeclaration(ctx, userID, "IBKR", "acct1", instID, "50", asOf)
+	row, _ := p.CreateHoldingDeclaration(ctx, userID, "IBKR", "acct1", instID, "50", asOf, time.Time{})
 
 	if err := p.DeleteHoldingDeclaration(ctx, row.ID); err != nil {
 		t.Fatalf("delete: %v", err)
@@ -106,10 +125,10 @@ func TestListHoldingDeclarations(t *testing.T) {
 	inst2, _ := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "A2", Canonical: false}}, "", nil, nil, nil)
 
 	asOf := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
-	if _, err := p.CreateHoldingDeclaration(ctx, userID, "IBKR", "acct1", inst1, "100", asOf); err != nil {
+	if _, err := p.CreateHoldingDeclaration(ctx, userID, "IBKR", "acct1", inst1, "100", asOf, time.Time{}); err != nil {
 		t.Fatalf("create decl 1: %v", err)
 	}
-	if _, err := p.CreateHoldingDeclaration(ctx, userID, "IBKR", "acct1", inst2, "200", asOf); err != nil {
+	if _, err := p.CreateHoldingDeclaration(ctx, userID, "IBKR", "acct1", inst2, "200", asOf, time.Time{}); err != nil {
 		t.Fatalf("create decl 2: %v", err)
 	}
 
@@ -173,7 +192,7 @@ func TestComputeRunningBalance(t *testing.T) {
 
 	from := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2025, 12, 31, 23, 59, 59, 0, time.UTC)
-	bal, err := p.ComputeRunningBalance(ctx, userID, "IBKR", "acct1", instID, from, to)
+	bal, err := p.ComputeRunningBalance(ctx, userID, "IBKR", "acct1", instID, from, to, from)
 	if err != nil {
 		t.Fatalf("compute: %v", err)
 	}
@@ -189,7 +208,7 @@ func TestUpsertAndDeleteInitializeTx(t *testing.T) {
 	instID, _ := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "UI1", Canonical: false}}, "", nil, nil, nil)
 
 	ts := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
-	err := p.UpsertInitializeTx(ctx, userID, "IBKR", "acct1", instID, "BUYSTOCK", ts, decf(50))
+	err := p.UpsertInitializeTx(ctx, userID, "IBKR", "acct1", instID, initTx(ts, 50))
 	if err != nil {
 		t.Fatalf("upsert: %v", err)
 	}
@@ -206,7 +225,7 @@ func TestUpsertAndDeleteInitializeTx(t *testing.T) {
 	// Upsert again with different qty (should update, not duplicate). Both legs
 	// move together: a recalculation that shifted only the pad would leave the
 	// group unbalanced.
-	err = p.UpsertInitializeTx(ctx, userID, "IBKR", "acct1", instID, "BUYSTOCK", ts, decf(75))
+	err = p.UpsertInitializeTx(ctx, userID, "IBKR", "acct1", instID, initTx(ts, 75))
 	if err != nil {
 		t.Fatalf("upsert update: %v", err)
 	}
@@ -261,7 +280,7 @@ func TestUpsertInitializeTx_GroupsThePosting(t *testing.T) {
 	instID, _ := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "IG1", Canonical: false}}, "", nil, nil, nil)
 
 	at := time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)
-	if err := p.UpsertInitializeTx(ctx, userID, "IBKR", "acct1", instID, "BUYSTOCK", at, decf(50)); err != nil {
+	if err := p.UpsertInitializeTx(ctx, userID, "IBKR", "acct1", instID, initTx(at, 50)); err != nil {
 		t.Fatalf("upsert: %v", err)
 	}
 
@@ -286,7 +305,7 @@ func TestUpsertInitializeTx_GroupsThePosting(t *testing.T) {
 	// Recalculating a declaration must move the existing group rather than
 	// replacing it, or every recalc would orphan one.
 	moved := at.Add(48 * time.Hour)
-	if err := p.UpsertInitializeTx(ctx, userID, "IBKR", "acct1", instID, "BUYSTOCK", moved, decf(75)); err != nil {
+	if err := p.UpsertInitializeTx(ctx, userID, "IBKR", "acct1", instID, initTx(moved, 75)); err != nil {
 		t.Fatalf("re-upsert: %v", err)
 	}
 	var groupID2 string
@@ -328,7 +347,7 @@ func TestUpsertInitializeTx_WritesTheEquityCounterparty(t *testing.T) {
 	instID, _ := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "EQ1", Canonical: false}}, "", nil, nil, nil)
 
 	at := time.Date(2025, 2, 1, 0, 0, 0, 0, time.UTC)
-	if err := p.UpsertInitializeTx(ctx, userID, "IBKR", "acct1", instID, "BUYSTOCK", at, decf(50)); err != nil {
+	if err := p.UpsertInitializeTx(ctx, userID, "IBKR", "acct1", instID, initTx(at, 50)); err != nil {
 		t.Fatalf("upsert: %v", err)
 	}
 
@@ -385,11 +404,142 @@ func TestComputeRunningBalance_excludesNonUser(t *testing.T) {
 
 	from := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2025, 12, 31, 23, 59, 59, 0, time.UTC)
-	bal, err := p.ComputeRunningBalance(ctx, userID, "IBKR", "acct1", instID, from, to)
+	bal, err := p.ComputeRunningBalance(ctx, userID, "IBKR", "acct1", instID, from, to, from)
 	if err != nil {
 		t.Fatalf("compute: %v", err)
 	}
 	if bal.String() != "100" {
 		t.Fatalf("running balance = %v, want 100: the EQUITY leg must not be summed", bal)
 	}
+}
+
+// TestCreateHoldingDeclaration_DefaultsShareCountBasis pins the as-traded default:
+// a declaration that says nothing about denomination is in the share count current
+// on the date it refers to.
+func TestCreateHoldingDeclaration_DefaultsShareCountBasis(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|decl-basis-default", "U", "u@b.com")
+	instID, _ := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "BD1", Canonical: false}}, "", nil, nil, nil)
+
+	asOf := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	row, err := p.CreateHoldingDeclaration(ctx, userID, "IBKR", "acct1", instID, "500", asOf, time.Time{})
+	if err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if !row.ShareCountBasis.Equal(asOf) {
+		t.Fatalf("share_count_basis: want %v (as_of_date), got %v", asOf, row.ShareCountBasis)
+	}
+
+	// A stated basis survives, and moving as_of_date afterwards does not restate it:
+	// the denomination is what the user said, not a function of the date.
+	stated := time.Date(2025, 8, 5, 0, 0, 0, 0, time.UTC)
+	row, err = p.CreateHoldingDeclaration(ctx, userID, "IBKR", "acct2", instID, "500", asOf, stated)
+	if err != nil {
+		t.Fatalf("create with basis: %v", err)
+	}
+	if !row.ShareCountBasis.Equal(stated) {
+		t.Fatalf("stated share_count_basis: want %v, got %v", stated, row.ShareCountBasis)
+	}
+	moved := time.Date(2022, 1, 1, 0, 0, 0, 0, time.UTC)
+	row, err = p.UpdateHoldingDeclaration(ctx, row.ID, "500", moved, time.Time{})
+	if err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if !row.ShareCountBasis.Equal(stated) {
+		t.Fatalf("share_count_basis after moving as_of_date: want %v, got %v", stated, row.ShareCountBasis)
+	}
+}
+
+// TestComputeRunningBalance_ConvertsToDeclarationBasis is the reason the balance is
+// not a plain SUM(quantity). The two postings below are recorded either side of a
+// 2:1 split and are in different units, so adding them raw gives 150 -- a number in
+// no share count at all. Converted, the same history is 100 pre-split shares or 200
+// post-split ones, and which of those a declaration is compared against is the
+// declaration's to state.
+func TestComputeRunningBalance_ConvertsToDeclarationBasis(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|decl-basis-conv", "U", "u@b.com")
+	instID, _ := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "BC1", Canonical: false}}, "", nil, nil, nil)
+
+	preSplit := time.Date(2021, 3, 1, 10, 0, 0, 0, time.UTC)
+	exDate := time.Date(2022, 6, 1, 0, 0, 0, 0, time.UTC)
+	postSplit := time.Date(2023, 3, 1, 10, 0, 0, 0, time.UTC)
+	addSplit(t, p, instID, exDate, 1, 2)
+
+	// 50 shares bought before the split, and 50 more after -- 100 post-split shares
+	// for the first buy, plus 50, is 150 in post-split terms and 75 in pre-split.
+	if err := createTx(ctx, p, userID, "IBKR", "acct1", "", &apiv1.Tx{Timestamp: timestamppb.New(preSplit), InstrumentDescription: "BC1", Type: apiv1.TxType_BUYSTOCK, Quantity: "50", Account: "acct1"}, instID, nil); err != nil {
+		t.Fatalf("create pre-split buy: %v", err)
+	}
+	if err := createTx(ctx, p, userID, "IBKR", "acct1", "", &apiv1.Tx{Timestamp: timestamppb.New(postSplit), InstrumentDescription: "BC1", Type: apiv1.TxType_BUYSTOCK, Quantity: "50", Account: "acct1"}, instID, nil); err != nil {
+		t.Fatalf("create post-split buy: %v", err)
+	}
+
+	from := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	to := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	for _, tc := range []struct {
+		name  string
+		basis time.Time
+		want  string
+	}{
+		{"pre-split basis", preSplit, "75"},
+		{"post-split basis", postSplit, "150"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bal, err := p.ComputeRunningBalance(ctx, userID, "IBKR", "acct1", instID, from, to, tc.basis)
+			if err != nil {
+				t.Fatalf("compute: %v", err)
+			}
+			if bal.String() != tc.want {
+				t.Fatalf("running balance = %v, want %s", bal, tc.want)
+			}
+		})
+	}
+}
+
+// TestUpsertInitializeTx_DenominatesThePad verifies the pad is stored in its
+// declaration's share count rather than in the one current on the portfolio start
+// date. The two are unrelated, and letting the txs trigger infer the basis from the
+// timestamp made a pad declared in today's terms read as pre-split shares.
+func TestUpsertInitializeTx_DenominatesThePad(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|init-basis", "U", "u@b.com")
+	instID, _ := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "IB1", Canonical: false}}, "", nil, nil, nil)
+
+	startDay := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	basis := time.Date(2025, 8, 5, 0, 0, 0, 0, time.UTC)
+	if err := p.UpsertInitializeTx(ctx, userID, "IBKR", "acct1", instID, db.InitializeTx{
+		TxType: "BUYSTOCK", Timestamp: startDay, Quantity: decf(50), ShareCountBasis: basis,
+	}); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	assertPadBasis := func(want time.Time) {
+		t.Helper()
+		var legs int
+		if err := p.q.QueryRowContext(ctx, `
+			SELECT count(*) FROM txs
+			WHERE user_id = $1 AND synthetic_purpose = 'INITIALIZE'
+			  AND share_count_basis = $2
+		`, userID, want).Scan(&legs); err != nil {
+			t.Fatalf("read basis: %v", err)
+		}
+		if legs != 2 {
+			t.Fatalf("postings denominated at %v: want both legs, got %d", want, legs)
+		}
+	}
+	assertPadBasis(basis)
+
+	// Moving the portfolio start date moves the pad's timestamp. Its denomination is
+	// the declaration's and must not follow.
+	moved := startDay.AddDate(0, 0, -30)
+	if err := p.UpsertInitializeTx(ctx, userID, "IBKR", "acct1", instID, db.InitializeTx{
+		TxType: "BUYSTOCK", Timestamp: moved, Quantity: decf(75), ShareCountBasis: basis,
+	}); err != nil {
+		t.Fatalf("re-upsert: %v", err)
+	}
+	assertPadBasis(basis)
 }

--- a/server/db/postgres/txs_test.go
+++ b/server/db/postgres/txs_test.go
@@ -114,7 +114,9 @@ func TestReplaceTxsInPeriod_PreservesSyntheticInitializeTx(t *testing.T) {
 	}
 
 	// Seed an INITIALIZE synthetic tx and an unrelated real tx, both inside the period.
-	if err := p.UpsertInitializeTx(ctx, userID, "IBKR", "", instID, "BUYOTHER", initTs, decf(42)); err != nil {
+	if err := p.UpsertInitializeTx(ctx, userID, "IBKR", "", instID, db.InitializeTx{
+		TxType: "BUYOTHER", Timestamp: initTs, Quantity: decf(42), ShareCountBasis: initTs,
+	}); err != nil {
 		t.Fatalf("upsert initialize: %v", err)
 	}
 	oldTx := []*apiv1.Tx{

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -810,20 +810,99 @@ CREATE OR REPLACE FUNCTION split_factor_at(
     AND s.ex_date <= CURRENT_DATE;
 $$;
 
+-- holding_qty_in_basis returns a holding's quantity over a half-open [from, before)
+-- window, converted into a single share count basis, together with the two numbers
+-- a caller needs to bound the rounding in that conversion.
+--
+-- Postings are grouped by their own share_count_basis and summed before conversion,
+-- so the division happens once per distinct basis rather than once per posting. That
+-- is what makes the bound stateable: each group converts by an exact rational
+-- (num_b * den_d) / (den_b * num_d) -- the row's own factor to today divided by the
+-- target's -- so the whole result is exact unless a group's factor is not 1/1, and
+-- inexact_bases counts the groups that can carry a rounding. A caller comparing
+-- against a declared quantity allows inexact_bases units in the last place of the
+-- split-adjusted rounding scale, and nothing when the count is zero.
+--
+-- Only USER postings are read. The EQUITY counterparty of a pad shares its broker
+-- account and instrument, so including it would net a declared opening balance back
+-- to zero. p_include_synthetic is false when computing a pad, which must not feed
+-- back into its own recomputation, and true when checking a declaration against the
+-- holding as the user sees it. Either bound may be NULL for an open one.
+-- See docs/spec/bitemporality.md and docs/adr/0028-cumulative-split-factor-is-an-exact-rational.md.
+CREATE OR REPLACE FUNCTION holding_qty_in_basis(
+  p_user_id UUID,
+  p_broker TEXT,
+  p_account TEXT,
+  p_instrument_id UUID,
+  p_from TIMESTAMPTZ,
+  p_before TIMESTAMPTZ,
+  p_basis DATE,
+  p_include_synthetic BOOLEAN,
+  OUT qty NUMERIC,
+  OUT posting_count INT,
+  OUT inexact_bases INT
+) LANGUAGE sql STABLE AS $$
+  WITH per_basis AS (
+    SELECT t.share_count_basis AS basis, SUM(t.quantity) AS q, COUNT(*)::int AS n
+    FROM txs t
+    WHERE t.user_id = p_user_id
+      AND t.broker = p_broker
+      AND t.account = p_account
+      AND t.instrument_id = p_instrument_id
+      AND t.account_type = 'USER'
+      AND (p_include_synthetic OR t.synthetic_purpose IS NULL)
+      AND (p_from IS NULL OR t.timestamp >= p_from)
+      AND (p_before IS NULL OR t.timestamp < p_before)
+    GROUP BY t.share_count_basis
+  )
+  SELECT COALESCE(SUM(p.q * fb.num * fd.den / (fb.den * fd.num)), 0),
+         COALESCE(SUM(p.n), 0)::int,
+         COUNT(*) FILTER (WHERE fb.num * fd.den <> fb.den * fd.num)::int
+  FROM per_basis p,
+       LATERAL split_factor_at(p_instrument_id, p.basis) fb,
+       LATERAL split_factor_at(p_instrument_id, p_basis) fd;
+$$;
+
 -- Holding declarations: user-provided statement of known holding quantity at a date.
 -- Holdings are computed aggregates identified by (broker, account, instrument_id).
+--
+-- share_count_basis is the date at which the share count declared_qty is denominated
+-- in was current. It defaults to as_of_date: a user reading a quantity off a
+-- statement of that date means the share count current then. A user reading today's
+-- holdings screen means today's, and says so. Without the declaration stating which,
+-- it and the postings it is reconciled against can be in different units, and a
+-- correct portfolio disagrees with itself by the split factor.
+-- See docs/spec/bitemporality.md.
 CREATE TABLE holding_declarations (
-  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-  user_id         UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
-  broker          TEXT NOT NULL,
-  account         TEXT NOT NULL,
-  instrument_id   UUID NOT NULL REFERENCES instruments(id),
-  declared_qty    NUMERIC NOT NULL,
-  as_of_date      DATE NOT NULL,
-  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
-  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id           UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  broker            TEXT NOT NULL,
+  account           TEXT NOT NULL,
+  instrument_id     UUID NOT NULL REFERENCES instruments(id),
+  declared_qty      NUMERIC NOT NULL,
+  as_of_date        DATE NOT NULL,
+  share_count_basis DATE NOT NULL,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
   UNIQUE (user_id, broker, account, instrument_id)
 );
+
+-- The default lives here rather than in the application so that every path into the
+-- table -- the API, an integration test, a psql session -- lands on the same
+-- denomination. It is an insert-time decision: once a declaration states its basis,
+-- moving as_of_date does not restate it.
+CREATE OR REPLACE FUNCTION default_declaration_share_count_basis() RETURNS TRIGGER AS $$
+BEGIN
+  IF NEW.share_count_basis IS NULL THEN
+    NEW.share_count_basis := NEW.as_of_date;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_default_declaration_share_count_basis
+  BEFORE INSERT ON holding_declarations
+  FOR EACH ROW EXECUTE FUNCTION default_declaration_share_count_basis();
 
 -- Ignored asset classes: skip tx types mapping to these asset classes during ingestion.
 -- account = '' means all accounts for the broker; otherwise a specific broker+account pair.

--- a/server/service/api/declarations.go
+++ b/server/service/api/declarations.go
@@ -8,7 +8,9 @@ import (
 
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
 	"github.com/leedenison/portfoliodb/server/auth"
+	"github.com/leedenison/portfoliodb/server/db"
 	"github.com/shopspring/decimal"
+	"google.golang.org/genproto/googleapis/type/date"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -39,19 +41,37 @@ func (s *Server) ListHoldingDeclarations(ctx context.Context, req *apiv1.ListHol
 	}
 	decls := make([]*apiv1.HoldingDeclaration, len(rows))
 	for i, r := range rows {
-		decls[i] = &apiv1.HoldingDeclaration{
-			Id:           r.ID,
-			Broker:       r.Broker,
-			Account:      r.Account,
-			InstrumentId: r.InstrumentID,
-			DeclaredQty:  r.DeclaredQty,
-			AsOfDate:     timeToDate(r.AsOfDate),
-		}
+		decls[i] = declarationToProto(r)
 		if inst := instByID[r.InstrumentID]; inst != nil {
 			decls[i].Instrument = inst
 		}
 	}
 	return &apiv1.ListHoldingDeclarationsResponse{Declarations: decls}, nil
+}
+
+// declarationToProto converts a stored declaration to its wire form. The instrument
+// is left to the caller: only the list populates it.
+func declarationToProto(r *db.HoldingDeclarationRow) *apiv1.HoldingDeclaration {
+	return &apiv1.HoldingDeclaration{
+		Id:              r.ID,
+		Broker:          r.Broker,
+		Account:         r.Account,
+		InstrumentId:    r.InstrumentID,
+		DeclaredQty:     r.DeclaredQty,
+		AsOfDate:        timeToDate(r.AsOfDate),
+		ShareCountBasis: timeToDate(r.ShareCountBasis),
+	}
+}
+
+// shareCountBasis reads the declared denomination from a request, falling back to
+// as_of_date. That is the as-traded assumption -- a quantity read off a record of
+// some date is in the share count current then -- and it matches the default the
+// holding_declarations trigger applies. See docs/spec/bitemporality.md.
+func shareCountBasis(d *date.Date, asOfDate time.Time) time.Time {
+	if d == nil {
+		return asOfDate
+	}
+	return dateToTime(d)
 }
 
 // CreateHoldingDeclaration creates a declaration and computes the INITIALIZE tx.
@@ -61,6 +81,7 @@ func (s *Server) CreateHoldingDeclaration(ctx context.Context, req *apiv1.Create
 		return nil, authErr
 	}
 	asOfDate := dateToTime(req.GetAsOfDate())
+	basis := shareCountBasis(req.GetShareCountBasis(), asOfDate)
 	if _, err := strconv.ParseFloat(req.GetDeclaredQty(), 64); err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "invalid declared_qty: %v", err)
 	}
@@ -79,25 +100,17 @@ func (s *Server) CreateHoldingDeclaration(ctx context.Context, req *apiv1.Create
 		return nil, status.Errorf(codes.InvalidArgument, "as_of_date must be on or after the portfolio start date (%s)", startDay.Format("2006-01-02"))
 	}
 
-	init, err := s.computeInitializeValues(ctx, u.ID, req.GetBroker(), req.GetAccount(), req.GetInstrumentId(), req.GetDeclaredQty(), asOfDate, *startDate)
+	init, err := s.computeInitializeValues(ctx, u.ID, req.GetBroker(), req.GetAccount(), req.GetInstrumentId(), req.GetDeclaredQty(), asOfDate, basis, *startDate)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "compute INITIALIZE tx: %v", err)
 	}
 
-	row, err := s.db.CreateDeclarationWithInitializeTx(ctx, u.ID, req.GetBroker(), req.GetAccount(), req.GetInstrumentId(), req.GetDeclaredQty(), asOfDate, init.txType, init.timestamp, init.quantity)
+	row, err := s.db.CreateDeclarationWithInitializeTx(ctx, u.ID, req.GetBroker(), req.GetAccount(), req.GetInstrumentId(), req.GetDeclaredQty(), asOfDate, basis, init)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	decl := &apiv1.HoldingDeclaration{
-		Id:           row.ID,
-		Broker:       row.Broker,
-		Account:      row.Account,
-		InstrumentId: row.InstrumentID,
-		DeclaredQty:  row.DeclaredQty,
-		AsOfDate:     timeToDate(row.AsOfDate),
-	}
-	return &apiv1.CreateHoldingDeclarationResponse{Declaration: decl}, nil
+	return &apiv1.CreateHoldingDeclarationResponse{Declaration: declarationToProto(row)}, nil
 }
 
 // UpdateHoldingDeclaration updates a declaration and recomputes the INITIALIZE tx.
@@ -132,25 +145,22 @@ func (s *Server) UpdateHoldingDeclaration(ctx context.Context, req *apiv1.Update
 		return nil, status.Errorf(codes.InvalidArgument, "as_of_date must be on or after the portfolio start date (%s)", startDay.Format("2006-01-02"))
 	}
 
-	init, err := s.computeInitializeValues(ctx, u.ID, existing.Broker, existing.Account, existing.InstrumentID, req.GetDeclaredQty(), asOfDate, *startDate)
+	// An update that says nothing about denomination keeps the one the declaration
+	// already has, rather than re-deriving it from a moved as_of_date: restating the
+	// units of a quantity the user did not touch would silently change what they said.
+	basis := shareCountBasis(req.GetShareCountBasis(), existing.ShareCountBasis)
+
+	init, err := s.computeInitializeValues(ctx, u.ID, existing.Broker, existing.Account, existing.InstrumentID, req.GetDeclaredQty(), asOfDate, basis, *startDate)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "compute INITIALIZE tx: %v", err)
 	}
 
-	row, err := s.db.UpdateDeclarationWithInitializeTx(ctx, req.GetId(), req.GetDeclaredQty(), asOfDate, u.ID, existing.Broker, existing.Account, existing.InstrumentID, init.txType, init.timestamp, init.quantity)
+	row, err := s.db.UpdateDeclarationWithInitializeTx(ctx, req.GetId(), req.GetDeclaredQty(), asOfDate, basis, u.ID, existing.Broker, existing.Account, existing.InstrumentID, init)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 
-	decl := &apiv1.HoldingDeclaration{
-		Id:           row.ID,
-		Broker:       row.Broker,
-		Account:      row.Account,
-		InstrumentId: row.InstrumentID,
-		DeclaredQty:  row.DeclaredQty,
-		AsOfDate:     timeToDate(row.AsOfDate),
-	}
-	return &apiv1.UpdateHoldingDeclarationResponse{Declaration: decl}, nil
+	return &apiv1.UpdateHoldingDeclarationResponse{Declaration: declarationToProto(row)}, nil
 }
 
 // DeleteHoldingDeclaration deletes a declaration and its INITIALIZE tx.
@@ -175,28 +185,23 @@ func (s *Server) DeleteHoldingDeclaration(ctx context.Context, req *apiv1.Delete
 	return &apiv1.DeleteHoldingDeclarationResponse{}, nil
 }
 
-// initializeValues holds the computed values for an INITIALIZE tx.
-type initializeValues struct {
-	timestamp time.Time
-	quantity  decimal.Decimal
-	txType    string
-}
-
-// computeInitializeValues computes the INITIALIZE tx timestamp, quantity, and tx type.
-func (s *Server) computeInitializeValues(ctx context.Context, userID, broker, account, instrumentID, declaredQtyStr string, asOfDate time.Time, startDate time.Time) (*initializeValues, error) {
+// computeInitializeValues computes the pad that makes declaredQty true at asOfDate.
+// basis is the declaration's denomination: the running balance is converted into it
+// and the pad is written in it, so the subtraction has both sides in one share count.
+func (s *Server) computeInitializeValues(ctx context.Context, userID, broker, account, instrumentID, declaredQtyStr string, asOfDate, basis time.Time, startDate time.Time) (db.InitializeTx, error) {
 	// declared_qty is a decimal string on the wire and a NUMERIC column, so it
 	// never has to become a float. The subtraction below is exact, which is what
 	// makes the resulting pad reconcile to the declaration rather than to within
 	// a rounding of it.
 	declaredQty, err := decimal.NewFromString(declaredQtyStr)
 	if err != nil {
-		return nil, fmt.Errorf("parse declared_qty: %w", err)
+		return db.InitializeTx{}, fmt.Errorf("parse declared_qty: %w", err)
 	}
 	startDay := startDate.Truncate(24 * time.Hour)
 	dayAfterAsOf := asOfDate.AddDate(0, 0, 1)
-	runningBalance, err := s.db.ComputeRunningBalance(ctx, userID, broker, account, instrumentID, startDay, dayAfterAsOf)
+	runningBalance, err := s.db.ComputeRunningBalance(ctx, userID, broker, account, instrumentID, startDay, dayAfterAsOf, basis)
 	if err != nil {
-		return nil, fmt.Errorf("compute running balance: %w", err)
+		return db.InitializeTx{}, fmt.Errorf("compute running balance: %w", err)
 	}
 	initQty := declaredQty.Sub(runningBalance)
 	var assetClass string
@@ -204,6 +209,10 @@ func (s *Server) computeInitializeValues(ctx context.Context, userID, broker, ac
 	if err == nil && inst != nil && inst.AssetClass != nil {
 		assetClass = *inst.AssetClass
 	}
-	txType := txTypeForAssetClass(assetClass, initQty)
-	return &initializeValues{timestamp: startDay, quantity: initQty, txType: txType}, nil
+	return db.InitializeTx{
+		TxType:          txTypeForAssetClass(assetClass, initQty),
+		Timestamp:       startDay,
+		Quantity:        initQty,
+		ShareCountBasis: basis,
+	}, nil
 }

--- a/server/service/api/declarations_test.go
+++ b/server/service/api/declarations_test.go
@@ -13,13 +13,20 @@ import (
 	"google.golang.org/grpc/codes"
 )
 
+var (
+	asOfJun1 = time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+	// storedBasis is a denomination the declaration already carries, distinct from
+	// its as_of_date, so a test can tell "kept what was stored" from "re-derived".
+	storedBasis = time.Date(2025, 8, 5, 0, 0, 0, 0, time.UTC)
+)
+
 func TestListHoldingDeclarations_Success(t *testing.T) {
 	srv, mockDB := newAPIServerWithMock(t)
 	ctx := authCtx("user-1", "sub|1")
 	mockDB.EXPECT().
 		ListHoldingDeclarations(gomock.Any(), "user-1").
 		Return([]*db.HoldingDeclarationRow{
-			{ID: "d1", UserID: "user-1", Broker: "IBKR", Account: "acct1", InstrumentID: "inst-1", DeclaredQty: "100", AsOfDate: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)},
+			{ID: "d1", UserID: "user-1", Broker: "IBKR", Account: "acct1", InstrumentID: "inst-1", DeclaredQty: "100", AsOfDate: asOfJun1, ShareCountBasis: storedBasis},
 		}, nil)
 	mockDB.EXPECT().ListInstrumentsByIDs(gomock.Any(), []string{"inst-1"}).Return(nil, nil)
 
@@ -34,6 +41,11 @@ func TestListHoldingDeclarations_Success(t *testing.T) {
 	if d.GetBroker() != "IBKR" || d.GetDeclaredQty() != "100" || d.GetAsOfDate().GetYear() != 2025 || d.GetAsOfDate().GetMonth() != 6 || d.GetAsOfDate().GetDay() != 1 {
 		t.Fatalf("unexpected declaration: %+v", d)
 	}
+	// The denomination is part of what the declaration says, so it has to reach the
+	// client: a quantity read without it is in an unknown share count.
+	if b := d.GetShareCountBasis(); b.GetYear() != 2025 || b.GetMonth() != 8 || b.GetDay() != 5 {
+		t.Fatalf("share_count_basis: want 2025-08-05, got %+v", b)
+	}
 }
 
 func TestListHoldingDeclarations_Unauthenticated(t *testing.T) {
@@ -47,10 +59,11 @@ func TestCreateHoldingDeclaration_Success(t *testing.T) {
 	ctx := authCtx("user-1", "sub|1")
 	startDate := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
 	mockDB.EXPECT().GetPortfolioStartDate(gomock.Any(), "user-1").Return(&startDate, nil)
-	mockDB.EXPECT().ComputeRunningBalance(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", gomock.Any(), gomock.Any()).Return(decimal.NewFromInt(30), nil)
+	// Unset in the request, so the balance is asked for at as_of_date -- as-traded.
+	mockDB.EXPECT().ComputeRunningBalance(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", gomock.Any(), gomock.Any(), asOfJun1).Return(decimal.NewFromInt(30), nil)
 	mockDB.EXPECT().GetInstrument(gomock.Any(), "inst-1").Return(nil, nil)
 	mockDB.EXPECT().
-		CreateDeclarationWithInitializeTx(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", "100", time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC), "BUYOTHER", gomock.Any(), testutil.DecEq("70")).
+		CreateDeclarationWithInitializeTx(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", "100", asOfJun1, asOfJun1, padEq("BUYOTHER", "70", asOfJun1)).
 		Return(&db.HoldingDeclarationRow{
 			ID: "d1", UserID: "user-1", Broker: "IBKR", Account: "acct1", InstrumentID: "inst-1", DeclaredQty: "100",
 			AsOfDate: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
@@ -64,6 +77,32 @@ func TestCreateHoldingDeclaration_Success(t *testing.T) {
 	}
 	if resp.GetDeclaration().GetId() != "d1" {
 		t.Fatalf("unexpected id: %s", resp.GetDeclaration().GetId())
+	}
+}
+
+// TestCreateHoldingDeclaration_StatedShareCountBasis covers the other reading of a
+// declared quantity: a number copied off today's holdings screen rather than off a
+// statement of as_of_date. Both are reasonable, so the request says which, and
+// everything downstream of it -- the balance it is compared against and the pad it
+// produces -- is denominated the same way.
+func TestCreateHoldingDeclaration_StatedShareCountBasis(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	ctx := authCtx("user-1", "sub|1")
+	startDate := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	mockDB.EXPECT().GetPortfolioStartDate(gomock.Any(), "user-1").Return(&startDate, nil)
+	mockDB.EXPECT().ComputeRunningBalance(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", gomock.Any(), gomock.Any(), storedBasis).Return(decimal.NewFromInt(30), nil)
+	mockDB.EXPECT().GetInstrument(gomock.Any(), "inst-1").Return(nil, nil)
+	mockDB.EXPECT().
+		CreateDeclarationWithInitializeTx(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", "100", asOfJun1, storedBasis, padEq("BUYOTHER", "70", storedBasis)).
+		Return(&db.HoldingDeclarationRow{ID: "d1", UserID: "user-1", AsOfDate: asOfJun1, ShareCountBasis: storedBasis}, nil)
+
+	_, err := srv.CreateHoldingDeclaration(ctx, &apiv1.CreateHoldingDeclarationRequest{
+		Broker: "IBKR", Account: "acct1", InstrumentId: "inst-1", DeclaredQty: "100",
+		AsOfDate:        &date.Date{Year: 2025, Month: 6, Day: 1},
+		ShareCountBasis: &date.Date{Year: 2025, Month: 8, Day: 5},
+	})
+	if err != nil {
+		t.Fatalf("CreateHoldingDeclaration: %v", err)
 	}
 }
 
@@ -102,15 +141,15 @@ func TestUpdateHoldingDeclaration_Success(t *testing.T) {
 	ctx := authCtx("user-1", "sub|1")
 	existing := &db.HoldingDeclarationRow{
 		ID: "d1", UserID: "user-1", Broker: "IBKR", Account: "acct1", InstrumentID: "inst-1",
-		DeclaredQty: "100", AsOfDate: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
+		DeclaredQty: "100", AsOfDate: asOfJun1, ShareCountBasis: storedBasis,
 	}
 	mockDB.EXPECT().GetHoldingDeclaration(gomock.Any(), "d1").Return(existing, nil)
 	startDate := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
 	mockDB.EXPECT().GetPortfolioStartDate(gomock.Any(), "user-1").Return(&startDate, nil)
-	mockDB.EXPECT().ComputeRunningBalance(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", gomock.Any(), gomock.Any()).Return(decimal.NewFromInt(50), nil)
+	mockDB.EXPECT().ComputeRunningBalance(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", gomock.Any(), gomock.Any(), storedBasis).Return(decimal.NewFromInt(50), nil)
 	mockDB.EXPECT().GetInstrument(gomock.Any(), "inst-1").Return(nil, nil)
 	mockDB.EXPECT().
-		UpdateDeclarationWithInitializeTx(gomock.Any(), "d1", "200", time.Date(2025, 7, 1, 0, 0, 0, 0, time.UTC), "user-1", "IBKR", "acct1", "inst-1", "BUYOTHER", gomock.Any(), testutil.DecEq("150")).
+		UpdateDeclarationWithInitializeTx(gomock.Any(), "d1", "200", time.Date(2025, 7, 1, 0, 0, 0, 0, time.UTC), storedBasis, "user-1", "IBKR", "acct1", "inst-1", padEq("BUYOTHER", "150", storedBasis)).
 		Return(&db.HoldingDeclarationRow{
 			ID: "d1", UserID: "user-1", Broker: "IBKR", Account: "acct1", InstrumentID: "inst-1",
 			DeclaredQty: "200", AsOfDate: time.Date(2025, 7, 1, 0, 0, 0, 0, time.UTC),

--- a/server/service/api/recalc.go
+++ b/server/service/api/recalc.go
@@ -39,20 +39,15 @@ func recalcInitializeTx(ctx context.Context, database db.DB, decl *db.HoldingDec
 		return fmt.Errorf("parse declared_qty: %w", err)
 	}
 	dayAfterAsOf := decl.AsOfDate.AddDate(0, 0, 1)
-	runningBalance, err := database.ComputeRunningBalance(ctx, decl.UserID, decl.Broker, decl.Account, decl.InstrumentID, startDay, dayAfterAsOf)
+	runningBalance, err := database.ComputeRunningBalance(ctx, decl.UserID, decl.Broker, decl.Account, decl.InstrumentID, startDay, dayAfterAsOf, decl.ShareCountBasis)
 	if err != nil {
 		return fmt.Errorf("compute running balance: %w", err)
 	}
-	// Exact, so this is a real "the real txs already account for it" rather than
-	// a value that happened to land on zero.
+	// A zero pad means the real transactions already account for the declared
+	// balance exactly. That is the declaration agreeing with the data, not being
+	// superseded by it, and it is the outcome a checked declaration exists to
+	// report -- so the record stays and the pad is written as zero.
 	initQty := declaredQty.Sub(runningBalance)
-	if initQty.IsZero() {
-		// Real txs already fully account for the declared balance at as_of_date;
-		// the declaration is superseded by real data. Drop both atomically.
-		slog.Info("real txs fully account for declared balance; deleting declaration",
-			"user_id", decl.UserID, "declaration_id", decl.ID)
-		return database.DeleteDeclarationWithInitializeTx(ctx, decl.ID, decl.UserID, decl.Broker, decl.Account, decl.InstrumentID)
-	}
 	var assetClass string
 	if inst := instByID[decl.InstrumentID]; inst != nil && inst.AssetClass != nil {
 		assetClass = *inst.AssetClass
@@ -62,8 +57,12 @@ func recalcInitializeTx(ctx context.Context, database db.DB, decl *db.HoldingDec
 			assetClass = *inst.AssetClass
 		}
 	}
-	txType := txTypeForAssetClass(assetClass, initQty)
-	return database.UpsertInitializeTx(ctx, decl.UserID, decl.Broker, decl.Account, decl.InstrumentID, txType, startDay, initQty)
+	return database.UpsertInitializeTx(ctx, decl.UserID, decl.Broker, decl.Account, decl.InstrumentID, db.InitializeTx{
+		TxType:          txTypeForAssetClass(assetClass, initQty),
+		Timestamp:       startDay,
+		Quantity:        initQty,
+		ShareCountBasis: decl.ShareCountBasis,
+	})
 }
 
 // RecalcAllInitializeTxs recomputes all INITIALIZE txs for a user.

--- a/server/service/api/recalc_test.go
+++ b/server/service/api/recalc_test.go
@@ -2,15 +2,50 @@ package api
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/leedenison/portfoliodb/server/db"
 	"github.com/leedenison/portfoliodb/server/db/mock"
-	"github.com/leedenison/portfoliodb/server/testutil"
 	"github.com/shopspring/decimal"
 	"go.uber.org/mock/gomock"
 )
+
+// padEq matches an expected pad by type, quantity and denomination. The quantity is
+// taken as a decimal string for the reason testutil.DecEq exists, and the basis is
+// checked because a pad in the wrong share count is wrong by a split factor while
+// looking entirely plausible.
+func padEq(txType, qty string, basis time.Time) gomock.Matcher {
+	return padMatcher{txType: txType, qty: decimal.RequireFromString(qty), basis: basis}
+}
+
+type padMatcher struct {
+	txType string
+	qty    decimal.Decimal
+	basis  time.Time
+}
+
+func (m padMatcher) Matches(x any) bool {
+	got, ok := x.(db.InitializeTx)
+	return ok && got.TxType == m.txType && got.Quantity.Equal(m.qty) && got.ShareCountBasis.Equal(m.basis)
+}
+
+func (m padMatcher) String() string {
+	return fmt.Sprintf("is a %s pad of %s denominated at %s", m.txType, m.qty, m.basis.Format("2006-01-02"))
+}
+
+var (
+	testAsOf  = time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+	testBasis = time.Date(2025, 8, 5, 0, 0, 0, 0, time.UTC)
+)
+
+func testDecl(id, instrumentID, declaredQty string) *db.HoldingDeclarationRow {
+	return &db.HoldingDeclarationRow{
+		ID: id, UserID: "user-1", Broker: "IBKR", Account: "acct1", InstrumentID: instrumentID,
+		DeclaredQty: declaredQty, AsOfDate: testAsOf, ShareCountBasis: testBasis,
+	}
+}
 
 func TestRecalcInitializeTx_RecomputesQty(t *testing.T) {
 	ctrl := gomock.NewController(t)
@@ -18,15 +53,14 @@ func TestRecalcInitializeTx_RecomputesQty(t *testing.T) {
 	mockDB := mock.NewMockDB(ctrl)
 
 	startDate := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
-	decl := &db.HoldingDeclarationRow{
-		ID: "d1", UserID: "user-1", Broker: "IBKR", Account: "acct1", InstrumentID: "inst-1",
-		DeclaredQty: "100", AsOfDate: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
-	}
+	decl := testDecl("d1", "inst-1", "100")
 
 	mockDB.EXPECT().GetPortfolioStartDate(gomock.Any(), "user-1").Return(&startDate, nil)
-	mockDB.EXPECT().ComputeRunningBalance(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", gomock.Any(), gomock.Any()).Return(decimal.NewFromInt(40), nil)
+	// The balance is asked for in the declaration's denomination, not in whatever
+	// mixture the postings happen to be recorded in.
+	mockDB.EXPECT().ComputeRunningBalance(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", gomock.Any(), gomock.Any(), testBasis).Return(decimal.NewFromInt(40), nil)
 	mockDB.EXPECT().GetInstrument(gomock.Any(), "inst-1").Return(nil, nil)
-	mockDB.EXPECT().UpsertInitializeTx(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", "BUYOTHER", gomock.Any(), testutil.DecEq("60")).Return(nil)
+	mockDB.EXPECT().UpsertInitializeTx(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", padEq("BUYOTHER", "60", testBasis)).Return(nil)
 
 	if err := RecalcInitializeTx(context.Background(), mockDB, decl); err != nil {
 		t.Fatalf("RecalcInitializeTx: %v", err)
@@ -38,15 +72,10 @@ func TestRecalcInitializeTx_NoRealTxs_DeletesInitialize(t *testing.T) {
 	defer ctrl.Finish()
 	mockDB := mock.NewMockDB(ctrl)
 
-	decl := &db.HoldingDeclarationRow{
-		ID: "d1", UserID: "user-1", Broker: "IBKR", Account: "acct1", InstrumentID: "inst-1",
-		DeclaredQty: "100", AsOfDate: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
-	}
-
 	mockDB.EXPECT().GetPortfolioStartDate(gomock.Any(), "user-1").Return(nil, nil)
 	mockDB.EXPECT().DeleteInitializeTx(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1").Return(nil)
 
-	if err := RecalcInitializeTx(context.Background(), mockDB, decl); err != nil {
+	if err := RecalcInitializeTx(context.Background(), mockDB, testDecl("d1", "inst-1", "100")); err != nil {
 		t.Fatalf("RecalcInitializeTx: %v", err)
 	}
 }
@@ -58,35 +87,32 @@ func TestRecalcInitializeTx_StartDatePastDeclaration_DeletesBoth(t *testing.T) {
 
 	// Start date moved to July, but declaration is for June
 	startDate := time.Date(2025, 7, 1, 10, 0, 0, 0, time.UTC)
-	decl := &db.HoldingDeclarationRow{
-		ID: "d1", UserID: "user-1", Broker: "IBKR", Account: "acct1", InstrumentID: "inst-1",
-		DeclaredQty: "100", AsOfDate: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
-	}
 
 	mockDB.EXPECT().GetPortfolioStartDate(gomock.Any(), "user-1").Return(&startDate, nil)
 	mockDB.EXPECT().DeleteDeclarationWithInitializeTx(gomock.Any(), "d1", "user-1", "IBKR", "acct1", "inst-1").Return(nil)
 
-	if err := RecalcInitializeTx(context.Background(), mockDB, decl); err != nil {
+	if err := RecalcInitializeTx(context.Background(), mockDB, testDecl("d1", "inst-1", "100")); err != nil {
 		t.Fatalf("RecalcInitializeTx: %v", err)
 	}
 }
 
-func TestRecalcInitializeTx_ZeroQty_DeletesDeclaration(t *testing.T) {
+// TestRecalcInitializeTx_ZeroQty_KeepsDeclaration covers the case where the real
+// transactions already account for the declared balance exactly. That is the
+// declaration agreeing with the data, which is the outcome a checked declaration
+// exists to report -- so the record survives and the pad is written as zero.
+func TestRecalcInitializeTx_ZeroQty_KeepsDeclaration(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockDB := mock.NewMockDB(ctrl)
 
 	startDate := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
-	decl := &db.HoldingDeclarationRow{
-		ID: "d1", UserID: "user-1", Broker: "IBKR", Account: "acct1", InstrumentID: "inst-1",
-		DeclaredQty: "100", AsOfDate: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC),
-	}
 
 	mockDB.EXPECT().GetPortfolioStartDate(gomock.Any(), "user-1").Return(&startDate, nil)
-	mockDB.EXPECT().ComputeRunningBalance(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", gomock.Any(), gomock.Any()).Return(decimal.NewFromInt(100), nil)
-	mockDB.EXPECT().DeleteDeclarationWithInitializeTx(gomock.Any(), "d1", "user-1", "IBKR", "acct1", "inst-1").Return(nil)
+	mockDB.EXPECT().ComputeRunningBalance(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", gomock.Any(), gomock.Any(), testBasis).Return(decimal.NewFromInt(100), nil)
+	mockDB.EXPECT().GetInstrument(gomock.Any(), "inst-1").Return(nil, nil)
+	mockDB.EXPECT().UpsertInitializeTx(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", padEq("BUYOTHER", "0", testBasis)).Return(nil)
 
-	if err := RecalcInitializeTx(context.Background(), mockDB, decl); err != nil {
+	if err := RecalcInitializeTx(context.Background(), mockDB, testDecl("d1", "inst-1", "100")); err != nil {
 		t.Fatalf("RecalcInitializeTx: %v", err)
 	}
 }
@@ -98,17 +124,17 @@ func TestRecalcAllInitializeTxs_RecalcsEachDeclaration(t *testing.T) {
 
 	startDate := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
 	decls := []*db.HoldingDeclarationRow{
-		{ID: "d1", UserID: "user-1", Broker: "IBKR", Account: "acct1", InstrumentID: "inst-1", DeclaredQty: "100", AsOfDate: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)},
-		{ID: "d2", UserID: "user-1", Broker: "IBKR", Account: "acct1", InstrumentID: "inst-2", DeclaredQty: "50", AsOfDate: time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)},
+		testDecl("d1", "inst-1", "100"),
+		testDecl("d2", "inst-2", "50"),
 	}
 	mockDB.EXPECT().ListHoldingDeclarations(gomock.Any(), "user-1").Return(decls, nil)
 	mockDB.EXPECT().ListInstrumentsByIDs(gomock.Any(), gomock.Any()).Return(nil, nil)
 	// Each declaration triggers a recalc
 	mockDB.EXPECT().GetPortfolioStartDate(gomock.Any(), "user-1").Return(&startDate, nil).Times(2)
-	mockDB.EXPECT().ComputeRunningBalance(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", gomock.Any(), gomock.Any()).Return(decimal.NewFromInt(20), nil)
-	mockDB.EXPECT().UpsertInitializeTx(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", "BUYOTHER", gomock.Any(), testutil.DecEq("80")).Return(nil)
-	mockDB.EXPECT().ComputeRunningBalance(gomock.Any(), "user-1", "IBKR", "acct1", "inst-2", gomock.Any(), gomock.Any()).Return(decimal.NewFromInt(10), nil)
-	mockDB.EXPECT().UpsertInitializeTx(gomock.Any(), "user-1", "IBKR", "acct1", "inst-2", "BUYOTHER", gomock.Any(), testutil.DecEq("40")).Return(nil)
+	mockDB.EXPECT().ComputeRunningBalance(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", gomock.Any(), gomock.Any(), testBasis).Return(decimal.NewFromInt(20), nil)
+	mockDB.EXPECT().UpsertInitializeTx(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", padEq("BUYOTHER", "80", testBasis)).Return(nil)
+	mockDB.EXPECT().ComputeRunningBalance(gomock.Any(), "user-1", "IBKR", "acct1", "inst-2", gomock.Any(), gomock.Any(), testBasis).Return(decimal.NewFromInt(10), nil)
+	mockDB.EXPECT().UpsertInitializeTx(gomock.Any(), "user-1", "IBKR", "acct1", "inst-2", padEq("BUYOTHER", "40", testBasis)).Return(nil)
 
 	if err := RecalcAllInitializeTxs(context.Background(), mockDB, "user-1"); err != nil {
 		t.Fatalf("RecalcAllInitializeTxs: %v", err)


### PR DESCRIPTION
First of three PRs for 0043 (split holding declarations into pads and checked
assertions). This one settles denomination, which the issue says has to be
settled before a verification pass is worth building -- otherwise a correct
portfolio fails every assertion by the split factor.

## Problem

`declared_qty` had no stated denomination, and the balance the pad reconciles it
against was a plain `SUM(quantity)` over postings whose `share_count_basis`
differs. That mixes share counts, which bitemporality rule 4 forbids: a posting
recorded before a split and one recorded after are in different units, so adding
them raw gives a number in no share count at all. The pad built from it is wrong
by part of the split factor.

Separately, the pad's own basis was left to the `txs` trigger, which seeds it
from `timestamp`. The pad is dated at the portfolio start date but denominated
where its declaration is; the two are unrelated, and the trigger also left the
basis behind whenever a recalculation moved the pad's timestamp.

## Changes

- `holding_declarations.share_count_basis DATE NOT NULL`, defaulting to
  `as_of_date` via a `BEFORE INSERT` trigger, the way `txs` and `eod_prices` do.
  Insert-time only: moving `as_of_date` later does not restate a denomination
  the user already gave.
- `holding_qty_in_basis(...)` converts each posting from its own basis into a
  target one using the exact-rational `split_factor_at` (ADR 0028), grouping by
  basis and summing before converting so the division happens once per
  denomination rather than once per posting. It also returns the posting count
  and the number of bases whose factor is not `1/1`, which is the bound on its
  own rounding -- zero when no split falls in the window, which is the common
  case.
- `ComputeRunningBalance` reads it, taking the declaration's basis as its target.
- `UpsertInitializeTx` writes `share_count_basis` explicitly on both legs, in the
  insert list and the `DO UPDATE` list.
- `db.InitializeTx` replaces the growing positional argument lists on the pad
  helpers.
- `share_count_basis` on `HoldingDeclaration` and the create/update requests
  (optional; unset means `as_of_date`).
- The form asks the question as the two readings it actually has -- the share
  count on the as of date, or today's -- rather than as a bare date picker, and
  the table shows which.
- Drops the branch that deleted a declaration when its pad came out zero. A zero
  pad is the real transactions agreeing with the declaration exactly, which is
  the outcome a checked declaration exists to report; `fixed-point.md` already
  says a declaration is never discarded.
- `docs/spec/fixed-point.md` and `docs/spec/bitemporality.md` updated.

## Not here

Widening the unique key so a holding can carry more than one declaration (PR 2),
and the verification pass that compares an assertion to the computed holding
(PR 3). `ComputeHoldings` still tests for a closed position on
`SUM(t.quantity)`, which has the same basis-mixing exposure -- pre-existing and
out of scope here.

## Verification

- `make check` -- clean
- `make server-test` -- pass
- `make db-test` -- pass, including new integration coverage: the trigger's
  `as_of_date` default, a stated basis surviving a moved `as_of_date`, a holding
  that splits 2:1 mid-window reading 75 pre-split and 150 post-split from the
  same postings, and the pad keeping its declaration's basis when its timestamp
  moves.
- `make client-test` -- pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
