### PR TITLE
Allow many declarations per holding; the earliest is the pad (0043)

### DIFF
--- a/client/app/holdings/declaration-form.tsx
+++ b/client/app/holdings/declaration-form.tsx
@@ -143,12 +143,13 @@ export function DeclarationForm({
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
       <h3 className="text-lg font-semibold text-text-primary">
-        {editing ? "Edit Checkpoint" : "New Opening Balance Checkpoint"}
+        {editing ? "Edit Checkpoint" : "New Checkpoint"}
       </h3>
       <p className="text-sm text-text-muted">
-        Enter the number of units you held at a specific date. The system will
-        calculate an opening balance so that your records show this quantity on
-        that date.
+        Enter the number of units you held at a specific date. If this is the earliest
+        checkpoint for the holding, the system calculates an opening balance so that your
+        records show this quantity on that date. If it is a later one, it is checked
+        against what your transactions add up to.
       </p>
 
       {error && <ErrorAlert>{error}</ErrorAlert>}

--- a/client/app/holdings/opening-balances.tsx
+++ b/client/app/holdings/opening-balances.tsx
@@ -12,7 +12,7 @@ import {
   listBrokersAndAccounts,
   protoDateToStr,
 } from "@/lib/portfolio-api";
-import { IdentifierType } from "@/gen/api/v1/api_pb";
+import { DeclarationKind, IdentifierType } from "@/gen/api/v1/api_pb";
 import type { HoldingDeclaration } from "@/gen/api/v1/api_pb";
 import { DeclarationForm } from "./declaration-form";
 
@@ -109,8 +109,10 @@ export function OpeningBalances() {
             </button>
           </div>
           <p className="text-sm text-text-muted">
-            Set checkpoints for known holding quantities at a point in time. The system will
-            calculate an opening balance so that your records show this quantity on the date you specify.
+            Set checkpoints for known holding quantities at a point in time. The earliest
+            checkpoint for a holding becomes its opening balance: the system calculates one so
+            that your records show this quantity on the date you specify. Later checkpoints are
+            checked against what your transactions add up to.
           </p>
           <div className="overflow-x-auto rounded-md border border-border bg-surface shadow-xs">
             <table className="w-full min-w-[480px] border-collapse text-sm">
@@ -134,6 +136,9 @@ export function OpeningBalances() {
                   <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-text-muted">
                     Share Count
                   </th>
+                  <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-text-muted">
+                    Role
+                  </th>
                   <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wider text-text-muted">
                     Actions
                   </th>
@@ -143,7 +148,7 @@ export function OpeningBalances() {
                 {declarations.length === 0 ? (
                   <tr>
                     <td
-                      colSpan={7}
+                      colSpan={8}
                       className="px-4 py-8 text-center text-text-muted"
                     >
                       No opening balance checkpoints.
@@ -176,6 +181,9 @@ export function OpeningBalances() {
                         </td>
                         <td className="px-4 py-3 text-text-muted">
                           {shareCountLabel(d)}
+                        </td>
+                        <td className="px-4 py-3 text-text-muted">
+                          {d.kind === DeclarationKind.PAD ? "Opening balance" : "Checked"}
                         </td>
                         <td className="px-4 py-3 text-right">
                           <button

--- a/docs/spec/fixed-point.md
+++ b/docs/spec/fixed-point.md
@@ -12,7 +12,17 @@ The date of the earliest transaction across all holdings for a given user. This 
 
 ### Holding Declaration
 
-A user-provided statement: "I held **N** units of **holding X** on **date D**." This is the source of truth for what the user knew about their holdings. It is stored as a first-class record and is never discarded. The INITIALIZE transaction is derived from it.
+A user-provided statement: "I held **N** units of **holding X** on **date D**." This is the source of truth for what the user knew about their holdings. It is stored as a first-class record and is never discarded.
+
+A holding may carry a declaration at each of several dates, and their roles differ.
+
+### Pad and Assertion
+
+The **earliest** declaration for a holding is its **pad**. The INITIALIZE transaction is derived from it, which makes the declared quantity true at that date by construction -- so a pad can never catch an error.
+
+Every **later** declaration is an **assertion**. It generates nothing. It is checked against what the transactions add up to at its own date, and a disagreement means something is wrong with the data: a misparsed broker CSV, a missed transfer, a converter that silently dropped a row. That check is where the safety comes from; the pad is what makes a portfolio with incomplete history usable in the first place. The pair is beancount's `pad` and `balance`.
+
+The role is derived from the declaration dates, not stored. Adding a declaration earlier than the current pad makes it the pad and demotes the incumbent to an assertion; deleting the pad promotes the next-earliest. Nothing has to be kept in step, because there is no stored discriminator to disagree with the rows.
 
 ### INITIALIZE Transaction
 
@@ -41,8 +51,10 @@ Holdings are computed aggregates (there is no holdings table), so a holding is i
 
 **Constraints:**
 
-- `UNIQUE (user_id, broker, account, instrument_id)` -- one declaration per holding per user.
+- `UNIQUE (user_id, broker, account, instrument_id, as_of_date)` -- a holding may carry a declaration at each of several dates, but not two at one date, which would be two answers to the same question with nothing to choose between them.
 - `as_of_date` must be on or after the user's portfolio start date (enforced in application logic, since the portfolio start date is dynamic).
+
+There is no `kind` column: the earliest `as_of_date` per holding is the pad and the rest are assertions, derived on read.
 
 ### Denomination
 
@@ -89,37 +101,38 @@ It is excluded from holdings and from every other quantity aggregation, along wi
 
 **Preconditions:**
 
-1. At least one real transaction must exist for the user (across any holding). If no real transactions exist, the declaration is rejected — there is no portfolio start date to anchor the INITIALIZE transaction to.
-2. The user must not already have a declaration for this holding. If they do, the request is treated as an update (see below).
+1. At least one real transaction must exist for the user (across any holding). If no real transactions exist, the declaration is rejected -- there is no portfolio start date to anchor the INITIALIZE transaction to.
+2. The user must not already have a declaration for this holding at this `as_of_date`. If they do, the request is rejected with `ALREADY_EXISTS`; declaring a different quantity at a *different* date is the normal case, not a conflict.
 3. `as_of_date` must be on or after the user's portfolio start date.
 
 **Procedure:**
 
 1. Store the holding declaration record (`user_id`, `broker`, `account`, `instrument_id`, `declared_qty`, `as_of_date`, `share_count_basis`).
 2. Determine the portfolio start date: the date of the earliest real transaction for this user across all holdings.
-3. Compute the running unit balance for this holding from all real transactions (excluding any existing INITIALIZE) for the same `(broker, account, instrument_id)` that fall on or between the portfolio start date and `as_of_date` inclusive, converting each posting from its own `share_count_basis` into the declaration's.
-4. Calculate the INITIALIZE quantity: `declared_qty - running_balance`. Both are
+3. Identify the holding's pad: the earliest of its declarations, including the one being stored. The steps below are computed from that declaration, which may not be the one the request wrote -- a later declaration is an assertion and changes nothing about the pad.
+4. Compute the running unit balance for this holding from all real transactions (excluding any existing INITIALIZE) for the same `(broker, account, instrument_id)` that fall on or between the portfolio start date and `as_of_date` inclusive, converting each posting from its own `share_count_basis` into the declaration's.
+5. Calculate the INITIALIZE quantity: `declared_qty - running_balance`. Both are
    exact decimals and subtraction is closed, so the pad reconciles the holding to
    the declaration exactly rather than to within a rounding of it.
-5. Create (or replace) the INITIALIZE transaction for this holding with:
+6. Create (or replace) the INITIALIZE transaction for this holding with:
    - `date` = portfolio start date, at `00:00:00` (midnight, start of day)
-   - `quantity` = the value computed in step 4
+   - `quantity` = the value computed in step 5
    - `share_count_basis` = the declaration's. The pad is dated where the history
      begins but denominated where the declaration is; the two are unrelated, and
      inferring the basis from the timestamp made the pad wrong by a split factor.
    - `broker`, `account`, `instrument_id` = copied from the declaration
    - `synthetic_purpose` = `'INITIALIZE'`
-6. Create (or replace) its `EQUITY` counterparty in the same group, identical but for `account_type` and a negated `quantity`.
+7. Create (or replace) its `EQUITY` counterparty in the same group, identical but for `account_type` and a negated `quantity`.
 
 **Note on quantity:** The INITIALIZE quantity may be negative. This represents a short position at portfolio inception and is permitted.
 
 ### Updating a Declaration
 
-The user may edit the declared quantity or the `as_of_date`. The procedure is identical to creation: update the declaration record, then recalculate and replace the INITIALIZE transaction using the same procedure above.
+The user may edit the declared quantity, the `as_of_date` or the `share_count_basis`. The procedure is identical to creation: update the declaration record, then recalculate and replace the INITIALIZE transaction from whichever declaration pads the holding once the edit lands. Moving an `as_of_date` can hand the pad to a sibling or take it from one, so the pad is never recomputed from the edited row alone. Moving it onto a date the holding already has is rejected with `ALREADY_EXISTS`.
 
 ### Deleting a Declaration
 
-When a user deletes a declaration, delete both the declaration record and the associated INITIALIZE group. Deleting the group takes both postings, so no path can leave the counterparty behind without the pad it balances. The holding's history will revert to showing only real transactions, with an implied zero balance at portfolio inception.
+Deleting an **assertion** leaves the pad alone. Deleting the **pad** promotes the next-earliest declaration, and the INITIALIZE transaction is recalculated from it. Only deleting a holding's last declaration removes the INITIALIZE group: deleting the group takes both postings, so no path can leave the counterparty behind without the pad it balances, and the holding's history reverts to showing only real transactions with an implied zero balance at portfolio inception.
 
 ### Recalculation Triggers
 
@@ -139,13 +152,13 @@ The portfolio start date changes when:
 
 1. Determine the new portfolio start date.
 2. Validate that all existing declarations still have `as_of_date` on or after the new start date. (If the start date moved earlier, this is always satisfied. If it moved later, some declarations may now be invalid — see Edge Cases.)
-3. For every INITIALIZE transaction owned by this user (across all holdings): recalculate using the stored declaration and the new portfolio start date. Update both the date and the quantity.
+3. For every holding this user has declarations for: recalculate its INITIALIZE transaction from the holding's pad -- its earliest surviving declaration -- and the new portfolio start date. Update both the date and the quantity. The unit of recalculation is the holding, not the declaration: which declaration pads a holding depends on the others, so a single declaration is not enough to know whether it is the pad.
 
 #### Trigger 2: Transaction History Changes Between Start Date and Declaration Date
 
 When a real transaction is added, edited, or deleted for a holding that has a declaration, and that transaction falls on or between the portfolio start date and the declaration's `as_of_date`:
 
-1. Recalculate only the INITIALIZE transaction for that specific holding, using the stored declaration.
+1. Recalculate only the INITIALIZE transaction for that specific holding, from its pad.
 
 **Note:** If both triggers fire simultaneously (e.g. a new earliest transaction is added for a holding that also has a declaration), the portfolio-start-date recalculation in Trigger 1 is sufficient — it already recalculates all INITIALIZE transactions.
 
@@ -165,7 +178,7 @@ If the user declares "I held 150 units of AAPL on March 15" and there are no rea
 
 ### Portfolio start date moves later and passes a declaration date
 
-This can happen if the user deletes early transactions. If the new portfolio start date would be after an existing declaration's `as_of_date`, the system should delete the affected declaration(s) first, and warn the user that this will happen.
+This can happen if the user deletes early transactions. A declaration about a date the history no longer reaches can be neither padded to nor checked against, so the affected declarations are deleted first and the user warned that this will happen. If the pad was among them, the next-earliest survivor becomes the pad; if nothing survives for a holding, its INITIALIZE transaction goes too.
 
 ### User edits the INITIALIZE transaction directly
 
@@ -175,7 +188,7 @@ INITIALIZE transactions should not be directly editable through the normal trans
 
 ### Visibility of Declarations
 
-The holding declaration UI lives as an "Opening Balances" tab alongside the "Holdings" tab on the Holdings page.
+The holding declaration UI lives as an "Opening Balances" tab alongside the "Holdings" tab on the Holdings page. It shows each declaration's role, so a user can see which of a holding's checkpoints seeds the opening balance and which are checked.
 
 ### Transaction List
 
@@ -196,6 +209,5 @@ The declaration form should:
 
 ## Future Extensions
 
-- **TRUE_UP synthetic transactions:** Additional fixed points after portfolio inception that insert corrective transactions at their own dates. The `synthetic_purpose` field is already designed to accommodate this.
+- **TRUE_UP synthetic transactions:** Additional fixed points after portfolio inception that insert corrective transactions at their own dates, for a user who wants a disagreeing assertion plugged rather than reported. The `synthetic_purpose` field is already designed to accommodate this.
 - **Cost basis on INITIALIZE transactions:** Allowing users to optionally declare cost basis alongside units, for gain/loss reporting.
-- **Multiple declarations per holding:** For TRUE_UP support, the unique constraint on declarations would be relaxed to `UNIQUE (user_id, broker, account, instrument_id, as_of_date)`.

--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -873,6 +873,19 @@ message GetPortfolioValuationResponse {
   repeated ValuationPoint points = 1;
 }
 
+// DeclarationKind distinguishes the declaration that seeds an opening balance from
+// the ones that are checked against it. It is derived from the declaration dates for
+// a holding, not chosen: the earliest is the pad and the rest are assertions.
+enum DeclarationKind {
+  DECLARATION_KIND_UNSPECIFIED = 0;
+  // The earliest declaration for a holding. It generates the INITIALIZE transaction
+  // that makes the declared quantity true, so it is true by construction.
+  DECLARATION_KIND_PAD = 1;
+  // A later declaration. It generates nothing and is checked against the computed
+  // holding at its as_of_date.
+  DECLARATION_KIND_ASSERT = 2;
+}
+
 // HoldingDeclaration is a user-provided statement of known holding quantity at a date.
 message HoldingDeclaration {
   string id = 1;
@@ -887,6 +900,8 @@ message HoldingDeclaration {
   // was read off a current holdings view. Always populated on read.
   // See docs/spec/bitemporality.md.
   google.type.Date share_count_basis = 8;
+  // Read-only; derived from the declaration dates for this holding.
+  DeclarationKind kind = 9;
 }
 
 message ListHoldingDeclarationsRequest {}

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -4,6 +4,7 @@ package db
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"time"
 
@@ -11,6 +12,11 @@ import (
 	"github.com/shopspring/decimal"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
+
+// ErrDuplicate reports that a write collided with a uniqueness constraint. The db
+// layer translates the driver's error into this so a caller can react to it without
+// knowing which driver, or which constraint, produced it.
+var ErrDuplicate = errors.New("duplicate")
 
 // Plugin category constants.
 const (
@@ -615,6 +621,9 @@ type HoldingDeclarationRow struct {
 	// ShareCountBasis is the date at which the share count DeclaredQty is
 	// denominated in was current. Defaults to AsOfDate. See docs/spec/bitemporality.md.
 	ShareCountBasis time.Time
+	// Kind is derived, not stored: the earliest declaration for a holding is the
+	// pad and the rest are assertions. Reads populate it; writes ignore it.
+	Kind apiv1.DeclarationKind
 }
 
 // InitializeTx is the derived pad for a holding declaration: the synthetic posting
@@ -651,8 +660,11 @@ type HoldingDeclarationDB interface {
 	CreateDeclarationWithInitializeTx(ctx context.Context, userID, broker, account, instrumentID, declaredQty string, asOfDate, shareCountBasis time.Time, init InitializeTx) (*HoldingDeclarationRow, error)
 	// UpdateDeclarationWithInitializeTx atomically updates a declaration and upserts its INITIALIZE tx.
 	UpdateDeclarationWithInitializeTx(ctx context.Context, id, declaredQty string, asOfDate, shareCountBasis time.Time, userID, broker, account, instrumentID string, init InitializeTx) (*HoldingDeclarationRow, error)
-	// DeleteDeclarationWithInitializeTx atomically deletes a declaration and its INITIALIZE tx.
-	DeleteDeclarationWithInitializeTx(ctx context.Context, id, userID, broker, account, instrumentID string) error
+	// DeleteDeclarationWithInitializeTx atomically deletes a declaration and either
+	// rewrites the holding's pad from init or, when init is nil, deletes it. A
+	// deleted assertion leaves the pad alone; a deleted pad promotes the
+	// next-earliest declaration to take its place.
+	DeleteDeclarationWithInitializeTx(ctx context.Context, id, userID, broker, account, instrumentID string, init *InitializeTx) error
 }
 
 // InstrumentDB provides instrument resolution and plugin config.

--- a/server/db/postgres/declarations.go
+++ b/server/db/postgres/declarations.go
@@ -7,13 +7,33 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
 	"github.com/leedenison/portfoliodb/server/db"
 	"github.com/shopspring/decimal"
 )
 
-// declarationCols is the projection every declaration read shares, so a column added
-// to the table reaches all of them at once.
+// declarationCols is the stored projection every declaration read shares, so a
+// column added to the table reaches all of them at once. It is also what the write
+// paths return: kind cannot be derived there, because an INSERT's own row is not
+// visible to a subquery in its RETURNING clause, so a create would always call
+// itself the pad.
 const declarationCols = `id, user_id, broker, account, instrument_id, declared_qty, as_of_date, share_count_basis`
+
+// declarationKind derives the pad/assert discriminator rather than storing it, so
+// there is no column to keep in step with the rows. The earliest declaration for a
+// holding seeds its opening balance; every later one is checked against the computed
+// holding. Written as a correlated subquery rather than a window so that it is
+// correct for a single-row read too, and the unique key on (user_id, broker,
+// account, instrument_id, as_of_date) serves the lookup directly.
+const declarationKind = `CASE WHEN d.as_of_date = (
+	    SELECT MIN(e.as_of_date) FROM holding_declarations e
+	    WHERE e.user_id = d.user_id AND e.broker = d.broker
+	      AND e.account = d.account AND e.instrument_id = d.instrument_id)
+	  THEN 'PAD' ELSE 'ASSERT' END AS kind`
+
+// declarationReadCols is the projection for reads, qualified for declarationKind.
+const declarationReadCols = `d.id, d.user_id, d.broker, d.account, d.instrument_id,
+	d.declared_qty, d.as_of_date, d.share_count_basis, ` + declarationKind
 
 type declarationRow struct {
 	ID              uuid.UUID `db:"id"`
@@ -24,10 +44,11 @@ type declarationRow struct {
 	DeclaredQty     string    `db:"declared_qty"`
 	AsOfDate        time.Time `db:"as_of_date"`
 	ShareCountBasis time.Time `db:"share_count_basis"`
+	Kind            *string   `db:"kind"` // absent from the write paths' projection
 }
 
 func (r *declarationRow) toRow() *db.HoldingDeclarationRow {
-	return &db.HoldingDeclarationRow{
+	out := &db.HoldingDeclarationRow{
 		ID:              r.ID.String(),
 		UserID:          r.UserID.String(),
 		Broker:          r.Broker,
@@ -36,6 +57,21 @@ func (r *declarationRow) toRow() *db.HoldingDeclarationRow {
 		DeclaredQty:     r.DeclaredQty,
 		AsOfDate:        r.AsOfDate,
 		ShareCountBasis: r.ShareCountBasis,
+	}
+	if r.Kind != nil {
+		out.Kind = strToDeclarationKind(*r.Kind)
+	}
+	return out
+}
+
+func strToDeclarationKind(s string) apiv1.DeclarationKind {
+	switch s {
+	case "PAD":
+		return apiv1.DeclarationKind_DECLARATION_KIND_PAD
+	case "ASSERT":
+		return apiv1.DeclarationKind_DECLARATION_KIND_ASSERT
+	default:
+		return apiv1.DeclarationKind_DECLARATION_KIND_UNSPECIFIED
 	}
 }
 
@@ -62,6 +98,9 @@ func (p *Postgres) CreateHoldingDeclaration(ctx context.Context, userID, broker,
 		RETURNING `+declarationCols,
 		userUUID, broker, account, instUUID, declaredQty, asOfDate, basis).StructScan(&row)
 	if err != nil {
+		if isUniqueViolation(err) {
+			return nil, fmt.Errorf("create holding declaration: %w", db.ErrDuplicate)
+		}
 		return nil, fmt.Errorf("create holding declaration: %w", err)
 	}
 	return row.toRow(), nil
@@ -89,6 +128,9 @@ func (p *Postgres) UpdateHoldingDeclaration(ctx context.Context, id, declaredQty
 		RETURNING `+declarationCols,
 		declaredQty, asOfDate, basis, declID).StructScan(&row)
 	if err != nil {
+		if isUniqueViolation(err) {
+			return nil, fmt.Errorf("update holding declaration: %w", db.ErrDuplicate)
+		}
 		return nil, fmt.Errorf("update holding declaration: %w", err)
 	}
 	return row.toRow(), nil
@@ -119,8 +161,8 @@ func (p *Postgres) GetHoldingDeclaration(ctx context.Context, id string) (*db.Ho
 	}
 	var row declarationRow
 	err = p.q.QueryRowxContext(ctx, `
-		SELECT `+declarationCols+`
-		FROM holding_declarations WHERE id = $1
+		SELECT `+declarationReadCols+`
+		FROM holding_declarations d WHERE d.id = $1
 	`, declID).StructScan(&row)
 	if err != nil {
 		return nil, fmt.Errorf("get holding declaration: %w", err)
@@ -136,9 +178,9 @@ func (p *Postgres) ListHoldingDeclarations(ctx context.Context, userID string) (
 	}
 	var rows []declarationRow
 	err = p.q.SelectContext(ctx, &rows, `
-		SELECT `+declarationCols+`
-		FROM holding_declarations WHERE user_id = $1
-		ORDER BY broker, account, as_of_date
+		SELECT `+declarationReadCols+`
+		FROM holding_declarations d WHERE d.user_id = $1
+		ORDER BY d.broker, d.account, d.instrument_id, d.as_of_date
 	`, userUUID)
 	if err != nil {
 		return nil, fmt.Errorf("list holding declarations: %w", err)
@@ -352,12 +394,18 @@ func (p *Postgres) UpdateDeclarationWithInitializeTx(ctx context.Context, id, de
 }
 
 // DeleteDeclarationWithInitializeTx implements db.HoldingDeclarationDB.
-func (p *Postgres) DeleteDeclarationWithInitializeTx(ctx context.Context, id, userID, broker, account, instrumentID string) error {
+func (p *Postgres) DeleteDeclarationWithInitializeTx(ctx context.Context, id, userID, broker, account, instrumentID string, init *db.InitializeTx) error {
 	return p.runInTx(ctx, func(tx queryable) error {
 		txp := &Postgres{q: tx}
 		if err := txp.DeleteHoldingDeclaration(ctx, id); err != nil {
 			return err
 		}
-		return txp.DeleteInitializeTx(ctx, userID, broker, account, instrumentID)
+		// A holding keeps its pad for as long as it has any declaration left: what
+		// was deleted may have been an assertion, or the pad with a later
+		// declaration behind it ready to take over. Only an empty holding loses it.
+		if init == nil {
+			return txp.DeleteInitializeTx(ctx, userID, broker, account, instrumentID)
+		}
+		return txp.UpsertInitializeTx(ctx, userID, broker, account, instrumentID, *init)
 	})
 }

--- a/server/db/postgres/declarations_test.go
+++ b/server/db/postgres/declarations_test.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"maps"
 	"testing"
 	"time"
@@ -50,20 +51,90 @@ func TestCreateHoldingDeclaration(t *testing.T) {
 	}
 }
 
-func TestCreateHoldingDeclaration_DuplicateRejected(t *testing.T) {
+// TestCreateHoldingDeclaration_ManyPerHolding pins the widened key: a holding may
+// carry a declaration at each of several dates -- the earliest seeding its opening
+// balance and the later ones checked against it -- but not two at one date, which
+// would be two answers to the same question with nothing to choose between them.
+func TestCreateHoldingDeclaration_ManyPerHolding(t *testing.T) {
 	p := testDBTx(t)
 	ctx := context.Background()
 	userID, _ := p.GetOrCreateUser(ctx, "sub|decl2", "U", "u@u.com")
 	instID, _ := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "GOOG", Canonical: false}}, "", nil, nil, nil)
 
 	asOf := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
-	_, err := p.CreateHoldingDeclaration(ctx, userID, "IBKR", "acct1", instID, "100", asOf, time.Time{})
-	if err != nil {
+	later := time.Date(2025, 12, 31, 0, 0, 0, 0, time.UTC)
+	if _, err := p.CreateHoldingDeclaration(ctx, userID, "IBKR", "acct1", instID, "100", asOf, time.Time{}); err != nil {
 		t.Fatalf("first create: %v", err)
 	}
-	_, err = p.CreateHoldingDeclaration(ctx, userID, "IBKR", "acct1", instID, "200", asOf, time.Time{})
-	if err == nil {
-		t.Fatal("expected duplicate error")
+	if _, err := p.CreateHoldingDeclaration(ctx, userID, "IBKR", "acct1", instID, "200", later, time.Time{}); err != nil {
+		t.Fatalf("second create at a later date: %v", err)
+	}
+
+	_, err := p.CreateHoldingDeclaration(ctx, userID, "IBKR", "acct1", instID, "300", asOf, time.Time{})
+	if !errors.Is(err, db.ErrDuplicate) {
+		t.Fatalf("second create at the same date: want db.ErrDuplicate, got %v", err)
+	}
+}
+
+// TestListHoldingDeclarations_DerivesKind checks the pad/assert discriminator, which
+// is computed from the dates rather than stored. The earliest declaration for a
+// holding is its pad; every later one is an assertion. Two holdings are seeded so a
+// query that partitioned wrongly would call both earliest rows pads, or neither.
+func TestListHoldingDeclarations_DerivesKind(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|decl-kind", "U", "u@k.com")
+	instA, _ := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "KA", Canonical: false}}, "", nil, nil, nil)
+	instB, _ := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "KB", Canonical: false}}, "", nil, nil, nil)
+
+	d2021 := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	d2022 := time.Date(2022, 12, 31, 0, 0, 0, 0, time.UTC)
+	d2023 := time.Date(2023, 12, 31, 0, 0, 0, 0, time.UTC)
+	// Inserted newest first, so the answer cannot come from insertion order.
+	for _, seed := range []struct {
+		inst string
+		asOf time.Time
+		qty  string
+	}{
+		{instA, d2023, "650"},
+		{instA, d2022, "500"},
+		{instA, d2021, "500"},
+		{instB, d2022, "10"},
+	} {
+		if _, err := p.CreateHoldingDeclaration(ctx, userID, "IBKR", "acct1", seed.inst, seed.qty, seed.asOf, time.Time{}); err != nil {
+			t.Fatalf("seed %s at %s: %v", seed.inst, seed.asOf.Format("2006-01-02"), err)
+		}
+	}
+
+	rows, err := p.ListHoldingDeclarations(ctx, userID)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	got := map[string]apiv1.DeclarationKind{}
+	for _, r := range rows {
+		got[r.InstrumentID+"@"+r.AsOfDate.Format("2006-01-02")] = r.Kind
+	}
+	want := map[string]apiv1.DeclarationKind{
+		instA + "@2021-01-01": apiv1.DeclarationKind_DECLARATION_KIND_PAD,
+		instA + "@2022-12-31": apiv1.DeclarationKind_DECLARATION_KIND_ASSERT,
+		instA + "@2023-12-31": apiv1.DeclarationKind_DECLARATION_KIND_ASSERT,
+		// Earliest for its own holding, so a pad despite being later than instA's.
+		instB + "@2022-12-31": apiv1.DeclarationKind_DECLARATION_KIND_PAD,
+	}
+	if !maps.Equal(got, want) {
+		t.Fatalf("derived kinds: got %v, want %v", got, want)
+	}
+
+	// A single-row read has to reach the same answer, which is why the derivation is
+	// a correlated subquery and not a window over the rows the query returns.
+	for _, r := range rows {
+		one, err := p.GetHoldingDeclaration(ctx, r.ID)
+		if err != nil {
+			t.Fatalf("get %s: %v", r.ID, err)
+		}
+		if one.Kind != r.Kind {
+			t.Errorf("kind for %s: list says %v, get says %v", r.ID, r.Kind, one.Kind)
+		}
 	}
 }
 
@@ -496,6 +567,51 @@ func TestComputeRunningBalance_ConvertsToDeclarationBasis(t *testing.T) {
 				t.Fatalf("running balance = %v, want %s", bal, tc.want)
 			}
 		})
+	}
+}
+
+// TestDeleteDeclarationWithInitializeTx_KeepsThePadForSurvivors covers what deleting
+// one of a holding's declarations does to the pad. Deleting one that leaves others
+// behind rewrites the pad from whichever now pads the holding; deleting the last one
+// takes the pad with it, since there is nothing left to pad to.
+func TestDeleteDeclarationWithInitializeTx_KeepsThePadForSurvivors(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|decl-del-pad", "U", "u@d.com")
+	instID, _ := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "DP1", Canonical: false}}, "", nil, nil, nil)
+
+	pad := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	next := time.Date(2023, 12, 31, 0, 0, 0, 0, time.UTC)
+	padRow, err := p.CreateDeclarationWithInitializeTx(ctx, userID, "IBKR", "acct1", instID, "500", pad, time.Time{}, initTx(pad, 500))
+	if err != nil {
+		t.Fatalf("create pad declaration: %v", err)
+	}
+	nextRow, err := p.CreateHoldingDeclaration(ctx, userID, "IBKR", "acct1", instID, "650", next, time.Time{})
+	if err != nil {
+		t.Fatalf("create assertion: %v", err)
+	}
+
+	// Delete the pad's declaration, promoting the assertion behind it.
+	promoted := initTx(next, 650)
+	if err := p.DeleteDeclarationWithInitializeTx(ctx, padRow.ID, userID, "IBKR", "acct1", instID, &promoted); err != nil {
+		t.Fatalf("delete pad declaration: %v", err)
+	}
+	if got := initQtyByAccountType(t, p, userID); !maps.Equal(got, map[apiv1.AccountType]string{
+		apiv1.AccountType_ACCOUNT_TYPE_USER:   "650",
+		apiv1.AccountType_ACCOUNT_TYPE_EQUITY: "-650",
+	}) {
+		t.Fatalf("INITIALIZE legs after promoting: got %v", got)
+	}
+
+	// Delete the last declaration and the pad goes with it.
+	if err := p.DeleteDeclarationWithInitializeTx(ctx, nextRow.ID, userID, "IBKR", "acct1", instID, nil); err != nil {
+		t.Fatalf("delete last declaration: %v", err)
+	}
+	if got := initQtyByAccountType(t, p, userID); len(got) != 0 {
+		t.Fatalf("INITIALIZE legs after deleting the last declaration: want none, got %v", got)
+	}
+	if got := countOrphanGroups(t, p, userID); got != 0 {
+		t.Errorf("orphan tx_groups after delete: want 0, got %d", got)
 	}
 }
 

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -873,6 +873,15 @@ $$;
 -- it and the postings it is reconciled against can be in different units, and a
 -- correct portfolio disagrees with itself by the split factor.
 -- See docs/spec/bitemporality.md.
+--
+-- The unique key carries as_of_date, so a holding may hold several declarations at
+-- different dates. The earliest is the pad: it generates the INITIALIZE transaction
+-- that makes the declared quantity true, and it is true by construction, so it can
+-- never catch an error. The later ones are assertions -- statements the computed
+-- holding is checked against, which is where the safety comes from. The
+-- discriminator is not stored: deriving it from MIN(as_of_date) leaves nothing to
+-- drift out of step with the rows.
+-- See docs/spec/fixed-point.md and docs/adr/0011-synthetic-initialize-transactions.md.
 CREATE TABLE holding_declarations (
   id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id           UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
@@ -884,7 +893,7 @@ CREATE TABLE holding_declarations (
   share_count_basis DATE NOT NULL,
   created_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
   updated_at        TIMESTAMPTZ NOT NULL DEFAULT now(),
-  UNIQUE (user_id, broker, account, instrument_id)
+  UNIQUE (user_id, broker, account, instrument_id, as_of_date)
 );
 
 -- The default lives here rather than in the application so that every path into the

--- a/server/service/api/declarations.go
+++ b/server/service/api/declarations.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"strconv"
 	"time"
@@ -60,7 +61,78 @@ func declarationToProto(r *db.HoldingDeclarationRow) *apiv1.HoldingDeclaration {
 		DeclaredQty:     r.DeclaredQty,
 		AsOfDate:        timeToDate(r.AsOfDate),
 		ShareCountBasis: timeToDate(r.ShareCountBasis),
+		Kind:            r.Kind,
 	}
+}
+
+// padDeclaration returns the declaration that seeds a holding's opening balance --
+// the earliest of them -- or nil when the holding has none. The pad is derived from
+// the set rather than flagged on a row, so adding an earlier declaration or deleting
+// the current pad simply changes which one this returns.
+func padDeclaration(decls []*db.HoldingDeclarationRow) *db.HoldingDeclarationRow {
+	var pad *db.HoldingDeclarationRow
+	for _, d := range decls {
+		if pad == nil || d.AsOfDate.Before(pad.AsOfDate) {
+			pad = d
+		}
+	}
+	return pad
+}
+
+// holdingDeclarations filters a user's declarations to one holding, dropping the
+// declaration with the given id. Callers pass the id of the row they are about to
+// replace or delete, so what comes back is the rest of the holding as it will be
+// once the write lands. Pass "" to keep all of them.
+func holdingDeclarations(all []*db.HoldingDeclarationRow, broker, account, instrumentID, excludeID string) []*db.HoldingDeclarationRow {
+	out := make([]*db.HoldingDeclarationRow, 0, len(all))
+	for _, d := range all {
+		if d.Broker == broker && d.Account == account && d.InstrumentID == instrumentID && d.ID != excludeID {
+			out = append(out, d)
+		}
+	}
+	return out
+}
+
+// holdingPad is the pad a write settles on: the transaction to store, and the
+// as_of_date of the declaration it came from. Declaration dates are unique within a
+// holding, so that date is what tells a caller whether the row it just wrote is the
+// pad -- which the pending row's absent id cannot.
+type holdingPad struct {
+	init *db.InitializeTx // nil when the holding has no declarations left
+	asOf time.Time
+}
+
+// padAfterWrite computes the pad for a holding as it will stand once the pending
+// write lands. pending is the declaration being created or updated, or nil for a
+// delete; excludeID drops the row being replaced or removed. The pad is nil only
+// when the holding will have no declarations left, which is the one case where it is
+// removed rather than rewritten.
+func (s *Server) padAfterWrite(ctx context.Context, userID, broker, account, instrumentID, excludeID string, pending *db.HoldingDeclarationRow, startDate time.Time) (holdingPad, error) {
+	all, err := s.db.ListHoldingDeclarations(ctx, userID)
+	if err != nil {
+		return holdingPad{}, err
+	}
+	decls := holdingDeclarations(all, broker, account, instrumentID, excludeID)
+	if pending != nil {
+		decls = append(decls, pending)
+	}
+	pad := padDeclaration(decls)
+	if pad == nil {
+		return holdingPad{}, nil
+	}
+	init, err := s.computeInitializeValues(ctx, userID, broker, account, instrumentID, pad.DeclaredQty, pad.AsOfDate, pad.ShareCountBasis, startDate)
+	if err != nil {
+		return holdingPad{}, err
+	}
+	return holdingPad{init: &init, asOf: pad.AsOfDate}, nil
+}
+
+// kindOf reports whether the declaration at asOfDate is its holding's pad.
+func (p holdingPad) kindOf(asOfDate time.Time) apiv1.DeclarationKind {
+	if p.init != nil && asOfDate.Equal(p.asOf) {
+		return apiv1.DeclarationKind_DECLARATION_KIND_PAD
+	}
+	return apiv1.DeclarationKind_DECLARATION_KIND_ASSERT
 }
 
 // shareCountBasis reads the declared denomination from a request, falling back to
@@ -100,15 +172,23 @@ func (s *Server) CreateHoldingDeclaration(ctx context.Context, req *apiv1.Create
 		return nil, status.Errorf(codes.InvalidArgument, "as_of_date must be on or after the portfolio start date (%s)", startDay.Format("2006-01-02"))
 	}
 
-	init, err := s.computeInitializeValues(ctx, u.ID, req.GetBroker(), req.GetAccount(), req.GetInstrumentId(), req.GetDeclaredQty(), asOfDate, basis, *startDate)
+	// The new declaration joins whatever the holding already has, and the earliest of
+	// the set is the pad -- so a declaration earlier than the current pad takes over
+	// from it, and a later one is an assertion that generates nothing.
+	pending := &db.HoldingDeclarationRow{DeclaredQty: req.GetDeclaredQty(), AsOfDate: asOfDate, ShareCountBasis: basis}
+	pad, err := s.padAfterWrite(ctx, u.ID, req.GetBroker(), req.GetAccount(), req.GetInstrumentId(), "", pending, *startDate)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "compute INITIALIZE tx: %v", err)
 	}
 
-	row, err := s.db.CreateDeclarationWithInitializeTx(ctx, u.ID, req.GetBroker(), req.GetAccount(), req.GetInstrumentId(), req.GetDeclaredQty(), asOfDate, basis, init)
+	row, err := s.db.CreateDeclarationWithInitializeTx(ctx, u.ID, req.GetBroker(), req.GetAccount(), req.GetInstrumentId(), req.GetDeclaredQty(), asOfDate, basis, *pad.init)
 	if err != nil {
+		if errors.Is(err, db.ErrDuplicate) {
+			return nil, status.Error(codes.AlreadyExists, "a declaration for this holding already exists at that date")
+		}
 		return nil, status.Error(codes.Internal, err.Error())
 	}
+	row.Kind = pad.kindOf(row.AsOfDate)
 
 	return &apiv1.CreateHoldingDeclarationResponse{Declaration: declarationToProto(row)}, nil
 }
@@ -150,15 +230,22 @@ func (s *Server) UpdateHoldingDeclaration(ctx context.Context, req *apiv1.Update
 	// units of a quantity the user did not touch would silently change what they said.
 	basis := shareCountBasis(req.GetShareCountBasis(), existing.ShareCountBasis)
 
-	init, err := s.computeInitializeValues(ctx, u.ID, existing.Broker, existing.Account, existing.InstrumentID, req.GetDeclaredQty(), asOfDate, basis, *startDate)
+	// Moving as_of_date can hand the pad to a sibling or take it from one, so the pad
+	// is recomputed from the holding as it will stand, not from this row alone.
+	pending := &db.HoldingDeclarationRow{DeclaredQty: req.GetDeclaredQty(), AsOfDate: asOfDate, ShareCountBasis: basis}
+	pad, err := s.padAfterWrite(ctx, u.ID, existing.Broker, existing.Account, existing.InstrumentID, existing.ID, pending, *startDate)
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "compute INITIALIZE tx: %v", err)
 	}
 
-	row, err := s.db.UpdateDeclarationWithInitializeTx(ctx, req.GetId(), req.GetDeclaredQty(), asOfDate, basis, u.ID, existing.Broker, existing.Account, existing.InstrumentID, init)
+	row, err := s.db.UpdateDeclarationWithInitializeTx(ctx, req.GetId(), req.GetDeclaredQty(), asOfDate, basis, u.ID, existing.Broker, existing.Account, existing.InstrumentID, *pad.init)
 	if err != nil {
+		if errors.Is(err, db.ErrDuplicate) {
+			return nil, status.Error(codes.AlreadyExists, "a declaration for this holding already exists at that date")
+		}
 		return nil, status.Error(codes.Internal, err.Error())
 	}
+	row.Kind = pad.kindOf(row.AsOfDate)
 
 	return &apiv1.UpdateHoldingDeclarationResponse{Declaration: declarationToProto(row)}, nil
 }
@@ -179,7 +266,24 @@ func (s *Server) DeleteHoldingDeclaration(ctx context.Context, req *apiv1.Delete
 	if existing.UserID != u.ID {
 		return nil, status.Error(codes.NotFound, "declaration not found")
 	}
-	if err := s.db.DeleteDeclarationWithInitializeTx(ctx, req.GetId(), u.ID, existing.Broker, existing.Account, existing.InstrumentID); err != nil {
+
+	// Deleting an assertion leaves the pad alone; deleting the pad promotes the
+	// next-earliest declaration to take its place. Only the last declaration for a
+	// holding takes the pad with it, and a portfolio with no transactions left has no
+	// start date to anchor one to.
+	var pad holdingPad
+	startDate, err := s.db.GetPortfolioStartDate(ctx, u.ID)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	if startDate != nil {
+		pad, err = s.padAfterWrite(ctx, u.ID, existing.Broker, existing.Account, existing.InstrumentID, existing.ID, nil, *startDate)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "compute INITIALIZE tx: %v", err)
+		}
+	}
+
+	if err := s.db.DeleteDeclarationWithInitializeTx(ctx, req.GetId(), u.ID, existing.Broker, existing.Account, existing.InstrumentID, pad.init); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	return &apiv1.DeleteHoldingDeclarationResponse{}, nil

--- a/server/service/api/declarations_test.go
+++ b/server/service/api/declarations_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
@@ -59,6 +60,7 @@ func TestCreateHoldingDeclaration_Success(t *testing.T) {
 	ctx := authCtx("user-1", "sub|1")
 	startDate := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
 	mockDB.EXPECT().GetPortfolioStartDate(gomock.Any(), "user-1").Return(&startDate, nil)
+	mockDB.EXPECT().ListHoldingDeclarations(gomock.Any(), "user-1").Return(nil, nil)
 	// Unset in the request, so the balance is asked for at as_of_date -- as-traded.
 	mockDB.EXPECT().ComputeRunningBalance(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", gomock.Any(), gomock.Any(), asOfJun1).Return(decimal.NewFromInt(30), nil)
 	mockDB.EXPECT().GetInstrument(gomock.Any(), "inst-1").Return(nil, nil)
@@ -90,6 +92,7 @@ func TestCreateHoldingDeclaration_StatedShareCountBasis(t *testing.T) {
 	ctx := authCtx("user-1", "sub|1")
 	startDate := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
 	mockDB.EXPECT().GetPortfolioStartDate(gomock.Any(), "user-1").Return(&startDate, nil)
+	mockDB.EXPECT().ListHoldingDeclarations(gomock.Any(), "user-1").Return(nil, nil)
 	mockDB.EXPECT().ComputeRunningBalance(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", gomock.Any(), gomock.Any(), storedBasis).Return(decimal.NewFromInt(30), nil)
 	mockDB.EXPECT().GetInstrument(gomock.Any(), "inst-1").Return(nil, nil)
 	mockDB.EXPECT().
@@ -103,6 +106,122 @@ func TestCreateHoldingDeclaration_StatedShareCountBasis(t *testing.T) {
 	})
 	if err != nil {
 		t.Fatalf("CreateHoldingDeclaration: %v", err)
+	}
+}
+
+// TestCreateHoldingDeclaration_LaterIsAnAssertion covers the second declaration for
+// a holding. The earlier one keeps the pad, so the pad is recomputed from it rather
+// than from the row being written, and the new one generates nothing.
+func TestCreateHoldingDeclaration_LaterIsAnAssertion(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	ctx := authCtx("user-1", "sub|1")
+	startDate := time.Date(2020, 1, 1, 10, 0, 0, 0, time.UTC)
+	padAsOf := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	assertAsOf := time.Date(2023, 12, 31, 0, 0, 0, 0, time.UTC)
+
+	mockDB.EXPECT().GetPortfolioStartDate(gomock.Any(), "user-1").Return(&startDate, nil)
+	mockDB.EXPECT().ListHoldingDeclarations(gomock.Any(), "user-1").Return([]*db.HoldingDeclarationRow{
+		{ID: "d1", UserID: "user-1", Broker: "IBKR", Account: "acct1", InstrumentID: "inst-1", DeclaredQty: "500", AsOfDate: padAsOf, ShareCountBasis: padAsOf},
+	}, nil)
+	// Balanced and padded at the existing declaration's date, not the new one's.
+	mockDB.EXPECT().ComputeRunningBalance(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", gomock.Any(), gomock.Any(), padAsOf).Return(decimal.NewFromInt(100), nil)
+	mockDB.EXPECT().GetInstrument(gomock.Any(), "inst-1").Return(nil, nil)
+	mockDB.EXPECT().
+		CreateDeclarationWithInitializeTx(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", "650", assertAsOf, assertAsOf, padEq("BUYOTHER", "400", padAsOf)).
+		Return(&db.HoldingDeclarationRow{ID: "d2", UserID: "user-1", AsOfDate: assertAsOf, ShareCountBasis: assertAsOf}, nil)
+
+	resp, err := srv.CreateHoldingDeclaration(ctx, &apiv1.CreateHoldingDeclarationRequest{
+		Broker: "IBKR", Account: "acct1", InstrumentId: "inst-1", DeclaredQty: "650",
+		AsOfDate: &date.Date{Year: 2023, Month: 12, Day: 31},
+	})
+	if err != nil {
+		t.Fatalf("CreateHoldingDeclaration: %v", err)
+	}
+	if got := resp.GetDeclaration().GetKind(); got != apiv1.DeclarationKind_DECLARATION_KIND_ASSERT {
+		t.Fatalf("kind: want ASSERT, got %v", got)
+	}
+}
+
+// TestCreateHoldingDeclaration_EarlierTakesOverThePad is the same case from the
+// other side: a declaration earlier than the current pad becomes the pad, and the
+// one that used to hold it becomes an assertion.
+func TestCreateHoldingDeclaration_EarlierTakesOverThePad(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	ctx := authCtx("user-1", "sub|1")
+	startDate := time.Date(2020, 1, 1, 10, 0, 0, 0, time.UTC)
+	oldPad := time.Date(2023, 12, 31, 0, 0, 0, 0, time.UTC)
+	newPad := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+
+	mockDB.EXPECT().GetPortfolioStartDate(gomock.Any(), "user-1").Return(&startDate, nil)
+	mockDB.EXPECT().ListHoldingDeclarations(gomock.Any(), "user-1").Return([]*db.HoldingDeclarationRow{
+		{ID: "d1", UserID: "user-1", Broker: "IBKR", Account: "acct1", InstrumentID: "inst-1", DeclaredQty: "650", AsOfDate: oldPad, ShareCountBasis: oldPad},
+	}, nil)
+	mockDB.EXPECT().ComputeRunningBalance(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", gomock.Any(), gomock.Any(), newPad).Return(decimal.NewFromInt(100), nil)
+	mockDB.EXPECT().GetInstrument(gomock.Any(), "inst-1").Return(nil, nil)
+	mockDB.EXPECT().
+		CreateDeclarationWithInitializeTx(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", "500", newPad, newPad, padEq("BUYOTHER", "400", newPad)).
+		Return(&db.HoldingDeclarationRow{ID: "d2", UserID: "user-1", AsOfDate: newPad, ShareCountBasis: newPad}, nil)
+
+	resp, err := srv.CreateHoldingDeclaration(ctx, &apiv1.CreateHoldingDeclarationRequest{
+		Broker: "IBKR", Account: "acct1", InstrumentId: "inst-1", DeclaredQty: "500",
+		AsOfDate: &date.Date{Year: 2021, Month: 1, Day: 1},
+	})
+	if err != nil {
+		t.Fatalf("CreateHoldingDeclaration: %v", err)
+	}
+	if got := resp.GetDeclaration().GetKind(); got != apiv1.DeclarationKind_DECLARATION_KIND_PAD {
+		t.Fatalf("kind: want PAD, got %v", got)
+	}
+}
+
+// TestCreateHoldingDeclaration_SameDate rejects a second declaration at a date the
+// holding already has. The two would say different things about one moment, and
+// nothing decides between them.
+func TestCreateHoldingDeclaration_SameDate(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	ctx := authCtx("user-1", "sub|1")
+	startDate := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
+	mockDB.EXPECT().GetPortfolioStartDate(gomock.Any(), "user-1").Return(&startDate, nil)
+	mockDB.EXPECT().ListHoldingDeclarations(gomock.Any(), "user-1").Return(nil, nil)
+	mockDB.EXPECT().ComputeRunningBalance(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", gomock.Any(), gomock.Any(), asOfJun1).Return(decimal.NewFromInt(30), nil)
+	mockDB.EXPECT().GetInstrument(gomock.Any(), "inst-1").Return(nil, nil)
+	mockDB.EXPECT().
+		CreateDeclarationWithInitializeTx(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", "100", asOfJun1, asOfJun1, gomock.Any()).
+		Return(nil, fmt.Errorf("create holding declaration: %w", db.ErrDuplicate))
+
+	_, err := srv.CreateHoldingDeclaration(ctx, &apiv1.CreateHoldingDeclarationRequest{
+		Broker: "IBKR", Account: "acct1", InstrumentId: "inst-1", DeclaredQty: "100",
+		AsOfDate: &date.Date{Year: 2025, Month: 6, Day: 1},
+	})
+	testutil.RequireGRPCCode(t, err, codes.AlreadyExists)
+}
+
+// TestDeleteHoldingDeclaration_PromotesTheNextPad covers deleting the pad while
+// later declarations remain: the holding keeps a pad, rewritten from whichever
+// declaration is now earliest.
+func TestDeleteHoldingDeclaration_PromotesTheNextPad(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	ctx := authCtx("user-1", "sub|1")
+	startDate := time.Date(2020, 1, 1, 10, 0, 0, 0, time.UTC)
+	oldPad := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	next := time.Date(2023, 12, 31, 0, 0, 0, 0, time.UTC)
+
+	mockDB.EXPECT().GetHoldingDeclaration(gomock.Any(), "d1").Return(&db.HoldingDeclarationRow{
+		ID: "d1", UserID: "user-1", Broker: "IBKR", Account: "acct1", InstrumentID: "inst-1", AsOfDate: oldPad, ShareCountBasis: oldPad,
+	}, nil)
+	mockDB.EXPECT().GetPortfolioStartDate(gomock.Any(), "user-1").Return(&startDate, nil)
+	mockDB.EXPECT().ListHoldingDeclarations(gomock.Any(), "user-1").Return([]*db.HoldingDeclarationRow{
+		{ID: "d1", UserID: "user-1", Broker: "IBKR", Account: "acct1", InstrumentID: "inst-1", DeclaredQty: "500", AsOfDate: oldPad, ShareCountBasis: oldPad},
+		{ID: "d2", UserID: "user-1", Broker: "IBKR", Account: "acct1", InstrumentID: "inst-1", DeclaredQty: "650", AsOfDate: next, ShareCountBasis: next},
+	}, nil)
+	mockDB.EXPECT().ComputeRunningBalance(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", gomock.Any(), gomock.Any(), next).Return(decimal.NewFromInt(50), nil)
+	mockDB.EXPECT().GetInstrument(gomock.Any(), "inst-1").Return(nil, nil)
+	mockDB.EXPECT().
+		DeleteDeclarationWithInitializeTx(gomock.Any(), "d1", "user-1", "IBKR", "acct1", "inst-1", padEq("BUYOTHER", "600", next)).
+		Return(nil)
+
+	if _, err := srv.DeleteHoldingDeclaration(ctx, &apiv1.DeleteHoldingDeclarationRequest{Id: "d1"}); err != nil {
+		t.Fatalf("DeleteHoldingDeclaration: %v", err)
 	}
 }
 
@@ -146,6 +265,7 @@ func TestUpdateHoldingDeclaration_Success(t *testing.T) {
 	mockDB.EXPECT().GetHoldingDeclaration(gomock.Any(), "d1").Return(existing, nil)
 	startDate := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
 	mockDB.EXPECT().GetPortfolioStartDate(gomock.Any(), "user-1").Return(&startDate, nil)
+	mockDB.EXPECT().ListHoldingDeclarations(gomock.Any(), "user-1").Return(nil, nil)
 	mockDB.EXPECT().ComputeRunningBalance(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", gomock.Any(), gomock.Any(), storedBasis).Return(decimal.NewFromInt(50), nil)
 	mockDB.EXPECT().GetInstrument(gomock.Any(), "inst-1").Return(nil, nil)
 	mockDB.EXPECT().
@@ -185,7 +305,8 @@ func TestDeleteHoldingDeclaration_Success(t *testing.T) {
 		ID: "d1", UserID: "user-1", Broker: "IBKR", Account: "acct1", InstrumentID: "inst-1",
 	}
 	mockDB.EXPECT().GetHoldingDeclaration(gomock.Any(), "d1").Return(existing, nil)
-	mockDB.EXPECT().DeleteDeclarationWithInitializeTx(gomock.Any(), "d1", "user-1", "IBKR", "acct1", "inst-1").Return(nil)
+	mockDB.EXPECT().GetPortfolioStartDate(gomock.Any(), "user-1").Return(nil, nil)
+	mockDB.EXPECT().DeleteDeclarationWithInitializeTx(gomock.Any(), "d1", "user-1", "IBKR", "acct1", "inst-1", gomock.Nil()).Return(nil)
 
 	_, err := srv.DeleteHoldingDeclaration(ctx, &apiv1.DeleteHoldingDeclarationRequest{Id: "d1"})
 	if err != nil {

--- a/server/service/api/recalc.go
+++ b/server/service/api/recalc.go
@@ -10,30 +10,113 @@ import (
 	"github.com/shopspring/decimal"
 )
 
-// RecalcInitializeTx recomputes the INITIALIZE tx for a single holding declaration.
-// Called when a real tx changes within the declaration's date range.
-func RecalcInitializeTx(ctx context.Context, database db.DB, decl *db.HoldingDeclarationRow) error {
-	return recalcInitializeTx(ctx, database, decl, nil)
+// holdingKey identifies the holding a set of declarations belongs to. Holdings are
+// computed aggregates, so there is no id to key them by.
+type holdingKey struct {
+	broker       string
+	account      string
+	instrumentID string
 }
 
-func recalcInitializeTx(ctx context.Context, database db.DB, decl *db.HoldingDeclarationRow, instByID map[string]*db.InstrumentRow) error {
-	startDate, err := database.GetPortfolioStartDate(ctx, decl.UserID)
+// RecalcAllInitializeTxs recomputes every INITIALIZE tx for a user. Called when the
+// portfolio start date may have changed (e.g. after bulk tx replace).
+//
+// The unit of recalculation is the holding, not the declaration: which declaration
+// pads a holding depends on the others, so a single declaration is not enough to
+// know whether it is the pad. Declarations that the start date has moved past are
+// pruned first, and each surviving holding's earliest declaration becomes its pad.
+func RecalcAllInitializeTxs(ctx context.Context, database db.DB, userID string) error {
+	decls, err := database.ListHoldingDeclarations(ctx, userID)
+	if err != nil {
+		return fmt.Errorf("list declarations: %w", err)
+	}
+	if len(decls) == 0 {
+		return nil
+	}
+
+	startDate, err := database.GetPortfolioStartDate(ctx, userID)
 	if err != nil {
 		return fmt.Errorf("get portfolio start date: %w", err)
 	}
 	if startDate == nil {
-		// No real txs remain; delete the INITIALIZE tx if it exists.
-		return database.DeleteInitializeTx(ctx, decl.UserID, decl.Broker, decl.Account, decl.InstrumentID)
+		// No real txs remain, so there is no start date to anchor a pad to. The
+		// declarations are what the user said and survive; the derived pads do not.
+		for key := range byHolding(decls) {
+			if err := database.DeleteInitializeTx(ctx, userID, key.broker, key.account, key.instrumentID); err != nil {
+				return fmt.Errorf("delete pad for %s/%s/%s: %w", key.broker, key.account, key.instrumentID, err)
+			}
+		}
+		return nil
 	}
 	startDay := startDate.Truncate(24 * time.Hour)
-	if decl.AsOfDate.Before(startDay) {
-		// Start date moved past declaration date; delete declaration and INITIALIZE tx.
+
+	before := byHolding(decls)
+	kept, err := pruneBeforeStart(ctx, database, decls, startDay)
+	if err != nil {
+		return err
+	}
+	after := byHolding(kept)
+
+	// A holding whose last declaration was pruned has nothing left to pad to.
+	for key := range before {
+		if len(after[key]) == 0 {
+			if err := database.DeleteInitializeTx(ctx, userID, key.broker, key.account, key.instrumentID); err != nil {
+				return fmt.Errorf("delete pad for %s/%s/%s: %w", key.broker, key.account, key.instrumentID, err)
+			}
+		}
+	}
+
+	// Batch-load instruments for asset class lookup.
+	instIDs := make([]string, 0, len(kept))
+	for _, decl := range kept {
+		instIDs = append(instIDs, decl.InstrumentID)
+	}
+	instByID := map[string]*db.InstrumentRow{}
+	if len(instIDs) > 0 {
+		instRows, err := database.ListInstrumentsByIDs(ctx, instIDs)
+		if err != nil {
+			return fmt.Errorf("load instruments: %w", err)
+		}
+		for _, r := range instRows {
+			instByID[r.ID] = r
+		}
+	}
+
+	for key, group := range byHolding(kept) {
+		pad := padDeclaration(group)
+		if err := recalcHoldingPad(ctx, database, pad, startDay, instByID); err != nil {
+			return fmt.Errorf("recalc pad for %s/%s/%s: %w", key.broker, key.account, key.instrumentID, err)
+		}
+	}
+	return nil
+}
+
+// pruneBeforeStart deletes the declarations the portfolio start date has moved past
+// -- a statement about a date the history no longer reaches cannot be padded to or
+// checked against -- and returns those that survive. Only the declaration rows go
+// here; the caller settles each holding's pad afterwards from what is left, so this
+// does not need the atomic delete the user-facing path uses.
+func pruneBeforeStart(ctx context.Context, database db.DB, decls []*db.HoldingDeclarationRow, startDay time.Time) ([]*db.HoldingDeclarationRow, error) {
+	kept := make([]*db.HoldingDeclarationRow, 0, len(decls))
+	for _, decl := range decls {
+		if !decl.AsOfDate.Before(startDay) {
+			kept = append(kept, decl)
+			continue
+		}
 		slog.Warn("portfolio start date moved past declaration as_of_date; deleting declaration",
 			"user_id", decl.UserID, "declaration_id", decl.ID,
 			"as_of_date", decl.AsOfDate.Format("2006-01-02"),
 			"start_date", startDay.Format("2006-01-02"))
-		return database.DeleteDeclarationWithInitializeTx(ctx, decl.ID, decl.UserID, decl.Broker, decl.Account, decl.InstrumentID)
+		if err := database.DeleteHoldingDeclaration(ctx, decl.ID); err != nil {
+			return nil, fmt.Errorf("delete declaration %s: %w", decl.ID, err)
+		}
 	}
+	return kept, nil
+}
+
+// recalcHoldingPad rewrites a holding's INITIALIZE tx from the declaration that pads
+// it. instByID may be nil, in which case the instrument is loaded on demand.
+func recalcHoldingPad(ctx context.Context, database db.DB, decl *db.HoldingDeclarationRow, startDay time.Time, instByID map[string]*db.InstrumentRow) error {
 	declaredQty, err := decimal.NewFromString(decl.DeclaredQty)
 	if err != nil {
 		return fmt.Errorf("parse declared_qty: %w", err)
@@ -65,33 +148,14 @@ func recalcInitializeTx(ctx context.Context, database db.DB, decl *db.HoldingDec
 	})
 }
 
-// RecalcAllInitializeTxs recomputes all INITIALIZE txs for a user.
-// Called when the portfolio start date may have changed (e.g. after bulk tx replace).
-func RecalcAllInitializeTxs(ctx context.Context, database db.DB, userID string) error {
-	decls, err := database.ListHoldingDeclarations(ctx, userID)
-	if err != nil {
-		return fmt.Errorf("list declarations: %w", err)
-	}
-	if len(decls) == 0 {
-		return nil
-	}
-	// Batch-load instruments for asset class lookup
-	instIDs := make([]string, 0, len(decls))
+func keyOf(decl *db.HoldingDeclarationRow) holdingKey {
+	return holdingKey{broker: decl.Broker, account: decl.Account, instrumentID: decl.InstrumentID}
+}
+
+func byHolding(decls []*db.HoldingDeclarationRow) map[holdingKey][]*db.HoldingDeclarationRow {
+	out := map[holdingKey][]*db.HoldingDeclarationRow{}
 	for _, decl := range decls {
-		instIDs = append(instIDs, decl.InstrumentID)
+		out[keyOf(decl)] = append(out[keyOf(decl)], decl)
 	}
-	instRows, err := database.ListInstrumentsByIDs(ctx, instIDs)
-	if err != nil {
-		return fmt.Errorf("load instruments: %w", err)
-	}
-	instByID := make(map[string]*db.InstrumentRow, len(instRows))
-	for _, r := range instRows {
-		instByID[r.ID] = r
-	}
-	for _, decl := range decls {
-		if err := recalcInitializeTx(ctx, database, decl, instByID); err != nil {
-			return fmt.Errorf("recalc declaration %s: %w", decl.ID, err)
-		}
-	}
-	return nil
+	return out
 }

--- a/server/service/api/recalc_test.go
+++ b/server/service/api/recalc_test.go
@@ -28,7 +28,14 @@ type padMatcher struct {
 
 func (m padMatcher) Matches(x any) bool {
 	got, ok := x.(db.InitializeTx)
-	return ok && got.TxType == m.txType && got.Quantity.Equal(m.qty) && got.ShareCountBasis.Equal(m.basis)
+	if !ok {
+		p, isPtr := x.(*db.InitializeTx)
+		if !isPtr || p == nil {
+			return false
+		}
+		got = *p
+	}
+	return got.TxType == m.txType && got.Quantity.Equal(m.qty) && got.ShareCountBasis.Equal(m.basis)
 }
 
 func (m padMatcher) String() string {
@@ -47,90 +54,154 @@ func testDecl(id, instrumentID, declaredQty string) *db.HoldingDeclarationRow {
 	}
 }
 
-func TestRecalcInitializeTx_RecomputesQty(t *testing.T) {
+// declAt is testDecl at a chosen date, for the cases about which declaration pads.
+func declAt(id, instrumentID, declaredQty string, asOf time.Time) *db.HoldingDeclarationRow {
+	d := testDecl(id, instrumentID, declaredQty)
+	d.AsOfDate = asOf
+	d.ShareCountBasis = asOf
+	return d
+}
+
+func TestRecalcAllInitializeTxs_RecomputesQty(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockDB := mock.NewMockDB(ctrl)
 
 	startDate := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
-	decl := testDecl("d1", "inst-1", "100")
-
+	mockDB.EXPECT().ListHoldingDeclarations(gomock.Any(), "user-1").Return([]*db.HoldingDeclarationRow{testDecl("d1", "inst-1", "100")}, nil)
 	mockDB.EXPECT().GetPortfolioStartDate(gomock.Any(), "user-1").Return(&startDate, nil)
+	mockDB.EXPECT().ListInstrumentsByIDs(gomock.Any(), gomock.Any()).Return(nil, nil)
 	// The balance is asked for in the declaration's denomination, not in whatever
 	// mixture the postings happen to be recorded in.
 	mockDB.EXPECT().ComputeRunningBalance(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", gomock.Any(), gomock.Any(), testBasis).Return(decimal.NewFromInt(40), nil)
-	mockDB.EXPECT().GetInstrument(gomock.Any(), "inst-1").Return(nil, nil)
 	mockDB.EXPECT().UpsertInitializeTx(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", padEq("BUYOTHER", "60", testBasis)).Return(nil)
 
-	if err := RecalcInitializeTx(context.Background(), mockDB, decl); err != nil {
-		t.Fatalf("RecalcInitializeTx: %v", err)
+	if err := RecalcAllInitializeTxs(context.Background(), mockDB, "user-1"); err != nil {
+		t.Fatalf("RecalcAllInitializeTxs: %v", err)
 	}
 }
 
-func TestRecalcInitializeTx_NoRealTxs_DeletesInitialize(t *testing.T) {
+// TestRecalcAllInitializeTxs_PadsTheEarliest is the rule the whole pad/assert split
+// rests on: a holding's earliest declaration seeds its opening balance, and the
+// later ones generate nothing at all.
+func TestRecalcAllInitializeTxs_PadsTheEarliest(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockDB := mock.NewMockDB(ctrl)
 
+	pad := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	assert := time.Date(2023, 12, 31, 0, 0, 0, 0, time.UTC)
+	startDate := time.Date(2020, 1, 1, 10, 0, 0, 0, time.UTC)
+
+	// Listed newest first, so the choice cannot come from the ordering.
+	mockDB.EXPECT().ListHoldingDeclarations(gomock.Any(), "user-1").Return([]*db.HoldingDeclarationRow{
+		declAt("d2", "inst-1", "650", assert),
+		declAt("d1", "inst-1", "500", pad),
+	}, nil)
+	mockDB.EXPECT().GetPortfolioStartDate(gomock.Any(), "user-1").Return(&startDate, nil)
+	mockDB.EXPECT().ListInstrumentsByIDs(gomock.Any(), gomock.Any()).Return(nil, nil)
+	// Exactly one balance and one upsert: the assertion is not padded to.
+	mockDB.EXPECT().ComputeRunningBalance(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", gomock.Any(), gomock.Any(), pad).Return(decimal.NewFromInt(100), nil)
+	mockDB.EXPECT().UpsertInitializeTx(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", padEq("BUYOTHER", "400", pad)).Return(nil)
+
+	if err := RecalcAllInitializeTxs(context.Background(), mockDB, "user-1"); err != nil {
+		t.Fatalf("RecalcAllInitializeTxs: %v", err)
+	}
+}
+
+func TestRecalcAllInitializeTxs_NoRealTxs_DeletesInitialize(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockDB := mock.NewMockDB(ctrl)
+
+	mockDB.EXPECT().ListHoldingDeclarations(gomock.Any(), "user-1").Return([]*db.HoldingDeclarationRow{testDecl("d1", "inst-1", "100")}, nil)
 	mockDB.EXPECT().GetPortfolioStartDate(gomock.Any(), "user-1").Return(nil, nil)
+	// The declaration is what the user said and survives; only the derived pad goes.
 	mockDB.EXPECT().DeleteInitializeTx(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1").Return(nil)
 
-	if err := RecalcInitializeTx(context.Background(), mockDB, testDecl("d1", "inst-1", "100")); err != nil {
-		t.Fatalf("RecalcInitializeTx: %v", err)
+	if err := RecalcAllInitializeTxs(context.Background(), mockDB, "user-1"); err != nil {
+		t.Fatalf("RecalcAllInitializeTxs: %v", err)
 	}
 }
 
-func TestRecalcInitializeTx_StartDatePastDeclaration_DeletesBoth(t *testing.T) {
+// TestRecalcAllInitializeTxs_StartDatePastDeclaration_PromotesTheNext covers a start
+// date that moved forward past the pad. The pad's declaration is about a date the
+// history no longer reaches and goes; the assertion behind it becomes the pad.
+func TestRecalcAllInitializeTxs_StartDatePastDeclaration_PromotesTheNext(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockDB := mock.NewMockDB(ctrl)
 
-	// Start date moved to July, but declaration is for June
-	startDate := time.Date(2025, 7, 1, 10, 0, 0, 0, time.UTC)
+	old := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	next := time.Date(2023, 12, 31, 0, 0, 0, 0, time.UTC)
+	startDate := time.Date(2022, 1, 1, 10, 0, 0, 0, time.UTC)
 
+	mockDB.EXPECT().ListHoldingDeclarations(gomock.Any(), "user-1").Return([]*db.HoldingDeclarationRow{
+		declAt("d1", "inst-1", "500", old),
+		declAt("d2", "inst-1", "650", next),
+	}, nil)
 	mockDB.EXPECT().GetPortfolioStartDate(gomock.Any(), "user-1").Return(&startDate, nil)
-	mockDB.EXPECT().DeleteDeclarationWithInitializeTx(gomock.Any(), "d1", "user-1", "IBKR", "acct1", "inst-1").Return(nil)
+	mockDB.EXPECT().DeleteHoldingDeclaration(gomock.Any(), "d1").Return(nil)
+	mockDB.EXPECT().ListInstrumentsByIDs(gomock.Any(), gomock.Any()).Return(nil, nil)
+	mockDB.EXPECT().ComputeRunningBalance(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", gomock.Any(), gomock.Any(), next).Return(decimal.NewFromInt(50), nil)
+	mockDB.EXPECT().UpsertInitializeTx(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", padEq("BUYOTHER", "600", next)).Return(nil)
 
-	if err := RecalcInitializeTx(context.Background(), mockDB, testDecl("d1", "inst-1", "100")); err != nil {
-		t.Fatalf("RecalcInitializeTx: %v", err)
+	if err := RecalcAllInitializeTxs(context.Background(), mockDB, "user-1"); err != nil {
+		t.Fatalf("RecalcAllInitializeTxs: %v", err)
 	}
 }
 
-// TestRecalcInitializeTx_ZeroQty_KeepsDeclaration covers the case where the real
+// TestRecalcAllInitializeTxs_StartDatePastAll_DeletesTheHoldingsPad is the same
+// pruning with nothing left behind it, so the holding loses its pad as well.
+func TestRecalcAllInitializeTxs_StartDatePastAll_DeletesTheHoldingsPad(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockDB := mock.NewMockDB(ctrl)
+
+	startDate := time.Date(2025, 7, 1, 10, 0, 0, 0, time.UTC)
+	mockDB.EXPECT().ListHoldingDeclarations(gomock.Any(), "user-1").Return([]*db.HoldingDeclarationRow{testDecl("d1", "inst-1", "100")}, nil)
+	mockDB.EXPECT().GetPortfolioStartDate(gomock.Any(), "user-1").Return(&startDate, nil)
+	mockDB.EXPECT().DeleteHoldingDeclaration(gomock.Any(), "d1").Return(nil)
+	mockDB.EXPECT().DeleteInitializeTx(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1").Return(nil)
+
+	if err := RecalcAllInitializeTxs(context.Background(), mockDB, "user-1"); err != nil {
+		t.Fatalf("RecalcAllInitializeTxs: %v", err)
+	}
+}
+
+// TestRecalcAllInitializeTxs_ZeroQty_KeepsDeclaration covers the case where the real
 // transactions already account for the declared balance exactly. That is the
 // declaration agreeing with the data, which is the outcome a checked declaration
 // exists to report -- so the record survives and the pad is written as zero.
-func TestRecalcInitializeTx_ZeroQty_KeepsDeclaration(t *testing.T) {
+func TestRecalcAllInitializeTxs_ZeroQty_KeepsDeclaration(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockDB := mock.NewMockDB(ctrl)
 
 	startDate := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
-
+	mockDB.EXPECT().ListHoldingDeclarations(gomock.Any(), "user-1").Return([]*db.HoldingDeclarationRow{testDecl("d1", "inst-1", "100")}, nil)
 	mockDB.EXPECT().GetPortfolioStartDate(gomock.Any(), "user-1").Return(&startDate, nil)
+	mockDB.EXPECT().ListInstrumentsByIDs(gomock.Any(), gomock.Any()).Return(nil, nil)
 	mockDB.EXPECT().ComputeRunningBalance(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", gomock.Any(), gomock.Any(), testBasis).Return(decimal.NewFromInt(100), nil)
-	mockDB.EXPECT().GetInstrument(gomock.Any(), "inst-1").Return(nil, nil)
 	mockDB.EXPECT().UpsertInitializeTx(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", padEq("BUYOTHER", "0", testBasis)).Return(nil)
 
-	if err := RecalcInitializeTx(context.Background(), mockDB, testDecl("d1", "inst-1", "100")); err != nil {
-		t.Fatalf("RecalcInitializeTx: %v", err)
+	if err := RecalcAllInitializeTxs(context.Background(), mockDB, "user-1"); err != nil {
+		t.Fatalf("RecalcAllInitializeTxs: %v", err)
 	}
 }
 
-func TestRecalcAllInitializeTxs_RecalcsEachDeclaration(t *testing.T) {
+func TestRecalcAllInitializeTxs_RecalcsEachHolding(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	mockDB := mock.NewMockDB(ctrl)
 
 	startDate := time.Date(2025, 1, 1, 10, 0, 0, 0, time.UTC)
-	decls := []*db.HoldingDeclarationRow{
+	mockDB.EXPECT().ListHoldingDeclarations(gomock.Any(), "user-1").Return([]*db.HoldingDeclarationRow{
 		testDecl("d1", "inst-1", "100"),
 		testDecl("d2", "inst-2", "50"),
-	}
-	mockDB.EXPECT().ListHoldingDeclarations(gomock.Any(), "user-1").Return(decls, nil)
+	}, nil)
+	mockDB.EXPECT().GetPortfolioStartDate(gomock.Any(), "user-1").Return(&startDate, nil)
 	mockDB.EXPECT().ListInstrumentsByIDs(gomock.Any(), gomock.Any()).Return(nil, nil)
-	// Each declaration triggers a recalc
-	mockDB.EXPECT().GetPortfolioStartDate(gomock.Any(), "user-1").Return(&startDate, nil).Times(2)
 	mockDB.EXPECT().ComputeRunningBalance(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", gomock.Any(), gomock.Any(), testBasis).Return(decimal.NewFromInt(20), nil)
 	mockDB.EXPECT().UpsertInitializeTx(gomock.Any(), "user-1", "IBKR", "acct1", "inst-1", padEq("BUYOTHER", "80", testBasis)).Return(nil)
 	mockDB.EXPECT().ComputeRunningBalance(gomock.Any(), "user-1", "IBKR", "acct1", "inst-2", gomock.Any(), gomock.Any(), testBasis).Return(decimal.NewFromInt(10), nil)


### PR DESCRIPTION
Second of three PRs for 0043. **Stacked on #325** -- review that first; this
PR's base is its branch and will retarget to `main` when it merges.

## Problem

`UNIQUE (user_id, broker, account, instrument_id)` allowed one declaration per
holding, ever. That forecloses the half of the design that carries the safety: a
pad is true by construction and can never catch an error, while a later
statement that disagrees with the computed holding is exactly what catches a
misparsed broker CSV, a missed transfer, or a converter that silently drops a
row. Under the old key a user could not make that later statement, and a
corrected declaration destroyed the prior one -- listed as a known divergence in
`docs/spec/bitemporality.md`.

## Changes

- Unique key widened to `(user_id, broker, account, instrument_id, as_of_date)`.
  Two declarations at one date are still rejected: two answers to the same
  question with nothing to choose between them.
- `DeclarationKind` (`PAD` / `ASSERT`), **derived, not stored**. The earliest
  declaration for a holding is its pad; the rest are assertions. Written as a
  correlated subquery rather than a window so a single-row read reaches the same
  answer as the list, and so the widened unique key serves the lookup directly.
  Nothing has to be kept in step, because there is no stored discriminator to
  disagree with the rows.
- The unit of pad recalculation becomes the **holding**. Which declaration pads a
  holding depends on the others, so a single declaration is not enough to know
  whether it is the pad; `RecalcInitializeTx` is therefore gone and
  `RecalcAllInitializeTxs` prunes declarations the start date has moved past,
  then rewrites one pad per surviving holding.
- Create and update recompute the pad from the holding as it will stand once the
  write lands, so an earlier declaration takes the pad over and a later one
  changes nothing.
- `DeleteDeclarationWithInitializeTx` takes the pad to write, or nil to remove
  it: deleting an assertion leaves the pad alone, deleting the pad promotes the
  next-earliest, and only a holding's last declaration takes the pad with it.
- `db.ErrDuplicate` carries a uniqueness collision out of the db layer without
  the api package learning about the driver; the handlers map it to
  `AlreadyExists`.
- Opening Balances gains a Role column, and the copy no longer implies a second
  checkpoint replaces the first.
- `docs/spec/fixed-point.md` updated throughout: a Pad and Assertion concept
  section, the widened constraint, the create/update/delete procedures, the
  recalculation triggers, and the start-date edge case. The "multiple
  declarations per holding" future extension is dropped -- it is now current.

## Not here

The verification pass that actually checks an assertion against the computed
holding, and the surfacing of a mismatch (PR 3). Until then an assertion is
stored and labelled but inert, which is why the `bitemporality.md` known
divergence stays for now.

## Verification

- `make check` -- clean
- `make server-test` -- pass, including new coverage for pad selection: earliest
  wins regardless of list order, a pruned pad promotes the next-earliest, a
  pruned last declaration takes the pad, and create returns the right kind when
  the new row takes over the pad or does not.
- `make db-test` -- pass, including the widened key accepting a second date and
  rejecting a second row at the same date with `db.ErrDuplicate`, kind derivation
  across two holdings (so a wrong partition would show up), list and get
  agreeing, and delete promoting then removing the pad.
- `make client-test` -- pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
