### PR TITLE
Check assertions against the computed holding and surface the gap (0043)

### DIFF
--- a/client/app/holdings/declaration-form.tsx
+++ b/client/app/holdings/declaration-form.tsx
@@ -162,6 +162,7 @@ export function DeclarationForm({
                 Broker
               </label>
               <select
+                data-testid="declaration-broker"
                 value={broker}
                 onChange={(e) => { setBroker(e.target.value); setAccount(""); }}
                 className={inputClass}
@@ -179,6 +180,7 @@ export function DeclarationForm({
                 Account
               </label>
               <select
+                data-testid="declaration-account"
                 value={account}
                 onChange={(e) => setAccount(e.target.value)}
                 className={inputClass}
@@ -212,6 +214,7 @@ export function DeclarationForm({
             ) : (
               <>
                 <input
+                  data-testid="declaration-instrument-search"
                   type="text"
                   value={instrumentSearch}
                   onChange={(e) => setInstrumentSearch(e.target.value)}
@@ -230,6 +233,7 @@ export function DeclarationForm({
                       return (
                         <button
                           key={inst.id}
+                          data-testid="declaration-instrument-option"
                           type="button"
                           onClick={() => selectInstrument(inst)}
                           className="block w-full px-3 py-2 text-left text-sm hover:bg-primary-light/10"
@@ -257,6 +261,7 @@ export function DeclarationForm({
             Units Held
           </label>
           <input
+            data-testid="declaration-qty"
             type="number"
             step="any"
             value={declaredQty}
@@ -270,6 +275,7 @@ export function DeclarationForm({
             As Of Date
           </label>
           <input
+            data-testid="declaration-as-of-date"
             type="date"
             value={asOfDate}
             onChange={(e) => setAsOfDate(e.target.value)}
@@ -310,6 +316,7 @@ export function DeclarationForm({
 
       <div className="flex gap-3">
         <button
+          data-testid="declaration-submit"
           type="submit"
           disabled={submitting}
           className="rounded-md bg-accent px-4 py-2 text-sm font-semibold text-white transition-colors hover:bg-accent-dark disabled:opacity-50"

--- a/client/app/holdings/opening-balances.tsx
+++ b/client/app/holdings/opening-balances.tsx
@@ -4,6 +4,7 @@ import { useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { ErrorAlert } from "@/app/components/error-alert";
 import { useAuthedQuery } from "@/hooks/use-authed-query";
+import { usePortfolio } from "@/contexts/portfolio-context";
 import { errorMessage } from "@/lib/errors";
 import { qk } from "@/lib/query-keys";
 import {
@@ -28,8 +29,25 @@ function shareCountLabel(decl: HoldingDeclaration): string {
   return `As of ${basis}`;
 }
 
+/**
+ * What the check says about a declaration. A pad is true by construction, so it
+ * reports what it is rather than that it passed -- calling it "matches" would suggest
+ * it had found something out. An assertion that disagrees says by how much, because
+ * the size of the gap is what identifies the missing transaction.
+ */
+function checkStatus(decl: HoldingDeclaration): { label: string; alert: boolean } {
+  if (decl.kind === DeclarationKind.PAD) return { label: "Opening balance", alert: false };
+  if (!decl.computedQty) return { label: "—", alert: false };
+  if (decl.matched) return { label: "Matches", alert: false };
+  const delta = Number(decl.delta);
+  const sign = delta > 0 ? "+" : "";
+  return { label: `Off by ${sign}${parseFloat(delta.toFixed(4))}`, alert: true };
+}
+
 export function OpeningBalances() {
   const queryClient = useQueryClient();
+  const { selected: selectedPortfolio } = usePortfolio();
+  const portfolioId = selectedPortfolio?.id;
   const [deleteError, setDeleteError] = useState<string | null>(null);
   const [showForm, setShowForm] = useState(false);
   const [editingDecl, setEditingDecl] = useState<HoldingDeclaration | null>(null);
@@ -59,8 +77,17 @@ export function OpeningBalances() {
   const loadError = declError ?? brokersError;
   const error = deleteError ?? (loadError ? errorMessage(loadError) : null);
 
-  const refreshDeclarations = () =>
-    queryClient.invalidateQueries({ queryKey: qk.holdingDeclarations() });
+  // Writing a declaration writes the pad it derives, which is a posting -- so the
+  // holdings the sibling tab shows move with it. Invalidating only the declaration
+  // list left that tab reading the figure from before the opening balance existed,
+  // because it shares this page and never remounts. Every other view of the pad is
+  // on a page of its own and refetches when it mounts.
+  const refreshDeclarations = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries({ queryKey: qk.holdingDeclarations() }),
+      queryClient.invalidateQueries({ queryKey: qk.holdings(portfolioId) }),
+    ]);
+  };
 
   const handleDelete = async (id: string) => {
     setDeleteError(null);
@@ -102,6 +129,7 @@ export function OpeningBalances() {
           <div className="flex justify-end">
             <button
               type="button"
+              data-testid="add-declaration"
               onClick={() => setShowForm(true)}
               className="rounded-md bg-accent px-3.5 py-1.5 text-sm font-semibold text-white transition-colors hover:bg-accent-dark"
             >
@@ -112,10 +140,11 @@ export function OpeningBalances() {
             Set checkpoints for known holding quantities at a point in time. The earliest
             checkpoint for a holding becomes its opening balance: the system calculates one so
             that your records show this quantity on the date you specify. Later checkpoints are
-            checked against what your transactions add up to.
+            checked against what your transactions add up to, and a disagreement means a
+            transaction is missing or wrong.
           </p>
           <div className="overflow-x-auto rounded-md border border-border bg-surface shadow-xs">
-            <table className="w-full min-w-[480px] border-collapse text-sm">
+            <table data-testid="declarations-table" className="w-full min-w-[480px] border-collapse text-sm">
               <thead>
                 <tr className="border-b-2 border-primary-dark/10 bg-primary-dark/3">
                   <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-text-muted">
@@ -137,7 +166,7 @@ export function OpeningBalances() {
                     Share Count
                   </th>
                   <th className="px-4 py-3 text-left text-xs font-semibold uppercase tracking-wider text-text-muted">
-                    Role
+                    Status
                   </th>
                   <th className="px-4 py-3 text-right text-xs font-semibold uppercase tracking-wider text-text-muted">
                     Actions
@@ -162,6 +191,7 @@ export function OpeningBalances() {
                     return (
                       <tr
                         key={d.id}
+                        data-testid="declaration-row"
                         className="border-b border-border/40 transition-colors last:border-0 hover:bg-primary-light/10"
                       >
                         <td className="px-4 py-3 text-text-muted">
@@ -182,8 +212,15 @@ export function OpeningBalances() {
                         <td className="px-4 py-3 text-text-muted">
                           {shareCountLabel(d)}
                         </td>
-                        <td className="px-4 py-3 text-text-muted">
-                          {d.kind === DeclarationKind.PAD ? "Opening balance" : "Checked"}
+                        <td
+                          className={
+                            checkStatus(d).alert
+                              ? "px-4 py-3 font-medium text-amber-700 dark:text-amber-400"
+                              : "px-4 py-3 text-text-muted"
+                          }
+                          data-testid="declaration-status"
+                        >
+                          {checkStatus(d).label}
                         </td>
                         <td className="px-4 py-3 text-right">
                           <button

--- a/client/app/holdings/page.tsx
+++ b/client/app/holdings/page.tsx
@@ -8,9 +8,10 @@ import { ErrorAlert } from "@/app/components/error-alert";
 import { useAuthedQuery } from "@/hooks/use-authed-query";
 import { errorMessage } from "@/lib/errors";
 import { qk } from "@/lib/query-keys";
-import { getHoldings } from "@/lib/portfolio-api";
+import { getHoldings, listHoldingDeclarations } from "@/lib/portfolio-api";
 import { getBrokerLabel } from "@/lib/csv/converters";
-import { IdentifierType } from "@/gen/api/v1/api_pb";
+import { DeclarationKind, IdentifierType } from "@/gen/api/v1/api_pb";
+import type { HoldingDeclaration } from "@/gen/api/v1/api_pb";
 import { OpeningBalances } from "./opening-balances";
 
 type Tab = "holdings" | "opening-balances";
@@ -31,6 +32,18 @@ export default function UserHoldingsPage() {
     queryKey: qk.holdings(portfolioId),
     queryFn: () => getHoldings({ portfolioId }),
   });
+
+  // The tab carries the count of checkpoints that disagree with the transactions, so
+  // a user who is not looking at the tab still learns there is something to look at.
+  // It reads the list the tab itself renders, so the two share a cache entry and the
+  // badge costs no extra request.
+  const { data: declarations = [] } = useAuthedQuery<HoldingDeclaration[]>({
+    queryKey: qk.holdingDeclarations(),
+    queryFn: listHoldingDeclarations,
+  });
+  const mismatches = declarations.filter(
+    (d) => d.kind === DeclarationKind.ASSERT && !!d.computedQty && !d.matched
+  ).length;
 
   return (
     <AppShell>
@@ -67,6 +80,7 @@ export default function UserHoldingsPage() {
             <div className="flex gap-0 border-b border-border">
               <button
                 type="button"
+                data-testid="tab-holdings"
                 onClick={() => setActiveTab("holdings")}
                 className={
                   "px-4 py-2 text-sm font-medium transition-colors " +
@@ -79,6 +93,7 @@ export default function UserHoldingsPage() {
               </button>
               <button
                 type="button"
+                data-testid="tab-opening-balances"
                 onClick={() => setActiveTab("opening-balances")}
                 className={
                   "px-4 py-2 text-sm font-medium transition-colors " +
@@ -88,6 +103,14 @@ export default function UserHoldingsPage() {
                 }
               >
                 Opening Balances
+                {mismatches > 0 && (
+                  <span
+                    data-testid="declaration-mismatch-badge"
+                    className="ml-2 rounded-full bg-amber-100 px-2 py-0.5 text-xs font-semibold text-amber-800 dark:bg-amber-900/40 dark:text-amber-300"
+                  >
+                    {mismatches}
+                  </span>
+                )}
               </button>
             </div>
 

--- a/docs/adr/0030-declarations-are-padded-then-asserted.md
+++ b/docs/adr/0030-declarations-are-padded-then-asserted.md
@@ -1,0 +1,63 @@
+# A holding's earliest declaration pads; the rest are checked
+
+A holding declaration is a user's statement that they held N units on a date. The
+first one for a holding generates an INITIALIZE transaction to make that true --
+beancount's `pad` -- which means it is true by construction and can never catch an
+error. Every later declaration is checked against what the transactions add up to
+instead, and a disagreement is the only signal the system has that a broker CSV
+was misparsed, a transfer missed, or a row silently dropped by a converter. The
+pair is beancount's `pad` and `balance`, and the safety comes entirely from the
+second half.
+
+## Why the discriminator is derived, not stored
+
+A `kind` column would be a second statement of something the dates already say,
+and the two could disagree. Adding a declaration earlier than the current pad, or
+deleting the pad, changes which declaration seeds the opening balance -- with a
+stored column each of those becomes a write that can be missed. Derived from
+`MIN(as_of_date)` per holding there is nothing to maintain and no state to
+reconcile, at the cost of one indexed subquery per row read.
+
+The corollary is that the unit of recalculation is the holding rather than the
+declaration: which declaration pads a holding depends on the others, so a single
+declaration is not enough to know whether it is the pad.
+
+## Why the check is computed on read
+
+The three existing surfaces for data problems -- `validation_errors`,
+`identification_errors`, `unhandled_corporate_events` -- are stored rows written
+when a problem is detected. An assertion is not like them. Its verdict is a
+function of the current transaction set, which moves under an ingestion, an
+instrument merge, an option split application and a `RecomputeSplitAdjustments`
+pass alike. There is no one place all of those funnel through, so a stored verdict
+would need invalidating from each and would be wrong the moment one was missed.
+
+Computed in the read query it is current by construction -- which is what
+0043's "re-verify after any ingestion or recompute" asks for, with no triggers at
+all -- and it closes on its own when the data comes back into agreement, which
+none of the stored surfaces can do. The cost is recomputing a small aggregate per
+declaration on each read; declarations are a handful per user.
+
+## Why the tolerance is not zero, and not a constant
+
+The comparison crosses a rounding. Both sides are exact decimals, but converting a
+posting from its own `share_count_basis` into the declaration's divides by the
+cumulative split factor, and a reverse split in an awkward ratio has no finite
+decimal form (see 0028-cumulative-split-factor-is-an-exact-rational.md and
+0026-exact-decimals-bounded-by-closure.md).
+
+Postings are therefore grouped by basis and summed before conversion, so the
+division happens once per denomination rather than once per posting, and the
+tolerance is the number of contributing bases whose factor is not `1/1`, in units
+of the last place of the declared scale. That is a bound that can be stated,
+unlike a fixed epsilon, and it collapses to exactly zero when no split falls in
+the window -- which is the common case, so most assertions are checked exactly.
+
+An absolute constant was rejected for the reason 0026 gives: it is silently
+scale-dependent, too loose for a small holding and too tight for a large one.
+
+## Why a pad reports no verdict
+
+A pad's own check can only ever pass, because the INITIALIZE transaction is what
+makes it pass. Reporting that as a result would suggest it had found something
+out. It is labelled as the opening balance instead.

--- a/docs/issues/0043-holding-declarations-pad-assert.md
+++ b/docs/issues/0043-holding-declarations-pad-assert.md
@@ -1,6 +1,7 @@
 ---
-status: open
+status: closed
 title: Split holding declarations into pads and checked assertions
+dependencies: [0042]
 ---
 
 Allow more than one declaration per holding and distinguish declarations that

--- a/docs/spec/bitemporality.md
+++ b/docs/spec/bitemporality.md
@@ -223,5 +223,4 @@ The model above is normative. These parts of the system do not yet comply:
 | Divergence | Issue |
 | --- | --- |
 | No daily scheduler fires the blanket recompute, so a stored future-dated split never activates when its `ex_date` crosses | 0050 |
-| Holding declarations permit one assertion per holding, so a corrected declaration destroys the prior one | 0043 |
 | Corporate actions adjust totals rather than lots | 0044 |

--- a/docs/spec/fixed-point.md
+++ b/docs/spec/fixed-point.md
@@ -22,7 +22,7 @@ The **earliest** declaration for a holding is its **pad**. The INITIALIZE transa
 
 Every **later** declaration is an **assertion**. It generates nothing. It is checked against what the transactions add up to at its own date, and a disagreement means something is wrong with the data: a misparsed broker CSV, a missed transfer, a converter that silently dropped a row. That check is where the safety comes from; the pad is what makes a portfolio with incomplete history usable in the first place. The pair is beancount's `pad` and `balance`.
 
-The role is derived from the declaration dates, not stored. Adding a declaration earlier than the current pad makes it the pad and demotes the incumbent to an assertion; deleting the pad promotes the next-earliest. Nothing has to be kept in step, because there is no stored discriminator to disagree with the rows.
+The role is derived from the declaration dates, not stored. Adding a declaration earlier than the current pad makes it the pad and demotes the incumbent to an assertion; deleting the pad promotes the next-earliest. Nothing has to be kept in step, because there is no stored discriminator to disagree with the rows. See adr/0030-declarations-are-padded-then-asserted.md.
 
 ### INITIALIZE Transaction
 
@@ -134,6 +134,22 @@ The user may edit the declared quantity, the `as_of_date` or the `share_count_ba
 
 Deleting an **assertion** leaves the pad alone. Deleting the **pad** promotes the next-earliest declaration, and the INITIALIZE transaction is recalculated from it. Only deleting a holding's last declaration removes the INITIALIZE group: deleting the group takes both postings, so no path can leave the counterparty behind without the pad it balances, and the holding's history reverts to showing only real transactions with an implied zero balance at portfolio inception.
 
+### Verification
+
+An assertion is compared against the holding it describes. The comparison is computed on read, not stored: a holding's computed quantity moves under an ingestion, an instrument merge, an option split application and a split recompute alike, so a stored verdict would need invalidating from each of them. Derived at read time it is current after all of them with no trigger, and it clears on its own when the data comes back into agreement. See adr/0030-declarations-are-padded-then-asserted.md.
+
+The computed side is the sum of the holding's `USER` postings up to and including `as_of_date`, **including the pad** -- an assertion checks the holding as the user sees it, opening balance and all. Each posting is converted from its own `share_count_basis` into the declaration's, so both sides of the comparison are in one share count.
+
+**Tolerance.** Postings are grouped by their own basis and summed before conversion, so the division happens once per denomination rather than once per posting. A group whose conversion factor is not `1/1` can round once, at the declared scale of the split-adjusted columns. The assertion reconciles when
+
+```
+abs(computed_qty - declared_qty) <= inexact_bases * 10^-12
+```
+
+where `inexact_bases` is the number of contributing bases converting by something other than `1/1`. When no split falls in the window -- the common case -- that count is zero and the comparison is exact.
+
+A pad always reconciles: the INITIALIZE transaction is what makes it true, so its own check can only pass and reporting it as a result would suggest it had found something out.
+
 ### Recalculation Triggers
 
 INITIALIZE transactions are derived data. They must be recalculated when the inputs to their calculation change. There are two categories of change that require recalculation.
@@ -188,7 +204,7 @@ INITIALIZE transactions should not be directly editable through the normal trans
 
 ### Visibility of Declarations
 
-The holding declaration UI lives as an "Opening Balances" tab alongside the "Holdings" tab on the Holdings page. It shows each declaration's role, so a user can see which of a holding's checkpoints seeds the opening balance and which are checked.
+The holding declaration UI lives as an "Opening Balances" tab alongside the "Holdings" tab on the Holdings page. Each row shows its status: the pad reads as the opening balance, an assertion that reconciles reads as matching, and one that does not says by how much -- the size of the gap is what identifies the missing transaction. The tab itself carries a count of the assertions that disagree, so a user not looking at it still learns there is something to look at.
 
 ### Transaction List
 

--- a/e2e/fixtures/opening-balances-lose-tx.sql
+++ b/e2e/fixtures/opening-balances-lose-tx.sql
@@ -1,0 +1,13 @@
+-- Lose the AMZN buy seeded by instruments.sql, the way a converter that silently
+-- drops a row does.
+--
+-- Deleting the group takes both its postings, which is what ingestion's own delete
+-- path does: the group is the unit of deletion, so no path can leave a counterparty
+-- behind without the posting it balances.
+--
+-- Nothing else is touched. The declarations still say what the user said, and no
+-- recompute is triggered -- which is the point: a checked declaration is measured on
+-- read, so the next read of it disagrees without anything having invalidated it.
+
+DELETE FROM tx_groups
+WHERE id = 'e2e00000-0000-0000-0000-000000000201';

--- a/e2e/tests/opening-balances.spec.ts
+++ b/e2e/tests/opening-balances.spec.ts
@@ -1,0 +1,110 @@
+import { test, expect, type Page } from "@playwright/test";
+import { TIMEOUT_FAST } from "../helpers/timeouts";
+import { seedSession, injectSession, closeRedis } from "../helpers/auth";
+import { resetAndSeedBase, seedFixture, closeDB } from "../helpers/db";
+
+// No cassette: nothing here calls a plugin. The instruments are pre-identified by
+// the fixture, so no identification runs.
+
+// The seeded AMZN position: 8 shares bought on 2024-01-15.
+const AMZN_QTY = 8;
+// The pad's declaration: 20 shares held on the buy date, so the opening balance the
+// system derives is 12 -- what the user held before their history begins.
+const PAD_QTY = 20;
+const PAD_DATE = "2024-01-15";
+// The assertion: 20 shares still held a few days later. 12 from the pad plus the 8
+// bought, so it reconciles.
+const ASSERT_QTY = 20;
+const ASSERT_DATE = "2024-01-20";
+
+async function openTab(page: Page) {
+  await page.goto("/holdings");
+  await expect(page.locator("[data-testid='page-holdings']")).toBeVisible({
+    timeout: TIMEOUT_FAST,
+  });
+  await page.locator("[data-testid='tab-opening-balances']").click();
+}
+
+async function addCheckpoint(page: Page, qty: number, asOfDate: string) {
+  await page.locator("[data-testid='add-declaration']").click();
+  await page.locator("[data-testid='declaration-broker']").selectOption("FIDELITY");
+  await page.locator("[data-testid='declaration-account']").selectOption("ACC-1");
+  await page.locator("[data-testid='declaration-instrument-search']").fill("AMZN");
+  await page.locator("[data-testid='declaration-instrument-option']").first().click();
+  await page.locator("[data-testid='declaration-qty']").fill(String(qty));
+  await page.locator("[data-testid='declaration-as-of-date']").fill(asOfDate);
+  await page.locator("[data-testid='declaration-submit']").click();
+  await expect(page.locator("[data-testid='declarations-table']")).toBeVisible({
+    timeout: TIMEOUT_FAST,
+  });
+}
+
+test.describe("opening balances: pads and checked assertions", () => {
+  let userSession: string;
+
+  test.beforeAll(async () => {
+    await resetAndSeedBase();
+    await seedFixture("instruments.sql");
+    userSession = await seedSession("user");
+  });
+
+  test.afterAll(async () => {
+    await closeRedis();
+    await closeDB();
+  });
+
+  test("the earliest checkpoint pads, a later one is checked, and losing a transaction breaks it", async ({
+    context,
+    page,
+  }) => {
+    await injectSession(context, userSession);
+    await openTab(page);
+
+    // The first checkpoint for the holding seeds its opening balance. It is true by
+    // construction -- the system derives a transaction to make it so -- which is why
+    // it reports what it is rather than that it passed.
+    await addCheckpoint(page, PAD_QTY, PAD_DATE);
+    const rows = page.locator("[data-testid='declaration-row']");
+    await expect(rows).toHaveCount(1);
+    await expect(rows.first().locator("[data-testid='declaration-status']")).toHaveText(
+      "Opening balance"
+    );
+
+    // The declared quantity is now what the holdings page shows, which is the pad
+    // doing its job: 12 units from before the history began, plus the 8 bought. The
+    // EQUITY counterparty that balances the pad does not net it back to nothing.
+    await page.locator("[data-testid='tab-holdings']").click();
+    const amzn = page
+      .locator("[data-testid='holdings-table'] tbody tr")
+      .filter({ hasText: "AMZN" });
+    await expect(amzn).toHaveCount(1, { timeout: TIMEOUT_FAST });
+    await expect(amzn).toContainText(String(PAD_QTY));
+
+    // A second, later checkpoint generates nothing. It is measured against what the
+    // transactions add up to at its own date, and here they agree.
+    await openTab(page);
+    await addCheckpoint(page, ASSERT_QTY, ASSERT_DATE);
+    await expect(rows).toHaveCount(2);
+    const assertRow = rows.filter({ hasText: ASSERT_DATE });
+    await expect(assertRow.locator("[data-testid='declaration-status']")).toHaveText("Matches");
+    await expect(page.locator("[data-testid='declaration-mismatch-badge']")).toHaveCount(0);
+
+    // Lose the AMZN buy, the way a converter that drops a row does. Nothing is
+    // recomputed and nothing is invalidated: the check is derived on read, so the
+    // next read of it simply disagrees.
+    await seedFixture("opening-balances-lose-tx.sql");
+    await openTab(page);
+
+    await expect(assertRow.locator("[data-testid='declaration-status']")).toHaveText(
+      `Off by -${AMZN_QTY}`
+    );
+    // The pad still reads as a pad: it was made true by construction and cannot
+    // catch anything, which is exactly why the assertion has to exist.
+    await expect(
+      rows.filter({ hasText: PAD_DATE }).locator("[data-testid='declaration-status']")
+    ).toHaveText("Opening balance");
+
+    // A user not looking at the tab still learns there is something to look at.
+    await expect(page.locator("[data-testid='declaration-mismatch-badge']")).toHaveText("1");
+  });
+});

--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -902,6 +902,24 @@ message HoldingDeclaration {
   google.type.Date share_count_basis = 8;
   // Read-only; derived from the declaration dates for this holding.
   DeclarationKind kind = 9;
+  // What the transactions add up to at as_of_date, in share_count_basis, including
+  // the holding's pad. Numeric string. Read-only, and recomputed on every read, so
+  // it follows an ingestion, an instrument merge or a split recompute with nothing
+  // to invalidate. See docs/spec/fixed-point.md#verification.
+  string computed_qty = 10;
+  // computed_qty - declared_qty. Numeric string; positive means the transactions
+  // account for more than was declared. Read-only.
+  string delta = 11;
+  // How far delta may stray from zero before it means something. Numeric string,
+  // derived from the rounding scale of the split conversion and the number of share
+  // count bases that contribute one; zero when no split falls in the window, which
+  // is the common case. Read-only.
+  string tolerance = 12;
+  // Whether the declaration reconciles: abs(delta) <= tolerance. Always true for a
+  // pad, which is made true by construction. Read-only.
+  bool matched = 13;
+  // How many postings the computed quantity was summed from. Read-only.
+  int32 posting_count = 14;
 }
 
 message ListHoldingDeclarationsRequest {}

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -624,6 +624,27 @@ type HoldingDeclarationRow struct {
 	// Kind is derived, not stored: the earliest declaration for a holding is the
 	// pad and the rest are assertions. Reads populate it; writes ignore it.
 	Kind apiv1.DeclarationKind
+	// Verified is what the transactions add up to at AsOfDate, computed on read.
+	// Nil on the write paths, which return the stored row only.
+	Verified *DeclarationCheck
+}
+
+// DeclarationCheck is a declaration measured against the holding it describes.
+//
+// It carries the two counts the comparison needs to bound its own rounding rather
+// than a verdict, because the tolerance is a policy question -- how much
+// disagreement is worth reporting -- and belongs with the handler that answers it,
+// not with the query that measures.
+type DeclarationCheck struct {
+	// ComputedQty is the sum of the holding's USER postings up to and including
+	// AsOfDate, converted into the declaration's ShareCountBasis. Includes the pad.
+	ComputedQty decimal.Decimal
+	// PostingCount is how many postings contributed.
+	PostingCount int32
+	// InexactBases is how many share count bases contributed a conversion that is
+	// not 1/1 -- the only places the sum can carry a rounding. Zero means the
+	// comparison against DeclaredQty is exact.
+	InexactBases int32
 }
 
 // InitializeTx is the derived pad for a holding declaration: the synthetic posting

--- a/server/db/postgres/declarations.go
+++ b/server/db/postgres/declarations.go
@@ -31,9 +31,29 @@ const declarationKind = `CASE WHEN d.as_of_date = (
 	      AND e.account = d.account AND e.instrument_id = d.instrument_id)
 	  THEN 'PAD' ELSE 'ASSERT' END AS kind`
 
-// declarationReadCols is the projection for reads, qualified for declarationKind.
+// declarationVerify computes what the transactions actually add up to at a
+// declaration's as_of_date, in the declaration's own share count. This is what turns
+// a stored statement into a checked one.
+//
+// It is computed on read rather than stored. A holding's computed quantity moves
+// under an ingestion, an instrument merge, an option split application and a split
+// recompute alike, and there is no single place all of those pass through -- so a
+// materialised verdict would need invalidating from each of them and would be stale
+// the moment one was missed. Derived here it is current by construction, and it
+// closes on its own when the data comes back into agreement.
+//
+// The pad is included (p_include_synthetic is true): an assertion checks the holding
+// as the user sees it, opening balance and all. That is also why a pad's own
+// assertion always reconciles -- the INITIALIZE tx is what makes it true.
+const declarationVerify = `LATERAL holding_qty_in_basis(
+	    d.user_id, d.broker, d.account, d.instrument_id,
+	    NULL, (d.as_of_date + 1)::timestamptz, d.share_count_basis, true) v`
+
+// declarationReadCols is the projection for reads, qualified for declarationKind and
+// declarationVerify.
 const declarationReadCols = `d.id, d.user_id, d.broker, d.account, d.instrument_id,
-	d.declared_qty, d.as_of_date, d.share_count_basis, ` + declarationKind
+	d.declared_qty, d.as_of_date, d.share_count_basis,
+	v.qty AS computed_qty, v.posting_count, v.inexact_bases, ` + declarationKind
 
 type declarationRow struct {
 	ID              uuid.UUID `db:"id"`
@@ -44,7 +64,11 @@ type declarationRow struct {
 	DeclaredQty     string    `db:"declared_qty"`
 	AsOfDate        time.Time `db:"as_of_date"`
 	ShareCountBasis time.Time `db:"share_count_basis"`
-	Kind            *string   `db:"kind"` // absent from the write paths' projection
+	// The verification columns and kind are absent from the write paths' projection.
+	ComputedQty  *decimal.Decimal `db:"computed_qty"`
+	PostingCount *int32           `db:"posting_count"`
+	InexactBases *int32           `db:"inexact_bases"`
+	Kind         *string          `db:"kind"`
 }
 
 func (r *declarationRow) toRow() *db.HoldingDeclarationRow {
@@ -61,7 +85,21 @@ func (r *declarationRow) toRow() *db.HoldingDeclarationRow {
 	if r.Kind != nil {
 		out.Kind = strToDeclarationKind(*r.Kind)
 	}
+	if r.ComputedQty != nil {
+		out.Verified = &db.DeclarationCheck{
+			ComputedQty:  *r.ComputedQty,
+			PostingCount: derefInt32(r.PostingCount),
+			InexactBases: derefInt32(r.InexactBases),
+		}
+	}
 	return out
+}
+
+func derefInt32(v *int32) int32 {
+	if v == nil {
+		return 0
+	}
+	return *v
 }
 
 func strToDeclarationKind(s string) apiv1.DeclarationKind {
@@ -162,7 +200,8 @@ func (p *Postgres) GetHoldingDeclaration(ctx context.Context, id string) (*db.Ho
 	var row declarationRow
 	err = p.q.QueryRowxContext(ctx, `
 		SELECT `+declarationReadCols+`
-		FROM holding_declarations d WHERE d.id = $1
+		FROM holding_declarations d, `+declarationVerify+`
+		WHERE d.id = $1
 	`, declID).StructScan(&row)
 	if err != nil {
 		return nil, fmt.Errorf("get holding declaration: %w", err)
@@ -179,7 +218,8 @@ func (p *Postgres) ListHoldingDeclarations(ctx context.Context, userID string) (
 	var rows []declarationRow
 	err = p.q.SelectContext(ctx, &rows, `
 		SELECT `+declarationReadCols+`
-		FROM holding_declarations d WHERE d.user_id = $1
+		FROM holding_declarations d, `+declarationVerify+`
+		WHERE d.user_id = $1
 		ORDER BY d.broker, d.account, d.instrument_id, d.as_of_date
 	`, userUUID)
 	if err != nil {

--- a/server/db/postgres/declarations_test.go
+++ b/server/db/postgres/declarations_test.go
@@ -570,6 +570,126 @@ func TestComputeRunningBalance_ConvertsToDeclarationBasis(t *testing.T) {
 	}
 }
 
+// TestListHoldingDeclarations_ChecksAgainstTheHolding is the point of the whole
+// pad/assert split: an assertion is measured against what the transactions add up
+// to, so a missing one shows up as a difference. The pad is included in that sum --
+// an assertion checks the holding as the user sees it -- which is also why the pad's
+// own check is always level.
+func TestListHoldingDeclarations_ChecksAgainstTheHolding(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|decl-verify", "U", "u@v.com")
+	instID, _ := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "VF1", Canonical: false}}, "", nil, nil, nil)
+
+	padDate := time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC)
+	buyAt := time.Date(2022, 6, 1, 10, 0, 0, 0, time.UTC)
+	assertDate := time.Date(2023, 12, 31, 0, 0, 0, 0, time.UTC)
+
+	// A pad of 500 at the start, one real buy of 150, and an assertion of 650.
+	if err := p.UpsertInitializeTx(ctx, userID, "IBKR", "acct1", instID, db.InitializeTx{
+		TxType: "BUYSTOCK", Timestamp: padDate, Quantity: decf(500), ShareCountBasis: padDate,
+	}); err != nil {
+		t.Fatalf("upsert pad: %v", err)
+	}
+	if err := createTx(ctx, p, userID, "IBKR", "acct1", "", &apiv1.Tx{Timestamp: timestamppb.New(buyAt), InstrumentDescription: "VF1", Type: apiv1.TxType_BUYSTOCK, Quantity: "150", Account: "acct1"}, instID, nil); err != nil {
+		t.Fatalf("create buy: %v", err)
+	}
+	if _, err := p.CreateHoldingDeclaration(ctx, userID, "IBKR", "acct1", instID, "500", padDate, time.Time{}); err != nil {
+		t.Fatalf("create pad declaration: %v", err)
+	}
+	if _, err := p.CreateHoldingDeclaration(ctx, userID, "IBKR", "acct1", instID, "650", assertDate, time.Time{}); err != nil {
+		t.Fatalf("create assertion: %v", err)
+	}
+
+	checked := func() map[string]string {
+		t.Helper()
+		rows, err := p.ListHoldingDeclarations(ctx, userID)
+		if err != nil {
+			t.Fatalf("list: %v", err)
+		}
+		out := map[string]string{}
+		for _, r := range rows {
+			if r.Verified == nil {
+				t.Fatalf("declaration %s came back unchecked", r.AsOfDate.Format("2006-01-02"))
+			}
+			if r.Verified.InexactBases != 0 {
+				t.Errorf("no split falls in this window, so the check should be exact; got %d inexact bases", r.Verified.InexactBases)
+			}
+			out[r.AsOfDate.Format("2006-01-02")] = r.Verified.ComputedQty.String()
+		}
+		return out
+	}
+
+	if got, want := checked(), map[string]string{"2021-01-01": "500", "2023-12-31": "650"}; !maps.Equal(got, want) {
+		t.Fatalf("computed quantities: got %v, want %v", got, want)
+	}
+
+	// Lose the buy, the way a converter dropping a row would. The assertion is the
+	// only thing in the system that notices.
+	if _, err := p.q.ExecContext(ctx, `
+		DELETE FROM tx_groups g WHERE g.user_id = $1 AND EXISTS (
+			SELECT 1 FROM txs t WHERE t.group_id = g.id AND t.synthetic_purpose IS NULL)
+	`, userID); err != nil {
+		t.Fatalf("delete buy: %v", err)
+	}
+	if got, want := checked(), map[string]string{"2021-01-01": "500", "2023-12-31": "500"}; !maps.Equal(got, want) {
+		t.Fatalf("computed quantities after losing the buy: got %v, want %v", got, want)
+	}
+}
+
+// TestListHoldingDeclarations_ChecksAcrossASplit denominates both sides of the
+// comparison. The postings are recorded either side of a 2:1 split, so an assertion
+// stated in pre-split shares and one stated in post-split shares describe the same
+// holding with different numbers, and both have to reconcile.
+func TestListHoldingDeclarations_ChecksAcrossASplit(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|decl-verify-split", "U", "u@v.com")
+	instID, _ := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "VS1", Canonical: false}}, "", nil, nil, nil)
+
+	preSplit := time.Date(2021, 3, 1, 10, 0, 0, 0, time.UTC)
+	exDate := time.Date(2022, 6, 1, 0, 0, 0, 0, time.UTC)
+	postSplit := time.Date(2023, 3, 1, 10, 0, 0, 0, time.UTC)
+	addSplit(t, p, instID, exDate, 1, 2)
+
+	for _, at := range []time.Time{preSplit, postSplit} {
+		if err := createTx(ctx, p, userID, "IBKR", "acct1", "", &apiv1.Tx{Timestamp: timestamppb.New(at), InstrumentDescription: "VS1", Type: apiv1.TxType_BUYSTOCK, Quantity: "50", Account: "acct1"}, instID, nil); err != nil {
+			t.Fatalf("create buy at %s: %v", at.Format("2006-01-02"), err)
+		}
+	}
+
+	// 50 shares bought pre-split are 100 post-split, plus 50 more: 150 in post-split
+	// terms, 75 in pre-split terms. The two as_of dates differ only because a holding
+	// takes one declaration per date; both are after the last buy, so the two
+	// declarations see the same postings.
+	for _, tc := range []struct {
+		name  string
+		asOf  time.Time
+		basis time.Time
+		want  string
+	}{
+		{"pre-split basis", time.Date(2023, 12, 30, 0, 0, 0, 0, time.UTC), preSplit, "75"},
+		{"post-split basis", time.Date(2023, 12, 31, 0, 0, 0, 0, time.UTC), postSplit, "150"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			row, err := p.CreateHoldingDeclaration(ctx, userID, "IBKR", "acct1", instID, tc.want, tc.asOf, tc.basis)
+			if err != nil {
+				t.Fatalf("create declaration: %v", err)
+			}
+			got, err := p.GetHoldingDeclaration(ctx, row.ID)
+			if err != nil {
+				t.Fatalf("get: %v", err)
+			}
+			if got.Verified == nil {
+				t.Fatal("declaration came back unchecked")
+			}
+			if got.Verified.ComputedQty.String() != tc.want {
+				t.Fatalf("computed qty = %s, want %s", got.Verified.ComputedQty, tc.want)
+			}
+		})
+	}
+}
+
 // TestDeleteDeclarationWithInitializeTx_KeepsThePadForSurvivors covers what deleting
 // one of a holding's declarations does to the pad. Deleting one that leaves others
 // behind rewrites the pad from whichever now pads the holding; deleting the last one

--- a/server/service/api/declarations.go
+++ b/server/service/api/declarations.go
@@ -50,10 +50,16 @@ func (s *Server) ListHoldingDeclarations(ctx context.Context, req *apiv1.ListHol
 	return &apiv1.ListHoldingDeclarationsResponse{Declarations: decls}, nil
 }
 
-// declarationToProto converts a stored declaration to its wire form. The instrument
-// is left to the caller: only the list populates it.
+// declarationScale is the rounding scale the split-adjusted columns declare, and so
+// the size of one unit in the last place of a converted quantity. See
+// docs/adr/0026-exact-decimals-bounded-by-closure.md.
+const declarationScale = -12
+
+// declarationToProto converts a stored declaration to its wire form, checking it
+// against the computed holding when the read supplied one. The instrument is left to
+// the caller: only the list populates it.
 func declarationToProto(r *db.HoldingDeclarationRow) *apiv1.HoldingDeclaration {
-	return &apiv1.HoldingDeclaration{
+	out := &apiv1.HoldingDeclaration{
 		Id:              r.ID,
 		Broker:          r.Broker,
 		Account:         r.Account,
@@ -63,6 +69,35 @@ func declarationToProto(r *db.HoldingDeclarationRow) *apiv1.HoldingDeclaration {
 		ShareCountBasis: timeToDate(r.ShareCountBasis),
 		Kind:            r.Kind,
 	}
+	if r.Verified == nil {
+		return out
+	}
+	declared, err := decimal.NewFromString(r.DeclaredQty)
+	if err != nil {
+		// A declared_qty that will not parse is a stored value the write path
+		// validated, so this cannot happen from the API. Report the declaration
+		// without a verdict rather than failing the whole list for it.
+		return out
+	}
+
+	// The tolerance is a bound, not a fudge factor. Each share count basis that
+	// contributes a conversion by something other than 1/1 can round once, at the
+	// declared scale of the split-adjusted columns -- so that many units in the last
+	// place is the most the two sides can differ by while still agreeing. When no
+	// split falls in the window, which is the common case, no basis converts
+	// inexactly and the comparison is exact.
+	tolerance := decimal.New(int64(r.Verified.InexactBases), declarationScale)
+	delta := r.Verified.ComputedQty.Sub(declared)
+
+	out.ComputedQty = decStr(r.Verified.ComputedQty)
+	out.Delta = decStr(delta)
+	out.Tolerance = decStr(tolerance)
+	out.PostingCount = r.Verified.PostingCount
+	// A pad is made true by construction, so its own check can only ever pass and
+	// reporting it as a result would suggest it had found something out.
+	out.Matched = r.Kind == apiv1.DeclarationKind_DECLARATION_KIND_PAD ||
+		delta.Abs().LessThanOrEqual(tolerance)
+	return out
 }
 
 // padDeclaration returns the declaration that seeds a holding's opening balance --

--- a/server/service/api/declarations_test.go
+++ b/server/service/api/declarations_test.go
@@ -49,6 +49,70 @@ func TestListHoldingDeclarations_Success(t *testing.T) {
 	}
 }
 
+// TestListHoldingDeclarations_Checks covers the tolerance rule. It is a bound, not a
+// fudge factor: each share count basis that converts by something other than 1/1 can
+// round once at the declared scale of the split-adjusted columns, so that many units
+// in the last place is the most the two sides can differ by and still agree. With no
+// split in the window nothing converts inexactly and the comparison is exact.
+func TestListHoldingDeclarations_Checks(t *testing.T) {
+	ulp := "0.000000000001"
+	for _, tc := range []struct {
+		name          string
+		kind          apiv1.DeclarationKind
+		declared      string
+		computed      string
+		inexactBases  int32
+		wantDelta     string
+		wantTolerance string
+		wantMatched   bool
+	}{
+		{"exact agreement", apiv1.DeclarationKind_DECLARATION_KIND_ASSERT, "650", "650", 0, "0", "0", true},
+		{"a missing transaction", apiv1.DeclarationKind_DECLARATION_KIND_ASSERT, "650", "500", 0, "-150", "0", false},
+		{"no split, so no slack at all", apiv1.DeclarationKind_DECLARATION_KIND_ASSERT, "650", "650.000000000001", 0, "0.000000000001", "0", false},
+		{"one inexact basis, within its rounding", apiv1.DeclarationKind_DECLARATION_KIND_ASSERT, "650", "650.000000000001", 1, "0.000000000001", ulp, true},
+		{"one inexact basis, beyond its rounding", apiv1.DeclarationKind_DECLARATION_KIND_ASSERT, "650", "650.000000000002", 1, "0.000000000002", ulp, false},
+		{"two inexact bases widen the bound", apiv1.DeclarationKind_DECLARATION_KIND_ASSERT, "650", "650.000000000002", 2, "0.000000000002", "0.000000000002", true},
+		// A pad is made true by construction, so its own check can only pass.
+		{"a pad always reconciles", apiv1.DeclarationKind_DECLARATION_KIND_PAD, "500", "400", 0, "-100", "0", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got := declarationToProto(&db.HoldingDeclarationRow{
+				ID: "d1", DeclaredQty: tc.declared, AsOfDate: asOfJun1, ShareCountBasis: asOfJun1, Kind: tc.kind,
+				Verified: &db.DeclarationCheck{
+					ComputedQty:  decimal.RequireFromString(tc.computed),
+					PostingCount: 3,
+					InexactBases: tc.inexactBases,
+				},
+			})
+			if got.GetComputedQty() != tc.computed {
+				t.Errorf("computed_qty = %s, want %s", got.GetComputedQty(), tc.computed)
+			}
+			if got.GetDelta() != tc.wantDelta {
+				t.Errorf("delta = %s, want %s", got.GetDelta(), tc.wantDelta)
+			}
+			if got.GetTolerance() != tc.wantTolerance {
+				t.Errorf("tolerance = %s, want %s", got.GetTolerance(), tc.wantTolerance)
+			}
+			if got.GetMatched() != tc.wantMatched {
+				t.Errorf("matched = %v, want %v", got.GetMatched(), tc.wantMatched)
+			}
+			if got.GetPostingCount() != 3 {
+				t.Errorf("posting_count = %d, want 3", got.GetPostingCount())
+			}
+		})
+	}
+}
+
+// TestListHoldingDeclarations_UncheckedRow covers the write paths, which return the
+// stored row without measuring it. A declaration with no check reports no verdict
+// rather than a default one, so a create cannot read as "matched".
+func TestListHoldingDeclarations_UncheckedRow(t *testing.T) {
+	got := declarationToProto(&db.HoldingDeclarationRow{ID: "d1", DeclaredQty: "650", AsOfDate: asOfJun1, ShareCountBasis: asOfJun1})
+	if got.GetComputedQty() != "" || got.GetDelta() != "" || got.GetMatched() {
+		t.Fatalf("unchecked declaration carried a verdict: %+v", got)
+	}
+}
+
 func TestListHoldingDeclarations_Unauthenticated(t *testing.T) {
 	srv, _ := newAPIServerWithMock(t)
 	_, err := srv.ListHoldingDeclarations(ctxNoAuth(), &apiv1.ListHoldingDeclarationsRequest{})


### PR DESCRIPTION
Last of three PRs for 0043. **Stacked on #326** (which is stacked on #325) --
review those first; this PR's base will retarget as they merge. **Closes 0043.**

## Problem

After #326 an assertion is stored and labelled, but inert: nothing measures it.
That is the half of the design that carries the safety. A pad is true by
construction and can never catch an error; a later declaration compared against
what the transactions add up to is the only signal the system has that a broker
CSV was misparsed, a transfer missed, or a row silently dropped.

## Changes

- **The check is computed in the read query**, not stored. A holding's computed
  quantity moves under an ingestion, an instrument merge, an option split
  application and a `RecomputeSplitAdjustments` pass alike, and there is no one
  place all of those funnel through -- so a stored verdict would need
  invalidating from each and would be wrong the moment one was missed. Derived on
  read it is current by construction (which is what the issue's "re-verify after
  any ingestion or recompute" asks for, with no triggers at all) and it clears on
  its own when the data comes back into agreement, which none of the three
  existing problem surfaces can do.
- The computed side sums the holding's `USER` postings up to `as_of_date`,
  **including the pad** -- an assertion checks the holding as the user sees it --
  converting each from its own `share_count_basis` into the declaration's, via
  the `holding_qty_in_basis` primitive added in #325.
- **Tolerance is a stateable bound, not a constant.** Postings group by basis and
  sum before converting, so each denomination rounds at most once at the declared
  scale of the split-adjusted columns; the tolerance is the count of bases whose
  factor is not `1/1`, in units of the last place. With no split in the window --
  the common case -- that count is zero and the comparison is exact. An absolute
  epsilon was rejected for the reason ADR 0026 gives: it is silently
  scale-dependent.
- `computed_qty`, `delta`, `tolerance`, `matched` and `posting_count` on
  `HoldingDeclaration`, read-only, decimals as strings per ADR 0027. A pad always
  reports `matched` -- its own check can only pass, and reporting it as a result
  would suggest it had found something out.
- Opening Balances gains a Status column ("Opening balance" / "Matches" / amber
  "Off by N" -- the size of the gap is what identifies the missing transaction),
  and the tab carries a count of the assertions that disagree, derived from the
  list it already fetches so the badge costs no extra request.
- **Bug fix the e2e spec found:** writing a declaration writes the pad it
  derives, so the sibling Holdings tab needed invalidating too. It shares the
  page and never remounts, so it was showing the figure from before the opening
  balance existed.
- New ADR `0030-declarations-are-padded-then-asserted.md`: why the discriminator
  is derived, why the check is computed on read, why the tolerance is neither
  zero nor a constant, and why a pad reports no verdict.
- `docs/spec/fixed-point.md` gains a Verification section; the 0043 known
  divergence is removed from `docs/spec/bitemporality.md`; 0043 is closed.

## Verification

- `make check` -- clean
- `make server-test` -- pass. New table test over the tolerance rule: exact
  agreement, a missing transaction, a sub-ulp difference with no split (rejected,
  because nothing converted inexactly), one inexact basis either side of its
  rounding, two bases widening the bound, and a pad reconciling regardless. Plus
  a write-path row carrying no verdict at all, so a create cannot read as
  "matched".
- `make db-test` -- pass. New integration coverage: a pad and an assertion both
  measured, then the buy deleted and the assertion moving to disagree with
  nothing recomputed; and the same check across a 2:1 split reading 75 in
  pre-split terms and 150 in post-split terms from the same postings.
- `make e2e-test` -- **34 passed**, including a new `opening-balances.spec.ts`
  (the tab had no e2e coverage at all): create the pad, confirm it reaches
  holdings, add a reconciling assertion, drop the buy via a fixture, and see the
  status turn to "Off by -8" and the tab badge appear.
- `make client-test` -- pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
