### PR TITLE
Settle lot identity, unknown basis and the gain policy encoding (0044)

### DIFF
--- a/docs/adr/0031-lots-are-derived-and-unknown-basis-is-a-value.md
+++ b/docs/adr/0031-lots-are-derived-and-unknown-basis-is-a-value.md
@@ -1,0 +1,137 @@
+# Lots are derived, and an unknown cost basis is a value
+
+Lot identity and disposal matching (0044) settle four things that the cost basis
+methods built on top of them (0045) cannot revise later, because each one decides
+the key or the columns of the lot record.
+
+## A lot is opened by sign, not by transaction type
+
+A `USER` posting whose quantity has the same sign as the running position opens or
+augments a lot; one whose sign opposes it reduces lots. Quantities are signed with
+no type-based sign flip ([0020](0020-double-entry-postings.md)), so this needs no
+enumeration over the 24 `TxType` values and covers `REINVEST`, `CLOSUREOPT`,
+inbound transfers, pads and short positions alike. A type-driven rule would also
+call a `BUY` that covers a short an acquisition, which is the one case the sign
+rule gets right for free. It is the same objection
+[0022](0022-typed-per-account-cash-flow-boundary.md) raised to classifying cash
+flows by transaction type.
+
+Lot identity is therefore the acquiring posting's `txs.id`, and the cost is a read
+over the group that posting already belongs to: its `weight`, exact and stored
+([0029](0029-posting-weight-is-stored.md)), plus the group's `EXPENSE` legs.
+
+## Whether the basis is known is read off the counterparty, not flagged
+
+Nothing records it, because the acquisition's counterparty leg already says it: a
+`USER` cash leg means known, part `IMBALANCE` means partially known, `EQUITY`
+means a pad and so unknown by construction, and `TRANSFER_CLEARING` means pending
+until the pair is matched. This is the same read the cash-flow boundary performs,
+and a separate flag would be a second place to say it that can disagree.
+
+## An unknown basis stays unknown
+
+`cost` is NULL where it is not known, and the gain figures report a known/unknown
+split rather than a number that papers over the gap. This is what lets a portfolio
+with incomplete history be usable without its gains being fiction.
+
+### Considered options
+
+- **Zero cost.** Rejected: it reports the whole proceeds as gain.
+- **The market price on the pad or transfer date.** Rejected, and it is the
+  tempting one, because the price series can supply it and the result looks like a
+  fact. [0026](0026-exact-decimals-bounded-by-closure.md) already ruled on this
+  shape -- encoding an estimate as an exact decimal misrepresents its provenance --
+  and [0024](0024-group-balance-is-checked-on-weight.md) recorded the asymmetry
+  that decides it: a residual left visible is attributable and fixable, while
+  converting wrongly deletes a holding and puts cash in its place, silently. A
+  fabricated basis is the second kind of error. An estimate remains available as
+  something the user invokes explicitly and that carries its provenance.
+- **Refusing to compute gains until the user declares a basis.** Rejected: it
+  blocks reporting entirely on exactly the portfolios with incomplete history that
+  pads exist to serve.
+
+The acquisition **date** does take a default, the pad or transfer date, but for
+ordering only. It must not drive the 30-day rule or a long/short-term split; being
+the only date available does not make it an acquisition date.
+
+## The cost basis method parameterises a re-derivation
+
+The method is an input to the derivation, not a column on a lot. Changing it
+rebuilds the lot set, in the manner of the `split_adjusted_*` recompute.
+
+Lots are the journal and a Section 104 pool is a view over them, so per-lot and
+pooled are not competing models. The fork dissolves by separating the two jobs a
+lot does: **quantity** is per `(user, broker, account, instrument)` because
+holdings are, while **cost** is drawn from a scope the method chooses -- the
+individual lot for specific identification, FIFO and LIFO, and a
+`(user, instrument)` pool for Section 104, because the UK pool belongs to the
+person rather than the account. A Section 104 disposal removes quantity from its
+own account and draws cost from the user-level pool, so the two never collide and
+one table shape serves both.
+
+A pool is consequently a `lots` row with no acquiring posting and no account,
+which is why a disposal links to a lot rather than to an acquiring `txs.id`.
+
+- **Considered and rejected: fanning a pool disposal pro rata across every
+  remaining lot.** It keeps the link pointed at a transaction, but writes one row
+  per surviving acquisition for every disposal and attributes a per-lot split that
+  is arbitrary and means nothing under a method that has no per-lot identity.
+
+## Lots are stored, unlike the declaration check
+
+[0030](0030-declarations-are-padded-then-asserted.md) reached the opposite
+conclusion for an assertion's verdict, and computed it on read so that nothing
+has to invalidate it. Lots face the same invalidation problem -- an ingestion, an
+instrument merge and a `RecomputeSplitAdjustments` pass all move the inputs -- and
+still get stored, because the two differ in size. A declaration check is a small
+aggregate over a handful of rows per user, so recomputing it per read is
+free. Matching a disposal is a replay of the whole transaction history for an
+instrument, under a method with three ordered stages, one of which looks forward
+30 days.
+
+Storing it therefore risks drift where the read-computed check cannot. The
+answer is not a stored verdict trusted on faith but a periodic re-derivation that
+asserts equality against the stored set -- the reconciliation pattern 0043 uses
+for the same reason.
+
+## The matching rule is recorded on each match, not inferred from the setting
+
+`matched_by` names the rule that produced each row -- `NOMINATED`, `FIFO`, `LIFO`,
+`HIFO`, `SAME_DAY`, `THIRTY_DAY`, `POOL` -- following the shape 0068 uses for its
+transfer link. One Section 104 disposal splits across three rules, so a single
+per-user method cannot describe what happened. Nominated matches are user or
+broker input rather than output and cannot be re-derived, so a rebuild has to keep
+them and regenerate only the rest; without the discriminator there is nothing to
+tell input from output and a rebuild destroys the user's choices silently. And the
+setting is one mutable row, so a historical match that does not say how it was
+made becomes unexplainable the moment it changes.
+
+## Consequences
+
+**A gain cannot be a leg of a balanced group.** Beancount's disposal leg weighs at
+cost, so the gain is the residual and falls out of the zero-sum rule. Ours weighs
+at price ([0024](0024-group-balance-is-checked-on-weight.md)), so a `SELLSTOCK`
+group already balances against its cash row and there is no residual for a gain to
+occupy. Making one available would require the disposal to weigh at cost, which
+would make the exact `check_tx_group_balance()` trigger depend on lot matching,
+which depends on a user-configurable method -- a database constraint that moves
+when a setting changes. Gains are a derived layer over postings, computed as
+`proceeds - SUM(cost_out)` and not stored.
+
+**A pad's declared basis stays out of the postings.** A user-declared cost is an
+input to the lot derivation, not a leg: the `INITIALIZE` posting and its `EQUITY`
+counterparty go on weighing in shares. Putting cost into them would need the pad to
+weigh in currency, which is the shape 0024 rejected for transfer legs and for the
+same reason. It is declared as a total rather than a per-share price, because a
+total is split-invariant and so needs no `share_count_basis` of its own, and
+because deriving a total from a per-share price divides. See 0075.
+
+**Transfer matching gates coverage, not correctness of the model.** Without 0068
+an inbound transfer yields an unknown-basis lot, which the rules above handle.
+Under Section 104 it does not matter at all, since the pool spans the person and an
+intra-user transfer never touches it; under the per-account methods it is the
+difference between a basis that arrives and one that stays unknown.
+
+**A pool has no acquisition to inherit a share count basis from**, so the rule in
+[spec/bitemporality.md](../spec/bitemporality.md) that a lot inherits the
+acquisition's `share_count_basis` does not reach it and a pool declares its own.

--- a/docs/issues/0044-lot-identity-disposal-matching.md
+++ b/docs/issues/0044-lot-identity-disposal-matching.md
@@ -27,27 +27,263 @@ aggregation.
 ## Inspiration
 
 Beancount's inventory model, where a posting carries a cost
-(`10 SYM0 {£4.50}`) and a disposal nominates the lot it reduces, so that the
-gain falls out of the requirement that the transaction balances rather than
-being computed separately.
+(`10 SYM0 {£4.50}`) and a disposal nominates the lot it reduces.
 
-## Design
+The borrowing stops at the data model. Beancount makes the gain fall out of the
+requirement that the transaction balances, which works because its disposal leg
+weighs at **cost**, leaving the gain as the residual. Ours weighs at **price**
+(adr/0024-group-balance-is-checked-on-weight.md), so a `SELLSTOCK` group already
+balances against its cash row and there is no residual for a gain to occupy. See
+[Gains are derived, not posted](#gains-are-derived-not-posted).
 
-- Acquisitions get a lot identity; disposals reference the lot or lots they
-  reduce, with a quantity per reference where a disposal spans lots.
-- Beancount derives inventory by replaying the journal rather than storing it.
-  Deriving on every query is expensive here and storing risks drift, so the
-  likely shape is stored lots plus a periodic re-derivation that asserts
-  equality -- the same reconciliation pattern as 0043.
-- Corporate actions must adjust lots, not just totals: `split_factor_at` and
-  the `split_adjusted_*` recompute need a lot-aware equivalent. A lot inherits
-  the `share_count_basis` of the acquisition that created it, so the lot-aware
-  factor reads that column rather than the disposal date or the query date --
-  see docs/spec/bitemporality.md. Note the word collision: "cost basis" in 0045
-  is a money quantity and is unrelated to share count basis.
-- Composes with 0036: with grouped postings, the disposal and the resulting
-  gain are legs of one balanced group and the gain is implied by the zero-sum
-  rule.
+## What opens a lot
 
-This issue covers the data model only. The choice of matching method and the
-gains computation are 0045.
+A lot is opened or augmented by a `USER` posting whose quantity has the **same
+sign as the running position**, and reduced by one whose sign opposes it.
+Quantities are signed with no type-based sign flip (docs/spec/csv-format.md,
+adr/0020-double-entry-postings.md), so the rule needs no enumeration over the 24
+`TxType` values and covers `REINVEST`, `CLOSUREOPT`, inbound transfers, pads and
+short positions alike. A classification over tx types would also get a `BUY`
+that covers a short wrong, calling it an acquisition. This is the objection
+adr/0022-typed-per-account-cash-flow-boundary.md raised to classifying cash flows
+by tx type, in the same shape.
+
+Lot identity is the acquiring posting's `txs.id`. Nothing new is minted.
+
+## Where a lot's cost comes from
+
+The acquisition's `weight` is exactly `quantity * unit_price * contract_size` in
+the settlement currency, stored and exact
+(adr/0029-posting-weight-is-stored.md), and the `EXPENSE` legs of its group are
+the incidental acquisition costs, which have been separate postings since 0040.
+So the cost is a read over the group the acquisition already belongs to.
+
+It is stored on the lot anyway, for the reason 0029 stores weight: instrument
+state moves under a posting after ingest, so a re-derived cost could disagree
+with the one the lot was built on.
+
+## Whether a lot's cost is known
+
+Nothing needs to record this. The acquisition's counterparty leg already says
+it, and reading it is the same read the cash-flow boundary does:
+
+| Counterparty in the group | Basis                                                       |
+| ------------------------- | ----------------------------------------------------------- |
+| `USER` cash leg           | Known and exact.                                             |
+| Part `IMBALANCE`          | Partially known -- the residual is missing from the cost.    |
+| `EQUITY`                  | A pad. Value entering from before the history begins, so unknown by construction. |
+| `TRANSFER_CLEARING`       | Pending. Known once the pair is matched, unknown when the far side is outside our data. |
+
+**Unknown is a value, not a default.** `cost` is NULL where it is not known, and
+the gain figures downstream report a known/unknown split rather than a number
+that covers the gap. Fabricating a basis -- zero cost, or the market price on the
+date -- is rejected on the grounds already recorded twice in this repository:
+adr/0026-exact-decimals-bounded-by-closure.md, that encoding an estimate as an
+exact decimal misrepresents its provenance; and ADR 0024's asymmetry, that a
+residual left visible is attributable and fixable while converting wrongly
+deletes a holding and puts cash in its place, silently. It is also the
+covered/noncovered split a US 1099-B carries, which exists because
+transferred-in positions with no basis are ordinary rather than exceptional.
+
+An unknown basis is filled in, in order of authority:
+
+1. the user declares it on the holding declaration (0075);
+2. the matched counterparty supplies it (0068);
+3. an explicitly user-invoked estimate from the price series, stored with its
+   provenance and never applied silently.
+
+The acquisition **date** does get a default -- the pad or transfer date -- but for
+ordering only. It must not drive the 30-day rule or a long/short-term split,
+because it is not an acquisition date and does not become one by being the only
+date available.
+
+Worth stating because it bounds the damage: performance needs no cost basis at
+all. TWR and MWR need the market value at period start and the flows across the
+boundary, which valuation and 0037 already supply. A padded portfolio has
+correct returns and incomplete gains, not both broken.
+
+## Transfers
+
+adr/0024-group-balance-is-checked-on-weight.md rejected carrying the cost on both
+legs of a securities transfer, so a `JRNLSEC` weighs in shares and its
+`TRANSFER_CLEARING` counterparty holds shares rather than money. Cost therefore
+cannot ride the postings, and reaches the receiving side another way:
+
+- **Matched intra-user.** Not a disposal. The lots move along the group-to-group
+  link 0068 records, keeping their acquisition dates and their costs.
+- **Unmatched inbound.** Quantity known, cost unknown.
+- **Unmatched outbound.** Presumed a transfer rather than a sale. The removed
+  cost is recorded so that it restates when the pair arrives.
+
+0068 is not a dependency. Without it an inbound transfer yields an unknown-basis
+lot, which the model above already handles; what it gates is *coverage*. Under
+Section 104 it does not matter at all, because the pool spans the person and an
+intra-user transfer never touches it. Under the per-account methods it is the
+difference between a basis that arrives and one that stays unknown.
+
+## Corporate actions
+
+Corporate actions must adjust lots, not just totals: `split_factor_at` and the
+`split_adjusted_*` recompute need a lot-aware equivalent. A lot inherits the
+`share_count_basis` of the acquisition that created it, so the lot-aware factor
+reads that column rather than the disposal date or the query date -- see
+docs/spec/bitemporality.md. A pool has many acquisitions and so no single one to
+inherit from, and declares its own instead.
+
+Note the word collision: "cost basis" here and in 0045 is a money quantity and is
+unrelated to share count basis.
+
+## The method parameterises the derivation
+
+Lots are the journal and a Section 104 pool is a view over them, so per-lot and
+pooled are not alternatives. The apparent fork dissolves by separating the two
+jobs a lot does:
+
+- **quantity** is per `(user, broker, account, instrument)`, because holdings
+  are;
+- **cost** is drawn from a scope the method chooses -- the individual lot for
+  specific identification, FIFO and LIFO; a `(user, instrument)` pool for
+  Section 104, because the UK pool belongs to the person rather than the account.
+
+These never collide. A Section 104 disposal removes quantity from its own account
+and draws cost from the user-level pool. So one table shape serves both methods,
+and the method is an input to the derivation rather than a column on a lot:
+changing it rebuilds the lot set, in the same way a new split rebuilds the
+`split_adjusted_*` cache.
+
+Section 104's first two stages are ordinary lot matching and produce ordinary
+match rows; only the third consumes the pool. The 30-day stage looks **forward**,
+at acquisitions in the 30 days following the disposal, which is why a disposal's
+matching is not final when it is first recorded.
+
+## Data model
+
+```sql
+-- A parcel of an instrument with a cost. One row per acquiring posting under
+-- specific identification, FIFO and LIFO; one row per (user, instrument) pool
+-- under Section 104, which has no acquiring posting and no single account.
+lots
+  id                 UUID PK
+  user_id            UUID NOT NULL
+  instrument_id      UUID NOT NULL
+  broker, account    TEXT            -- NULL for a pool, which is person-scoped
+  acquired_tx_id     UUID            -- NULL for a pool
+  acquired_at        TIMESTAMPTZ     -- ordering only where it is a pad or transfer default
+  qty                NUMERIC NOT NULL
+  share_count_basis  DATE NOT NULL   -- the acquisition's; a pool declares its own
+  cost               NUMERIC         -- NULL means the basis is not known
+  cost_currency      TEXT
+  unknown_qty        NUMERIC         -- pool only: the quantity whose cost is not known
+
+-- Which lots a disposal drew from, and under which rule.
+lot_disposals
+  id              UUID PK
+  disposal_tx_id  UUID NOT NULL      -- the reducing posting
+  lot_id          UUID NOT NULL
+  qty             NUMERIC NOT NULL   -- in the LOT's share_count_basis
+  cost_out        NUMERIC            -- NULL where the lot's basis is not known
+  matched_by      TEXT NOT NULL
+  matched_at      TIMESTAMPTZ NOT NULL
+```
+
+The schema goes into `server/migrations/001_initial.sql` rather than a new
+migration file.
+
+Two properties are load-bearing, and are why this is two tables rather than one
+link between two `txs` rows:
+
+- **The link points at a lot, not at an acquiring transaction.** A Section 104
+  disposal draws from the pool, and a pool is not a transaction. Were `lot_id` a
+  `txs.id`, a pool disposal could only be expressed by fanning it pro rata across
+  every remaining acquisition -- many rows per disposal, carrying a split that is
+  arbitrary and means nothing.
+- **Under Section 104 the lot machinery tracks cost only.** Quantity per account
+  is already `SUM(quantity)` grouped by `(broker, account, instrument_id)` and
+  needs no lots. Under specific identification and FIFO the lots track both,
+  because cost attaches to an identified parcel. That is the whole of the
+  difference between the methods at the storage layer.
+
+Remaining quantity and remaining cost are derived -- `lots.qty` and `lots.cost`
+less the matched sums -- rather than being mutable running columns, so there is no
+running balance to drift and the re-derivation below has something exact to
+assert against.
+
+### The matching rule is recorded per match
+
+`matched_by` is one of `NOMINATED`, `FIFO`, `LIFO`, `HIFO`, `SAME_DAY`,
+`THIRTY_DAY` or `POOL`, on the row rather than read back off the user's setting.
+This follows the shape 0068 uses for its transfer link -- store the link, how it
+was made, and when -- for three reasons:
+
+- **One Section 104 disposal splits across three rules**: some quantity matched
+  same-day, some against acquisitions in the following 30 days, the remainder
+  from the pool. A single per-user method cannot describe what happened. This is
+  also the column that makes 0045's requirement to show the matching decisions
+  renderable.
+- **Nominated matches are input, not output.** Under specific identification the
+  user or the broker chooses the lots, and that choice cannot be re-derived. A
+  rebuild must keep `NOMINATED` rows and regenerate only the rest; without the
+  discriminator there is nothing to tell one from the other, and a rebuild
+  destroys the user's choices silently.
+- **The setting moves.** It is one mutable per-user row following the user's
+  jurisdiction, so a historical match that does not say how it was made becomes
+  unexplainable the moment it changes.
+
+The rule for a given disposal comes from an explicit nomination where there is
+one -- from the broker's data, or from the user in the UI -- and otherwise from
+the user's configured cost basis method. Nothing stores a jurisdiction today.
+
+### Re-derivation
+
+Beancount derives inventory by replaying the journal rather than storing it.
+Deriving on every query is expensive here and storing risks drift, so lots are
+stored and periodically re-derived, with the re-derivation asserting equality --
+the same reconciliation pattern as 0043. Every non-pool `lots` row is
+recomputable from its acquiring posting and that posting's group, which is what
+lets the whole set be rebuilt when the method changes.
+
+Derived match rows are disposable and cascade on group delete, as 0068's link
+does; `NOMINATED` rows survive. A method change deletes the derived rows and
+re-runs.
+
+One recompute trigger is easy to miss. Because the 30-day rule looks forward, a
+newly ingested **acquisition** can change the matching of a disposal already
+recorded. Re-derivation must therefore trigger on acquisitions landing within 30
+days after an existing disposal, not only on new disposals. It belongs alongside
+the split recompute and the declaration re-verify in
+docs/spec/bitemporality.md#retroactive-restatement.
+
+## Gains are derived, not posted
+
+The gain is not stored and is not a posting. Proceeds is the disposal posting's
+`weight`, already stored and exact, so a realised gain is
+`proceeds - SUM(cost_out)`: a subtraction over stored values, inside the
+adr/0026-exact-decimals-bounded-by-closure.md boundary. Storing it would be a
+second place for the same fact.
+
+Making it a leg of the group is not available. It would require the disposal to
+weigh at cost rather than at price, which would make the exact
+`check_tx_group_balance()` trigger depend on lot matching, which depends on a
+user-configurable method -- a database constraint that moves when a setting
+changes. Gains are a derived layer over postings.
+
+## Sequencing
+
+This change is additive. It creates two tables and changes no column on `txs`, so
+holdings, valuation and the balance constraint are untouched, and no existing row
+is migrated or rewritten.
+
+It also needs no re-ingest. Every input the derivation reads is already stored:
+the acquiring posting, its cost (`weight` since 0041, the `EXPENSE` legs since
+0040), its group membership, and its basis provenance in the counterparty's
+`account_type`. Nothing the converters currently discard is required. The lot set
+is rebuildable from whatever is in `txs` at the time, so it can be built, dropped
+and rebuilt without touching ingested data.
+
+## Scope
+
+This issue covers the data model. The choice of matching method and the gains
+computation are 0045; declaring a cost basis alongside a pad is 0075.
+
+The reasoning behind the decisions above is in
+adr/0031-lots-are-derived-and-unknown-basis-is-a-value.md.

--- a/docs/issues/0045-realised-gains-cost-basis-methods.md
+++ b/docs/issues/0045-realised-gains-cost-basis-methods.md
@@ -27,23 +27,76 @@ comes first.
 ## Design
 
 - Method configurable rather than hard-coded, since it follows the user's
-  jurisdiction: specific identification, FIFO, and Section 104 at minimum.
+  jurisdiction: specific identification, FIFO, and Section 104 at minimum. It
+  parameterises the derivation rather than being stored on a lot, so changing it
+  rebuilds the lot set; 0044 records which rule produced each match.
 - Section 104 needs same-day matching first, then the 30-day rule, then the
-  pool -- ordering matters and is the usual source of error.
+  pool -- ordering matters and is the usual source of error. The 30-day stage
+  looks **forward**, at acquisitions in the 30 days after the disposal, so a
+  disposal's matching is not final when it is first recorded and a later
+  acquisition restates it.
 - Report realised gains per disposal and aggregated per tax year, with the
   matching decisions visible so a user can check them.
 - Unrealised gain is the complement: current value less remaining basis.
 
+## What is reported
+
+An **estimate of the taxable gain**, never a liability. Nothing here computes a
+rate, an annual exemption or an amount owed, and the reporting says so. That
+posture is what keeps 0054 validly closed: it was declined on the grounds that
+PortfolioDB does not report figures to a tax authority, and an explicitly
+non-authoritative estimate does not disturb that.
+
+It follows that a period is allowed to have no figure. Where a disposal draws on
+a lot whose cost is unknown (0044), the period carries a statement that the
+taxable gain could not be calculated because information is missing, naming what
+is missing, rather than a number computed over a fabricated basis. Under
+Section 104 that matters more than it does per-lot: an unknown contribution makes
+the *average* unknown, so it reaches every later disposal from that pool and not
+only the ones matched to it. The pool therefore carries its unknown-cost quantity
+as a figure of its own, so a disposal can report the proportion of its basis that
+is missing instead of collapsing entirely.
+
+Two things this needs exist nowhere and have no issue of their own yet:
+
+- **A per-account tax treatment.** An ISA or a SIPP is outside CGT entirely and
+  must be excluded from the pool. Accounts are implicit today -- distinct
+  `(broker, account)` pairs in `txs` -- and 0037 deferred an accounts table to
+  0046, which says of itself that it is not urgent and possibly not correct.
+- **A stored jurisdiction and tax-year calendar.** The method follows the former,
+  and the UK year begins on 6 April against the US calendar year.
+
+Neither blocks 0044. Both block reporting a per-tax-year figure that is right for
+a user with a tax-wrapped account.
+
+## Currency
+
+`weight` is denominated in each posting's settlement currency, so a GBP pool over
+a security bought in USD needs an FX conversion per acquisition. That divides,
+which puts a pooled cost for a foreign-currency security past the exactness
+boundary regardless of the arithmetic below. Say so where the figure is reported
+rather than presenting it as exact.
+
 ## Exactness
 
 The methods differ here too. Specific identification and FIFO only add, subtract
-and multiply, so a realised gain computed under either is exact once 0042 lands.
-Section 104 pooling averages, and an average divides: a pooled cost per share is
-not generally representable, so the pool carries a declared rounding scale and
-the rounding accumulates across acquisitions. That has to be decided with the
-pool's data model rather than discovered afterwards, because the pool is carried
-forward and a rounding policy applied to a running balance is not something a
-later change can revise cleanly. See
+and multiply, so a realised gain computed under either is exact, now that 0042
+has made quantities and prices exact decimals. Section 104 pooling averages, and
+an average divides.
+
+The rounding that follows does not have to accumulate, though, and the way to
+stop it belongs with the pool's data model rather than being discovered
+afterwards. **Store the pool as `(total_qty, total_cost)` and never as a cost per
+share.** A per-share average is not generally representable, so storing one
+rounds on every acquisition and carries the error forward in a running balance --
+which is the shape a later change cannot revise cleanly. Storing the two totals
+instead means acquisitions only ever add, which is exact, and a disposal computes
+
+    cost_out = total_cost * qty_out / total_qty
+
+multiplying first and dividing once. The remainder stays in the pool exactly, so
+there is one rounding per disposal rather than a running one. This is also the
+order HMRC's worked examples use. See
 adr/0026-exact-decimals-bounded-by-closure.md.
 
 ## Note

--- a/docs/issues/0075-declared-cost-basis-on-a-pad.md
+++ b/docs/issues/0075-declared-cost-basis-on-a-pad.md
@@ -1,0 +1,76 @@
+---
+status: open
+title: Declare a cost basis alongside a pad
+dependencies: [0044]
+---
+
+Let a holding declaration state what the declared position cost, so that the lot
+a pad creates has a basis instead of an unknown one.
+
+## Motivation
+
+A pad is a declared quantity with no cost -- that is what makes it a pad. Under
+0044 the lot it creates therefore carries a NULL basis, and every disposal that
+draws on it reports that the gain could not be calculated. For a user whose
+transaction history does not reach back to inception, that is most of their
+oldest holdings, which are also the ones with the largest gains.
+
+0044 deliberately refuses to invent a basis
+(adr/0031-lots-are-derived-and-unknown-basis-is-a-value.md). This is the
+declaration path it refuses in favour of: the user knows what they paid, and
+`holding_declarations` is already the place they say what they know.
+
+docs/spec/fixed-point.md has listed this as a future extension since the
+declaration model was written.
+
+## Design
+
+`holding_declarations` gains a nullable `declared_cost NUMERIC` and a
+`cost_currency TEXT`. Four properties settle the rest.
+
+**A total, not a per-share price.** Total cost is split-invariant -- the
+`quantity * unit_price == split_adjusted_quantity * split_adjusted_unit_price`
+identity in docs/spec/corporate-events.md is exactly that -- so a declared total
+needs no `share_count_basis` of its own and is never restated when a split lands.
+A per-share price would need one, and deriving a total from it divides
+(adr/0026-exact-decimals-bounded-by-closure.md).
+
+**The declared cost is the cost of the declared position; the pad lot takes the
+remainder.** This mirrors `init_qty = declared_qty - running_balance`: the pad
+lot's cost is `declared_cost` less the cost of the lots the real transactions
+leave open at `as_of_date`. A subtraction, so it stays exact, and the
+recalculation triggers in docs/spec/fixed-point.md apply unchanged.
+
+Where that goes negative the declaration disagrees with the imported history --
+the real transactions already account for more cost than the user says the
+position cost. That is a reportable problem rather than a basis: the pad lot's
+cost stays NULL and the mismatch is surfaced, in the manner of the assertion
+check in 0043.
+
+**Only the pad carries one.** An assertion generates nothing, so a cost declared
+on one has nothing to attach to. A *checked* cost assertion is the obvious
+symmetry and is deliberately out of scope; it wants the disposal history to be
+trustworthy first.
+
+**The INITIALIZE group does not change.** The pad posting and its `EQUITY`
+counterparty go on weighing in shares. Putting the cost into them would need the
+pad to weigh in currency, which is the shape
+adr/0024-group-balance-is-checked-on-weight.md rejected for transfer legs and for
+the same reason. The declared cost is an input to the lot derivation, exactly as a
+real acquisition's cost is read from its group.
+
+## Plumbing
+
+The declaration API, recalc and UI already exist in
+server/service/api/declarations.go, server/service/api/recalc.go and the Opening
+Balances tab. The two fields carry through all three. The form needs to be clear
+that it is asking for the total paid for the whole declared position, including
+any dealing costs, and that leaving it blank is allowed and means the gains
+reporting will say the basis is unknown.
+
+## Note
+
+This does not make a padded portfolio's gains authoritative. A declared cost is a
+user's recollection, and 0045 reports an estimate of taxable gain rather than a
+liability in any case. What it removes is the case where a gain cannot be reported
+at all.

--- a/docs/issues/0076-declaration-csv-import-export.md
+++ b/docs/issues/0076-declaration-csv-import-export.md
@@ -1,0 +1,108 @@
+---
+status: open
+title: Import and export holding declarations as CSV
+---
+
+Let a user import and export their holding declarations as a CSV, so that pads
+and assertions can be entered in bulk and edited outside the application.
+
+## Motivation
+
+Declarations are created one at a time through a form. That is workable for a pad
+-- a user seeds an opening balance once -- but it is the wrong shape for the half
+of the mechanism that carries the safety.
+
+An assertion is checked against what the transactions add up to, and it is the
+only thing in the system that catches a misparsed broker CSV, a missed transfer or
+a converter that silently dropped a row
+(adr/0030-declarations-are-padded-then-asserted.md). To catch anything it has to
+be entered, and the natural source is a statement: one date, every holding in the
+account, several dozen rows. A user who has to fill in a form per holding per
+statement will do it once and never again, so the assertion half of pad-and-assert
+goes unused and the pad -- which is true by construction and can never catch an
+error -- is all that is left.
+
+The same argument applies to the pad at inception. A portfolio with forty holdings
+is forty forms before the opening balances are right.
+
+Export matters as much as import, for three reasons. It is what makes editing
+practical: pull the current declarations, reconcile them against a statement in a
+spreadsheet, put them back. It is the only way to get the data out, and a
+declaration is a user's own statement rather than something recoverable from a
+broker. And it is what makes the round trip testable.
+
+## Design
+
+A CSV, following the conventions the other import formats already share -- header
+names case-insensitive, `#` comment metadata, extra columns ignored. See
+docs/spec/csv-format.md, which gains a fourth format alongside the transaction
+CSV, the price CSV and the corporate event JSON.
+
+Columns, with `broker` supplied by the upload request as it is for transactions:
+
+| Column                                            | Required | Notes                                              |
+| ------------------------------------------------- | -------- | -------------------------------------------------- |
+| `account`                                         | Yes      | The broker account the holding is in.               |
+| `instrument_description`                          | Yes      | As for a transaction row.                           |
+| `declared_qty`                                    | Yes      | Exact decimal. May be negative -- a short at inception is permitted. |
+| `as_of_date`                                      | Yes      | The date the declaration refers to.                 |
+| `share_count_basis`                               | No       | Defaults to `as_of_date`, as the table trigger does. |
+| `symbol_type`, `symbol`, `exchange_type`, `exchange` | No    | Identifier hints, exactly as the transaction CSV defines them. |
+
+Once 0075 lands the format also carries `declared_cost` and `cost_currency`. The
+format should be specified with them in mind even if it ships first, so that
+adding them is a new optional column rather than a second format.
+
+### Instrument identity is the hard part
+
+A declaration references `instrument_id`, which is a UUID and cannot appear in a
+user-facing file. Resolution therefore goes through the same identification path a
+transaction upload uses: the description plus an optional identifier hint, through
+the identifier plugins.
+
+That has a consequence worth deciding rather than discovering. A transaction that
+fails to identify is still an event that happened, and the system keeps it and
+surfaces the failure. A declaration that fails to identify is a statement about a
+holding the system cannot name -- there is nothing for it to pad and nothing to
+check it against -- so it is likely better rejected as a row error than stored
+against an unresolved instrument. Settle which, and surface failures the way
+transaction uploads do.
+
+### Re-importing an exported file must be a no-op
+
+`UNIQUE (user_id, broker, account, instrument_id, as_of_date)` means a re-import
+collides on every unchanged row. The declaration API answers that with
+`ALREADY_EXISTS`, which is right for a user creating one by hand and wrong here:
+it would fail the export-edit-import loop that is the point of the feature.
+
+Import is an upsert on that key. A row whose quantity has changed restates the
+declaration; a row identical to what is stored changes nothing.
+
+### Absence is not deletion
+
+A bulk transaction upload replaces a period, so a row missing from the file is
+removed (adr/0002-transaction-ingestion-model.md). Declarations do not work that
+way and the asymmetry should be explicit, because it is the natural assumption to
+make. A declaration missing from an imported file is left alone; deleting one
+stays an explicit action. A file assembled from one statement covers one date and
+one account, and treating everything outside it as retracted would delete the
+user's other checkpoints.
+
+### The file carries no kind column
+
+Pad and assertion are derived from the declaration dates, not stored
+(adr/0030-declarations-are-padded-then-asserted.md). An export may show which is
+which for the reader's benefit, but importing it would be a second statement of
+what `as_of_date` already says, and the two could disagree.
+
+### Export
+
+Streaming, following `ExportInstruments` and `ExportPrices`. It exports the user's
+own declarations only.
+
+## Plumbing
+
+`ListHoldingDeclarations`, `CreateHoldingDeclaration` and
+`UpdateHoldingDeclaration` already exist, as does the Opening Balances tab that
+would host the upload and download controls. The CSV upload UI from 0012 is the
+pattern for the import side.

--- a/docs/issues/0076-declaration-csv-import-export.md
+++ b/docs/issues/0076-declaration-csv-import-export.md
@@ -25,48 +25,79 @@ error -- is all that is left.
 The same argument applies to the pad at inception. A portfolio with forty holdings
 is forty forms before the opening balances are right.
 
-Export matters as much as import, for three reasons. It is what makes editing
-practical: pull the current declarations, reconcile them against a statement in a
-spreadsheet, put them back. It is the only way to get the data out, and a
-declaration is a user's own statement rather than something recoverable from a
-broker. And it is what makes the round trip testable.
+Export matters as much as import, and the expected flow is create-export-import
+rather than authoring a file from nothing: a user creates declarations in the UI,
+where the instrument is picked and identity is therefore already resolved, then
+exports to reconcile against a statement in a spreadsheet and imports the result.
+Hand-assembling a file is possible but is not the case to design for. Export is
+also the only way to get the data out, a declaration being the user's own
+statement rather than something recoverable from a broker.
 
 ## Design
 
-A CSV, following the conventions the other import formats already share -- header
-names case-insensitive, `#` comment metadata, extra columns ignored. See
+A CSV, following the conventions the other formats already share -- header names
+case-insensitive, `#` comment metadata, extra columns ignored. See
 docs/spec/csv-format.md, which gains a fourth format alongside the transaction
 CSV, the price CSV and the corporate event JSON.
 
+The **price CSV is the precedent, not the transaction CSV.** There is no
+transaction export -- only `ListTxs` -- so the transaction CSV is an import-only
+format, and its identity columns are optional *hints* because a broker file's
+primary handle on an instrument is the broker's own description. The price CSV is
+the format an export writes and an import reads back, and it makes identity a
+required, explicit identifier for exactly that reason: a round trip has to resolve
+to the same instrument deterministically rather than through a description guess.
+Declarations are a round-trip format, so they take that shape.
+
 Columns, with `broker` supplied by the upload request as it is for transactions:
 
-| Column                                            | Required | Notes                                              |
-| ------------------------------------------------- | -------- | -------------------------------------------------- |
-| `account`                                         | Yes      | The broker account the holding is in.               |
-| `instrument_description`                          | Yes      | As for a transaction row.                           |
-| `declared_qty`                                    | Yes      | Exact decimal. May be negative -- a short at inception is permitted. |
-| `as_of_date`                                      | Yes      | The date the declaration refers to.                 |
-| `share_count_basis`                               | No       | Defaults to `as_of_date`, as the table trigger does. |
-| `symbol_type`, `symbol`, `exchange_type`, `exchange` | No    | Identifier hints, exactly as the transaction CSV defines them. |
+| Column                | Required | Notes                                                               |
+| --------------------- | -------- | ------------------------------------------------------------------- |
+| `identifier_type`     | Yes      | Identifier type used to resolve the instrument. Any IdentifierType enum value. |
+| `identifier_value`    | Yes      | Identifier value.                                                    |
+| `identifier_domain`   | No       | Domain for the identifier: MIC for `MIC_TICKER`, exchange code for `OPENFIGI_TICKER`, source for `BROKER_DESCRIPTION`, empty otherwise. |
+| `account`             | Yes      | The broker account the holding is in.                                |
+| `declared_qty`        | Yes      | Exact decimal. May be negative -- a short at inception is permitted. |
+| `as_of_date`          | Yes      | The date the declaration refers to.                                  |
+| `share_count_basis`   | No       | Defaults to `as_of_date`, as the table trigger does.                 |
+| `instrument_description` | No    | Written by the export so a reader can tell the rows apart. Not read on import, where the identifier decides. |
+
+`declared_qty` is parsed and emitted as an exact decimal, so a file written by the
+export re-imports to the same stored value to the digit, as the price CSV
+guarantees. Trailing zeroes are not preserved.
 
 Once 0075 lands the format also carries `declared_cost` and `cost_currency`. The
 format should be specified with them in mind even if it ships first, so that
 adding them is a new optional column rather than a second format.
 
-### Instrument identity is the hard part
+### Which identifier the export writes
 
-A declaration references `instrument_id`, which is a UUID and cannot appear in a
-user-facing file. Resolution therefore goes through the same identification path a
-transaction upload uses: the description plus an optional identifier hint, through
-the identifier plugins.
+`bestIdentifierJoin` in server/db/postgres/identifier_priority.go already selects
+the highest-priority canonical identifier per instrument, and its comment requires
+that every export surfacing a single identifier use it so the ordering stays
+consistent. This export uses it too; nothing new is needed.
 
-That has a consequence worth deciding rather than discovering. A transaction that
-fails to identify is still an event that happened, and the system keeps it and
-surfaces the failure. A declaration that fails to identify is a statement about a
-holding the system cannot name -- there is nothing for it to pad and nothing to
-check it against -- so it is likely better rejected as a row error than stored
-against an unresolved instrument. Settle which, and surface failures the way
-transaction uploads do.
+Two consequences follow from identity being current state rather than a
+time-varying fact (adr/0004-instrument-resolution-and-merge.md).
+
+A row can fail to resolve on import even though the instrument was picked in the
+UI when the declaration was created -- if the priority order lands on an
+identifier the resolution path cannot take back. In the flow this feature is for
+that is a defect rather than user error, so it should fail loudly.
+
+And a merge between export and import can move an identifier to a different
+instrument, so a file re-imported across one lands somewhere else. That is the
+same class of problem as 0053 and is not solved here, but the round trip is where
+a user would first meet it.
+
+### An unresolved declaration has nothing to attach to
+
+A transaction that fails to identify is still an event that happened, so the
+system keeps it and surfaces the failure. A declaration that fails to identify is
+a statement about a holding the system cannot name -- there is nothing for it to
+pad and nothing to check it against -- so it is likely better rejected as a row
+error than stored against an unresolved instrument. Settle which, and surface
+failures the way transaction uploads do.
 
 ### Re-importing an exported file must be a no-op
 

--- a/docs/issues/0077-transaction-csv-export.md
+++ b/docs/issues/0077-transaction-csv-export.md
@@ -1,0 +1,103 @@
+---
+status: open
+title: Export transactions as CSV
+---
+
+Export a user's transactions in the standard transaction CSV, so that the format
+round-trips and the data can be got back out.
+
+## Motivation
+
+The standard transaction CSV is import-only. `ListTxs` is a paged read for the
+transaction list, not an export, so there is no way to take transaction data out
+of the system: no backup, no move between instances, and no way to inspect what a
+converter actually stored other than through the UI a row at a time.
+
+It also leaves the most heavily used format in the repository as the only one that
+is never read back. Prices, corporate events and instrument identities all export
+and re-import; every broker converter targets this format and none of them can be
+checked by round-tripping their output through storage and out again.
+
+The gap is visible in the format itself. Because nothing writes the file, its
+identity columns were designed for what a broker supplies -- a description plus an
+optional hint -- rather than for what a writer can guarantee. 0076 hit the same
+question for declarations and took the price CSV's shape instead, and the two
+should agree.
+
+## Design
+
+Stream the user's own transactions, following `ExportPrices` and
+`ExportCorporateEvents` in shape but scoped with `RequireUser` rather than
+`RequireAdmin` -- transactions are user data, unlike prices and corporate events,
+which are shared.
+
+### Identity
+
+The export writes `identifier_type`, `identifier_value` and `identifier_domain`,
+selected with `bestIdentifierJoin` in server/db/postgres/identifier_priority.go,
+whose comment requires that every export surfacing a single identifier per
+instrument use it so the priority order stays consistent. This is what 0076 does
+for declarations.
+
+That leaves the transaction CSV accepting two spellings of the same thing: the
+existing `symbol_type` / `symbol` / `exchange_type` / `exchange` hint columns that
+converters emit, and the `identifier_*` trio the export writes. Converging on the
+latter is the better end state -- `exchange_type` is derivable from
+`identifier_type`, since `MIC_TICKER` and `OPENFIGI_TICKER` already say which
+system the domain belongs to, so the price CSV's form carries the same information
+in one column fewer. Decide whether this issue accepts both and deprecates the
+older spelling, or converts the converters. Accepting both first is the cheaper
+order, since the import already ignores unknown columns.
+
+### The file has to carry share_count_basis per row
+
+The transaction CSV states the share count only as a file-level
+`# share_count_basis=` comment. That is enough for an import, where one file comes
+from one source, but not for an export: `txs.share_count_basis` is per row, and a
+period can span rows on different bases -- which is exactly what a source that
+restates historical rows produces. A single file-level value cannot express that,
+and defaulting the rows to their own dates would silently restate any row whose
+basis was not its date.
+
+So the export needs a per-row `share_count_basis` column, and the import needs to
+read it, with the file-level comment kept as the default for rows that omit it.
+This is the same gap 0057 records on the price side.
+
+### What is not exported
+
+- **The derived pair.** `split_adjusted_quantity` and `split_adjusted_unit_price`
+  are a recomputable cache carrying a rounding
+  (adr/0026-exact-decimals-bounded-by-closure.md). The export writes the raw
+  `quantity` and `unit_price`, which are exact, and the import recomputes the
+  cache. Emitting both would also invite mixing share counts, which
+  docs/spec/bitemporality.md rule 4 forbids.
+- **`weight` and `weight_commodity`**, which are computed at ingest from the raw
+  columns and the tx type (adr/0024-group-balance-is-checked-on-weight.md).
+- **Synthetic INITIALIZE postings and their `EQUITY` counterparties.** These are
+  derived from holding declarations, are excluded from replace-by-period, and are
+  exported by 0076 as the declarations they come from. Emitting them here would
+  re-import a pad as a real transaction and collide with the partial unique index
+  that allows one per holding per account type.
+
+### Round trip
+
+Transactions have no natural key (adr/0002-transaction-ingestion-model.md), so an
+exported file does not re-import to the same rows in the way a price file does.
+Two consequences to state rather than discover:
+
+- **Group identity is not preserved.** `group_ref` is scoped to an upload and is
+  not stored, so the export synthesises one per group and a re-import creates new
+  groups with new ids. The postings and their grouping are equivalent; the ids are
+  not.
+- **Re-import replaces rather than appends**, because bulk upload is
+  replace-by-period. Re-importing an export of a period therefore lands on the
+  same set rather than doubling it -- which is the useful behaviour, but it depends
+  on the period being right, so the export should record the window it covers in
+  the file the way the price CSV records coverage.
+
+Routed postings -- `IMBALANCE`, `TRANSFER_CLEARING`, `SOURCE_ROUNDING` -- are
+server-generated, but the format already accepts them as `account_type` values and
+a group exported with its residual sums to zero, so nothing is routed again on
+re-import. Exporting them is therefore idempotent and keeps the file a faithful
+picture of what is stored. Confirm that against the balancer rather than assuming
+it.

--- a/docs/issues/0077-transaction-csv-export.md
+++ b/docs/issues/0077-transaction-csv-export.md
@@ -21,8 +21,8 @@ checked by round-tripping their output through storage and out again.
 The gap is visible in the format itself. Because nothing writes the file, its
 identity columns were designed for what a broker supplies -- a description plus an
 optional hint -- rather than for what a writer can guarantee. 0076 hit the same
-question for declarations and took the price CSV's shape instead, and the two
-should agree.
+question for declarations and took the price CSV's shape instead. Three formats
+should not spell one concept three ways, so this issue converges them.
 
 ## Design
 
@@ -39,15 +39,37 @@ whose comment requires that every export surfacing a single identifier per
 instrument use it so the priority order stays consistent. This is what 0076 does
 for declarations.
 
-That leaves the transaction CSV accepting two spellings of the same thing: the
-existing `symbol_type` / `symbol` / `exchange_type` / `exchange` hint columns that
-converters emit, and the `identifier_*` trio the export writes. Converging on the
-latter is the better end state -- `exchange_type` is derivable from
-`identifier_type`, since `MIC_TICKER` and `OPENFIGI_TICKER` already say which
-system the domain belongs to, so the price CSV's form carries the same information
-in one column fewer. Decide whether this issue accepts both and deprecates the
-older spelling, or converts the converters. Accepting both first is the cheaper
-order, since the import already ignores unknown columns.
+### One spelling, not two
+
+The transaction CSV's existing `symbol_type` / `symbol` / `exchange_type` /
+`exchange` columns are **replaced** by that trio rather than kept alongside it.
+Two spellings of one concept across two formats is not an acceptable end state,
+and the project is pre-release, so this is a clean cut with no transitional
+acceptance of the old names.
+
+`exchange_type` disappears entirely rather than being renamed. It says whether the
+domain is a MIC or an OpenFIGI exchange code, which `identifier_type` already
+says: `MIC_TICKER` and `OPENFIGI_TICKER` differ in exactly that. So the price
+CSV's form carries the same information in one column fewer, and it takes with it
+the three paired-presence checks the pair currently needs in
+client/lib/csv/standard.ts -- that `exchange` requires `exchange_type`, that
+`exchange_type` requires `exchange`, and that the type is one of the known values.
+
+The conversion is smaller than the phrase "update the converters" suggests,
+because the names never reach a converter:
+
+- **The wire format is already identifier-shaped.** `Tx.identifier_hints` is a
+  `repeated InstrumentIdentifier` of type, value and domain. Nothing on the API
+  changes.
+- **No converter emits these column names.** They exist only as CSV headers,
+  parsed in client/lib/csv/standard.ts and mapped into `identifierHints` there.
+  The Fidelity, IBKR and Schwab converters produce rows, not headers, and are
+  untouched.
+
+So the surface is docs/spec/csv-format.md, the parsing and error messages in
+client/lib/csv/standard.ts, client/lib/csv/standard.test.ts, and the three e2e
+fixtures that carry the old headers: e2e/fixtures/split-txs.csv,
+e2e/fixtures/standard-3-stocks.csv and e2e/fixtures/fetch-blocks-stocks.csv.
 
 ### The file has to carry share_count_basis per row
 

--- a/docs/spec/bitemporality.md
+++ b/docs/spec/bitemporality.md
@@ -188,7 +188,9 @@ the split chain -- stay exact and can be recomputed from at any time.
    derives itself.
 6. **Lots inherit the share count basis of the acquisition that created them.**
    A lot-aware equivalent of `split_factor_at` reads `share_count_basis` from the
-   acquiring transaction, not from the disposal or the query date.
+   acquiring transaction, not from the disposal or the query date. A Section 104
+   pool has many acquisitions and so none to inherit from, and declares its own
+   (see adr/0031-lots-are-derived-and-unknown-basis-is-a-value.md).
 7. **`as_of` on read APIs is valid time.** `GetHoldings(as_of)` rewinds the
    world, not our knowledge of it: it returns the transactions that had occurred
    by that date, with quantities expressed in **today's** share count.
@@ -211,6 +213,7 @@ passed. It is normal, not exceptional.
 | A bulk upload replaces a period | Every transaction in that broker and period | Holdings and valuation follow from the transaction set; nothing is materialised |
 | A transaction earlier than the current earliest arrives, or history between the start date and a declaration changes | The derived INITIALIZE transaction | See [fixed-point.md](fixed-point.md) |
 | Instrument identity changes or two instruments merge | Which transactions roll up to which instrument | Holdings and valuation follow; the prior identity is not retained -- see [identifiers.md](identifiers.md) |
+| An acquisition arrives within 30 days after a recorded disposal | Which lots that disposal matched, under Section 104's forward-looking 30-day rule | Re-derive the disposal's matches -- see 0044 |
 
 Restatement of a user-visible quantity should be surfaced rather than applied
 silently -- see [fixed-point.md](fixed-point.md), which sets the same requirement

--- a/docs/spec/fixed-point.md
+++ b/docs/spec/fixed-point.md
@@ -226,4 +226,4 @@ The declaration form should:
 ## Future Extensions
 
 - **TRUE_UP synthetic transactions:** Additional fixed points after portfolio inception that insert corrective transactions at their own dates, for a user who wants a disagreeing assertion plugged rather than reported. The `synthetic_purpose` field is already designed to accommodate this.
-- **Cost basis on INITIALIZE transactions:** Allowing users to optionally declare cost basis alongside units, for gain/loss reporting.
+- **Cost basis on INITIALIZE transactions:** Allowing users to optionally declare cost basis alongside units, for gain/loss reporting. A declared cost is an input to the lot derivation rather than a leg, so nothing above changes: the pad and its `EQUITY` counterparty go on weighing in shares. See adr/0031-lots-are-derived-and-unknown-basis-is-a-value.md; the work is 0075.


### PR DESCRIPTION
Docs only. Answers the four questions 0044 left open, each of which decides the key or the columns of the lot record and so could not be deferred to 0045. Also opens three follow-on issues.

## What is decided

**A lot is opened by sign, not by tx type.** A `USER` posting whose quantity matches the running position augments a lot; one that opposes it reduces lots. No enumeration over the 24 `TxType` values, and it is the only rule that treats a `BUY` covering a short as a reduction -- the objection ADR 0022 raised to classifying cash flows by type.

**Cost is a read over the group.** The acquisition's `weight`, exact and stored since 0029, plus the `EXPENSE` legs 0040 split out. Whether it is known is read off the counterparty leg's `account_type`, which already distinguishes a real cash leg from a pad's `EQUITY`, an unmatched transfer's `TRANSFER_CLEARING`, and a partial `IMBALANCE`. No new flag.

**Unknown basis stays unknown.** `cost` is NULL and the gain reports a known/unknown split. Zero cost and market-price-on-the-date are both rejected on grounds ADR 0026 and ADR 0024 already recorded. 0075 adds the declaration path this is refused in favour of.

**The method parameterises the derivation.** Quantity is per account because holdings are; cost comes from the lot under specific identification and FIFO, and from a `(user, instrument)` pool under Section 104, because the UK pool belongs to the person. They never collide, so one table shape serves both -- and a pool is a `lots` row with no acquiring posting, which is why `lot_disposals` links to a lot rather than a `txs.id`. The rule producing each match is stored per row, because one Section 104 disposal splits across three of them and a `NOMINATED` match is input a rebuild must not destroy.

## Two corrections to existing text

- 0044 claimed the gain is implied by the zero-sum rule. It is not: our disposal leg weighs at price rather than cost (ADR 0024), so the group already balances. Making a gain leg available would put the exact balance trigger downstream of a user-configurable method.
- 0045 claimed pooling's rounding accumulates across acquisitions. It need not, if the pool is stored as `(total_qty, total_cost)` rather than as an average -- one rounding per disposal, remainder exact.

## Scope notes

- 0068 gates coverage rather than being a dependency. Without it an inbound transfer yields an unknown-basis lot, which the model handles, and under Section 104 it does not arise at all.
- Capital gains reporting is scoped as a non-authoritative estimate of taxable gain, never a liability, which keeps 0054 validly closed. A period may carry a warning instead of a figure.
- The implementation will be additive -- two tables, no column on `txs`, no re-ingest. Recorded in 0044 so a later reader does not assume otherwise.
- Two gaps are named in 0045 without an issue: per-account tax treatment (ISA/SIPP are outside CGT) and a stored jurisdiction with a tax-year calendar.

## New issues

**0075 -- Declare a cost basis alongside a pad.** The escalation path the unknown-basis policy exists to be pointed at. A declared total rather than a per-share price, since a total is split-invariant; the pad lot takes the remainder, mirroring `init_qty = declared_qty - running_balance`; and nothing about the `INITIALIZE` group changes, because a declared cost is an input to the lot derivation rather than a leg.

**0076 -- Import and export holding declarations as CSV.** Declarations are created one at a time through a form, which fits a pad but not an assertion -- and the assertion is where the safety comes from, a pad being true by construction. The expected flow is create in the UI, export, edit against a statement, import. Takes the price CSV's `identifier_type`/`identifier_value`/`identifier_domain` shape rather than the transaction CSV's optional hints, because a round trip must resolve deterministically; the export selects with the existing `bestIdentifierJoin`. Also records that re-import upserts rather than returning `ALREADY_EXISTS` per row, that absence is not deletion unlike replace-by-period, and that the file carries no `kind` column since pad and assertion are derived from the dates.

**0077 -- Export transactions as CSV.** The transaction CSV is import-only; `ListTxs` is a paged read, not an export. That leaves the most heavily used format in the repository as the only one never read back, and is why its identity columns were designed for what a broker supplies rather than what a writer can guarantee. Takes the same identifier shape as 0076. Records that the file needs `share_count_basis` per row rather than only the file-level comment (the same gap 0057 has for prices), that the split-adjusted pair, `weight` and synthetic INITIALIZE postings are not exported, and that the round trip is not row-identical since transactions have no natural key.

## Files

- `docs/issues/0044-lot-identity-disposal-matching.md` -- rewritten
- `docs/issues/0045-realised-gains-cost-basis-methods.md` -- exactness, reporting posture, currency
- `docs/issues/0075-declared-cost-basis-on-a-pad.md` -- new
- `docs/issues/0076-declaration-csv-import-export.md` -- new
- `docs/issues/0077-transaction-csv-export.md` -- new
- `docs/adr/0031-lots-are-derived-and-unknown-basis-is-a-value.md` -- new
- `docs/spec/bitemporality.md` -- rule 6 pool caveat; 30-day rematch in the restatement table
- `docs/spec/fixed-point.md` -- future-extension pointer

🤖 Generated with [Claude Code](https://claude.com/claude-code)