### PR TITLE
Compute holdings in one share count (0074)

### DIFF
--- a/client/app/holdings/page.tsx
+++ b/client/app/holdings/page.tsx
@@ -178,12 +178,11 @@ export default function UserHoldingsPage() {
                                   {ticker || h.instrument?.name || h.instrumentDescription || "\u2014"}
                                 </td>
                                 <td className="px-4 py-3 text-right font-mono tabular-nums text-text-primary">
-                                  {/* Decimal strings render as supplied; "0" is the
-                                      unadjusted sentinel this has always used. */}
-                                  <div>{h.splitAdjustedQuantity && h.splitAdjustedQuantity !== "0" ? h.splitAdjustedQuantity : h.quantity}</div>
-                                  {h.splitAdjustedQuantity && h.splitAdjustedQuantity !== "0" && h.splitAdjustedQuantity !== h.quantity && (
-                                    <div className="text-xs text-text-muted">(raw: {h.quantity})</div>
-                                  )}
+                                  {/* Decimal strings render as supplied. The position is
+                                      in today's share count and is the only quantity a
+                                      holding has; the as-traded figures are per posting
+                                      and live in the transaction list. */}
+                                  {h.splitAdjustedQuantity}
                                 </td>
                               </tr>
                             );

--- a/docs/issues/0074-holdings-mix-share-counts.md
+++ b/docs/issues/0074-holdings-mix-share-counts.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Compute holdings in one share count rather than summing raw quantities
 dependencies: [0043]
 ---
@@ -39,23 +39,38 @@ Two things read that sum:
 one, grouping by basis so the division happens once per denomination, and
 returns the counts needed to bound its own rounding.
 
-## Design
+## Resolution
 
-Decide what the raw column on `Holding` is for. There are two readings and they
-lead to different work:
+The raw column was settled as a diagnostic and dropped from the API. Rule 7 of
+bitemporality.md already fixes the holdings API's denomination as today's share
+count, so `split_adjusted_quantity` *is* the position and a second aggregate
+beside it is either a restatement of the same number or a figure in no share
+count at all. `Holding.quantity` is gone, the two queries no longer select
+`SUM(t.quantity)`, and the holdings table renders one figure. Nothing about
+per-row raw quantity changed: `txs.quantity` and its `share_count_basis` are what
+the recompute pass and `holding_qty_in_basis` read, and the transaction list
+still shows them where they mean something.
 
-- It is a *diagnostic* -- what the source actually said, before adjustment. Then
-  it is not a quantity that may be summed at all, and the fix is to stop
-  aggregating it: report it per basis, or drop it from the API and the table.
-- It is a *position in as-traded terms*. Then it needs a stated basis like a
-  declaration has, and `holding_qty_in_basis` computes it.
+`qty_is_zero` took a second argument rather than being replaced. It now tests a
+sum of `split_adjusted_quantity` against zero to within one unit in the last
+place per contributing posting that may have rounded. Callers count those as the
+postings whose adjusted quantity differs from their raw one: a row that converted
+by 1/1 cannot have rounded, and counting the rest overstates only by the ones
+that converted exactly, which is the safe direction for a bound. When no split
+falls in the window the count is zero and the test is exact. The NULL branch
+stayed as it was.
 
-The closed-position test is not ambiguous either way: it should read the
-split-adjusted sum, where every row is already in one denomination. `qty_is_zero`
-is exact since 0042, but the adjusted columns carry the declared rounding scale
-that ADR 0028 explains, so the test needs the same kind of bound the assertion
-comparison uses rather than an equality against zero.
+The tighter per-basis count `holding_qty_in_basis` returns was not used. It
+bounds a sum computed from the raw column once per denomination, not a sum of
+values already rounded per row, and two of the three queries could not call that
+function anyway -- it is keyed by user and hardcodes `account_type = 'USER'`.
 
-`ListResidualBalances` sums raw `quantity` the same way. Money is unaffected, but
-a residual left by an unpaired `JRNLSEC` is a quantity of shares and is exposed
-to the same error.
+`ListResidualBalances` and `CountResidualBalances` share one aggregate and were
+fixed with it. Money is unaffected because currency instruments never split, so
+only share residuals move, and they now report in today's share count.
+
+`GetUserValuation` was folded in although this issue did not name it: its day
+grid gated on `NOT qty_is_zero(dh.qty)` over a cumulative split-adjusted sum,
+which is the same equality against zero on a rounded number. The per-day count of
+inexact postings accumulates over the same window as the position it bounds, and
+`daily_holdings` became a lateral join so one lookup returns both.

--- a/docs/spec/performance.md
+++ b/docs/spec/performance.md
@@ -28,9 +28,20 @@ error of its own. Its inputs are `split_adjusted_quantity`, though, which carrie
 the split adjustment's declared rounding scale (see
 [Share count](#share-count) below), so the position is exact to that scale rather
 than exact outright, with the bound growing in the number of contributing
-postings. For valuation that rounding is immaterial and is tolerated rather than
-tracked; where it is not tolerable -- the balance constraint, a checked holding
-declaration -- the raw columns are read instead.
+postings. Summing the raw column instead is not an option: each posting is
+denominated in its own `share_count_basis`, and postings recorded either side of
+a split do not add.
+
+In the value that rounding is immaterial and is tolerated. It is tracked in one
+place: the test that decides whether a position is closed, which an error of one
+unit in the last place is enough to fail. `qty_is_zero` therefore takes the count
+of contributing postings that may have rounded -- those whose adjusted quantity
+differs from their raw one -- and allows one unit in the last place for each,
+which makes the test exact when no split falls in the window. The same test gates
+holdings, the valuation day grid and the residual balance report. Where the
+rounding is not tolerable at all -- the balance constraint, a checked holding
+declaration -- the raw columns are read instead, per basis
+(`holding_qty_in_basis`).
 
 Valuing the position is approximate for a stronger reason: it multiplies by a
 market price and divides by an FX rate, and a division has no exact decimal

--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -453,16 +453,19 @@ message ListTxsResponse {
 message Holding {
   Broker broker = 1;
   string instrument_description = 2;
-  // A sum of the contributing postings' quantities, as a decimal string. Sums
-  // are closed, so the holding is exact.
-  string quantity = 3 [(buf.validate.field).string.pattern = "^-?[0-9]+(\\.[0-9]+)?$"];
   // Resolved instrument id (UUID). Set when identification ran for the underlying txs.
   string instrument_id = 4;
   Instrument instrument = 5;  // optional; set when instrument_id was resolved
   string account = 6;  // account string from txs; holdings are grouped by (broker, account, instrument)
-  // Split-adjusted quantity (sum of split_adjusted_quantity across txs). Exact
-  // to the columns' declared rounding scale rather than exact outright, with the
-  // bound growing in the number of contributing postings; see spec/performance.md.
+  // The position, in today's share count: a sum of the contributing postings'
+  // split_adjusted_quantity, which is the only denomination they share. The raw
+  // quantities are each in their own posting's share_count_basis and are not
+  // summable at all, so no as-traded figure is reported here; the transaction
+  // list carries them per posting. See spec/bitemporality.md.
+  //
+  // Exact to the columns' declared rounding scale rather than exact outright,
+  // with the bound growing in the number of contributing postings; see
+  // spec/performance.md.
   string split_adjusted_quantity = 7 [(buf.validate.field).string.pattern = "^-?[0-9]+(\\.[0-9]+)?$"];
 }
 
@@ -1306,8 +1309,11 @@ message ResidualBalance {
   string commodity = 5;          // instrument name: the ISO code for money, the ticker for a security
   AssetClass asset_class = 6;    // CASH means the balance is money; anything else is a quantity
   TxType tx_type = 7;            // the kind of event that left the balance
-  // Decimal; a signed sum over the contributing postings' weights, which are
-  // exact, so a residual reported here is real rather than an artefact.
+  // Decimal; a signed sum over the contributing postings' split-adjusted
+  // quantities, which is the only denomination they share. Money never splits,
+  // so a cash residual is exact and one reported here is real rather than an
+  // artefact; a share residual carries the adjustment's declared rounding scale
+  // and is measured against that bound before it is reported at all.
   string balance = 8 [(buf.validate.field).string.pattern = "^-?[0-9]+(\\.[0-9]+)?$"];
   int32 posting_count = 9;
   // The oldest and newest postings contributing to the balance. For a transfer

--- a/server/db/postgres/declarations_test.go
+++ b/server/db/postgres/declarations_test.go
@@ -450,7 +450,7 @@ func TestUpsertInitializeTx_WritesTheEquityCounterparty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("holdings: %v", err)
 	}
-	if len(holdings) != 1 || holdings[0].Quantity != "50" {
+	if len(holdings) != 1 || holdings[0].SplitAdjustedQuantity != "50" {
 		t.Fatalf("holdings: want a single holding of 50, got %+v", holdings)
 	}
 }

--- a/server/db/postgres/holdings.go
+++ b/server/db/postgres/holdings.go
@@ -11,6 +11,19 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
+// holdingClosedTest drops the holdings that are closed. It reads the
+// split-adjusted sum because that is the only one denominated in a single share
+// count: raw quantity is in its own row's share_count_basis, so a buy recorded
+// before a split and a sell recorded after it are in different units, and their
+// sum is neither zero when the position closed nor the position when it did not.
+//
+// The adjusted column is exact only to its declared rounding scale, so the test
+// is bounded rather than an equality against zero, by the count of rows that may
+// have rounded. See qty_is_zero in the schema.
+const holdingClosedTest = `HAVING NOT qty_is_zero(
+		SUM(t.split_adjusted_quantity),
+		COUNT(*) FILTER (WHERE t.split_adjusted_quantity <> t.quantity)::int)`
+
 // ComputeHoldings implements db.HoldingsDB.
 func (p *Postgres) ComputeHoldings(ctx context.Context, userID string, broker *apiv1.Broker, account string, asOf *timestamppb.Timestamp) ([]*apiv1.Holding, *timestamppb.Timestamp, error) {
 	userUUID, err := uuid.Parse(userID)
@@ -23,7 +36,7 @@ func (p *Postgres) ComputeHoldings(ctx context.Context, userID string, broker *a
 	}
 	qb := psql.Select("t.broker", "t.account",
 		"COALESCE(i.name, MAX(t.instrument_description)) AS instrument_description",
-		"t.instrument_id", "SUM(t.quantity) AS quantity",
+		"t.instrument_id",
 		"SUM(t.split_adjusted_quantity) AS split_adjusted_quantity").
 		From("txs t").
 		LeftJoin("instruments i ON i.id = t.instrument_id").
@@ -34,7 +47,7 @@ func (p *Postgres) ComputeHoldings(ctx context.Context, userID string, broker *a
 		Where(sq.Eq{"t.account_type": "USER"}).
 		Where(sq.LtOrEq{"t.timestamp": asOfT}).
 		GroupBy("t.broker", "t.account", "t.instrument_id", "i.name").
-		Suffix("HAVING NOT qty_is_zero(SUM(t.quantity))")
+		Suffix(holdingClosedTest)
 	if broker != nil {
 		brokerStr, err := brokerToStr(*broker)
 		if err != nil {
@@ -74,15 +87,14 @@ func (p *Postgres) ComputeHoldingsForPortfolio(ctx context.Context, portfolioID 
 	err = p.q.SelectContext(ctx, &hrows, `
 		SELECT t.broker, t.account,
 			COALESCE(i.name, MAX(t.instrument_description)) AS instrument_description,
-			t.instrument_id, SUM(t.quantity) AS quantity,
+			t.instrument_id,
 			SUM(t.split_adjusted_quantity) AS split_adjusted_quantity
 		FROM txs t
 		INNER JOIN portfolio_matched_txs m ON m.tx_id = t.id AND m.portfolio_id = $1
 		LEFT JOIN instruments i ON i.id = t.instrument_id
 		WHERE t.timestamp <= $2 AND t.account_type = 'USER'
 		GROUP BY t.broker, t.account, t.instrument_id, i.name
-		HAVING NOT qty_is_zero(SUM(t.quantity))
-	`, portUUID, asOfT)
+		`+holdingClosedTest, portUUID, asOfT)
 	if err != nil {
 		return nil, nil, fmt.Errorf("compute holdings for portfolio: %w", err)
 	}

--- a/server/db/postgres/holdings_test.go
+++ b/server/db/postgres/holdings_test.go
@@ -86,7 +86,7 @@ func TestComputeHoldings_signedQuantity(t *testing.T) {
 	var googQty string
 	for _, h := range holdings {
 		if h.InstrumentDescription == "GOOG" {
-			googQty = h.Quantity
+			googQty = h.SplitAdjustedQuantity
 			break
 		}
 	}
@@ -135,7 +135,7 @@ func TestComputeHoldings_fractionalQuantitiesSumExactly(t *testing.T) {
 	var got string
 	for _, h := range holdings {
 		if h.InstrumentDescription == "FRAC" {
-			got = h.Quantity
+			got = h.SplitAdjustedQuantity
 			break
 		}
 	}
@@ -178,7 +178,156 @@ func TestComputeHoldings_excludesNonUserAccountTypes(t *testing.T) {
 	if len(holdings) != 1 {
 		t.Fatalf("expected 1 holding, got %d", len(holdings))
 	}
-	if got := holdings[0].Quantity; got != "40" {
+	if got := holdings[0].SplitAdjustedQuantity; got != "40" {
 		t.Errorf("holding quantity = %v, want 40: the EQUITY counter-leg must not net against the position", got)
+	}
+}
+
+// splitStraddlingHolding seeds one instrument with a split between two postings and
+// returns the user and instrument ids. The buy is denominated in the pre-split share
+// count and the sell in the post-split one, which is the case the closed-position
+// test used to get wrong: the raw quantities are in different units and their sum
+// means nothing.
+func splitStraddlingHolding(t *testing.T, p *Postgres, sub, buyQty, sellQty string, from, to int) (string, string) {
+	t.Helper()
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, sub, "U", sub+"@u.com")
+	instID, err := p.EnsureInstrument(ctx, "", "", "", "", "", "",
+		[]db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "SPL" + sub, Canonical: false}}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+	preSplit := time.Date(2021, 3, 1, 10, 0, 0, 0, time.UTC)
+	exDate := time.Date(2022, 6, 1, 0, 0, 0, 0, time.UTC)
+	postSplit := time.Date(2023, 3, 1, 10, 0, 0, 0, time.UTC)
+	// The split goes in first so the insert trigger denominates each posting's
+	// split_adjusted_quantity against it.
+	addSplit(t, p, instID, exDate, from, to)
+
+	buy := &apiv1.Tx{Timestamp: timestamppb.New(preSplit), InstrumentDescription: "SPL" + sub,
+		Type: apiv1.TxType_BUYSTOCK, Quantity: buyQty, Account: "A"}
+	if err := createTx(ctx, p, userID, "IBKR", "A", "", buy, instID, nil); err != nil {
+		t.Fatalf("create pre-split buy: %v", err)
+	}
+	sell := &apiv1.Tx{Timestamp: timestamppb.New(postSplit), InstrumentDescription: "SPL" + sub,
+		Type: apiv1.TxType_SELLSTOCK, Quantity: sellQty, Account: "A"}
+	if err := createTx(ctx, p, userID, "IBKR", "A", "", sell, instID, nil); err != nil {
+		t.Fatalf("create post-split sell: %v", err)
+	}
+	// The insert trigger seeds the adjusted columns from the raw ones; converting
+	// them is the recompute pass's job, which ingestion runs after a split lands.
+	if err := p.RecomputeSplitAdjustments(ctx, instID); err != nil {
+		t.Fatalf("recompute split adjustments: %v", err)
+	}
+	return userID, instID
+}
+
+// TestComputeHoldings_closedAcrossSplit is the phantom holding 0074 names. 100 shares
+// bought before a 2:1 split are 200 after it, so selling 200 closes the position --
+// but the raw quantities sum to -100, and a test against that sum reported a short
+// position the user never held.
+func TestComputeHoldings_closedAcrossSplit(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := splitStraddlingHolding(t, p, "sub|split-closed", "100", "-200", 1, 2)
+
+	holdings, _, err := p.ComputeHoldings(ctx, userID, nil, "", nil)
+	if err != nil {
+		t.Fatalf("holdings: %v", err)
+	}
+	if len(holdings) != 0 {
+		t.Fatalf("expected no holdings, got %+v", holdings)
+	}
+}
+
+// TestComputeHoldings_openAcrossSplit is the other half of the same error: the raw
+// sum is zero here, so the holding used to vanish, though half the position is still
+// held.
+func TestComputeHoldings_openAcrossSplit(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := splitStraddlingHolding(t, p, "sub|split-open", "100", "-100", 1, 2)
+
+	holdings, _, err := p.ComputeHoldings(ctx, userID, nil, "", nil)
+	if err != nil {
+		t.Fatalf("holdings: %v", err)
+	}
+	if len(holdings) != 1 {
+		t.Fatalf("expected 1 holding, got %+v", holdings)
+	}
+	// 100 pre-split shares are 200 post-split; selling 100 leaves 100.
+	if got := holdings[0].SplitAdjustedQuantity; got != "100" {
+		t.Fatalf("holding quantity = %v, want 100", got)
+	}
+}
+
+// TestComputeHoldings_closedAcrossInexactSplit is why the closed-position test is a
+// bound rather than an equality against zero. A 3:1 reverse split converts by a
+// third, which has no exact decimal form, so each pre-split posting rounds at the
+// split-adjusted columns' declared scale. Two buys of 10 store 3.333333333333 each;
+// the 6.666666666667 the broker then sold is what the position actually was, and
+// the sum of the three lands 1e-12 from zero. The position is closed and the
+// holding must not be listed.
+func TestComputeHoldings_closedAcrossInexactSplit(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|split-inexact", "U", "u@si.com")
+	instID, err := p.EnsureInstrument(ctx, "", "", "", "", "", "",
+		[]db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "REV", Canonical: false}}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+	preSplit := time.Date(2021, 3, 1, 10, 0, 0, 0, time.UTC)
+	exDate := time.Date(2022, 6, 1, 0, 0, 0, 0, time.UTC)
+	postSplit := time.Date(2023, 3, 1, 10, 0, 0, 0, time.UTC)
+	addSplit(t, p, instID, exDate, 3, 1)
+
+	for _, q := range []string{"10", "10"} {
+		buy := &apiv1.Tx{Timestamp: timestamppb.New(preSplit), InstrumentDescription: "REV",
+			Type: apiv1.TxType_BUYSTOCK, Quantity: q, Account: "A"}
+		if err := createTx(ctx, p, userID, "IBKR", "A", "", buy, instID, nil); err != nil {
+			t.Fatalf("create pre-split buy: %v", err)
+		}
+	}
+	sell := &apiv1.Tx{Timestamp: timestamppb.New(postSplit), InstrumentDescription: "REV",
+		Type: apiv1.TxType_SELLSTOCK, Quantity: "-6.666666666667", Account: "A"}
+	if err := createTx(ctx, p, userID, "IBKR", "A", "", sell, instID, nil); err != nil {
+		t.Fatalf("create post-split sell: %v", err)
+	}
+	if err := p.RecomputeSplitAdjustments(ctx, instID); err != nil {
+		t.Fatalf("recompute split adjustments: %v", err)
+	}
+
+	holdings, _, err := p.ComputeHoldings(ctx, userID, nil, "", nil)
+	if err != nil {
+		t.Fatalf("holdings: %v", err)
+	}
+	if len(holdings) != 0 {
+		t.Fatalf("expected no holdings, got %+v", holdings)
+	}
+}
+
+// TestComputeHoldingsForPortfolio_closedAcrossSplit pins the same fix in the
+// portfolio query, which carries its own copy of the aggregate.
+func TestComputeHoldingsForPortfolio_closedAcrossSplit(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := splitStraddlingHolding(t, p, "sub|split-port", "100", "-200", 1, 2)
+	port, err := p.CreatePortfolio(ctx, userID, "P")
+	if err != nil {
+		t.Fatalf("create portfolio: %v", err)
+	}
+	if err := p.SetPortfolioFilters(ctx, port.GetId(), []db.PortfolioFilter{
+		{FilterType: "broker", FilterValue: "IBKR"},
+	}); err != nil {
+		t.Fatalf("set filters: %v", err)
+	}
+
+	holdings, _, err := p.ComputeHoldingsForPortfolio(ctx, port.GetId(), nil)
+	if err != nil {
+		t.Fatalf("holdings: %v", err)
+	}
+	if len(holdings) != 0 {
+		t.Fatalf("expected no holdings, got %+v", holdings)
 	}
 }

--- a/server/db/postgres/instruments_test.go
+++ b/server/db/postgres/instruments_test.go
@@ -102,7 +102,7 @@ func TestEnsureInstrument_mergeWhenMultipleInstrumentsMatch(t *testing.T) {
 	totalQty := decimal.Zero
 	for _, h := range holdings {
 		if h.InstrumentId == survivor {
-			totalQty = totalQty.Add(decimal.RequireFromString(h.Quantity))
+			totalQty = totalQty.Add(decimal.RequireFromString(h.SplitAdjustedQuantity))
 		}
 	}
 	if !totalQty.Equal(decimal.NewFromInt(15)) {

--- a/server/db/postgres/postgres.go
+++ b/server/db/postgres/postgres.go
@@ -325,7 +325,6 @@ type holdingRow struct {
 	Account     string          `db:"account"`
 	InstDesc    string          `db:"instrument_description"`
 	InstID      *string         `db:"instrument_id"`
-	Quantity    decimal.Decimal `db:"quantity"`
 	SplitAdjQty decimal.Decimal `db:"split_adjusted_quantity"`
 }
 
@@ -333,7 +332,6 @@ func (r *holdingRow) toProto() *apiv1.Holding {
 	h := &apiv1.Holding{
 		Broker:                strToBroker(r.Broker),
 		InstrumentDescription: r.InstDesc,
-		Quantity:              r.Quantity.String(),
 		SplitAdjustedQuantity: r.SplitAdjQty.String(),
 		Account:               r.Account,
 	}

--- a/server/db/postgres/residual_balances.go
+++ b/server/db/postgres/residual_balances.go
@@ -37,7 +37,11 @@ const residualBalanceAgg = `
 		COALESCE(i.name, t.instrument_id::text) AS commodity,
 		COALESCE(i.asset_class, '')             AS asset_class,
 		t.tx_type,
-		SUM(t.quantity)   AS balance,
+		-- The split-adjusted column, not the raw one: money never splits and the
+		-- two agree for it, but a residual left by an unpaired JRNLSEC is a
+		-- quantity of shares, and raw quantities recorded either side of a split
+		-- are in different denominations and do not sum. See qty_is_zero.
+		SUM(t.split_adjusted_quantity) AS balance,
 		COUNT(*)::int     AS posting_count,
 		MIN(t.timestamp)  AS oldest,
 		MAX(t.timestamp)  AS newest
@@ -52,7 +56,9 @@ const residualBalanceAgg = `
 		AND ($2::timestamptz IS NULL OR t.timestamp <  $2)
 		AND ($3 = '' OR t.account_type = $3)
 	GROUP BY t.account_type, t.broker, t.account, t.instrument_id, i.name, i.asset_class, t.tx_type
-	HAVING NOT qty_is_zero(SUM(t.quantity))`
+	HAVING NOT qty_is_zero(
+		SUM(t.split_adjusted_quantity),
+		COUNT(*) FILTER (WHERE t.split_adjusted_quantity <> t.quantity)::int)`
 
 // residualBalanceRow is the sqlx-scannable shape for a residual balance.
 type residualBalanceRow struct {

--- a/server/db/postgres/residual_balances_test.go
+++ b/server/db/postgres/residual_balances_test.go
@@ -344,3 +344,68 @@ func TestCountResidualBalances_StalenessBoundary(t *testing.T) {
 		t.Errorf("stale transfers = %d, want 1 (the 8-day-old side, not the 6-day-old one)", stale)
 	}
 }
+
+// TestListResidualBalances_ShareResidualAcrossSplit is why the aggregate reads the
+// split-adjusted column. A residual left by an unpaired JRNLSEC is a quantity of
+// shares, and the two postings below straddle a 2:1 split, so their raw quantities
+// are in different share counts. Added raw they net to -100 and the report claims a
+// share residual nobody left behind; converted, the transfer balances and there is
+// nothing to report.
+func TestListResidualBalances_ShareResidualAcrossSplit(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID := newUser(t, p, "sub|residual-split")
+	instID, err := p.EnsureInstrument(ctx, "", "", "", "", "", "",
+		[]db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "JRN", Canonical: false}}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+	// 400 days ago is before the split, 10 days ago after it.
+	addSplit(t, p, instID, time.Now().UTC().AddDate(0, 0, -200), 1, 2)
+	seedResiduals(t, p, userID,
+		residualSeed{"IBKR", "A1", instID, apiv1.TxType_JRNLSEC, apiv1.AccountType_ACCOUNT_TYPE_TRANSFER_CLEARING, "100", 400},
+		residualSeed{"IBKR", "A1", instID, apiv1.TxType_JRNLSEC, apiv1.AccountType_ACCOUNT_TYPE_TRANSFER_CLEARING, "-200", 10},
+	)
+	if err := p.RecomputeSplitAdjustments(ctx, instID); err != nil {
+		t.Fatalf("recompute split adjustments: %v", err)
+	}
+
+	rows, err := p.ListResidualBalances(ctx, db.ResidualBalanceOpts{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("expected no residual balances, got %+v", rows)
+	}
+}
+
+// TestListResidualBalances_ShareResidualReportedInTodaysShareCount is the other
+// half: a real residual is reported, and in the share count the rest of the system
+// uses. Half the transferred position came back, which is 100 of today's shares.
+func TestListResidualBalances_ShareResidualReportedInTodaysShareCount(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID := newUser(t, p, "sub|residual-split-open")
+	instID, err := p.EnsureInstrument(ctx, "", "", "", "", "", "",
+		[]db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "JRN2", Canonical: false}}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+	addSplit(t, p, instID, time.Now().UTC().AddDate(0, 0, -200), 1, 2)
+	seedResiduals(t, p, userID,
+		residualSeed{"IBKR", "A1", instID, apiv1.TxType_JRNLSEC, apiv1.AccountType_ACCOUNT_TYPE_TRANSFER_CLEARING, "100", 400},
+		residualSeed{"IBKR", "A1", instID, apiv1.TxType_JRNLSEC, apiv1.AccountType_ACCOUNT_TYPE_TRANSFER_CLEARING, "-100", 10},
+	)
+	if err := p.RecomputeSplitAdjustments(ctx, instID); err != nil {
+		t.Fatalf("recompute split adjustments: %v", err)
+	}
+
+	rows, err := p.ListResidualBalances(ctx, db.ResidualBalanceOpts{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	got := findBalance(t, rows, apiv1.Broker_IBKR, "A1", apiv1.TxType_JRNLSEC)
+	if got.Balance.String() != "100" {
+		t.Errorf("balance = %v, want 100 (200 post-split shares in, 100 out)", got.Balance)
+	}
+}

--- a/server/db/postgres/txs_test.go
+++ b/server/db/postgres/txs_test.go
@@ -46,7 +46,7 @@ func TestReplaceTxsInPeriod_and_ComputeHoldings(t *testing.T) {
 	var aaplQty string
 	for _, h := range holdings {
 		if h.InstrumentDescription == "AAPL" {
-			aaplQty = h.Quantity
+			aaplQty = h.SplitAdjustedQuantity
 			break
 		}
 	}
@@ -522,8 +522,8 @@ func TestCreateTx_AppendOnly(t *testing.T) {
 	}
 	holdings, _, _ := p.ComputeHoldings(ctx, userID, nil, "", nil)
 	for _, h := range holdings {
-		if h.InstrumentDescription == "GOOG" && h.Quantity != "15" {
-			t.Fatalf("append-only: expected total quantity 15, got %v", h.Quantity)
+		if h.InstrumentDescription == "GOOG" && h.SplitAdjustedQuantity != "15" {
+			t.Fatalf("append-only: expected total quantity 15, got %v", h.SplitAdjustedQuantity)
 		}
 	}
 }
@@ -763,7 +763,7 @@ func TestListTxsByPortfolio_ComputeHoldingsForPortfolio(t *testing.T) {
 	var aaplQty string
 	for _, h := range holdings {
 		if h.InstrumentDescription == "AAPL" {
-			aaplQty = h.Quantity
+			aaplQty = h.SplitAdjustedQuantity
 			break
 		}
 	}
@@ -822,7 +822,7 @@ func TestListTxsByPortfolio_ANDBetweenCategories(t *testing.T) {
 	}
 	var totalQty string
 	for _, h := range holdings {
-		totalQty += h.Quantity
+		totalQty += h.SplitAdjustedQuantity
 	}
 	if totalQty != "3" {
 		t.Fatalf("expected total quantity 3, got %v", totalQty)

--- a/server/db/postgres/valuation.go
+++ b/server/db/postgres/valuation.go
@@ -42,7 +42,13 @@ WITH portfolio_txs AS (
         t.instrument_id,
         t.instrument_description,
         t.timestamp::date AS tx_date,
-        SUM(t.split_adjusted_quantity) AS daily_qty` + txSource + `
+        SUM(t.split_adjusted_quantity) AS daily_qty,
+        -- How many of these postings may have rounded when they were converted
+        -- into today's share count, which is what bounds the running position's
+        -- test against zero further down. A row whose adjusted quantity equals
+        -- its raw one converted by 1/1 and cannot have rounded at all. See
+        -- qty_is_zero.
+        COUNT(*) FILTER (WHERE t.split_adjusted_quantity <> t.quantity)::int AS daily_inexact` + txSource + `
     GROUP BY t.instrument_id, t.instrument_description, t.timestamp::date
 ),
 -- Merge transactions by instrument_id for identified instruments so that
@@ -53,7 +59,8 @@ merged_txs AS (
         instrument_id,
         CASE WHEN instrument_id IS NULL THEN instrument_description END AS instrument_description,
         tx_date,
-        SUM(daily_qty) AS daily_qty
+        SUM(daily_qty) AS daily_qty,
+        SUM(daily_inexact)::int AS daily_inexact
     FROM portfolio_txs
     GROUP BY instrument_id,
              CASE WHEN instrument_id IS NULL THEN instrument_description END,
@@ -68,7 +75,15 @@ cumulative AS (
             PARTITION BY instrument_id, instrument_description
             ORDER BY tx_date
             ROWS UNBOUNDED PRECEDING
-        ) AS position
+        ) AS position,
+        -- Accumulated over the same window as the position it bounds: every
+        -- posting that has entered the running sum can have contributed a
+        -- rounding to it.
+        SUM(daily_inexact) OVER (
+            PARTITION BY instrument_id, instrument_description
+            ORDER BY tx_date
+            ROWS UNBOUNDED PRECEDING
+        )::int AS inexact
     FROM merged_txs
 ),
 date_series AS (
@@ -84,17 +99,22 @@ daily_holdings AS (
         ds.val_date,
         i.instrument_id,
         i.instrument_description,
-        (
-            SELECT c.position
-            FROM cumulative c
-            WHERE c.instrument_id IS NOT DISTINCT FROM i.instrument_id
-              AND c.instrument_description IS NOT DISTINCT FROM i.instrument_description
-              AND c.tx_date <= ds.val_date
-            ORDER BY c.tx_date DESC
-            LIMIT 1
-        ) AS qty
+        c.position AS qty,
+        c.inexact
     FROM date_series ds
     CROSS JOIN inst_list i
+    -- LEFT JOIN, so a date before the instrument's first transaction has a NULL
+    -- position rather than no row: qty_is_zero reads that as closed, which is
+    -- what keeps the day grid from starting a series before its history does.
+    LEFT JOIN LATERAL (
+        SELECT cu.position, cu.inexact
+        FROM cumulative cu
+        WHERE cu.instrument_id IS NOT DISTINCT FROM i.instrument_id
+          AND cu.instrument_description IS NOT DISTINCT FROM i.instrument_description
+          AND cu.tx_date <= ds.val_date
+        ORDER BY cu.tx_date DESC
+        LIMIT 1
+    ) c ON true
 ),
 -- Map held instruments to their FX pair instrument IDs (for currencies != display).
 fx_instruments AS (
@@ -299,7 +319,7 @@ valued AS (
     LEFT JOIN fx_rates fr
         ON fr.base_currency = inst.currency AND fr.val_date = dh.val_date
     LEFT JOIN display_fx_rate dfr ON dfr.val_date = dh.val_date
-    WHERE NOT qty_is_zero(dh.qty)
+    WHERE NOT qty_is_zero(dh.qty, dh.inexact)
 )
 SELECT
     val_date,

--- a/server/db/postgres/valuation_test.go
+++ b/server/db/postgres/valuation_test.go
@@ -1203,14 +1203,12 @@ func unpricedOn(t *testing.T, points []db.ValuationPoint, want time.Time) bool {
 }
 
 // TestGetUserValuation_ExcludesDatesBeforeFirstTx covers qty_is_zero's NULL
-// branch, which is the only reason the function still exists now that quantities
-// are exact and there is no residual to absorb. daily_holdings forward-fills the
-// last known position with a LIMIT 1 correlated subquery, so on every grid day
-// before an instrument's first tx the position is NULL rather than zero. The NULL
-// branch classifies that as "not held", so the row leaves the valued CTE and the
-// day drops out of the series entirely -- priced days before the first purchase
-// are absent rather than zero, and the instrument is never reported as unpriced
-// on them.
+// branch. daily_holdings forward-fills the last known position with a LIMIT 1
+// lateral, so on every grid day before an instrument's first tx there is no row to
+// carry forward and the position is NULL rather than zero. The NULL branch
+// classifies that as "not held", so the row leaves the valued CTE and the day drops
+// out of the series entirely -- priced days before the first purchase are absent
+// rather than zero, and the instrument is never reported as unpriced on them.
 func TestGetUserValuation_ExcludesDatesBeforeFirstTx(t *testing.T) {
 	p := testDBTx(t)
 	ctx := context.Background()
@@ -1262,5 +1260,81 @@ func TestGetUserValuation_ExcludesDatesBeforeFirstTx(t *testing.T) {
 	// A NULL position is not an unpriced one: the instrument simply was not held.
 	if len(points[0].UnpricedInstruments) != 0 {
 		t.Errorf("expected no unpriced instruments, got %v", points[0].UnpricedInstruments)
+	}
+}
+
+// TestGetUserValuation_ExcludesDatesAfterCloseAcrossInexactSplit covers the other
+// branch of the same test: the position is closed, but a reverse split converted its
+// postings by a third and each rounded at the split-adjusted columns' declared
+// scale, so the running sum lands 1e-12 from zero rather than on it. Tested against
+// exact zero the instrument stays "held" forever and every later grid day is valued
+// at a fraction of a share; bounded by the roundings that could have produced it,
+// the series ends where the position did.
+func TestGetUserValuation_ExcludesDatesAfterCloseAcrossInexactSplit(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+
+	userID, _ := p.GetOrCreateUser(ctx, "sub|closedsplit", "U", "u@closedsplit.com")
+	instID, err := p.EnsureInstrument(ctx, "STOCK", "", "USD", "REVQ", "", "", []db.IdentifierInput{
+		{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "REVQ", Canonical: false},
+	}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+
+	buyDate := time.Date(2025, 1, 3, 12, 0, 0, 0, time.UTC)
+	sellDate := time.Date(2025, 1, 7, 12, 0, 0, 0, time.UTC)
+	addSplit(t, p, instID, time.Date(2025, 1, 5, 0, 0, 0, 0, time.UTC), 3, 1)
+
+	// Two buys of 10 pre-split are 3.333333333333 each afterwards; the
+	// 6.666666666667 the broker then sold is what the position actually was.
+	for _, q := range []string{"10", "10"} {
+		buy := &apiv1.Tx{Timestamp: timestamppb.New(buyDate), InstrumentDescription: "REVQ",
+			Type: apiv1.TxType_BUYSTOCK, Quantity: q, Account: "main"}
+		if err := createTx(ctx, p, userID, "IBKR", "main", "", buy, instID, nil); err != nil {
+			t.Fatalf("create buy: %v", err)
+		}
+	}
+	sell := &apiv1.Tx{Timestamp: timestamppb.New(sellDate), InstrumentDescription: "REVQ",
+		Type: apiv1.TxType_SELLSTOCK, Quantity: "-6.666666666667", Account: "main"}
+	if err := createTx(ctx, p, userID, "IBKR", "main", "", sell, instID, nil); err != nil {
+		t.Fatalf("create sell: %v", err)
+	}
+	if err := p.RecomputeSplitAdjustments(ctx, instID); err != nil {
+		t.Fatalf("recompute split adjustments: %v", err)
+	}
+
+	var prices []db.EODPrice
+	for d := 3; d <= 9; d++ {
+		prices = append(prices, db.EODPrice{
+			InstrumentID: instID,
+			PriceDate:    time.Date(2025, 1, d, 0, 0, 0, 0, time.UTC),
+			Close:        decf(100.0),
+			DataProvider: "test",
+		})
+	}
+	if err := p.UpsertPrices(ctx, prices); err != nil {
+		t.Fatalf("upsert prices: %v", err)
+	}
+
+	points, err := p.GetUserValuation(ctx, userID,
+		time.Date(2025, 1, 3, 0, 0, 0, 0, time.UTC),
+		time.Date(2025, 1, 10, 0, 0, 0, 0, time.UTC), "USD")
+	if err != nil {
+		t.Fatalf("get user valuation: %v", err)
+	}
+	// Held from the buy up to the day before the sell, and nothing after it.
+	var dates []string
+	for _, pt := range points {
+		dates = append(dates, pt.Date.Format("2006-01-02"))
+	}
+	want := []string{"2025-01-03", "2025-01-04", "2025-01-05", "2025-01-06"}
+	if len(dates) != len(want) {
+		t.Fatalf("valued dates = %v, want %v", dates, want)
+	}
+	for i := range want {
+		if dates[i] != want[i] {
+			t.Fatalf("valued dates = %v, want %v", dates, want)
+		}
 	}
 }

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -929,12 +929,30 @@ CREATE TABLE ignored_asset_classes (
 
 CREATE INDEX idx_ignored_asset_classes_user ON ignored_asset_classes (user_id);
 
--- qty_is_zero is a null-safe test for a closed position. Quantities are exact
--- decimals, so summing buys against sells lands on zero and there is no residual
--- to absorb -- what the function still carries is the NULL branch, which the
--- valuation day grid depends on: a holding has no position on a date before its
--- instrument's first tx, and that reads as closed rather than as unknown.
-CREATE FUNCTION qty_is_zero(q numeric) RETURNS boolean
+-- qty_is_zero is a null-safe test for a closed position, applied to a sum of
+-- split_adjusted_quantity. Raw quantities cannot be summed at all: each is
+-- denominated in its own row's share_count_basis, so a buy recorded before a
+-- split and a sell recorded after it are in different units and adding them
+-- scales the total by part of the split factor. The split-adjusted column is
+-- already converted to today's share count, so the sum is in one denomination.
+--
+-- What that costs is exactness. The column declares a rounding scale of 12, so a
+-- row whose conversion did not land on a representable decimal rounds once, and a
+-- genuinely closed position sums to something near zero rather than to zero.
+-- inexact_postings is how many contributing rows may carry such a rounding, and
+-- one unit in the last place each is the most the sum can differ from a true
+-- zero. Callers count the rows whose adjusted quantity differs from their raw
+-- one: a row that converted by 1/1 cannot have rounded, and counting the rest
+-- overstates by the ones that converted exactly, which is the safe direction for
+-- a bound. Passing zero is an exact test.
+--
+-- The NULL branch is what the valuation day grid depends on: a holding has no
+-- position on a date before its instrument's first tx, and that reads as closed
+-- rather than as unknown.
+--
+-- See docs/spec/bitemporality.md, adr/0026-exact-decimals-bounded-by-closure.md
+-- and adr/0028-cumulative-split-factor-is-an-exact-rational.md.
+CREATE FUNCTION qty_is_zero(q numeric, inexact_postings int) RETURNS boolean
     LANGUAGE sql IMMUTABLE PARALLEL SAFE AS $$
-    SELECT q IS NULL OR q = 0
+    SELECT q IS NULL OR abs(q) <= COALESCE(inexact_postings, 0) * 1e-12
 $$;

--- a/server/service/api/holdings_test.go
+++ b/server/service/api/holdings_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestGetHoldings_Success(t *testing.T) {
 	srv, db := newAPIServerWithMock(t)
-	holdings := []*apiv1.Holding{{InstrumentDescription: "AAPL", Quantity: "10"}}
+	holdings := []*apiv1.Holding{{InstrumentDescription: "AAPL", SplitAdjustedQuantity: "10"}}
 	asOf := timestamppb.Now()
 	db.EXPECT().
 		ComputeHoldings(gomock.Any(), "user-1", (*apiv1.Broker)(nil), "", (*timestamppb.Timestamp)(nil)).
@@ -32,7 +32,7 @@ func TestGetHoldings_Success(t *testing.T) {
 
 func TestGetHoldings_WithPortfolioId_Success(t *testing.T) {
 	srv, db := newAPIServerWithMock(t)
-	holdings := []*apiv1.Holding{{InstrumentDescription: "AAPL", Quantity: "10"}}
+	holdings := []*apiv1.Holding{{InstrumentDescription: "AAPL", SplitAdjustedQuantity: "10"}}
 	asOf := timestamppb.Now()
 	db.EXPECT().
 		PortfolioBelongsToUser(gomock.Any(), "port-1", "user-1").


### PR DESCRIPTION
Closes 0074.

## Problem

Both holdings queries, and the residual balance aggregate, summed the raw `quantity` column across postings that are not in the same share count. Each posting is denominated in its own `share_count_basis`, so a buy recorded before a split and a sell recorded after it are in different units and adding them scales the total by part of the split factor -- the arithmetic bitemporality rule 4 forbids.

Buying 100 pre-split and selling the resulting 200 post-split netted to -100, so a closed position was listed as a phantom short; the converse made an open one vanish. The same sum reached the wire as `Holding.quantity`, which the holdings table rendered as `(raw: N)`.

## Fix

The closed-position test reads the split-adjusted sum, where every row is already converted to today's share count. That column declares a rounding scale of 12, so the test is a bound rather than an equality against zero: `qty_is_zero` gained a second argument, the count of contributing postings that may have rounded, and allows one unit in the last place for each. Callers count the rows whose adjusted quantity differs from their raw one -- a row that converted by 1/1 cannot have rounded, and counting the rest overstates only by the ones that converted exactly, which is the safe direction for a bound. With no split in the window the count is zero and the test is exact.

`Holding.quantity` is dropped from the wire. Bitemporality rule 7 already fixes the holdings API's denomination as today's share count, so `split_adjusted_quantity` is the position, and a second aggregate beside it is either a restatement or a figure in no share count at all. **Nothing per-row changed**: `txs.quantity` and its `share_count_basis` are what the recompute pass and `holding_qty_in_basis` read, and the transaction list still shows them.

`GetUserValuation` was folded in although 0074 does not name it: its day grid gated on the same equality against zero over a cumulative split-adjusted sum. The count of inexact postings accumulates over the same window as the position it bounds, and `daily_holdings` became a lateral join so one lookup returns both.

## Rejected

The tighter per-basis count `holding_qty_in_basis` returns. It bounds a sum computed from the raw column once per denomination, not a sum of values already rounded per row, and two of the three queries could not call that function anyway -- it is keyed by user and hardcodes `account_type = 'USER'`.

## Testing

`make check`, `make test` and `make e2e-test` all pass. Each new test was confirmed to fail against the old predicate before the fix was restored:

- holdings closed / open across a 2:1 split, and closed across a 3:1 reverse split where the sum lands 1e-12 from zero
- the same phantom through `ComputeHoldingsForPortfolio`
- a share residual that nets to zero across a split, and one reported in today's share count
- a valuation series that ends where the position did rather than running on at a fraction of a share

🤖 Generated with [Claude Code](https://claude.com/claude-code)