### PR TITLE
Type a Fidelity Buy or Sell of cash as the cash movement it is (0065)

### DIFF
--- a/client/lib/csv/converters/fidelity-csv.test.ts
+++ b/client/lib/csv/converters/fidelity-csv.test.ts
@@ -196,6 +196,91 @@ describe("convertFidelityToStandard", () => {
     expect(result.txs[0]!.quantity).toBe("1.26");
   });
 
+  // Fidelity reports money leaving an account as a sale of the account's cash.
+  // Mapping on the transaction type alone made each one a security position sold
+  // in units of money, and left the account's balance short by the amount that
+  // moved. Rows from the Lee export, 2023-03-01, AG10041188, with the completion
+  // date in the format the broker's own download carries.
+  describe("a Buy or Sell of cash", () => {
+    const CASH_ASSET_HEADER =
+      "Order date,Completion date,Transaction type,Investments,Product Wrapper,Account Number,Source investment,Amount,Quantity,Price per unit,Reference Number,Status,Exchange,Symbol,Type,Action";
+    const TRANSFER =
+      "2023-03-01,01 Mar 2023,Transfer To Cash Management Account,Cash,Investment Account,AG10041188,,-401,401,1,730492674,Completed,,GBP,CASH,Cash";
+    const SELL =
+      "2023-03-01,01 Mar 2023,Sell,Cash,Investment Account,AG10041188,,-401,401,1,730492678,Completed,,GBP,CASH,Cash";
+    const CASH_IN =
+      "2023-03-01,01 Mar 2023,Cash In From Sell,Cash,Investment Account,AG10041188,,401,401,1,730492680,Completed,,GBP,CASH,Cash";
+
+    const convert = (rows: string[]) =>
+      convertFidelityToStandard([CASH_ASSET_HEADER, ...rows].join("\n"), { currency: "GBP" });
+
+    it("is a cash movement, not a security trade", () => {
+      const result = convert([SELL]);
+      expect(result.errors).toEqual([]);
+      expect(result.txs).toHaveLength(1);
+      expect(result.txs[0]!.type).toBe(TxType.CASHFLOW);
+      // The signed Amount, not the unsigned share count the row also carries.
+      expect(result.txs[0]!.quantity).toBe("-401");
+      expect(result.txs[0]!.tradingCurrency).toBe("GBP");
+    });
+
+    it("groups with its cash in, and the pair weighs nothing", () => {
+      const result = convert([SELL, CASH_IN]);
+      expect(result.txs[0]!.groupRef).toBe("730492678");
+      expect(result.txs[1]!.groupRef).toBe("730492678");
+      expectGroupsBalance(result.txs);
+    });
+
+    it("leaves the transfer beside it as the money that moved", () => {
+      // All three rows are the same 401. Only the transfer is a movement: the
+      // other two are the broker converting its own cash position, and net to
+      // zero. The account must end 401 down, matching the credit the cash
+      // management account records against it.
+      const result = convert([TRANSFER, SELL, CASH_IN]);
+      expect(result.errors).toEqual([]);
+      const total = result.txs.reduce((sum, tx) => sum.plus(tx.quantity), new Big(0));
+      expect(total.eq(-401)).toBe(true);
+      expect(result.txs.some((tx) => tx.type === TxType.SELLSTOCK)).toBe(false);
+    });
+
+    it("still reads a security sale as one", () => {
+      const result = convert([
+        '2022-02-08,10 Feb 2022,Sell,"WISE PLC, CLS A ORD GBP0.01 (WISE)",SIPP - Pension Savings Account,AP10013127,,-7266.49,1242,5.85,563466569,Completed,LON,WISE,STOCK,Sell',
+      ]);
+      expect(result.txs[0]!.type).toBe(TxType.SELLSTOCK);
+      expect(result.txs[0]!.quantity).toBe("-1242");
+    });
+
+    it("does not let a sale of cash claim a security sale's cash in", () => {
+      // Both settle in the same account on the same day. Amount separates them,
+      // and a security sale picks first regardless of export order.
+      const result = convert([
+        "2024-04-10,10 Apr 2024,Sell,Cash,Investment Account,AG10041188,,-19999,19999,1,917882556,Completed,,GBP,CASH,Cash",
+        "2024-04-10,10 Apr 2024,Cash In From Sell,Cash,Investment Account,AG10041188,,19999,19999,1,917882557,Completed,,GBP,CASH,Cash",
+        '2024-04-10,10 Apr 2024,Sell,"VANGUARD FUNDS PLC, S&P 500 (VUSA)",Investment Account,AG10041188,,-19502.15,325,60.0066,913741900,Completed,LON,VUSA,ETF,Sell',
+        "2024-04-10,10 Apr 2024,Cash In From Sell,Cash,Investment Account,AG10041188,,19502.15,19502.15,1,913741902,Completed,,GBP,CASH,Cash",
+      ]);
+
+      expect(result.txs[0]!.groupRef).toBe("917882556");
+      expect(result.txs[1]!.groupRef).toBe("917882556");
+      expect(result.txs[2]!.groupRef).toBe("913741900");
+      expect(result.txs[3]!.groupRef).toBe("913741900");
+    });
+
+    // The map-completeness test above feeds security rows through a header with
+    // no Type column, so the fallback has to keep them out of this rule.
+    it("falls back to the instrument description when the export omits Type", () => {
+      const csv = [
+        HEADER,
+        "8 Feb 2022,10 Feb 2022,Sell,Cash,AG10041188,401,1",
+        "8 Feb 2022,10 Feb 2022,Sell,ISHARES II PLC INRG,AG10041188,100,7.16",
+      ].join("\n");
+      const result = convertFidelityToStandard(csv, { currency: "GBP" });
+      expect(result.txs[0]!.type).toBe(TxType.CASHFLOW);
+      expect(result.txs[1]!.type).toBe(TxType.SELLSTOCK);
+    });
+  });
+
   it("parses Buy with positive quantity", () => {
     const csv = [
       "Order date,Completion date,Transaction type,Investments,Account Number,Quantity,Price per unit",

--- a/client/lib/csv/converters/fidelity-csv.ts
+++ b/client/lib/csv/converters/fidelity-csv.ts
@@ -93,6 +93,44 @@ export function isCashMovement(type: TxType): boolean {
   return isCashTxType(type) || type === TxType.JRNLFUND;
 }
 
+/** Security sale types, whose quantity is a share count to be negated. */
+const SELL_TYPES = new Set<TxType>([
+  TxType.SELLSTOCK,
+  TxType.SELLMF,
+  TxType.SELLDEBT,
+  TxType.SELLOPT,
+  TxType.SELLOTHER,
+]);
+
+/** Security purchase types, the mirror of SELL_TYPES. */
+const BUY_TYPES = new Set<TxType>([
+  TxType.BUYSTOCK,
+  TxType.BUYMF,
+  TxType.BUYDEBT,
+  TxType.BUYOPT,
+  TxType.BUYOTHER,
+]);
+
+/**
+ * The type a row carries once the asset it transacted is known.
+ *
+ * Fidelity models an account's cash as a tradable asset, so money leaving an
+ * account is reported as a sale of cash and money arriving as a purchase of it.
+ * Those rows carry `Buy` or `Sell` in the transaction type against an instrument
+ * named "Cash", and the type map alone turns them into a security position sold
+ * or bought in units of money.
+ *
+ * They are cash movements, and they settle inside the account against the
+ * `Cash In From Sell` or `Cash Out For Buy From Transfer` row Fidelity reports
+ * beside them, so they are the same CASHFLOW as any other trade's cash leg. The
+ * third row of the sequence -- a withdrawal or a transfer -- is the money that
+ * actually moved, and it stands on its own.
+ */
+export function typeForAsset(type: TxType, cashAsset: boolean): TxType {
+  if (!cashAsset) return type;
+  return BUY_TYPES.has(type) || SELL_TYPES.has(type) ? TxType.CASHFLOW : type;
+}
+
 /**
  * One row of a Fidelity export, reduced to what pairing needs. Shared by the CSV
  * and JSON converters so the two cannot disagree about how a trade is grouped.
@@ -113,6 +151,12 @@ export interface FidelityLeg {
   consideration: number;
   /** Broker reference number. NaN when the source did not supply one. */
   ref: number;
+  /**
+   * Whether the row transacted cash rather than a security. A cash `Buy` or
+   * `Sell` pairs against a different cash row than a security one does, so
+   * pairing needs this as well as typeForAsset.
+   */
+  cashAsset: boolean;
 }
 
 const AMOUNT_EPSILON = 0.005;
@@ -138,7 +182,13 @@ const CONSIDERATION_BAND = 0.005;
  * Fidelity reports the cash side of a trade as a separate row, so the two legs are
  * paired here rather than a cash leg being derived, which would post the money
  * twice. Both rules are measured against the sample exports in local/masters: sells
- * pair 91/91 and buys 78/78.
+ * pair 91/91 -- 69 of a security and 22 of cash -- and buys 78/78.
+ *
+ * A cash leg pairs with the row that names the same money, and the broker names it
+ * differently either side of the asset: a security sale settles through
+ * `Cash In From Sell` and so does a sale of cash, while a security purchase settles
+ * through `Cash Out For Buy` and a purchase of cash through
+ * `Cash Out For Buy From Transfer`.
  *
  * Charges (dealing fee, PTM levy, stamp duty, FX charge) are never grouped with a
  * trade. Fidelity dates them on the order date while the trade settles later, so
@@ -153,6 +203,14 @@ export function assignFidelityGroups(legs: FidelityLeg[]): string[] {
   const bucket = (l: FidelityLeg) => `${l.account}\u0000${l.dateKey}`;
   const indices = (type: string) =>
     legs.map((l, i) => (l.type === type && Number.isFinite(l.ref) ? i : -1)).filter((i) => i >= 0);
+  // Security trades pick their cash row first. Nothing in the sample exports needs
+  // it -- no bucket holds a cash and a security trade of equal amount -- but five
+  // hold both kinds, so this keeps which one wins from depending on the order the
+  // broker happened to export them in.
+  const securityFirst = (idx: number[]) => [
+    ...idx.filter((i) => !legs[i].cashAsset),
+    ...idx.filter((i) => legs[i].cashAsset),
+  ];
 
   const pair = (securityIdx: number, cashIdx: number) => {
     const ref = String(legs[securityIdx].ref);
@@ -177,7 +235,7 @@ export function assignFidelityGroups(legs: FidelityLeg[]): string[] {
   // Sells: the cash in equals the proceeds exactly, so the amount identifies it.
   const usedCash = new Set<number>();
   const cashIn = indices("Cash In From Sell");
-  for (const s of indices("Sell")) {
+  for (const s of securityFirst(indices("Sell"))) {
     const match = cashIn.find(
       (c) =>
         !usedCash.has(c) &&
@@ -196,11 +254,14 @@ export function assignFidelityGroups(legs: FidelityLeg[]): string[] {
   // out the cash row of a larger trade in the same bucket; among what survives, the
   // nearest reference number wins. Candidates are ranked globally rather than taken
   // in row order so that one buy cannot strand another by claiming its cash row.
+  // No ordering needed here as there is for sells: the two kinds of buy draw from
+  // disjoint pools of cash rows, so neither can claim the other's.
   const buys = indices("Buy");
   const cashOut = indices("Cash Out For Buy");
+  const cashOutTransfer = indices("Cash Out For Buy From Transfer");
   const candidates: Array<{ distance: number; buy: number; cash: number }> = [];
   for (const b of buys) {
-    for (const c of cashOut) {
+    for (const c of legs[b].cashAsset ? cashOutTransfer : cashOut) {
       if (bucket(legs[c]) !== bucket(legs[b])) continue;
       if (Math.abs(legs[b].amount) - Math.abs(legs[c].amount) < -AMOUNT_EPSILON) continue;
       if (!consistent(legs[b], legs[c])) continue;
@@ -278,6 +339,11 @@ export function convertFidelityToStandard(
   const amountCol = col("amount");
   const priceCol = col("price_per_unit");
   const refCol = col("reference_number");
+  // The asset class of the row's instrument (CASH, ETF, STOCK, FUND), which is
+  // what says whether a Buy or Sell transacted a security or the account's cash.
+  // Distinct from "Transaction type"; an export without it falls back to the
+  // instrument description, which is a required column.
+  const assetClassCol = col("type");
 
   if (orderDateCol < 0 || txTypeCol < 0 || investmentsCol < 0) {
     return {
@@ -308,13 +374,18 @@ export function convertFidelityToStandard(
     }
 
     const txTypeStr = get(txTypeCol);
-    const ofxType = txTypeStr ? FIDELITY_TYPE_TO_OFX[txTypeStr] : undefined;
-    if (ofxType === undefined) {
+    const mappedType = txTypeStr ? FIDELITY_TYPE_TO_OFX[txTypeStr] : undefined;
+    if (mappedType === undefined) {
       errors.push({ rowIndex, field: "type", message: txTypeStr ? `Unknown transaction type: ${txTypeStr}` : "Missing transaction type" });
       continue;
     }
 
-    const instrumentDescription = get(investmentsCol) || "Cash";
+    const investments = get(investmentsCol);
+    const assetClass = assetClassCol >= 0 ? get(assetClassCol) : "";
+    const cashAsset = assetClass ? assetClass === "CASH" : investments === "Cash";
+    const ofxType = typeForAsset(mappedType, cashAsset);
+
+    const instrumentDescription = investments || "Cash";
     const account = accountCol >= 0 ? get(accountCol) : "";
     const qtyStr = get(qtyCol);
     const amountStr = amountCol >= 0 ? get(amountCol) : "";
@@ -329,7 +400,7 @@ export function convertFidelityToStandard(
       // (Tax On Interest reports 0 against an Amount of -0.20), so for cash the
       // transacted value is Amount itself rather than a sign-corrected Quantity.
       quantity = amountDec;
-    } else if (ofxType === TxType.SELLSTOCK || ofxType === TxType.SELLMF || ofxType === TxType.SELLDEBT || ofxType === TxType.SELLOPT || ofxType === TxType.SELLOTHER) {
+    } else if (SELL_TYPES.has(ofxType)) {
       quantity = quantity.abs().times(-1);
     }
     const priceStr = priceCol >= 0 ? get(priceCol) : "";
@@ -355,6 +426,7 @@ export function convertFidelityToStandard(
           ? rawQtyDec.times(unitPriceDec).abs().toNumber()
           : 0,
       ref: refCol >= 0 ? parseInt(get(refCol), 10) : NaN,
+      cashAsset,
     });
     txs.push(
       create(TxSchema, {

--- a/extension/src/brokers/fidelity-json.test.ts
+++ b/extension/src/brokers/fidelity-json.test.ts
@@ -7,6 +7,7 @@ import { Big } from "@/lib/decimal";
 import { describe, expect, it } from "vitest";
 import { AccountType, IdentifierType, TxType } from "@/gen/api/v1/api_pb";
 import { convertFidelityJson, isValidIsin } from "./fidelity-json";
+import { expectGroupsBalance } from "@/lib/csv/group-balance.test-utils";
 
 const BUY = {
   accountNumber: "ACC-1",
@@ -171,6 +172,107 @@ describe("convertFidelityJson", () => {
   it("rejects a payload that is not a JSON array", () => {
     expect(convertFidelityJson("<html>signed out</html>").errors[0]!.message).toContain("not JSON");
     expect(convertFidelityJson('{"error":"nope"}').errors[0]!.message).toContain("array");
+  });
+});
+
+// Fidelity models an account's cash as a tradable asset, so money moving in or
+// out is reported as a Buy or Sell of it against a pseudo-ISIN. Mapping on the
+// transaction type alone made each one a security trade in units of money, and
+// lost the movement the third row of the sequence records. Rows from the
+// captured payload, AP10013127 on 18/05/2026 and AG10041188 on 15/04/2025.
+describe("convertFidelityJson cash-asset rows", () => {
+  const cash = (fields: Record<string, unknown>) => ({
+    accountNumber: "AP10013127",
+    assetName: "Cash",
+    isin: "AA00R0000000",
+    sedol: "R000000",
+    pricePerUnit: 1,
+    currency: "GBP",
+    status: "Completed",
+    dealDate: "18/05/2026",
+    settlementDate: "18/05/2026",
+    units: 12772.83,
+    valuation: 12772.83,
+    ...fields,
+  });
+
+  const BUY_CASH = cash({
+    transactionType: "Buy",
+    debitCreditIndicator: "CREDIT",
+    referenceId: "1288903396",
+  });
+  const CASH_OUT = cash({
+    transactionType: "Cash Out For Buy From Transfer",
+    debitCreditIndicator: "DEBIT",
+    referenceId: "1288903394",
+  });
+  const ARRIVAL = cash({
+    transactionType: "Cash In For Transfer",
+    debitCreditIndicator: "CREDIT",
+    referenceId: "1288903395",
+  });
+
+  it("is a cash movement, not a security trade", () => {
+    const result = convertFidelityJson(json(BUY_CASH));
+    expect(result.errors).toEqual([]);
+    const tx = result.txs[0]!;
+    expect(tx.type).toBe(TxType.CASHFLOW);
+    expect(tx.quantity).toBe("12772.83");
+    expect(tx.tradingCurrency).toBe("GBP");
+    expect(tx.identifierHints).toEqual([]);
+  });
+
+  it("groups a purchase of cash with the cash out beside it", () => {
+    const result = convertFidelityJson(json(CASH_OUT, BUY_CASH));
+    expect(result.txs[0]!.groupRef).toBe("1288903396");
+    expect(result.txs[1]!.groupRef).toBe("1288903396");
+    expectGroupsBalance(result.txs);
+  });
+
+  it("leaves the transfer beside it as the money that arrived", () => {
+    // All three rows are the same 12,772.83. Only the arrival is a movement;
+    // the other two are the broker converting its own cash position and net to
+    // zero, so the account must end that much up rather than level.
+    const result = convertFidelityJson(json(CASH_OUT, ARRIVAL, BUY_CASH));
+    expect(result.errors).toEqual([]);
+    const total = result.txs.reduce((sum, tx) => sum.plus(tx.quantity), new Big(0));
+    expect(total.eq(12772.83)).toBe(true);
+    expect(result.txs.some((tx) => tx.type === TxType.BUYSTOCK)).toBe(false);
+  });
+
+  it("reads a sale of cash the same way", () => {
+    const sell = cash({
+      accountNumber: "AG10041188",
+      isin: "AA00S0000000",
+      sedol: "S000000",
+      transactionType: "Sell",
+      debitCreditIndicator: "DEBIT",
+      units: 20000,
+      valuation: 20000,
+      referenceId: "1093663529",
+    });
+    const cashIn = cash({
+      accountNumber: "AG10041188",
+      isin: "AA00S0000000",
+      sedol: "S000000",
+      transactionType: "Cash In From Sell",
+      debitCreditIndicator: "CREDIT",
+      units: 20000,
+      valuation: 20000,
+      referenceId: "1093663530",
+    });
+
+    const result = convertFidelityJson(json(sell, cashIn));
+    expect(result.txs[0]!.type).toBe(TxType.CASHFLOW);
+    expect(result.txs[0]!.quantity).toBe("-20000");
+    expect(result.txs[0]!.groupRef).toBe("1093663529");
+    expect(result.txs[1]!.groupRef).toBe("1093663529");
+    expectGroupsBalance(result.txs);
+  });
+
+  it("still reads a purchase carrying a real identifier as a security trade", () => {
+    const result = convertFidelityJson(json(BUY));
+    expect(result.txs[0]!.type).toBe(TxType.BUYSTOCK);
   });
 });
 

--- a/extension/src/brokers/fidelity-json.ts
+++ b/extension/src/brokers/fidelity-json.ts
@@ -21,6 +21,7 @@ import {
   FIDELITY_TYPE_TO_OFX,
   isCashMovement,
   isCashTxType,
+  typeForAsset,
 } from "@/lib/csv/converters/fidelity-csv";
 import type { ParseError, StandardParseResult } from "@/lib/csv/standard";
 import { counterLegs } from "@/lib/csv/postings";
@@ -58,7 +59,8 @@ interface FidelityRow {
  * rows as well as cash ones, so the transaction type cannot be used to tell them
  * apart. They fail the check digit, and every genuine identifier in the sample
  * passes it, so validating is what keeps three fictional instruments out of the
- * security master.
+ * security master -- and, through typeForAsset, what stops a Buy or Sell of cash
+ * being posted as a security trade.
  */
 export function isValidIsin(value: string): boolean {
   if (!/^[A-Z]{2}[A-Z0-9]{9}\d$/.test(value)) return false;
@@ -121,8 +123,8 @@ export function convertFidelityJson(
     }
 
     const typeStr = row.transactionType ?? "";
-    const ofxType = typeStr ? FIDELITY_TYPE_TO_OFX[typeStr] : undefined;
-    if (ofxType === undefined) {
+    const mappedType = typeStr ? FIDELITY_TYPE_TO_OFX[typeStr] : undefined;
+    if (mappedType === undefined) {
       errors.push({
         rowIndex,
         field: "type",
@@ -130,6 +132,14 @@ export function convertFidelityJson(
       });
       return;
     }
+
+    const isin = row.isin ?? "";
+    // The check digit is what separates a cash pseudo-identifier from a real one,
+    // so the same test that keeps them out of the security master says whether the
+    // row transacted cash. There is no equivalent of the CSV export's Type column
+    // here; a row carrying no identifier at all falls back to the asset name.
+    const cashAsset = isin ? !isValidIsin(isin) : row.assetName === "Cash";
+    const ofxType = typeForAsset(mappedType, cashAsset);
 
     // units and valuation are both unsigned; direction lives only in the
     // indicator. For a cash movement the transacted value is the money, and
@@ -140,7 +150,6 @@ export function convertFidelityJson(
     const quantity = (row.debitCreditIndicator === "DEBIT" ? signed.times(-1) : signed).toString();
 
     const currency = row.currency ?? "";
-    const isin = row.isin ?? "";
     const sedol = row.sedol ?? "";
     const identifierHints = isValidIsin(isin)
       ? [
@@ -180,6 +189,7 @@ export function convertFidelityJson(
         .abs()
         .toNumber(),
       ref: parseInt(row.referenceId ?? "", 10),
+      cashAsset,
     });
     txs.push(
       create(TxSchema, {


### PR DESCRIPTION
First of three for 0065.

Fidelity models an account's cash as a tradable asset, so money leaving an account is reported as a *sale of cash* and money arriving as a *purchase of cash*. Both converters classify a row on `Transaction type` alone, so each of those rows became a security position bought or sold in units of money, against an instrument described as "Cash".

## The balance was wrong too

The rows arrive as a triplet with consecutive reference numbers. Lee's export, 2023-03-01, AG10041188:

| leg | row | before |
| --- | --- | --- |
| the movement | `Transfer To Cash Management Account` -401, ref ...674 | TRANSFER -401 |
| the trade of cash | `Sell` / `Investments=Cash` -401, ref ...678 | **SELLSTOCK -401 units of "Cash"** |
| its cash leg | `Cash In From Sell` +401, ref ...680 | CASHFLOW +401 |

The last two net to zero, so the transfer is the money that moved. Posting the trade of cash onto a phantom security left only the +401, and the account netted nothing on a day it should have netted -401 -- while the cash management account still recorded `Transfer Into Account` +401 against it. 22 rows across the two sample exports, the largest 200,500.

`local/scripts/convert-fidelity.py` had the same error by the opposite route: it dropped the `Sell` row and kept the orphan credit.

The extension payload carries the mirror -- `Buy` against a cash pseudo-ISIN, paired with `Cash Out For Buy From Transfer` -- where it is a transfer's *arrival* that is lost. That also explains the pair 0069 records under "Adjacent, probably not the same problem"; 0069 will be amended in the last PR of the series.

## The fix

Classify on the asset rather than the transaction type. Each source names its own discriminator:

- CSV: the `Type` column (`CASH`), falling back to the instrument description when an export omits it -- the existing tests use headers without it.
- Extension JSON: `isValidIsin`, which already tells Fidelity's `AA00S0000000`-style cash pseudo-identifiers from real ones and whose doc comment already described this exact phenomenon. There is no `Action` or `Type` field in the payload.

A trade of cash is a `CASHFLOW`. It keeps its existing pairing, so the two legs form a group that weighs nothing, and the withdrawal or transfer stands on its own as the movement.

Pairing follows the asset: a purchase of cash settles through `Cash Out For Buy From Transfer` rather than `Cash Out For Buy`, so the two kinds of buy draw from disjoint pools. Sells share one pool, so a security sale now picks from it first -- no bucket in either export holds a cash and a security sale of equal amount, but five hold both kinds.

Rows are never routed to `errors`: the upload modal blocks the whole file on any parse error.

## Verified

`make client-test` (286), `make extension-test` (91), `make lint-ts`, both typechecks.

Against the real exports, regenerating `local/standard-format`:

- Lee gains exactly 13 postings, all `CASHFLOW`, all grouped with their cash leg at zero weight. Helen gains 9, likewise.
- AG10041188 on 2023-03-01 nets -401 instead of 0, matching the credit the cash management account records against it. 2023-07-24 goes from +99,886.87 to -1,301.44.
- Unbalanced groups drop from 231 to 218 -- the 13 previously orphaned credits -- and the reported residual moves by exactly 477,367.48, the sum of the 13 amounts it had been offsetting.
- No security trade lost its group: 39/39 sells and 32/32 buys still pair in Lee.
- No posting carries a security type against an instrument described as `Cash`.

## Still to come

PR 2 converges the two converters' type maps on the remaining Helen-only types; PR 3 puts cash postings on the spec's `instrument_description` convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)