### PR TITLE
Converge the two Fidelity converters on one type map (0065)

### DIFF
--- a/client/lib/csv/converters/fidelity-csv.test.ts
+++ b/client/lib/csv/converters/fidelity-csv.test.ts
@@ -2,7 +2,7 @@ import { Big } from "@/lib/decimal";
 import { describe, it, expect } from "vitest";
 import { AccountType, TxType } from "@/gen/api/v1/api_pb";
 import { convertFidelityToStandard, FIDELITY_TYPE_TO_OFX } from "./fidelity-csv";
-import { expectGroupsBalance } from "@/lib/csv/group-balance.test-utils";
+import { expectGroupsBalance, residuals } from "@/lib/csv/group-balance.test-utils";
 
 const HEADER =
   "Order date,Completion date,Transaction type,Investments,Account Number,Quantity,Price per unit";
@@ -58,6 +58,19 @@ describe("convertFidelityToStandard", () => {
     expect(result.periodFrom.getFullYear()).toBe(2026);
     expect(result.periodFrom.getMonth()).toBe(0); // Jan
     expect(result.periodFrom.getDate()).toBe(21);
+  });
+
+  it("reads an ISO completion date, which some exports carry throughout", () => {
+    // The order date is ISO in every export and the completion date usually is
+    // not, but one of the two sample exports is ISO in both. Reading only the
+    // broker's own format rejected every row of that file.
+    const csv = [
+      "Order date,Completion date,Transaction type,Investments,Account Number,Quantity,Price per unit",
+      "2026-01-21,2026-01-23,Buy,ISHARES II PLC INRG,SIPP,100,7.16",
+    ].join("\n");
+    const result = convertFidelityToStandard(csv, { currency: "GBP" });
+    expect(result.errors).toEqual([]);
+    expect(result.periodFrom).toEqual(new Date(2026, 0, 23));
   });
 
   it("parses Cash Interest as INCOME", () => {
@@ -456,6 +469,120 @@ describe("transaction grouping", () => {
     expect(result.errors).toHaveLength(0);
     expect(result.txs).toHaveLength(1);
     expect(result.txs[0].groupRef).toBe("");
+  });
+});
+
+// Fidelity names a trade for the reason it happened, and names its cash leg to
+// match. Every row below is verbatim from the Helen export; before these types
+// were mapped the client rejected each one while the conversion script kept it,
+// so the two disagreed about which rows survived.
+describe("trades the broker names for their reason", () => {
+  const FULL =
+    "Order date,Completion date,Transaction type,Investments,Product Wrapper,Account Number,Source investment,Amount,Quantity,Price per unit,Reference Number,Status,Exchange,Symbol,Type,Action";
+  const convert = (rows: string[]) =>
+    convertFidelityToStandard([FULL, ...rows].join("\n"), { currency: "GBP" });
+
+  it("pairs a dividend reinvestment with the cash out that funded it", () => {
+    const result = convert([
+      '2022-02-11,15 Feb 2022,Buy From Dividend,"BAILLIE GIFFORD EUROPEAN GROWTH TST, ORD GBP0.025 (BGEU)",Investment ISA,AS10123702,"BAILLIE GIFFORD EUROPEAN GROWTH TST, ORD GBP0.025 (BGEU)",21.75,17,1.19,564234496,Completed,LON,BGEU,ETF,Buy',
+      '2022-02-11,15 Feb 2022,Cash Out For Dividend Reinvestment,Cash,Investment ISA,AS10123702,"BAILLIE GIFFORD EUROPEAN GROWTH TST, ORD GBP0.025 (BGEU)",-20.15,20.15,1,564234491,Completed,,GBP,CASH,Cash',
+    ]);
+
+    expect(result.errors).toEqual([]);
+    // A plain purchase: the dividend has already posted as its own Cash Dividend
+    // row, so typing this REINVEST would count the income twice.
+    expect(result.txs[0]!.type).toBe(TxType.BUYSTOCK);
+    expect(result.txs[0]!.quantity).toBe("17");
+    expect(result.txs[1]!.type).toBe(TxType.CASHFLOW);
+    expect(result.txs[0]!.groupRef).toBe("564234496");
+    expect(result.txs[1]!.groupRef).toBe("564234496");
+  });
+
+  it("pairs a rebate reinvestment with its cash out", () => {
+    const result = convert([
+      "2022-03-04,10 Mar 2022,Cash Out,Cash,SIPP - Pension Savings Account,AP10024612,M&G European Index Tracker,-7.81,7.81,1,574652308,Completed,,GBP,CASH,Cash",
+      "2022-03-04,10 Mar 2022,Buy From Rebate,M&G European Index Tracker,SIPP - Pension Savings Account,AP10024612,M&G European Index Tracker,7.81,9.24,0.85,574652321,Completed,LON,M&G European Index Tracker,FUND,Buy",
+    ]);
+
+    expect(result.errors).toEqual([]);
+    expect(result.txs[1]!.type).toBe(TxType.BUYSTOCK);
+    expect(result.txs[0]!.groupRef).toBe("574652321");
+    expect(result.txs[1]!.groupRef).toBe("574652321");
+    // The group does not weigh zero, and cannot: 9.24 units at the printed price
+    // of 0.85 is 7.854 against a cash out of 7.81. The price is rounded to the
+    // penny and the units are not, so the 0.044 is the source disagreeing with
+    // itself. The imbalance report is where that belongs.
+    expect(residuals(result.txs)).toEqual({ "574652321": { GBP: "0.044" } });
+  });
+
+  it("derives the income a reinvestment consumed, since no row reports it", () => {
+    // The one trade in either export with no cash row anywhere beside it: the
+    // income buys the units without arriving as money first.
+    const result = convert([
+      "2022-03-24,06 Apr 2022,Reinvestment From Income,Baillie Gifford Responsible Global Equity Income B Inc,Investment ISA,AS10123702,Baillie Gifford Responsible Global Equity Income B Inc,31.65,21.09,1.5,582193319,Completed,LON,Baillie Gifford Responsible Global Equity Income B Inc,FUND,Buy",
+    ]);
+
+    expect(result.errors).toEqual([]);
+    expect(result.txs).toHaveLength(2);
+    expect(result.txs[0]!.type).toBe(TxType.REINVEST);
+    expect(result.txs[0]!.quantity).toBe("21.09");
+    expect(result.txs[1]!.accountType).toBe(AccountType.INCOME);
+    // The posting's own weight, not the 31.65 the broker printed: taking that
+    // would leave the group short by the rounding in the quoted price.
+    expect(result.txs[1]!.quantity).toBe("-31.635");
+    expect(result.txs[1]!.instrumentDescription).toBe("GBP");
+    expect(result.txs[1]!.groupRef).toBe(result.txs[0]!.groupRef);
+    expectGroupsBalance(result.txs);
+  });
+
+  it("settles a switch through the rows the broker used for it", () => {
+    const result = convert([
+      "2023-06-28,29 Jun 2023,Cash Out,Cash,SIPP - Pension Savings Account,AP10024612,,-12091.15,12091.15,1,783688689,Completed,,GBP,CASH,Cash",
+      "2023-06-28,04 Jul 2023,Sell For Switch,M&G European Index Tracker,SIPP - Pension Savings Account,AP10024612,,-12091.15,12147.03,1,783688687,Completed,LON,M&G European Index Tracker,FUND,Sell",
+      "2023-06-28,29 Jun 2023,Buy For Switch,Cash,SIPP - Pension Savings Account,AP10024612,,12091.15,12091.15,1,783688692,Completed,,GBP,CASH,Cash",
+      "2023-06-28,04 Jul 2023,Cash In,Cash,SIPP - Pension Savings Account,AP10024612,,12091.15,12091.15,1,783688691,Completed,,GBP,CASH,Cash",
+    ]);
+
+    expect(result.errors).toEqual([]);
+    // The buy side names cash as the asset, so it is a movement of money rather
+    // than a purchase of a security called Cash, and it nets against its cash out.
+    expect(result.txs[2]!.type).toBe(TxType.CASHFLOW);
+    expect(result.txs[0]!.groupRef).toBe("783688692");
+    expect(result.txs[2]!.groupRef).toBe("783688692");
+    // The sale side is a real disposal, and its proceeds arrive as a Cash In.
+    expect(result.txs[1]!.type).toBe(TxType.SELLSTOCK);
+    expect(result.txs[1]!.groupRef).toBe("783688687");
+    expect(result.txs[3]!.groupRef).toBe("783688687");
+  });
+
+  it("retypes a Cash In that turned out to be a sale's proceeds", () => {
+    // Cash In is normally money from outside the account, and no lookup on the
+    // broker's name can tell the two apart -- only whether the row paired.
+    const paired = convert([
+      "2023-06-28,04 Jul 2023,Sell For Switch,M&G European Index Tracker,SIPP - Pension Savings Account,AP10024612,,-12091.15,12147.03,1,783688687,Completed,LON,M&G European Index Tracker,FUND,Sell",
+      "2023-06-28,04 Jul 2023,Cash In,Cash,SIPP - Pension Savings Account,AP10024612,,12091.15,12091.15,1,783688691,Completed,,GBP,CASH,Cash",
+    ]);
+    expect(paired.txs[1]!.type).toBe(TxType.CASHFLOW);
+    expect(paired.txs[1]!.tradingCurrency).toBe("GBP");
+
+    const alone = convert([
+      "2023-06-28,04 Jul 2023,Cash In,Cash,SIPP - Pension Savings Account,AP10024612,,12091.15,12091.15,1,783688691,Completed,,GBP,CASH,Cash",
+    ]);
+    expect(alone.txs[0]!.type).toBe(TxType.JRNLFUND);
+    expect(alone.txs[0]!.groupRef).toBe("");
+  });
+
+  it("skips a cancelled transaction and its cancelled cash row", () => {
+    const result = convert([
+      '2024-07-22,22 Jul 2024,Sell,"INVESCO MARKETS III PLC, INVESCO EQQQ (EQQQ)",Investment Account,AG10041188,,0,0,373.51,969683719,Cancelled,LON,EQQQ,ETF,Sell',
+      "2024-07-22,22 Jul 2024,Cash In From Sell,Cash,Investment Account,AG10041188,,0,0,1,969683721,Cancelled,,GBP,CASH,Cash",
+      "2024-07-22,22 Jul 2024,Dealing Fee,Cash,Investment Account,AG10041188,,-7.5,0,0,222050117,Completed,,GBP,CASH,Cash",
+    ]);
+
+    expect(result.errors).toEqual([]);
+    // The fee and its expense leg; nothing from the trade that never happened.
+    expect(result.txs).toHaveLength(2);
+    expect(result.txs[0]!.type).toBe(TxType.INVEXPENSE);
   });
 });
 

--- a/client/lib/csv/converters/fidelity-csv.ts
+++ b/client/lib/csv/converters/fidelity-csv.ts
@@ -19,14 +19,32 @@ import { Big, parseDecimal } from "@/lib/decimal";
 const ZERO = new Big(0);
 
 const FIDELITY_DATE_FORMAT = /^(\d{1,2})\s+([A-Za-z]{3})\s+(\d{4})$/;
+const ISO_DATE_FORMAT = /^(\d{4})-(\d{2})-(\d{2})$/;
 const MONTHS: Record<string, number> = {
   Jan: 0, Feb: 1, Mar: 2, Apr: 3, May: 4, Jun: 5,
   Jul: 6, Aug: 7, Sep: 8, Oct: 9, Nov: 10, Dec: 11,
 };
 
+/**
+ * Both date formats a Fidelity export uses.
+ *
+ * The download writes "10 Feb 2022" in the completion date and an ISO date in the
+ * order date, and some exports are ISO throughout. Reading only the first rejected
+ * every row of such a file, which is a whole export lost to a date format the
+ * source itself uses in the column beside it.
+ *
+ * Local midnight either way, matching how a date with no time is read everywhere
+ * else here.
+ */
 function parseFidelityDate(value: string): Date | null {
   const trimmed = value.trim();
   if (!trimmed) return null;
+  const iso = trimmed.match(ISO_DATE_FORMAT);
+  if (iso) {
+    const [, year, month, day] = iso;
+    const d = new Date(parseInt(year!, 10), parseInt(month!, 10) - 1, parseInt(day!, 10));
+    return Number.isNaN(d.getTime()) ? null : d;
+  }
   const m = trimmed.match(FIDELITY_DATE_FORMAT);
   if (!m) return null;
   const [, day, monthStr, year] = m;
@@ -44,8 +62,26 @@ function parseFidelityDate(value: string): Date | null {
 export const FIDELITY_TYPE_TO_OFX: Record<string, TxType> = {
   "Buy": TxType.BUYSTOCK,
   "Sell": TxType.SELLSTOCK,
+  // Fidelity names a trade for the reason it happened. All of these are ordinary
+  // trades that settle through a cash row of their own; only the reinvestment is
+  // different, and it is different in kind rather than in name.
+  "Buy From Dividend": TxType.BUYSTOCK,
+  "Buy From Rebate": TxType.BUYSTOCK,
+  "Buy For Switch": TxType.BUYSTOCK,
+  "Sell For Switch": TxType.SELLSTOCK,
+  // The only trade in the sample exports with no cash row anywhere beside it: the
+  // income buys the units without ever arriving as money, which is what REINVEST
+  // means. Its income leg is derived, since the source reports none.
+  "Reinvestment From Income": TxType.REINVEST,
   "Cash Interest": TxType.INCOME,
   "Cash Dividend": TxType.INCOME,
+  "Income Received": TxType.INCOME,
+  "Rebate": TxType.INCOME,
+  // A correction to interest already paid, and in the sample a credit of 0.02.
+  "Interest Adjustment": TxType.INCOME,
+  // Reverses a withdrawal in the same account on the same day, so it is the same
+  // kind of movement as the row it undoes.
+  "Adjustment": TxType.JRNLFUND,
   "Tax On Interest": TxType.INVEXPENSE,
   "Dealing Fee": TxType.INVEXPENSE,
   "Service Fee": TxType.INVEXPENSE,
@@ -58,6 +94,10 @@ export const FIDELITY_TYPE_TO_OFX: Record<string, TxType> = {
   "Transfer Out From Cash Management Account": TxType.TRANSFER,
   "Transfer Into Account": TxType.TRANSFER,
   "Cash In Ring-fenced For Fees": TxType.TRANSFER,
+  // Money arriving from outside the account. `Cash In` also settles the sale side
+  // of a switch, which no type map can express: whether a row is a journal or a
+  // trade's cash leg shows in whether it paired, so a paired one is retyped after
+  // grouping. See asTradeCashLeg.
   "Cash In": TxType.JRNLFUND,
   "Cash In Lump Sum": TxType.JRNLFUND,
   "Cash In For Transfer": TxType.JRNLFUND,
@@ -68,15 +108,25 @@ export const FIDELITY_TYPE_TO_OFX: Record<string, TxType> = {
   // lossiness. The types above keep JRNLFUND because their other side really is
   // outside the account.
   "Cash In From Sell": TxType.CASHFLOW,
+  "Cash Out": TxType.CASHFLOW,
   "Cash Out For Buy": TxType.CASHFLOW,
   "Cash Out For Buy From Transfer": TxType.CASHFLOW,
+  "Cash Out For Dividend Reinvestment": TxType.CASHFLOW,
 };
 
+/**
+ * Types whose posting is money, so it carries a currency on both sides.
+ *
+ * REINVEST is not one of them, though it names an income event: the posting is
+ * the units the income bought, and the server weighs it at quantity times price
+ * like any other security leg (transferTypes in
+ * server/service/ingestion/balance.go). Reading its money total as a quantity
+ * would post the dividend as a share count.
+ */
 export function isCashTxType(type: TxType): boolean {
   return (
     type === TxType.INCOME ||
     type === TxType.INVEXPENSE ||
-    type === TxType.REINVEST ||
     type === TxType.TRANSFER ||
     type === TxType.MARGININTEREST ||
     type === TxType.RETOFCAP ||
@@ -165,57 +215,103 @@ const AMOUNT_EPSILON = 0.005;
  * Widest relative gap tolerated between a cash leg and its trade's
  * quantity * unit price.
  *
- * The two never agree exactly: the export rounds the unit price, so the product's
- * error grows with the quantity. Across the sample exports the worst correctly
- * paired trade is 0.16% out, so 0.5% clears every real pairing while rejecting a
- * swapped cash row, which is off by whole percentage points.
+ * The two never agree exactly: the export rounds the unit price, and the error that
+ * leaves is the half-digit it dropped as a fraction of the price. That is worst on
+ * a cheap unit, since the same half-digit is a larger share of a smaller number --
+ * the widest correctly paired trade in the sample exports is a fund rebate of 9.24
+ * units at a price printed as 0.85, 0.56% out. 0.75% clears every real pairing
+ * while rejecting a swapped cash row, which is off by whole percentage points.
  *
  * This cannot replace the fee rule below. A fee gap is around 0.02% of a trade, far
  * inside this band, so two similar trades settling the same day would both pass it.
  */
-const CONSIDERATION_BAND = 0.005;
+const CONSIDERATION_BAND = 0.0075;
+
+/** Trade rows whose cash leg is money coming in. */
+const SELL_ROWS = ["Sell", "Sell For Switch"];
+
+/** Trade rows whose cash leg is money going out. */
+const BUY_ROWS = ["Buy", "Buy From Dividend", "Buy From Rebate", "Buy For Switch"];
 
 /**
- * Assigns a group_ref to each leg, returning refs parallel to the input. An empty
- * string means the leg is its own single-posting group.
+ * The broker type of the cash row a trade settles through, or "" for a row that
+ * is not a trade.
+ *
+ * Fidelity names the cash leg after the reason the trade happened rather than
+ * after the trade, so each variant settles through a row type of its own. A
+ * purchase of the account's own cash is the one that also turns on the asset: it
+ * arrives through a transfer, and the broker says so in the name.
+ */
+function cashLegType(leg: FidelityLeg): string {
+  switch (leg.type) {
+    case "Sell":
+      return "Cash In From Sell";
+    case "Sell For Switch":
+      return "Cash In";
+    case "Buy":
+      return leg.cashAsset ? "Cash Out For Buy From Transfer" : "Cash Out For Buy";
+    case "Buy From Dividend":
+      return "Cash Out For Dividend Reinvestment";
+    case "Buy From Rebate":
+    case "Buy For Switch":
+      return "Cash Out";
+    default:
+      return "";
+  }
+}
+
+/** What assignFidelityGroups worked out about each leg, parallel to its input. */
+export interface FidelityGroups {
+  /** Group ref. An empty string means the leg is its own single-posting group. */
+  refs: string[];
+  /** Whether the leg was paired as a trade's cash leg. */
+  cashLegs: boolean[];
+}
+
+/**
+ * Assigns a group_ref to each leg.
  *
  * Fidelity reports the cash side of a trade as a separate row, so the two legs are
  * paired here rather than a cash leg being derived, which would post the money
  * twice. Both rules are measured against the sample exports in local/masters: sells
  * pair 91/91 -- 69 of a security and 22 of cash -- and buys 78/78.
  *
- * A cash leg pairs with the row that names the same money, and the broker names it
- * differently either side of the asset: a security sale settles through
- * `Cash In From Sell` and so does a sale of cash, while a security purchase settles
- * through `Cash Out For Buy` and a purchase of cash through
- * `Cash Out For Buy From Transfer`.
+ * Which cash row a trade pairs with is cashLegType's to say.
  *
  * Charges (dealing fee, PTM levy, stamp duty, FX charge) are never grouped with a
  * trade. Fidelity dates them on the order date while the trade settles later, so
  * folding them in would misdate them, and their money is already accounted for by
  * their own rows.
  */
-export function assignFidelityGroups(legs: FidelityLeg[]): string[] {
+export function assignFidelityGroups(legs: FidelityLeg[]): FidelityGroups {
   const refs = legs.map(() => "");
+  const cashLegs = legs.map(() => false);
   // NUL separator, written as an escape so this file stays plain text. A Fidelity
   // date is "10 Feb 2022", so a separator a date could contain risks two different
   // (account, date) pairs collapsing onto one key.
   const bucket = (l: FidelityLeg) => `${l.account}\u0000${l.dateKey}`;
-  const indices = (type: string) =>
-    legs.map((l, i) => (l.type === type && Number.isFinite(l.ref) ? i : -1)).filter((i) => i >= 0);
+  const byType = new Map<string, number[]>();
+  legs.forEach((l, i) => {
+    if (!Number.isFinite(l.ref)) return;
+    const seen = byType.get(l.type);
+    if (seen) seen.push(i);
+    else byType.set(l.type, [i]);
+  });
+  const indices = (type: string) => byType.get(type) ?? [];
   // Security trades pick their cash row first. Nothing in the sample exports needs
   // it -- no bucket holds a cash and a security trade of equal amount -- but five
   // hold both kinds, so this keeps which one wins from depending on the order the
   // broker happened to export them in.
-  const securityFirst = (idx: number[]) => [
-    ...idx.filter((i) => !legs[i].cashAsset),
-    ...idx.filter((i) => legs[i].cashAsset),
-  ];
+  const tradeRows = (types: string[]) => {
+    const idx = types.flatMap(indices);
+    return [...idx.filter((i) => !legs[i].cashAsset), ...idx.filter((i) => legs[i].cashAsset)];
+  };
 
   const pair = (securityIdx: number, cashIdx: number) => {
     const ref = String(legs[securityIdx].ref);
     refs[securityIdx] = ref;
     refs[cashIdx] = ref;
+    cashLegs[cashIdx] = true;
   };
 
   // Both rules below match one broker-supplied total against another, so neither
@@ -234,9 +330,8 @@ export function assignFidelityGroups(legs: FidelityLeg[]): string[] {
 
   // Sells: the cash in equals the proceeds exactly, so the amount identifies it.
   const usedCash = new Set<number>();
-  const cashIn = indices("Cash In From Sell");
-  for (const s of securityFirst(indices("Sell"))) {
-    const match = cashIn.find(
+  for (const s of tradeRows(SELL_ROWS)) {
+    const match = indices(cashLegType(legs[s])).find(
       (c) =>
         !usedCash.has(c) &&
         bucket(legs[c]) === bucket(legs[s]) &&
@@ -254,14 +349,9 @@ export function assignFidelityGroups(legs: FidelityLeg[]): string[] {
   // out the cash row of a larger trade in the same bucket; among what survives, the
   // nearest reference number wins. Candidates are ranked globally rather than taken
   // in row order so that one buy cannot strand another by claiming its cash row.
-  // No ordering needed here as there is for sells: the two kinds of buy draw from
-  // disjoint pools of cash rows, so neither can claim the other's.
-  const buys = indices("Buy");
-  const cashOut = indices("Cash Out For Buy");
-  const cashOutTransfer = indices("Cash Out For Buy From Transfer");
   const candidates: Array<{ distance: number; buy: number; cash: number }> = [];
-  for (const b of buys) {
-    for (const c of legs[b].cashAsset ? cashOutTransfer : cashOut) {
+  for (const b of tradeRows(BUY_ROWS)) {
+    for (const c of indices(cashLegType(legs[b]))) {
       if (bucket(legs[c]) !== bucket(legs[b])) continue;
       if (Math.abs(legs[b].amount) - Math.abs(legs[c].amount) < -AMOUNT_EPSILON) continue;
       if (!consistent(legs[b], legs[c])) continue;
@@ -277,7 +367,25 @@ export function assignFidelityGroups(legs: FidelityLeg[]): string[] {
     pair(buy, cash);
   }
 
-  return refs;
+  return { refs, cashLegs };
+}
+
+/**
+ * Retypes a journal that turned out to be a trade's cash leg.
+ *
+ * `Cash In` is normally money arriving from outside the account, but a switch
+ * settles its sale through the same row type, and no lookup on the broker's own
+ * name can tell the two apart. Whether the row paired with a trade can: a leg
+ * that did settles inside the account, which is what CASHFLOW says. Left as
+ * JRNLFUND it would make the trade group read as a transfer, so the group's
+ * residual would be routed to TRANSFER_CLEARING rather than IMBALANCE.
+ */
+export function asTradeCashLeg(tx: Tx, currency: string): void {
+  if (tx.type !== TxType.JRNLFUND) return;
+  tx.type = TxType.CASHFLOW;
+  // isCashTxType covers CASHFLOW but not JRNLFUND, so the currency the row was
+  // denied as a journal is owed to it as a cash leg.
+  if (currency) tx.tradingCurrency = currency;
 }
 
 export function convertFidelityToStandard(
@@ -339,6 +447,7 @@ export function convertFidelityToStandard(
   const amountCol = col("amount");
   const priceCol = col("price_per_unit");
   const refCol = col("reference_number");
+  const statusCol = col("status");
   // The asset class of the row's instrument (CASH, ETF, STOCK, FUND), which is
   // what says whether a Buy or Sell transacted a security or the account's cash.
   // Distinct from "Transaction type"; an export without it falls back to the
@@ -363,6 +472,11 @@ export function convertFidelityToStandard(
     const rowIndex = i + 1;
     const values = parseCSVLine(lines[i]);
     const get = (idx: number) => (idx >= 0 && idx < values.length ? values[idx].trim() : "");
+
+    // A cancelled transaction reports zero units against zero value, so it adds
+    // nothing, and its cash row is cancelled beside it. Skipping it also keeps a
+    // trade that never happened from claiming a live trade's cash row.
+    if (statusCol >= 0 && get(statusCol) === "Cancelled") continue;
 
     const completionDateStr = completionDateCol >= 0 ? get(completionDateCol) : "";
     const orderDateStr = get(orderDateCol);
@@ -443,8 +557,12 @@ export function convertFidelityToStandard(
     );
   }
 
-  assignFidelityGroups(legs).forEach((ref, i) => {
+  const groups = assignFidelityGroups(legs);
+  groups.refs.forEach((ref, i) => {
     if (ref) txs[i].groupRef = ref;
+  });
+  groups.cashLegs.forEach((paired, i) => {
+    if (paired) asTradeCashLeg(txs[i], currency);
   });
   // After the refs are stamped, since that loop is index-parallel with legs.
   // Fidelity nets nothing into a trade total, so no fee is derived here: its

--- a/client/lib/csv/postings.test.ts
+++ b/client/lib/csv/postings.test.ts
@@ -4,7 +4,7 @@ import type { MessageInitShape } from "@bufbuild/protobuf";
 import { timestampFromDate } from "@bufbuild/protobuf/wkt";
 import type { Tx } from "@/gen/api/v1/api_pb";
 import { AccountType, IdentifierType, TxSchema, TxType } from "@/gen/api/v1/api_pb";
-import { counterLeg, counterLegs, feeLeg, refPrefix, FEE_EPSILON } from "./postings";
+import { counterLeg, counterLegs, feeLeg, refPrefix, reinvestLeg, FEE_EPSILON } from "./postings";
 import { Big } from "@/lib/decimal";
 import { expectGroupsBalance } from "./group-balance.test-utils";
 
@@ -131,6 +131,46 @@ describe("feeLeg", () => {
       .filter((l) => l.accountType !== AccountType.EXPENSE && l.type !== TxType.BUYSTOCK)
       .reduce((sum, l) => sum.plus(l.quantity), new Big(0));
     expect(cash.toString()).toBe("-23092.22034");
+  });
+});
+
+describe("reinvestLeg", () => {
+  // Quantities from the one reinvestment in the sample exports: 21.09 units of a
+  // fund at 1.50, against a printed total of 31.65.
+  const reinvest = tx({
+    type: TxType.REINVEST,
+    instrumentDescription: "Baillie Gifford Responsible Global Equity Income B Inc",
+    quantity: "21.09",
+    unitPrice: "1.5",
+    groupRef: "582193319",
+  });
+
+  it("names the income the units cost, in the income account", () => {
+    const leg = reinvestLeg(reinvest)!;
+    expect(leg.type).toBe(TxType.INCOME);
+    expect(leg.accountType).toBe(AccountType.INCOME);
+    // Quantity times price, not the total the broker printed: it is the weight of
+    // the posting this balances, so the group comes out at exactly zero.
+    expect(leg.quantity).toBe("-31.635");
+    expect(leg.unitPrice).toBe("1");
+    expect(leg.groupRef).toBe("582193319");
+    // Money, so it resolves to the currency rather than to the fund.
+    expect(leg.instrumentDescription).toBe("GBP");
+    expect(leg.identifierHints.map((h) => [h.type, h.value])).toEqual([
+      [IdentifierType.CURRENCY, "GBP"],
+    ]);
+    expectGroupsBalance([reinvest, leg]);
+  });
+
+  it("leaves every other type to counterLeg", () => {
+    expect(reinvestLeg(tx({ type: TxType.BUYSTOCK, quantity: "10", unitPrice: "5" }))).toBeUndefined();
+    expect(reinvestLeg(tx({ type: TxType.INCOME, quantity: "10" }))).toBeUndefined();
+  });
+
+  it("posts nothing for a reinvestment worth less than a rounding", () => {
+    expect(reinvestLeg(tx({ type: TxType.REINVEST, quantity: "0.001", unitPrice: "1" }))).toBeUndefined();
+    // A reinvestment reporting no price has no money to name.
+    expect(reinvestLeg(tx({ type: TxType.REINVEST, quantity: "21.09" }))).toBeUndefined();
   });
 });
 

--- a/client/lib/csv/postings.ts
+++ b/client/lib/csv/postings.ts
@@ -64,27 +64,22 @@ export function counterLeg(tx: Tx): Tx | undefined {
 }
 
 /**
- * The cash posting for a commission a broker folded into a trade's total.
+ * A money posting derived beside one the source reported, in the same group.
  *
- * `fee` is the charge as the broker reports it, positive; the posting is
- * negative because the money leaves the account. Its counter-leg comes from
- * counterLeg, so a derived fee and a separately reported one end up identical.
- * Returns undefined below FEE_EPSILON.
+ * The instrument description is the currency code, matching how an ordinary cash
+ * row arrives, so nothing downstream has to treat a derived posting specially.
  */
-export function feeLeg(from: Tx, fee: Big | undefined): Tx | undefined {
-  if (fee === undefined || fee.abs().lt(FEE_EPSILON)) return undefined;
+function moneyLeg(from: Tx, type: TxType, accountType: AccountType, quantity: Big): Tx {
   const currency = from.settlementCurrency || from.tradingCurrency;
   return create(TxSchema, {
     ...(from.timestamp ? { timestamp: clone(TimestampSchema, from.timestamp) } : {}),
-    // The currency code, matching how an ordinary cash row arrives, so nothing
-    // downstream has to treat a derived fee specially.
     instrumentDescription: currency,
-    type: TxType.INVEXPENSE,
-    quantity: fee.abs().times(-1).toString(),
+    type,
+    quantity: quantity.toString(),
     unitPrice: "1",
     account: from.account,
     groupRef: from.groupRef,
-    accountType: AccountType.USER,
+    accountType,
     ...(currency
       ? {
           tradingCurrency: currency,
@@ -99,6 +94,40 @@ export function feeLeg(from: Tx, fee: Big | undefined): Tx | undefined {
         }
       : {}),
   });
+}
+
+/**
+ * The cash posting for a commission a broker folded into a trade's total.
+ *
+ * `fee` is the charge as the broker reports it, positive; the posting is
+ * negative because the money leaves the account. Its counter-leg comes from
+ * counterLeg, so a derived fee and a separately reported one end up identical.
+ * Returns undefined below FEE_EPSILON.
+ */
+export function feeLeg(from: Tx, fee: Big | undefined): Tx | undefined {
+  if (fee === undefined || fee.abs().lt(FEE_EPSILON)) return undefined;
+  return moneyLeg(from, TxType.INVEXPENSE, AccountType.USER, fee.abs().times(-1));
+}
+
+/**
+ * The income a reinvestment consumed.
+ *
+ * A REINVEST posting increases a holding with no cash row beside it: the income
+ * buys the units without ever arriving as money, so there is nothing for the
+ * source to have reported and nothing to pair with. Its other side is therefore
+ * derived, and unlike counterLeg's it is not a sign flip -- the posting's
+ * quantity is a share count, and what balances it is money.
+ *
+ * The money is the posting's own weight, quantity times unit price, rather than
+ * the total the broker printed on the row. The two differ by the rounding in the
+ * quoted price, and taking the broker's would leave the group short by a residual
+ * of our choosing rather than one the source has.
+ */
+export function reinvestLeg(from: Tx): Tx | undefined {
+  if (from.type !== TxType.REINVEST) return undefined;
+  const value = new Big(from.quantity).times(from.unitPrice || "0");
+  if (value.abs().lt(FEE_EPSILON)) return undefined;
+  return moneyLeg(from, TxType.INCOME, AccountType.INCOME, value.times(-1));
 }
 
 /**
@@ -123,7 +152,9 @@ export function counterLegs(txs: Tx[]): Tx[] {
   const prefix = refPrefix(txs);
   const legs: Tx[] = [];
   txs.forEach((tx, i) => {
-    const leg = counterLeg(tx);
+    // A reinvestment's other side is money it never held, so it is built rather
+    // than mirrored; everything else that has one is a sign flip.
+    const leg = reinvestLeg(tx) ?? counterLeg(tx);
     if (!leg) return;
     if (!tx.groupRef) {
       tx.groupRef = `${prefix}${i}`;

--- a/extension/src/brokers/fidelity-json.test.ts
+++ b/extension/src/brokers/fidelity-json.test.ts
@@ -274,6 +274,34 @@ describe("convertFidelityJson cash-asset rows", () => {
     const result = convertFidelityJson(json(BUY));
     expect(result.txs[0]!.type).toBe(TxType.BUYSTOCK);
   });
+
+  it("retypes a Cash In that paired with a sale, keeping the row's own currency", () => {
+    // The payload names a currency per row rather than taking one from an upload
+    // option, so the retyped leg has to read it off the posting.
+    const sale = cash({
+      transactionType: "Sell For Switch",
+      assetName: "M&G European Index Tracker",
+      isin: "GB0002634946",
+      sedol: "0263494",
+      debitCreditIndicator: "DEBIT",
+      units: 12147.03,
+      valuation: 12091.15,
+      referenceId: "783688687",
+    });
+    const proceeds = cash({
+      transactionType: "Cash In",
+      debitCreditIndicator: "CREDIT",
+      units: 12091.15,
+      valuation: 12091.15,
+      referenceId: "783688691",
+    });
+
+    const result = convertFidelityJson(json(sale, proceeds));
+    expect(result.txs[0]!.type).toBe(TxType.SELLSTOCK);
+    expect(result.txs[1]!.type).toBe(TxType.CASHFLOW);
+    expect(result.txs[1]!.tradingCurrency).toBe("GBP");
+    expect(result.txs[1]!.groupRef).toBe("783688687");
+  });
 });
 
 describe("convertFidelityJson grouping", () => {

--- a/extension/src/brokers/fidelity-json.ts
+++ b/extension/src/brokers/fidelity-json.ts
@@ -18,6 +18,7 @@ import { IdentifierType, InstrumentIdentifierSchema, TxSchema } from "@/gen/api/
 import type { FidelityLeg } from "@/lib/csv/converters/fidelity-csv";
 import {
   assignFidelityGroups,
+  asTradeCashLeg,
   FIDELITY_TYPE_TO_OFX,
   isCashMovement,
   isCashTxType,
@@ -209,8 +210,12 @@ export function convertFidelityJson(
     );
   });
 
-  assignFidelityGroups(legs).forEach((ref, i) => {
+  const groups = assignFidelityGroups(legs);
+  groups.refs.forEach((ref, i) => {
     if (ref) txs[i].groupRef = ref;
+  });
+  groups.cashLegs.forEach((paired, i) => {
+    if (paired) asTradeCashLeg(txs[i], txs[i].settlementCurrency);
   });
   // After the refs are stamped, since that loop is index-parallel with legs.
   txs.push(...counterLegs(txs));


### PR DESCRIPTION
Second of three for 0065. **Stacked on #333** -- review that first; this PR targets its branch.

The client rejected eleven transaction types that `local/scripts/convert-fidelity.py` accepted, so the two disagreed about which rows survived a conversion of the same export. The script is meant to produce the standard CSV the client would, so that disagreement is itself the bug 0065 records alongside the cash rows.

## The mappings

All eleven appear in the sample exports. Each is read off what the rows do there:

| broker type | maps to | evidence |
| --- | --- | --- |
| `Buy From Dividend` | `BUYSTOCK` | real shares; the dividend already posted as its own `Cash Dividend` row, so `REINVEST` would count the income twice |
| `Buy From Rebate` | `BUYSTOCK` | as above, against a `Rebate` |
| `Buy For Switch` | `BUYSTOCK` | always `Type=CASH` in the sample, so #333's rule demotes it to `CASHFLOW` |
| `Sell For Switch` | `SELLSTOCK` | real units out |
| `Reinvestment From Income` | `REINVEST` | the only trade with no cash row anywhere beside it |
| `Income Received`, `Rebate`, `Interest Adjustment` | `INCOME` | positive cash, no security counterpart |
| `Adjustment` | `JRNLFUND` | +800 reversing an -800 `Withdrawal` in the same account and date |
| `Cash Out`, `Cash Out For Dividend Reinvestment` | `CASHFLOW` | the cash legs of `Buy From Rebate` and `Buy From Dividend` |

## What fell out of it

**Pairing follows the name.** Fidelity names a trade for the reason it happened and names its cash leg to match, so each variant settles through a row type of its own. `assignFidelityGroups` now asks `cashLegType` which cash row a trade settles through instead of assuming one.

**A reinvestment's income is derived.** `Reinvestment From Income` increases a holding with no cash row: the income buys the units without arriving as money, so there is nothing for the source to have reported. The new `reinvestLeg` in `postings.ts` builds it from the posting's own weight -- quantity times price -- rather than the total the broker printed. Those differ by the price's rounding, and taking the broker's would leave the group short by a residual of our choosing rather than one the source has. `REINVEST` also leaves `isCashTxType`, which had been making the converter read a reinvestment's money total as a share count.

**`Cash In` has two roles.** Normally money from outside the account, but a switch settles its sale through the same row type, and no lookup on the broker's name can separate them. Whether the row *paired with a trade* can, so `assignFidelityGroups` now reports which legs it paired as a cash leg and a paired `JRNLFUND` is retyped to `CASHFLOW`. Left alone it would make the trade group read as a transfer and route its residual to `TRANSFER_CLEARING` rather than `IMBALANCE`.

**Two more divergences in the same class.** The client now skips a `Cancelled` row, as the script and the extension already did. And it reads an ISO completion date: one of the two sample exports is ISO throughout, and the client had been rejecting **every one of its 674 rows** over a date format the source itself uses in the column beside it.

**The consideration band widens to 0.75%.** It exists to reject a cash row belonging to a different trade, which misses by whole percentage points. What it has to tolerate is the half-digit the export drops from the price -- worst on a cheap unit, where a fund rebate of 9.24 units at a printed 0.85 is 0.56% out and was being rejected.

## Verified

`make client-test` (296), `make extension-test` (92), `make lint-ts`, both typechecks.

Convergence measured directly -- the two type maps extracted and diffed are identical (33 entries, no differences), and both converters run over both master exports now produce **the same output**:

| | client | script |
| --- | --- | --- |
| Lee, postings | 1032 | 1032 |
| Lee, residual | -377,075.48 | -377,075.48 |
| Helen, postings | 1140 | 1140 |
| Helen, residual | -106,024.19 | -106,024.19 |

Type counts match exactly on both files, and the client reports **zero parse errors** on each -- previously 674 on one and 38 dropped rows on the other.

Every security trade in Helen's export now pairs: 92 trades, 0 ungrouped, against 23 buys and 1 sell stranded before. Unbalanced groups fall from 234 to 221.

One residual is deliberately kept rather than hidden: a `Buy From Rebate` group carries 0.044, because 9.24 units at a printed price of 0.85 is 7.854 against a cash out of 7.81. The price is rounded and the units are not; that is the source disagreeing with itself, and the imbalance report is where it belongs. The test asserts the exact figure.

## Still to come

PR 3 puts cash postings on the spec's `instrument_description` convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)