### PR TITLE
Resolve a Fidelity posting to what it actually is (0065)

### DIFF
--- a/client/lib/csv/converters/fidelity-csv.test.ts
+++ b/client/lib/csv/converters/fidelity-csv.test.ts
@@ -1,6 +1,6 @@
 import { Big } from "@/lib/decimal";
 import { describe, it, expect } from "vitest";
-import { AccountType, TxType } from "@/gen/api/v1/api_pb";
+import { AccountType, IdentifierType, TxType } from "@/gen/api/v1/api_pb";
 import { convertFidelityToStandard, FIDELITY_TYPE_TO_OFX } from "./fidelity-csv";
 import { expectGroupsBalance, residuals } from "@/lib/csv/group-balance.test-utils";
 
@@ -583,6 +583,77 @@ describe("trades the broker names for their reason", () => {
     // The fee and its expense leg; nothing from the trade that never happened.
     expect(result.txs).toHaveLength(2);
     expect(result.txs[0]!.type).toBe(TxType.INVEXPENSE);
+  });
+});
+
+// The export says "Cash" in the same column it names a security in, so reading it
+// through described money as an instrument. A posting is described by, and carries
+// the identifier of, whatever resolves it. See docs/spec/csv-format.md.
+describe("what a posting resolves to", () => {
+  const FULL =
+    "Order date,Completion date,Transaction type,Investments,Product Wrapper,Account Number,Source investment,Amount,Quantity,Price per unit,Reference Number,Status,Exchange,Symbol,Type,Action";
+  const convert = (rows: string[]) =>
+    convertFidelityToStandard([FULL, ...rows].join("\n"), { currency: "GBP" });
+
+  it("describes a cash posting by its currency and hints at it", () => {
+    const result = convert([
+      "2022-01-11,11 Jan 2022,Service Fee,Cash,Cash Management Account,AW10075724,,-3.24,3.24,1,550895422,Completed,,GBP,CASH,Cash",
+    ]);
+
+    expect(result.txs[0]!.instrumentDescription).toBe("GBP");
+    expect(result.txs[0]!.identifierHints.map((h) => [h.type, h.value])).toEqual([
+      [IdentifierType.CURRENCY, "GBP"],
+    ]);
+    // Including the expense leg it balances against, which was already money.
+    expect(result.txs[1]!.instrumentDescription).toBe("GBP");
+  });
+
+  it("describes a dividend by the currency it paid, not the payer", () => {
+    // Source investment names the security that paid it. Describing the posting
+    // by the payer would resolve the money into that holding; carrying the payer
+    // elsewhere is 0049's to decide.
+    const result = convert([
+      '2022-02-11,11 Feb 2022,Cash Dividend,Cash,Investment ISA,AS10123702,"BAILLIE GIFFORD EUROPEAN GROWTH TST, ORD GBP0.025 (BGEU)",22.67,22.67,1,564233724,Completed,,GBP,CASH,Cash',
+    ]);
+
+    expect(result.txs[0]!.instrumentDescription).toBe("GBP");
+    expect(result.txs[0]!.type).toBe(TxType.INCOME);
+  });
+
+  it("keeps a security's own description and offers its ticker", () => {
+    const result = convert([
+      '2022-02-08,10 Feb 2022,Sell,"WISE PLC, CLS A ORD GBP0.01 (WISE)",SIPP - Pension Savings Account,AP10013127,,-7266.49,1242,5.85,563466569,Completed,LON,WISE,STOCK,Sell',
+    ]);
+
+    expect(result.txs[0]!.instrumentDescription).toContain("WISE PLC");
+    expect(result.txs[0]!.identifierHints.map((h) => [h.type, h.value, h.domain])).toEqual([
+      [IdentifierType.MIC_TICKER, "WISE", "XLON"],
+    ]);
+  });
+
+  it("offers no ticker for a fund, which has none to offer", () => {
+    // The export repeats the fund's name in the symbol column, against a real
+    // exchange. Passing that on as a ticker would resolve to nothing and leave the
+    // name in the security master twice, so the row goes on its description alone.
+    const result = convert([
+      "2022-03-24,06 Apr 2022,Reinvestment From Income,Baillie Gifford Responsible Global Equity Income B Inc,Investment ISA,AS10123702,,31.65,21.09,1.5,582193319,Completed,LON,Baillie Gifford Responsible Global Equity Income B Inc,FUND,Buy",
+    ]);
+
+    expect(result.txs[0]!.identifierHints).toEqual([]);
+    expect(result.txs[0]!.instrumentDescription).toContain("Baillie Gifford");
+  });
+
+  it("names the exchange a ticker belongs to, where it knows the MIC", () => {
+    // A ticker identifies an instrument only within an exchange. An exchange with
+    // no MIC here is passed on bare rather than under a guess.
+    const result = convert([
+      '2024-06-03,05 Jun 2024,Buy,"RHEINMETALL AG, ORD NPV (RHM)",Investment Account,AG10041188,,5000,10,500,1000000001,Completed,ETR,RHM,STOCK,Buy',
+      '2024-06-03,05 Jun 2024,Buy,"SAFRAN SA, ORD EUR0.20 (SAF)",Investment Account,AG10041188,,5000,25,200,1000000002,Completed,XXX,SAF,STOCK,Buy',
+    ]);
+
+    expect(result.txs[0]!.identifierHints[0]!.domain).toBe("XETR");
+    expect(result.txs[1]!.identifierHints[0]!.value).toBe("SAF");
+    expect(result.txs[1]!.identifierHints[0]!.domain).toBe("");
   });
 });
 

--- a/client/lib/csv/converters/fidelity-csv.ts
+++ b/client/lib/csv/converters/fidelity-csv.ts
@@ -10,13 +10,24 @@ import { create } from "@bufbuild/protobuf";
 import { timestampFromDate } from "@bufbuild/protobuf/wkt";
 import { startOfNextDay } from "@/lib/dates";
 import type { Tx } from "@/gen/api/v1/api_pb";
-import { TxSchema, TxType } from "@/gen/api/v1/api_pb";
+import { IdentifierType, InstrumentIdentifierSchema, TxSchema, TxType } from "@/gen/api/v1/api_pb";
 import type { StandardParseResult, ParseError } from "@/lib/csv/standard";
 import { parseCSVLine } from "@/lib/csv/standard";
-import { counterLegs } from "@/lib/csv/postings";
+import { counterLegs, currencyHint } from "@/lib/csv/postings";
 import { Big, parseDecimal } from "@/lib/decimal";
 
 const ZERO = new Big(0);
+
+/**
+ * Fidelity exchange name to ISO 10383 MIC. These three are what the sample exports
+ * use; a symbol whose exchange is not named here is passed on without a domain
+ * rather than under a guess.
+ */
+const MIC_BY_EXCHANGE: Record<string, string> = {
+  LON: "XLON",
+  ETR: "XETR",
+  EPA: "XPAR",
+};
 
 const FIDELITY_DATE_FORMAT = /^(\d{1,2})\s+([A-Za-z]{3})\s+(\d{4})$/;
 const ISO_DATE_FORMAT = /^(\d{4})-(\d{2})-(\d{2})$/;
@@ -448,6 +459,8 @@ export function convertFidelityToStandard(
   const priceCol = col("price_per_unit");
   const refCol = col("reference_number");
   const statusCol = col("status");
+  const symbolCol = col("symbol");
+  const exchangeCol = col("exchange");
   // The asset class of the row's instrument (CASH, ETF, STOCK, FUND), which is
   // what says whether a Buy or Sell transacted a security or the account's cash.
   // Distinct from "Transaction type"; an export without it falls back to the
@@ -499,7 +512,14 @@ export function convertFidelityToStandard(
     const cashAsset = assetClass ? assetClass === "CASH" : investments === "Cash";
     const ofxType = typeForAsset(mappedType, cashAsset);
 
-    const instrumentDescription = investments || "Cash";
+    // A cash posting is described by its currency, which is what resolves it to
+    // the currency instrument rather than to a holding named after the broker's
+    // wording. The export says "Cash" in the same column it names a security in,
+    // so reading it through produced a security called Cash. See
+    // docs/spec/csv-format.md.
+    const instrumentDescription = isCashMovement(ofxType)
+      ? currency
+      : investments || txTypeStr;
     const account = accountCol >= 0 ? get(accountCol) : "";
     const qtyStr = get(qtyCol);
     const amountStr = amountCol >= 0 ? get(amountCol) : "";
@@ -519,6 +539,28 @@ export function convertFidelityToStandard(
     }
     const priceStr = priceCol >= 0 ? get(priceCol) : "";
     const unitPriceDec = parseDecimal(priceStr);
+
+    // A cash posting resolves to its currency; a security one to its ticker, which
+    // the export gives against an exchange name. A fund has no ticker and the export
+    // repeats its name in the symbol column instead, which would resolve to nothing
+    // and pollute the security master, so only a listed asset class offers one.
+    const symbol = symbolCol >= 0 ? get(symbolCol) : "";
+    const exchange = exchangeCol >= 0 ? get(exchangeCol) : "";
+    const listed = assetClass !== "FUND";
+    const identifierHints = isCashMovement(ofxType)
+      ? currency
+        ? [currencyHint(currency)]
+        : []
+      : symbol && exchange && listed
+        ? [
+            create(InstrumentIdentifierSchema, {
+              type: IdentifierType.MIC_TICKER,
+              value: symbol,
+              canonical: false,
+              ...(MIC_BY_EXCHANGE[exchange] ? { domain: MIC_BY_EXCHANGE[exchange] } : {}),
+            }),
+          ]
+        : [];
 
     const ts = date.getTime();
     if (ts < minTime) minTime = ts;
@@ -553,6 +595,7 @@ export function convertFidelityToStandard(
         ...(isCashTxType(ofxType) ? { tradingCurrency: currency } : {}),
         // Presence, not truthiness: a reported price of zero is a price.
         ...(unitPriceDec !== undefined ? { unitPrice: unitPriceDec.toString() } : {}),
+        ...(identifierHints.length > 0 ? { identifierHints } : {}),
       })
     );
   }

--- a/client/lib/csv/postings.ts
+++ b/client/lib/csv/postings.ts
@@ -64,6 +64,18 @@ export function counterLeg(tx: Tx): Tx | undefined {
 }
 
 /**
+ * The hint that resolves a posting to a currency rather than to a holding named
+ * after its description.
+ */
+export function currencyHint(currency: string) {
+  return create(InstrumentIdentifierSchema, {
+    type: IdentifierType.CURRENCY,
+    value: currency,
+    canonical: false,
+  });
+}
+
+/**
  * A money posting derived beside one the source reported, in the same group.
  *
  * The instrument description is the currency code, matching how an ordinary cash
@@ -84,13 +96,7 @@ function moneyLeg(from: Tx, type: TxType, accountType: AccountType, quantity: Bi
       ? {
           tradingCurrency: currency,
           settlementCurrency: currency,
-          identifierHints: [
-            create(InstrumentIdentifierSchema, {
-              type: IdentifierType.CURRENCY,
-              value: currency,
-              canonical: false,
-            }),
-          ],
+          identifierHints: [currencyHint(currency)],
         }
       : {}),
   });

--- a/docs/issues/0049-dividend-attribution-to-paying-security.md
+++ b/docs/issues/0049-dividend-attribution-to-paying-security.md
@@ -3,12 +3,18 @@ status: open
 title: Attribute cash dividends to the security that paid them
 ---
 
-A cash dividend currently resolves to the cash instrument with the description
-"Cash", losing which holding generated it. The spec says an income transaction
-should carry the description of the generating security
-(see spec/portfoliodb-spec.md), and Fidelity supplies it: the CSV has a
-`Source investment` column, and the underlying JSON carries `linkedAssetName`
-together with a real `linkedAssetIsin`.
+A cash dividend resolves to the cash instrument and carries no record of which
+holding generated it. The spec says an income transaction should carry the
+description of the generating security (see spec/portfoliodb-spec.md), and
+Fidelity supplies it: the CSV has a `Source investment` column, and the
+underlying JSON carries `linkedAssetName` together with a real `linkedAssetIsin`.
+
+The Fidelity converters now describe a cash posting by its currency and hint at
+the currency, so the payer is not merely unused -- it is dropped. Before 0065 the
+conversion script put `Source investment` in the description, which is one of the
+options below taken by accident rather than by decision, and the client never
+carried it at all. Whichever option is chosen has to put the payer somewhere
+deliberately.
 
 The decision to make is how income is modelled. The dividend increases **cash**,
 so the paying security must not become the transaction's instrument or the payout

--- a/docs/issues/0065-fidelity-cash-rows-typed-as-sell.md
+++ b/docs/issues/0065-fidelity-cash-rows-typed-as-sell.md
@@ -1,32 +1,46 @@
 ---
-status: open
+status: closed
 title: Fidelity cash rows typed as Sell become bogus security transactions
 milestone: M12
 ---
 
-The client Fidelity converter turns 13 rows in the sample export into `SELLSTOCK`
+The client Fidelity converter turned 13 rows in the sample export into `SELLSTOCK`
 transactions against an instrument described as "Cash".
 
 ## The problem
 
-Fidelity labels some pure cash movements with `Transaction type = Sell`. They are
-identifiable: `Action = Cash`, `Type = CASH`, and `Investments = Cash`. The client
-converter maps on `Transaction type` alone
-(`FIDELITY_TYPE_TO_OFX` in client/lib/csv/converters/fidelity-csv.ts), so each one
-becomes a negative-quantity `SELLSTOCK` whose instrument description is "Cash" --
-a security position that does not exist, sold in units of money.
+Fidelity models an account's cash as a tradable asset, so money leaving an account
+is reported as a sale of cash and money arriving as a purchase of it. Both
+converters mapped on `Transaction type` alone, so each of those rows became a
+security position bought or sold in units of money.
 
-`local/scripts/convert-fidelity.py` does not have the bug: it keys off the `Action`
-column first and drops these rows. The two converters therefore disagree about which
-rows survive, which is its own problem -- the script is meant to produce the same
-standard CSV the client would.
+The rows arrive as a triplet with consecutive reference numbers -- the movement,
+the trade of cash, and its cash leg -- and the last two net to zero. Posting the
+trade of cash onto a phantom security left only the cash leg, so an account that
+transferred 401 out netted nothing on the day while the receiving account still
+recorded the credit. 22 rows across the two sample exports, the largest 200,500.
+`local/scripts/convert-fidelity.py` had the same error by the opposite route: it
+dropped the `Sell` row and kept the orphan credit.
 
-## Design
+## What was done
 
-Classify on `Action` / `Type` rather than `Transaction type` alone, in both
-converters, and treat a `Sell` row whose instrument is cash as the cash movement it
-is. The extension's JSON payload carries neither column, so check which of its fields
-distinguishes the same rows before assuming the fix carries over.
+Classify on the asset rather than the transaction type. The CSV export says so in
+its `Type` column; the extension payload has no equivalent, and the answer there
+is the ISIN check digit, which `isValidIsin` already computed to keep Fidelity's
+cash pseudo-identifiers out of the security master. A trade of cash is a
+`CASHFLOW` that groups with the cash row beside it and weighs nothing, leaving the
+withdrawal or transfer as the money that moved.
 
-Found while adding transaction grouping (0064). It predates that work: grouping
-neither causes it nor makes it worse.
+The two converters also disagreed about which rows survived. That is now closed:
+eleven types the client rejected are mapped, a cancelled row is skipped by both,
+and the client reads the ISO dates one of the two exports carries throughout --
+it had been rejecting all 674 of its rows over a date format the source uses in
+the column beside it. Both converters now produce identical output on both master
+exports.
+
+Cash postings carry their currency as the description and the `CURRENCY`
+identifier hint, per docs/spec/csv-format.md, so nothing is described as "Cash"
+any more. See 0049 for what that means for dividend attribution.
+
+Found while adding transaction grouping (0064). It predated that work: grouping
+neither caused it nor made it worse.

--- a/docs/issues/0069-fidelity-duplicated-cash-in-rows.md
+++ b/docs/issues/0069-fidelity-duplicated-cash-in-rows.md
@@ -28,7 +28,9 @@ same shape and the same two duplicated credits.
 
 Both `Cash In` and `Cash In Lump Sum` map to `TxType.JRNLFUND` in
 client/lib/csv/converters/fidelity-csv.ts, so both post and the receiving account
-gains twice the transferred amount.
+gains twice the transferred amount. Since 0065 a `Cash In` that pairs with a trade
+is retyped to `CASHFLOW`, which does not touch these: neither of the two pairs
+with anything.
 
 ## What to establish
 
@@ -42,12 +44,15 @@ gains twice the transferred amount.
   subscription semantics and `Cash In` the movement, but the reference ordering
   is the opposite of that reading and the two are not consistently ordered.
 
-## Adjacent, probably not the same problem
+## Adjacent, explained by 0065
 
 `Cash In For Transfer` and `Cash Out For Buy From Transfer` appear as equal and
-opposite same-account, same-day pairs, twice, in the SIPP. They net to zero so
-they do not inflate a balance, but both are also mapped to `JRNLFUND` and they
-should be understood before the mapping is changed.
+opposite same-account, same-day pairs, twice, in the SIPP. They are not a pair:
+each sits in a triplet with a `Buy` row against Fidelity's cash pseudo-ISIN, and
+it is that `Buy` the `Cash Out For Buy From Transfer` cancels. 0065 types the
+`Buy` as the cash movement it is and groups the two, which leaves the
+`Cash In For Transfer` posting once, as the arrival it is. Nothing here is a
+duplicate.
 
 ## Why it matters here
 

--- a/extension/src/brokers/fidelity-json.test.ts
+++ b/extension/src/brokers/fidelity-json.test.ts
@@ -129,13 +129,24 @@ describe("convertFidelityJson", () => {
     expect(total.eq(0)).toBe(true);
   });
 
-  it("emits no identifier hint for a cash pseudo-ISIN", () => {
-    // These appear on Buy and Sell rows too, so the transaction type cannot be
-    // used to decide whether a row names a real security.
+  it("resolves a cash posting to its currency, never to a pseudo-ISIN", () => {
+    // The pseudo-identifiers appear on Buy and Sell rows too, so the transaction
+    // type cannot be used to decide whether a row names a real security. Nothing
+    // is passed on that would resolve to a fictional instrument.
+    const result = convertFidelityJson(json(SERVICE_FEE));
+    expect(result.txs[0]!.instrumentDescription).toBe("GBP");
+    expect(result.txs[0]!.identifierHints.map((h) => [h.type, h.value])).toEqual([
+      [IdentifierType.CURRENCY, "GBP"],
+    ]);
+  });
+
+  it("describes a cash posting by its currency even when the row names a payer", () => {
+    // assetName carries "Relationship Cash Source" on some rows and the paying
+    // security's name on others. Either would resolve the money into a holding.
     const result = convertFidelityJson(
-      json({ ...BUY, isin: "AA00S0000000", sedol: "S000000", assetName: "Cash" })
+      json({ ...SERVICE_FEE, transactionType: "Cash Dividend", assetName: "Relationship Cash Source", isin: "AA00K0000000", debitCreditIndicator: "CREDIT" })
     );
-    expect(result.txs[0]!.identifierHints).toEqual([]);
+    expect(result.txs[0]!.instrumentDescription).toBe("GBP");
   });
 
   it("falls back to the order date when a transaction has not settled", () => {
@@ -219,7 +230,11 @@ describe("convertFidelityJson cash-asset rows", () => {
     expect(tx.type).toBe(TxType.CASHFLOW);
     expect(tx.quantity).toBe("12772.83");
     expect(tx.tradingCurrency).toBe("GBP");
-    expect(tx.identifierHints).toEqual([]);
+    // Money, so it resolves to the currency and never to the pseudo-ISIN the row
+    // carries.
+    expect(tx.identifierHints.map((h) => [h.type, h.value])).toEqual([
+      [IdentifierType.CURRENCY, "GBP"],
+    ]);
   });
 
   it("groups a purchase of cash with the cash out beside it", () => {

--- a/extension/src/brokers/fidelity-json.ts
+++ b/extension/src/brokers/fidelity-json.ts
@@ -25,7 +25,7 @@ import {
   typeForAsset,
 } from "@/lib/csv/converters/fidelity-csv";
 import type { ParseError, StandardParseResult } from "@/lib/csv/standard";
-import { counterLegs } from "@/lib/csv/postings";
+import { counterLegs, currencyHint } from "@/lib/csv/postings";
 import { Big, decimalFromNumber } from "@/lib/decimal";
 import { parseSlashDate } from "../lib/dates";
 
@@ -152,24 +152,31 @@ export function convertFidelityJson(
 
     const currency = row.currency ?? "";
     const sedol = row.sedol ?? "";
-    const identifierHints = isValidIsin(isin)
-      ? [
-          create(InstrumentIdentifierSchema, {
-            type: IdentifierType.ISIN,
-            value: isin,
-            canonical: false,
-          }),
-          ...(sedol
-            ? [
-                create(InstrumentIdentifierSchema, {
-                  type: IdentifierType.SEDOL,
-                  value: sedol,
-                  canonical: false,
-                }),
-              ]
-            : []),
-        ]
-      : [];
+    // A cash movement resolves to its currency; anything else to the security its
+    // identifiers name. The pseudo-identifiers a cash row carries would resolve to
+    // a fictional instrument, so they are never passed on.
+    const identifierHints = isCashMovement(ofxType)
+      ? currency
+        ? [currencyHint(currency)]
+        : []
+      : isValidIsin(isin)
+        ? [
+            create(InstrumentIdentifierSchema, {
+              type: IdentifierType.ISIN,
+              value: isin,
+              canonical: false,
+            }),
+            ...(sedol
+              ? [
+                  create(InstrumentIdentifierSchema, {
+                    type: IdentifierType.SEDOL,
+                    value: sedol,
+                    canonical: false,
+                  }),
+                ]
+              : []),
+          ]
+        : [];
 
     const ts = date.getTime();
     if (ts < minTime) minTime = ts;
@@ -195,7 +202,13 @@ export function convertFidelityJson(
     txs.push(
       create(TxSchema, {
         timestamp: timestampFromDate(date),
-        instrumentDescription: row.assetName || "Cash",
+        // A cash posting is described by its currency, which is what resolves it
+        // to the currency instrument rather than to a holding named after the
+        // broker's wording -- the payload says "Cash" in the same field it names
+        // a security in. See docs/spec/csv-format.md.
+        instrumentDescription: isCashMovement(ofxType)
+          ? currency || typeStr
+          : row.assetName || typeStr,
         type: ofxType,
         quantity,
         account: row.accountNumber ?? "",


### PR DESCRIPTION
Last of three for 0065. **Stacked on #334**, which is stacked on #333 -- review those first.

Three conventions were in use for a cash posting's `instrument_description`: the client emitted the literal `"Cash"`, the conversion script substituted `Source investment` or the transaction type, and derived legs from `feeLeg` already emitted the currency code -- which is what [docs/spec/csv-format.md](docs/spec/csv-format.md) specifies.

The export says "Cash" in the same column it names a security in, so reading it through described money as an instrument. That is the description 0065's bogus sell rows appeared under.

## Cash resolves to its currency

Both converters now describe a cash posting by its currency and carry the `CURRENCY` identifier hint that resolves it, so a reported cash row and one derived by `feeLeg` are indistinguishable downstream. `currencyHint` is factored out of `postings.ts` and shared.

## Securities resolve to their ticker

Found while doing the above: the client emitted **no identifier hint at all** for a security, while the script emitted `MIC_TICKER`. The same export therefore resolved differently depending on which route it took. Both now offer the ticker with the MIC of the exchange it belongs to.

Two corrections that fell out of it:

- **No ticker for a fund.** The export repeats the fund's name in the symbol column, against a real exchange. Passing that on as a ticker would resolve to nothing and leave the name in the security master twice. 19 rows in one export.
- **ETR and EPA join the MIC map**, which had only LON. Eight rows trade on Xetra and Euronext Paris and were losing their exchange; a ticker identifies an instrument only within one. An exchange with no MIC here is still passed on bare rather than under a guess.

## Verified

`make client-test` (301), `make extension-test` (93), `make lint-ts`, both typechecks.

Both converters run over both master exports still produce identical output, and every posting now carries the identifier that resolves it:

| | Lee | Helen |
| --- | --- | --- |
| postings | 1032 | 1140 |
| `CURRENCY` | 961 | 1048 |
| `MIC_TICKER` with a MIC | 71 (XLON 63, XETR 4, XPAR 4) | 73 (XLON) |
| no hint | 0 | 19 (the funds) |
| distinct cash descriptions | `GBP` | `GBP` |

Group counts and residuals are unchanged from #334 -- this PR moves descriptions and hints, not money. No posting anywhere in either output is described as `Cash`.

## One thing this drops

The script had been putting `Source investment` -- the security that paid a dividend -- into the description of the cash row. That is one of the options 0049 is open to decide between, taken by accident rather than by decision, and the client never carried it at all. 0049 is amended here to record that the payer is now dropped rather than merely unused, so whichever option it settles on has to put the payer somewhere deliberately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)