### PR TITLE
Group the run a Fidelity deposit is reported through (0069)

### DIFF
--- a/client/lib/csv/converters/fidelity-csv.test.ts
+++ b/client/lib/csv/converters/fidelity-csv.test.ts
@@ -472,6 +472,130 @@ describe("transaction grouping", () => {
   });
 });
 
+// Money paid into a product account is reported as a run of three rows of the
+// same amount -- the subscription credited, spent, and credited again as the
+// money that lands -- with no security anywhere in it. Every row below is
+// verbatim from the master exports. Left ungrouped the run is three
+// single-posting groups, two of them JRNLFUND, so the account reports twice the
+// contribution it received and a residual the size of the deposit lands in
+// IMBALANCE.
+describe("deposits into a product account", () => {
+  const FULL =
+    "Order date,Completion date,Transaction type,Investments,Product Wrapper,Account Number,Source investment,Amount,Quantity,Price per unit,Reference Number,Status,Exchange,Symbol,Type,Action";
+  const convert = (rows: string[]) =>
+    convertFidelityToStandard([FULL, ...rows].join("\n"), { currency: "GBP" });
+
+  // The 2025-04-15 lump sum into Lee's ISA, and the cash management account row
+  // that paid for it.
+  const LUMP_SUM =
+    "2025-04-15,2025-04-15,Cash In Lump Sum,Cash,Investment ISA,AS10110796,,20000,20000,1,1093663545,Completed,,GBP,CASH,Cash";
+  const SPEND =
+    "2025-04-15,2025-04-15,Cash Out For Buy,Cash,Investment ISA,AS10110796,,-20000,20000,1,1093663546,Completed,,GBP,CASH,Cash";
+  const DEPARTURE =
+    "2025-04-15,2025-04-15,Transfer Out From Cash Management Account,Cash,Cash Management Account,AW10075724,,-20000,20000,1,1093663547,Completed,,GBP,CASH,Cash";
+  const ARRIVAL =
+    "2025-04-15,2025-04-15,Cash In,Cash,Investment ISA,AS10110796,,20000,20000,1,1093663548,Completed,,GBP,CASH,Cash";
+
+  it("groups the run so one deposit leaves one residual, not three", () => {
+    const result = convert([LUMP_SUM, SPEND, DEPARTURE, ARRIVAL]);
+
+    expect(result.errors).toEqual([]);
+    expect(result.txs.map((tx) => tx.groupRef)).toEqual([
+      "1093663545",
+      "1093663545",
+      "",
+      "1093663545",
+    ]);
+    // What each account is left with: the arrival and the departure it answers,
+    // equal and opposite, which is the pair 0068 has to match. Ungrouped the ISA
+    // offered two identical credits and an unexplained debit instead.
+    expect(residuals(result.txs)).toEqual({
+      "1093663545": { GBP: "20000" },
+      "#2": { GBP: "-20000" },
+    });
+  });
+
+  it("keeps the run's journals so its residual reads as a transfer", () => {
+    // The group has to carry a JRNLFUND for the server to route its residual to
+    // TRANSFER_CLEARING rather than IMBALANCE, so nothing here is retyped the way
+    // a trade's cash leg is.
+    const result = convert([LUMP_SUM, SPEND, ARRIVAL]);
+
+    expect(result.txs.map((tx) => tx.type)).toEqual([
+      TxType.JRNLFUND,
+      TxType.CASHFLOW,
+      TxType.JRNLFUND,
+    ]);
+  });
+
+  it("leaves a lump sum with no run to post on its own", () => {
+    // A deposit straight into the cash management account is money from outside
+    // with nothing beside it to cancel. All three in the sample are this shape.
+    const result = convert([
+      "2024-05-30,2024-05-30,Cash In Lump Sum,Cash,Cash Management Account,AW10075724,,19999,19999,1,944992689,Completed,,GBP,CASH,Cash",
+    ]);
+
+    expect(result.txs).toHaveLength(1);
+    expect(result.txs[0]!.groupRef).toBe("");
+    expect(result.txs[0]!.type).toBe(TxType.JRNLFUND);
+  });
+
+  it("groups a run whose rows settled on different days", () => {
+    // From the Helen export: the subscription and its spend completed on the 11th
+    // and the arrival on the 14th, so the settlement date the trade passes group
+    // on would split this run. The reference run does not.
+    const result = convert([
+      "2022-11-14,11 Nov 2022,Cash In Lump Sum,Cash,Investment Account,AG10045534,,19996,19996,1,681655048,Completed,,GBP,CASH,Cash",
+      "2022-11-14,11 Nov 2022,Cash Out For Buy,Cash,Investment Account,AG10045534,,-19996,19996,1,681655049,Completed,,GBP,CASH,Cash",
+      "2022-11-14,14 Nov 2022,Cash In,Cash,Investment Account,AG10045534,,19996,19996,1,681655050,Completed,,GBP,CASH,Cash",
+    ]);
+
+    expect(result.txs.map((tx) => tx.groupRef)).toEqual([
+      "681655048",
+      "681655048",
+      "681655048",
+    ]);
+  });
+
+  it("separates two runs of nearly equal amount in one account", () => {
+    // Both completed on the 14th, 19,996 and 19,995, references interleaved. Only
+    // the amount agreeing to the penny keeps one run's rows out of the other's.
+    const result = convert([
+      "2022-11-14,14 Nov 2022,Cash In Lump Sum,Cash,Investment Account,AG10045534,,19995,19995,1,681727827,Completed,,GBP,CASH,Cash",
+      "2022-11-14,14 Nov 2022,Cash In,Cash,Investment Account,AG10045534,,19996,19996,1,681655050,Completed,,GBP,CASH,Cash",
+      "2022-11-14,14 Nov 2022,Cash Out For Buy,Cash,Investment Account,AG10045534,,-19995,19995,1,681727828,Completed,,GBP,CASH,Cash",
+      "2022-11-14,14 Nov 2022,Cash In,Cash,Investment Account,AG10045534,,19995,19995,1,681727829,Completed,,GBP,CASH,Cash",
+    ]);
+
+    expect(result.txs.map((tx) => tx.groupRef)).toEqual([
+      "681727827",
+      "",
+      "681727827",
+      "681727827",
+    ]);
+  });
+
+  it("does not take a cash row the day's trade needs", () => {
+    // The same day's ISA buy, with its own cash row 40.8k references away. A run
+    // is built only from what the trade passes left, so neither claims the other's.
+    const result = convert([
+      LUMP_SUM,
+      SPEND,
+      ARRIVAL,
+      "2025-04-15,2025-04-17,Cash Out For Buy,Cash,Investment ISA,AS10110796,,-19969.2,19969.2,1,1093663610,Completed,,GBP,CASH,Cash",
+      '2025-04-15,2025-04-17,Buy,"VANECK UCITS ETFS PLC, SEMICONDUCTOR UCITS ETF A GBP ACC (SMGB)",Investment ISA,AS10110796,,19976.7,769,25.97,1093663611,Completed,LON,SMGB,ETF,Buy',
+    ]);
+
+    expect(result.txs.map((tx) => tx.groupRef)).toEqual([
+      "1093663545",
+      "1093663545",
+      "1093663545",
+      "1093663611",
+      "1093663611",
+    ]);
+  });
+});
+
 // Fidelity names a trade for the reason it happened, and names its cash leg to
 // match. Every row below is verbatim from the Helen export; before these types
 // were mapped the client rejected each one while the conversion script kept it,

--- a/client/lib/csv/converters/fidelity-csv.ts
+++ b/client/lib/csv/converters/fidelity-csv.ts
@@ -245,6 +245,34 @@ const SELL_ROWS = ["Sell", "Sell For Switch"];
 const BUY_ROWS = ["Buy", "Buy From Dividend", "Buy From Rebate", "Buy For Switch"];
 
 /**
+ * The rows a deposit into a product account is reported through, after the
+ * `Cash In Lump Sum` that opens it.
+ *
+ * Money paid into a wrapper arrives as a run of three rows of the same amount:
+ * the subscription is credited, spent, and credited again as the money that
+ * lands. No security is involved -- the `Cash Out For Buy` here has no `Buy`
+ * anywhere beside it -- and the three are one event, so they belong in one group.
+ * Left ungrouped they are three single-posting groups, two of them JRNLFUND, so
+ * the account reports twice the contribution it received and a residual the size
+ * of the deposit lands in IMBALANCE.
+ */
+const DEPOSIT_ROWS = ["Cash Out For Buy", "Cash In"];
+
+/**
+ * Widest reference-number gap tolerated between the row that opens a deposit and
+ * a member of it.
+ *
+ * The run ascends from the `Cash In Lump Sum` and is usually consecutive. The
+ * widest in the sample exports is 7, where a cash management account leg is
+ * numbered inside the run. What actually separates one deposit from another is
+ * the account, the amount agreeing to the penny, and the trade passes having
+ * already taken the cash rows they need: every span from 7 to 1000 groups the
+ * same 21 runs across both masters. So this is a guard against a distant
+ * coincidence rather than a discriminator.
+ */
+const DEPOSIT_REF_SPAN = 8;
+
+/**
  * The broker type of the cash row a trade settles through, or "" for a row that
  * is not a trade.
  *
@@ -376,6 +404,45 @@ export function assignFidelityGroups(legs: FidelityLeg[]): FidelityGroups {
     usedBuy.add(buy);
     usedCash.add(cash);
     pair(buy, cash);
+  }
+
+  // Deposits, last: a run is only ever built from cash rows the trade passes did
+  // not want, which is what stops a deposit taking the cash row of a trade of the
+  // same amount on the same day.
+  //
+  // Identified by account, amount and reference proximity rather than by
+  // bucket(). One run in the sample exports settles across two days -- the lump
+  // sum and its spend complete on the 11th, the arrival on the 14th -- so the
+  // date the trade passes group on would split it, while the reference run holds
+  // in all 21.
+  for (const s of indices("Cash In Lump Sum")) {
+    const members: number[] = [];
+    for (const type of DEPOSIT_ROWS) {
+      let best: number | undefined;
+      for (const c of indices(type)) {
+        if (usedCash.has(c)) continue;
+        if (legs[c].account !== legs[s].account) continue;
+        const gap = legs[c].ref - legs[s].ref;
+        if (gap <= 0 || gap > DEPOSIT_REF_SPAN) continue;
+        if (Math.abs(Math.abs(legs[c].amount) - Math.abs(legs[s].amount)) >= AMOUNT_EPSILON) {
+          continue;
+        }
+        if (best === undefined || legs[c].ref < legs[best].ref) best = c;
+      }
+      if (best !== undefined) {
+        members.push(best);
+        usedCash.add(best);
+      }
+    }
+    // A lump sum with no run is money paid in from outside -- the sample has
+    // three, all into a cash management account -- and stands on its own.
+    if (members.length === 0) continue;
+    // Only the group ref. None of these is a trade's cash leg, and the group
+    // needs to keep its JRNLFUND legs: they are what routes its residual to
+    // TRANSFER_CLEARING, where the departure it answers is also waiting.
+    const ref = String(legs[s].ref);
+    refs[s] = ref;
+    for (const m of members) refs[m] = ref;
   }
 
   return { refs, cashLegs };

--- a/docs/issues/0040-csv-fees-net-amount.md
+++ b/docs/issues/0040-csv-fees-net-amount.md
@@ -91,7 +91,10 @@ masters are disjoint, the CSV ending 2025-01-06 and the QFX starting 2025-01-23.
 - Fidelity `JRNLFUND` and `TRANSFER` single-posting groups, about 636k and 200k --
   external transfers, matched by 0068.
 - Helen-Fidelity's 23 unpaired `BUYSTOCK` groups and one `SELLSTOCK` -- trade and
-  cash pairing failures, 0065 and 0069.
+  cash pairing failures. Closed by 0065: neither master leaves an unpaired trade
+  group now. 0069 was a different failure in the same list -- a lone `CASHFLOW`
+  group per deposit, 8 in Lee and 13 in Helen -- and closing it left none of those
+  either.
 - Schwab's three groups worth 667,750 -- the export's quantities are split adjusted
   while its prices are as traded, so pre-split GOOG and TSLA rows cannot balance.
   That is 0057.

--- a/docs/issues/0068-match-in-flight-transfers.md
+++ b/docs/issues/0068-match-in-flight-transfers.md
@@ -87,9 +87,13 @@ designed for is real in principle -- a cross-broker transfer -- but there is no
 sample of one, so it cannot be calibrated against the masters the way the
 existing converter pairing rules were.
 
-The last two rows of that table are two credits into one account against a single
-arrival, which may be a double count. That is 0069, not this issue, but matching
-cannot be calibrated against the sample until it is settled.
+The last two rows of that table are two of the three rows a deposit into a product
+account is reported through, the third being a debit that cancels one of them.
+0069 settles that: the three are one group, so the ISA offers this issue a single
+`TRANSFER_CLEARING` arrival against the cash management account's equal and
+opposite departure. Before it the account offered two identical arrivals, either
+of which the matcher could have taken, leaving the other unmatched and therefore
+external for good.
 
 ## Design
 

--- a/docs/issues/0069-fidelity-duplicated-cash-in-rows.md
+++ b/docs/issues/0069-fidelity-duplicated-cash-in-rows.md
@@ -1,48 +1,81 @@
 ---
-status: open
-title: Investigate duplicated cash-in rows on Fidelity transfers
+status: closed
+title: Group the run a Fidelity deposit into a product account is reported through
 milestone: M12
 ---
 
-A transfer arriving in a Fidelity product account is reported as two credit rows
-of the same amount against a single departure, and the converter maps both to
-`JRNLFUND`, so the arrival is posted twice.
+Money paid into a Fidelity product account is reported as three rows of the same
+amount and the converter left all three ungrouped, so the account reported twice
+the contribution it received.
 
 ## Evidence
 
-`local/HAR/transactions-long-window.json` contains the pattern twice,
-identically. A lump sum leaves the cash management account once and arrives as
-two credits of the same amount. Accounts are named here by product type, and
-references by their offset from the first row of the sequence:
+The sequence below is verbatim from `local/HAR/transactions-long-window.json` and
+from both master CSV exports (2025-04-15, every row `Type=CASH`, every amount
+GBP 20,000). Accounts are named by product type; references by their last three
+digits.
 
-| account                 | ref  | type                                      | dr/cr  |
-| ----------------------- | ---- | ----------------------------------------- | ------ |
-| Investment Fund         | n    | Transfer To Cash Management Account        | DEBIT  |
-| Cash Management Account | n+3  | Transfer Into Account                      | CREDIT |
-| ISA                     | n+17 | Cash In Lump Sum                           | CREDIT |
-| Cash Management Account | n+19 | Transfer Out From Cash Management Account  | DEBIT  |
-| ISA                     | n+20 | Cash In                                    | CREDIT |
+| ref  | account         | type                                      | dr/cr  | emitted  |
+| ---- | --------------- | ----------------------------------------- | ------ | -------- |
+| ...528 | Investment Acct | Transfer To Cash Management Account      | DEBIT  | TRANSFER |
+| ...529 | Investment Acct | Sell (of Cash)                           | DEBIT  | CASHFLOW |
+| ...530 | Investment Acct | Cash In From Sell                        | CREDIT | CASHFLOW |
+| ...531 | Cash Mgmt       | Transfer Into Account                    | CREDIT | TRANSFER |
+| ...545 | ISA             | Cash In Lump Sum                         | CREDIT | JRNLFUND |
+| ...546 | ISA             | Cash Out For Buy                         | DEBIT  | CASHFLOW |
+| ...547 | Cash Mgmt       | Transfer Out From Cash Management Account | DEBIT  | TRANSFER |
+| ...548 | ISA             | Cash In                                  | CREDIT | JRNLFUND |
 
-Every row carries the same amount. The sequence recurs a year later with the
-same shape and the same two duplicated credits.
+No security appears anywhere in it. The `Cash Out For Buy` at ...546 has no `Buy`:
+the ISA's real trade that day is a `Buy` of SMGB for 19,976.70 (...611) with its
+own `Cash Out For Buy` of 19,969.20 (...610), both settling two days later, so the
+trade pairing already keeps them apart.
 
-Both `Cash In` and `Cash In Lump Sum` map to `TxType.JRNLFUND` in
-client/lib/csv/converters/fidelity-csv.ts, so both post and the receiving account
-gains twice the transferred amount. Since 0065 a `Cash In` that pairs with a trade
-is retyped to `CASHFLOW`, which does not touch these: neither of the two pairs
-with anything.
+The cash was never doubled. The ISA nets +20000 - 20000 + 20000, the cash
+management account nets zero, the investment account nets -20000. What was wrong
+was the grouping: the three ISA rows carried no `group_ref`, so each was a
+single-posting group with a full-size residual, and `routeResiduals` sent ...545
+and ...548 to `TRANSFER_CLEARING` and ...546 to `IMBALANCE`. An unmatched
+`TRANSFER_CLEARING` posting is an external flow
+(adr/0022-typed-per-account-cash-flow-boundary.md), so the ISA reported 40,000 of
+contribution for a 20,000 deposit and dropped a spurious -20,000 into the
+converter-lossiness report.
 
-## What to establish
+## What was established
 
-- Whether the two rows are genuinely the same money. The likely reading is that
-  one is the cash movement and the other is an ISA subscription record kept for
-  allowance tracking, in which case only one should post. Confirm against the
-  account's reported cash balance rather than inferring it from the row types.
-- Whether the CSV export carries the same duplication as the JSON, since the two
-  converters share the type mapping but not the source.
-- Which row to keep, if one is to be dropped. `Cash In Lump Sum` carries the
-  subscription semantics and `Cash In` the movement, but the reference ordering
-  is the opposite of that reading and the two are not consistently ordered.
+- **The two credits are not the same money posted twice.** They are two of three
+  rows recording one deposit, and the third cancels one of them. Confirmed by
+  arithmetic across all three accounts rather than by reading the row names; the
+  export carries no running balance to check against.
+- **The CSV carries the same shape as the JSON.** The pattern occurs 21 times
+  across the two master exports and is the ordinary shape of a deposit into a
+  wrapper, not something the JSON route invents.
+- **No row should be dropped.** All three are real postings and all three are
+  needed for the account's cash to come out right. They belong in one group.
+
+## Fix
+
+A deposit pass in `assignFidelityGroups`, after the trade passes so it only ever
+sees cash rows no trade wanted. It anchors on `Cash In Lump Sum` and takes the
+nearest unclaimed `Cash Out For Buy` and `Cash In` in the same account, equal in
+amount to the penny, at a higher reference within `DEPOSIT_REF_SPAN`.
+
+It keys on the reference run rather than on the `(account, dateKey)` bucket the
+trade passes use, because one run in the sample settles across two days while the
+reference run holds in all 21.
+
+Across both masters: 21 of 24 `Cash In Lump Sum` rows group into a run, no trade
+group is disturbed, and no `Cash In` or `Cash Out For Buy` is left unexplained.
+The three that stay alone are deposits straight into the cash management account
+-- money from outside with nothing beside it to cancel -- and they still post as a
+single `JRNLFUND`. Every field of the converted masters except `group_ref` is
+unchanged.
+
+The group keeps its `JRNLFUND` legs, so its residual routes to
+`TRANSFER_CLEARING`: one arrival of the deposit amount against the cash management
+account's equal and opposite departure, which is the pair 0068 has to match. It is
+the same shape a lone `Transfer Out` already produces, so both sides of the hop
+look alike.
 
 ## Adjacent, explained by 0065
 
@@ -52,11 +85,12 @@ each sits in a triplet with a `Buy` row against Fidelity's cash pseudo-ISIN, and
 it is that `Buy` the `Cash Out For Buy From Transfer` cancels. 0065 types the
 `Buy` as the cash movement it is and groups the two, which leaves the
 `Cash In For Transfer` posting once, as the arrival it is. Nothing here is a
-duplicate.
+duplicate, and the deposit pass does not touch it.
 
-## Why it matters here
+## Left as it is
 
-Any inflated cash balance flows straight into money-weighted return as a spurious
-external contribution. It also blocks calibration of 0068: the sample data is the
-only material available for measuring a transfer-matching rule, and a transfer
-whose arrival is recorded twice has no single counterpart to match against.
+`routedFor` stamps a residual with the type of the group's first posting, which
+for a deposit is whichever of the three the export listed first -- often the
+`Cash Out For Buy`. So the routed posting can read `CASHFLOW` while its account
+type is `TRANSFER_CLEARING`. The account type is what classifies the flow, so this
+only affects the `tx_type` column the imbalance report groups by.

--- a/extension/src/brokers/fidelity-json.test.ts
+++ b/extension/src/brokers/fidelity-json.test.ts
@@ -405,6 +405,57 @@ describe("convertFidelityJson grouping", () => {
     expect(result.txs[1]!.accountType).toBe(AccountType.EXPENSE);
   });
 
+  it("groups the run a deposit into a product account is reported through", () => {
+    // The same shape the CSV route sees, since both call assignFidelityGroups:
+    // the subscription credited, spent, and credited again as the money that
+    // lands. Grouped, the account is left with one residual for one deposit.
+    const deposit = (fields: Record<string, unknown>) =>
+      trade({
+        accountNumber: "AS10110796",
+        assetName: "Cash",
+        isin: "AA00S0000000",
+        units: 20000,
+        valuation: 20000,
+        pricePerUnit: 1,
+        dealDate: "15/04/2025",
+        settlementDate: "15/04/2025",
+        ...fields,
+      });
+    const result = convertFidelityJson(
+      json(
+        deposit({
+          transactionType: "Cash In Lump Sum",
+          debitCreditIndicator: "CREDIT",
+          referenceId: "1093663545",
+        }),
+        deposit({
+          transactionType: "Cash Out For Buy",
+          debitCreditIndicator: "DEBIT",
+          referenceId: "1093663546",
+        }),
+        deposit({
+          transactionType: "Cash In",
+          debitCreditIndicator: "CREDIT",
+          referenceId: "1093663548",
+        })
+      )
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(result.txs.map((tx) => tx.groupRef)).toEqual([
+      "1093663545",
+      "1093663545",
+      "1093663545",
+    ]);
+    // The journals stay journals, which is what routes the group's residual to
+    // TRANSFER_CLEARING rather than IMBALANCE.
+    expect(result.txs.map((tx) => tx.type)).toEqual([
+      TxType.JRNLFUND,
+      TxType.CASHFLOW,
+      TxType.JRNLFUND,
+    ]);
+  });
+
   it("leaves rows ungrouped when the payload carries no reference", () => {
     const result = convertFidelityJson(
       json(

--- a/server/service/ingestion/balance_test.go
+++ b/server/service/ingestion/balance_test.go
@@ -248,6 +248,19 @@ func TestRouteResiduals(t *testing.T) {
 			{commodity: "USD", quantity: "-25", accountType: apiv1.AccountType_ACCOUNT_TYPE_IMBALANCE},
 			{commodity: aaplID, quantity: "-10", accountType: apiv1.AccountType_ACCOUNT_TYPE_IMBALANCE},
 		},
+	}, {
+		// The shape a deposit into a Fidelity product account arrives in: three legs
+		// in one account, only two of them journals, netting to the money that
+		// landed. One transfer-typed leg is enough to classify the group, because
+		// the residual is the other side of the movement and that is in another
+		// account. Were it read leg by leg the deposit would route to imbalance.
+		name: "one transfer leg routes a mixed group's residual to clearing",
+		postings: []posting{
+			{desc: "USD", typ: apiv1.TxType_JRNLFUND, qty: "20000", settle: "USD", trading: "USD", instID: usdID, groupRef: "d1"},
+			{desc: "USD", typ: apiv1.TxType_CASHFLOW, qty: "-20000", settle: "USD", trading: "USD", instID: usdID, groupRef: "d1"},
+			{desc: "USD", typ: apiv1.TxType_JRNLFUND, qty: "20000", settle: "USD", trading: "USD", instID: usdID, groupRef: "d1"},
+		},
+		want: []routed{{commodity: "USD", quantity: "-20000", accountType: apiv1.AccountType_ACCOUNT_TYPE_TRANSFER_CLEARING}},
 	}}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Closes 0069.

Money paid into a Fidelity product account arrives as three rows of the same
amount -- the subscription credited, spent, and credited again as the money that
lands -- and no security appears anywhere in the sequence. The `Cash Out For Buy`
in it has no `Buy`; the day's real trade settles later and pairs with a cash row
of its own.

0069 read the two credits as the same money posted twice. They are not: the ISA
nets the deposit once, and the cash was never doubled. What was wrong was the
grouping. All three rows were single-posting groups, so `routeResiduals` sent the
two journals to `TRANSFER_CLEARING` and the debit to `IMBALANCE`, and an
unmatched clearing posting is an external flow -- the account reported twice the
contribution it received, against a residual the size of the deposit sitting in
the report that measures converter lossiness.

The three rows are one event, so they are one group. Its residual is the deposit,
routed to clearing because the group keeps its journals, which is how a movement
whose other side is in another account has always been represented here. That
leaves the arrival and the cash management account's departure equal and
opposite: the pair 0068 has to match, where before it was offered two identical
arrivals and could only have taken one.

## The rule

The pass runs after the trade passes, so a run is built only from cash rows no
trade wanted. It keys on account, amount to the penny and the reference run
rather than on the settlement date the trade passes bucket by, because one run in
the sample completes across two days.

## Measured against the masters

|                                                  | Lee | Helen |
| ------------------------------------------------ | --- | ----- |
| `Cash In Lump Sum` rows                           | 9   | 15    |
| grouped as a run                                  | 8   | 13    |
| left alone                                        | 1   | 2     |
| trade groups disturbed                            | 0   | 0     |
| `Cash In` / `Cash Out For Buy` left unexplained   | 0   | 0     |
| lone `CASHFLOW` groups, before -> after           | 8 -> 0 | 13 -> 0 |
| lone `JRNLFUND` groups, before -> after           | 25 -> 9 | 32 -> 6 |

The three left alone are deposits straight into the cash management account:
money from outside with nothing beside it to cancel. Every field of the converted
masters except `group_ref` is unchanged.

## Also here

- A `routeResiduals` case for the shape a deposit group now takes. There was no
  test for a group where only some legs are journals, which is the server-side
  contract the pass depends on.
- 0068's note that the two credits "may be a double count" replaced with the
  settled shape.
- 0040's residuals list: it attributed Helen's unpaired `BUYSTOCK` groups to 0065
  and 0069. 0065 closed those, and 0069's entry in that list was the lone
  `CASHFLOW` groups, now also gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)