### PR TITLE
Keep what the source called a row and its other side (0068)

### DIFF
--- a/client/lib/csv/standard.test.ts
+++ b/client/lib/csv/standard.test.ts
@@ -391,6 +391,45 @@ describe("group_ref", () => {
   });
 });
 
+describe("source references", () => {
+  it("carries the broker's own reference and the account it names", () => {
+    const csv = `date,instrument_description,type,quantity,account,group_ref,broker_ref,counterparty_account
+2025-04-15,GBP,TRANSFER,-20000,AG10041188,,1093663528,
+2025-04-15,GBP,TRANSFER,20000,AW10075724,,1093663531,AG10041188`;
+
+    const result = parseStandardCSV(csv);
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.txs).toHaveLength(2);
+    expect(result.txs[0].brokerRef).toBe("1093663528");
+    // Only the receiving side names the counterparty; the departure does not.
+    expect(result.txs[0].counterpartyAccount).toBe("");
+    expect(result.txs[1].brokerRef).toBe("1093663531");
+    expect(result.txs[1].counterpartyAccount).toBe("AG10041188");
+  });
+
+  it("is opaque: a reference that is not a number survives verbatim", () => {
+    const csv = `date,instrument_description,type,quantity,broker_ref
+2024-03-01,AAPL,BUYSTOCK,10,20240301U1234567`;
+
+    const result = parseStandardCSV(csv);
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.txs[0].brokerRef).toBe("20240301U1234567");
+  });
+
+  it("defaults to empty when the columns are absent", () => {
+    const csv = `date,instrument_description,type,quantity
+2024-03-01,AAPL,BUYSTOCK,10`;
+
+    const result = parseStandardCSV(csv);
+
+    expect(result.errors).toHaveLength(0);
+    expect(result.txs[0].brokerRef).toBe("");
+    expect(result.txs[0].counterpartyAccount).toBe("");
+  });
+});
+
 describe("account_type", () => {
   it("types the non-asset leg of a group", () => {
     const csv = `date,instrument_description,type,quantity,account,group_ref,account_type

--- a/client/lib/csv/standard.ts
+++ b/client/lib/csv/standard.ts
@@ -111,7 +111,7 @@ export function parseCSVLine(line: string): string[] {
  * Parse standard-format CSV text into Tx array and period.
  * Header names are case-insensitive. Required: date (or timestamp), instrument_description, type, quantity.
  * Optional: trading_currency, settlement_currency, unit_price, account, symbol_type, symbol, exchange_type,
- * exchange, group_ref, account_type.
+ * exchange, group_ref, account_type, broker_ref, counterparty_account.
  */
 export function parseStandardCSV(csvText: string): StandardParseResult {
   const errors: ParseError[] = [];
@@ -161,6 +161,8 @@ export function parseStandardCSV(csvText: string): StandardParseResult {
   const exchangeCol = col("exchange");
   const groupRefCol = col("group_ref");
   const accountTypeCol = col("account_type");
+  const brokerRefCol = col("broker_ref");
+  const counterpartyAccountCol = col("counterparty_account");
 
   if (dateCol < 0) errors.push({ rowIndex: 0, field: "header", message: "Missing required column: date or timestamp" });
   if (descCol < 0) errors.push({ rowIndex: 0, field: "header", message: "Missing required column: instrument_description" });
@@ -216,6 +218,10 @@ export function parseStandardCSV(csvText: string): StandardParseResult {
 
     const account = accountCol >= 0 ? get(accountCol) : "";
     const groupRef = groupRefCol >= 0 ? get(groupRefCol) : "";
+    // Opaque, and carried through verbatim. Both are what the source called this
+    // row and its other side, so there is nothing here to validate or normalise.
+    const brokerRef = brokerRefCol >= 0 ? get(brokerRefCol) : "";
+    const counterpartyAccount = counterpartyAccountCol >= 0 ? get(counterpartyAccountCol) : "";
 
     const accountTypeStr = accountTypeCol >= 0 ? get(accountTypeCol) : "";
     const accountType = parseAccountType(accountTypeStr);
@@ -271,6 +277,8 @@ export function parseStandardCSV(csvText: string): StandardParseResult {
         account,
         accountType,
         ...(groupRef ? { groupRef } : {}),
+        ...(brokerRef ? { brokerRef } : {}),
+        ...(counterpartyAccount ? { counterpartyAccount } : {}),
         ...(tradingCurrency ? { tradingCurrency } : {}),
         ...(settlementCurrency ? { settlementCurrency } : {}),
         ...(unitPrice !== undefined ? { unitPrice } : {}),

--- a/docs/spec/csv-format.md
+++ b/docs/spec/csv-format.md
@@ -26,6 +26,8 @@ Header names are case-insensitive. Supported column names:
 | `exchange`               | No       | Exchange code value (e.g. "XNAS" for MIC, "US" for OPENFIGI). Populates the domain field on the identifier hint. Required when `exchange_type` is present. |
 | `group_ref`              | No       | Opaque grouping key. Rows sharing a non-empty value are postings of one economic event. See [Transaction groups](#transaction-groups). |
 | `account_type`           | No       | What kind of leg the row is. Defaults to `USER`. See allowed values below. |
+| `broker_ref`             | No       | The source's own identifier for this row. See [Source references](#source-references). |
+| `counterparty_account`   | No       | The account the source names as the other side of this row, in the same broker. Advisory; see [Source references](#source-references). |
 
 `quantity` and `unit_price` are parsed as exact decimals and stored to the precision the file supplies, with no limit on decimal places. A converter deriving one leg from another must not round to reach a fixed scale. See adr/0026-exact-decimals-bounded-by-closure.md.
 
@@ -36,6 +38,23 @@ Each row is a **posting**: a signed amount of one commodity in one account (see 
 `group_ref` is opaque and scoped to one upload. Any value works as long as it is distinct per event within the file; a broker's own order or reference number is the natural choice. It is not stored and carries no meaning across uploads, so re-uploading a period produces new groups.
 
 Grouping is the converter's job. The server persists what it is given: it does not infer a missing leg, pair rows, or fold a fee into a cash amount (see adr/0021-converters-own-transaction-grouping.md).
+
+### Source references
+
+`broker_ref` is the source's own identifier for the row: a Fidelity `Reference Number`, an OFX `FITID`. Unlike `group_ref` it **is** stored, and it means the same thing across uploads. The two are easy to confuse and are opposites in every respect that matters:
+
+| | `group_ref` | `broker_ref` |
+| --- | --- | --- |
+| Whose | PortfolioDB's, invented by the converter | the broker's, transcribed |
+| Scope | one upload | durable |
+| Stored | no | yes |
+| Says | these rows are one event | this row is that row of the statement |
+
+`broker_ref` is not a natural key and nothing deduplicates on it. Idempotency is by replacement (see adr/0002-transaction-ingestion-model.md), and one source transaction can produce several postings that share a reference -- a trade and its cash leg, for instance. It exists because a broker issues the two sides of one transfer adjacent references, which is what lets the two be matched later.
+
+`counterparty_account` is the account the source names as the other side, in the same broker. It is **advisory**: a source can use the same field for something else -- Fidelity puts the product account a service fee was charged for in it, which is attribution rather than a transfer counterparty -- so it is read as a pointer only where the group turns out to be a transfer.
+
+Both are set only on rows transcribed from a source row. A converter's derived counter-leg carries neither, and neither does the counterparty the server routes to balance a group, so a value that is present always names something the source itself issued.
 
 **Fees are postings, not a column.** A commission, levy or duty is a row with `type=INVEXPENSE` and a negative `quantity` in the settlement currency, paired with an `account_type=EXPENSE` row for the same money. Put the pair in the trade's group when the broker charges it as part of the trade; give it a group of its own when the broker reports it as a separate cash event on its own date. Where a broker folds the commission into a single cash total, the converter splits that total into a consideration row and a fee row rather than posting it as one (see adr/0025-netted-cash-totals-are-split-into-legs.md).
 

--- a/docs/spec/postings.md
+++ b/docs/spec/postings.md
@@ -14,6 +14,26 @@ A posting is a signed amount of one commodity in one account at one point in tim
 | Commodity | `instrument_id`               |
 | Amount    | `quantity` (signed)           |
 | Date      | `timestamp`                   |
+| Source id | `broker_ref`                  |
+| Other side| `counterparty_account`        |
+
+The last two are what the source said about the row, kept rather than discarded.
+`broker_ref` is the source's own identifier for it -- a Fidelity `Reference Number`, an OFX
+`FITID` -- and `counterparty_account` is the account the source names as the other side,
+in the same broker. Both are set only on postings **transcribed from a source row**: a
+converter's derived counter-leg carries neither, and neither does a routed residual, so a
+value that is present always names something the source itself issued.
+
+`broker_ref` is not a natural key and carries no uniqueness constraint. Ingestion is
+idempotent by replacement (adr/0002-transaction-ingestion-model.md) and one source
+transaction can produce several postings sharing a reference. It is kept because a broker
+issues the two sides of one transfer adjacent references, which is what
+[matching](#transfers) reads.
+
+`counterparty_account` is advisory. A source can use the same field for something else --
+Fidelity puts the product account a service fee was charged for in it, which is attribution
+rather than a transfer counterparty -- so it is read as a pointer only for a group that
+produced a `TRANSFER_CLEARING` residual.
 
 Currencies are instruments, so a cash movement is an ordinary posting and needs no
 separate representation. Nothing in the read path distinguishes a cash posting from a

--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -213,6 +213,30 @@ message Tx {
   // Unset means USER, so an upload that says nothing about kind reads as an ordinary
   // broker account posting.
   AccountType account_type = 15 [(buf.validate.field).enum.defined_only = true];
+  // The source's own identifier for the row this posting was transcribed from:
+  // Fidelity's Reference Number, OFX's FITID. Set by the broker converter and
+  // stored, so unlike group_ref it is durable and means the same thing across
+  // uploads.
+  //
+  // Not a natural key. Ingestion idempotency is by replacement rather than by
+  // dedup on an identifier (docs/adr/0002-transaction-ingestion-model.md), and
+  // one source transaction can produce several postings that share a reference.
+  // Transfer matching reads it as a proximity signal, because a broker issues
+  // the two sides of one transfer adjacent references.
+  //
+  // Present only on postings transcribed from a source row: a converter's
+  // derived counter-leg and a server-routed residual carry none.
+  string broker_ref = 16;
+  // The account the source names as the other side of this row, in the same
+  // broker. Set by the broker converter where the source supplies it.
+  //
+  // Advisory rather than authoritative, because a source can use the same field
+  // for something else -- Fidelity puts the product account a service fee was
+  // charged for in it, which is attribution and not a transfer counterparty. It
+  // is read as a transfer pointer only for a group that produced a
+  // TRANSFER_CLEARING residual. Present only on transcribed postings, as
+  // broker_ref is.
+  string counterparty_account = 17;
 }
 
 // ApiService provides gRPC endpoints for the web front end: portfolio CRUD,

--- a/server/db/postgres/txs.go
+++ b/server/db/postgres/txs.go
@@ -23,14 +23,14 @@ var psql = sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
 const insertPostingSQL = `
 	WITH g AS (
 		INSERT INTO tx_groups (user_id, timestamp, job_id)
-		VALUES ($1, $4, $16)
+		VALUES ($1, $4, $18)
 		RETURNING id
 	)
 	INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type,
 	                 quantity, trading_currency, settlement_currency, unit_price,
 	                 instrument_id, share_count_basis, account_type,
-	                 weight, weight_commodity, group_id)
-	SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::date, $13, $14, $15, g.id FROM g
+	                 weight, weight_commodity, broker_ref, counterparty_account, group_id)
+	SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::date, $13, $14, $15, $16, $17, g.id FROM g
 	RETURNING group_id
 `
 
@@ -40,8 +40,8 @@ const insertPostingInGroupSQL = `
 	INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type,
 	                 quantity, trading_currency, settlement_currency, unit_price,
 	                 instrument_id, share_count_basis, account_type,
-	                 weight, weight_commodity, group_id)
-	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::date, $13, $14, $15, $16)
+	                 weight, weight_commodity, broker_ref, counterparty_account, group_id)
+	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12::date, $13, $14, $15, $16, $17, $18)
 `
 
 // groupResolver hands out the tx group for a tx's group_ref. An empty group_ref
@@ -169,6 +169,10 @@ func insertPostings(ctx context.Context, exec queryable, userUUID uuid.UUID, bro
 			userUUID, broker, acc, ts, t.InstrumentDescription, txTypeStr, qty,
 			nullStr(t.TradingCurrency), nullStr(t.SettlementCurrency), nullDecimal(price),
 			instUUID, shareCountBasis, acctTypeStr, w.Amount, w.Commodity,
+			// Stored as the source wrote them, and NULL where it wrote nothing:
+			// absent evidence is not the same as an empty reference, and only a
+			// derived posting is expected to carry none at all.
+			nullStr(t.GetBrokerRef()), nullStr(t.GetCounterpartyAccount()),
 		}
 		ref := t.GetGroupRef()
 		if groupID, ok := resolver.group(ref); ok {

--- a/server/db/postgres/txs_test.go
+++ b/server/db/postgres/txs_test.go
@@ -883,6 +883,78 @@ func TestReplaceTxsInPeriod_RoundTripsAccountType(t *testing.T) {
 	}
 }
 
+// TestReplaceTxsInPeriod_RoundTripsSourceReferences verifies the two evidence
+// columns reach storage as the source wrote them, and that a source that wrote
+// nothing stores NULL rather than an empty string. The distinction is the whole
+// point of the columns: absent evidence has to be told from an empty reference,
+// because only a derived posting is expected to carry none at all.
+func TestReplaceTxsInPeriod_RoundTripsSourceReferences(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|src-ref", "U", "u@ref.com")
+	instID, err := p.EnsureInstrument(ctx, "", "", "", "", "", "",
+		[]db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "Fidelity", Value: "GBP", Canonical: false}}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+	base := time.Date(2025, 4, 15, 0, 0, 0, 0, time.UTC)
+	// The two sides of one transfer hop, as Fidelity reports them: adjacent
+	// references, and only the receiving side naming where the money came from.
+	txs := []*apiv1.Tx{
+		{Timestamp: timestamppb.New(base), InstrumentDescription: "GBP", Type: apiv1.TxType_TRANSFER,
+			Quantity: "-20000", Account: "AG10041188", BrokerRef: "1093663528"},
+		{Timestamp: timestamppb.New(base), InstrumentDescription: "GBP", Type: apiv1.TxType_TRANSFER,
+			Quantity: "20000", Account: "AW10075724", BrokerRef: "1093663531", CounterpartyAccount: "AG10041188"},
+	}
+	from, to := timestamppb.New(base), timestamppb.New(base.Add(24*time.Hour))
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "Fidelity", "", from, to, txs, []string{instID, instID}, nil, nil); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+
+	rows, err := p.q.QueryContext(ctx, `
+		SELECT account, broker_ref, counterparty_account FROM txs
+		WHERE user_id = $1 ORDER BY account
+	`, userID)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	defer rows.Close()
+	type stored struct {
+		ref          *string
+		counterparty *string
+	}
+	got := map[string]stored{}
+	for rows.Next() {
+		var account string
+		var s stored
+		if err := rows.Scan(&account, &s.ref, &s.counterparty); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got[account] = s
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("stored %d postings, want 2", len(got))
+	}
+	departure, arrival := got["AG10041188"], got["AW10075724"]
+	if departure.ref == nil || *departure.ref != "1093663528" {
+		t.Errorf("departure broker_ref = %v, want 1093663528", departure.ref)
+	}
+	// The source named no counterparty on the departure, so nothing is stored --
+	// not an empty string.
+	if departure.counterparty != nil {
+		t.Errorf("departure counterparty_account = %q, want NULL", *departure.counterparty)
+	}
+	if arrival.ref == nil || *arrival.ref != "1093663531" {
+		t.Errorf("arrival broker_ref = %v, want 1093663531", arrival.ref)
+	}
+	if arrival.counterparty == nil || *arrival.counterparty != "AG10041188" {
+		t.Errorf("arrival counterparty_account = %v, want AG10041188", arrival.counterparty)
+	}
+}
+
 // TestTxs_AccountTypeCheckConstraint verifies the vocabulary is enforced by the
 // database, not only by the enum on the way in.
 func TestTxs_AccountTypeCheckConstraint(t *testing.T) {

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -58,28 +58,51 @@ CREATE TABLE tx_groups (
 CREATE INDEX idx_tx_groups_user_time ON tx_groups (user_id, timestamp);
 CREATE INDEX idx_tx_groups_job_id ON tx_groups (job_id);
 
--- Transactions. No natural key (broker statements often supply date only). Bulk idempotency
--- by replace-by-period (user_id, broker, period). Single-tx ingestion is append-only.
--- group_id is the economic event this row is a posting of. Every posting belongs to
--- exactly one group -- a lone posting is a group of one -- so that the balance
--- invariant has no rows it cannot reach. Deleting a group deletes its postings, which
--- makes the group the unit of deletion for replace-by-period.
+-- Transactions. Each row is a posting: a signed amount of one commodity in one account
+-- at one point in time. See docs/spec/postings.md. The sections below follow the column
+-- order of the table.
+--
+-- Ingestion and identity.
+-- No natural key (broker statements often supply date only). Bulk idempotency is by
+-- replace-by-period (user_id, broker, period); single-tx ingestion is append-only.
+-- See docs/adr/0002-transaction-ingestion-model.md.
+--
+-- What moved: instrument_description, instrument_id, tx_type.
+-- instrument_id is added by an ALTER further down, because instruments is created after
+-- this table and the foreign key needs it to exist. The column itself is declared here,
+-- where it belongs.
+--
+-- The amounts as the source wrote them: quantity, unit_price, trading_currency,
+-- settlement_currency. Transcribed and exact; see Numeric types below.
+--
+-- What the source called this row: broker_ref, counterparty_account.
+-- broker_ref is the source's own identifier for the row a posting was transcribed from:
+-- Fidelity's Reference Number, OFX's FITID. counterparty_account is the account the
+-- source named as the other side, in the same broker. Both are set only on postings
+-- transcribed from a source row -- never on a converter's derived counter-leg and never
+-- on a routed residual -- so a non-null value always names something the source itself
+-- issued.
+-- broker_ref is not a natural key and carries no uniqueness constraint: ingestion
+-- idempotency is by replacement, and one source transaction can produce several
+-- postings that share a reference. Transfer matching reads it as a proximity signal,
+-- because a broker issues the two sides of one transfer adjacent references.
+-- counterparty_account is advisory rather than authoritative. A source can reuse the
+-- same field for something else -- Fidelity puts the product account a service fee was
+-- charged for in it, which is attribution and not a transfer counterparty -- so it is
+-- read as a pointer only for a group that produced a TRANSFER_CLEARING residual.
+--
+-- What kind of leg it is: account_type, synthetic_purpose.
 -- account_type classifies the account this row lands in. USER is an ordinary broker
 -- account posting; the others are the non-asset side of an event that is one-sided in
 -- the source data and keep the broker and account of the event they belong to, so a
 -- residual stays attributable to the account that produced it. Holdings and the other
 -- quantity aggregations read USER only. See docs/adr/0022-typed-per-account-cash-flow-boundary.md.
--- share_count_basis is the date at which the share count the raw quantity and
--- unit_price are denominated in was current. It defaults to timestamp::date --
--- the as-traded assumption, that a broker log line accounts only for events
--- prior to the trade. A source that restates historical rows (a broker's live
--- web UI showing post-split quantities) declares its own on the upload.
--- See docs/spec/bitemporality.md.
--- split_adjusted_quantity / split_adjusted_unit_price hold the values that result
--- from applying every stock split with ex_date > share_count_basis for the tx's
--- instrument. They equal the raw quantity/unit_price when no later split exists.
--- They are recomputed idempotently from the raw columns whenever splits change
--- (see RecomputeTxSplitAdjustments).
+--
+-- The event and its balance: group_id, weight, weight_commodity.
+-- group_id is the economic event this row is a posting of. Every posting belongs to
+-- exactly one group -- a lone posting is a group of one -- so that the balance
+-- invariant has no rows it cannot reach. Deleting a group deletes its postings, which
+-- makes the group the unit of deletion for replace-by-period.
 -- weight is what this posting contributes to its group's balance and weight_commodity
 -- names what that contribution is denominated in: 'cur:<code>' for money,
 -- 'inst:<uuid>' for a security, 'desc:<text>' when the instrument never resolved. A
@@ -94,6 +117,21 @@ CREATE INDEX idx_tx_groups_job_id ON tx_groups (job_id);
 -- these after ingest, and it rewrites weight_commodity alongside instrument_id.
 -- See docs/adr/0029-posting-weight-is-stored.md and
 -- docs/adr/0024-group-balance-is-checked-on-weight.md.
+--
+-- Share counts: share_count_basis, split_adjusted_quantity, split_adjusted_unit_price.
+-- share_count_basis is the date at which the share count the raw quantity and
+-- unit_price are denominated in was current. It defaults to timestamp::date --
+-- the as-traded assumption, that a broker log line accounts only for events
+-- prior to the trade. A source that restates historical rows (a broker's live
+-- web UI showing post-split quantities) declares its own on the upload.
+-- See docs/spec/bitemporality.md.
+-- split_adjusted_quantity / split_adjusted_unit_price hold the values that result
+-- from applying every stock split with ex_date > share_count_basis for the tx's
+-- instrument. They equal the raw quantity/unit_price when no later split exists.
+-- They are recomputed idempotently from the raw columns whenever splits change
+-- (see RecomputeTxSplitAdjustments).
+--
+-- Numeric types.
 -- quantity and unit_price are transcribed decimals and are exact, so they are
 -- bare NUMERIC. The split-adjusted pair is not: the cumulative split factor is a
 -- rational and a reverse /3 has no finite decimal form, so the pair declares a
@@ -106,26 +144,37 @@ CREATE INDEX idx_tx_groups_job_id ON tx_groups (job_id);
 CREATE TABLE txs (
   id                        UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id                   UUID NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+
   broker                    TEXT NOT NULL,
   account                   TEXT NOT NULL,
   timestamp                 TIMESTAMPTZ NOT NULL,
+
   instrument_description    TEXT NOT NULL,
+  instrument_id             UUID,
   tx_type                   TEXT NOT NULL,
+
   quantity                  NUMERIC NOT NULL,
-  split_adjusted_quantity   NUMERIC(38, 12) NOT NULL,
+  unit_price                NUMERIC,
   trading_currency          TEXT,
   settlement_currency       TEXT,
-  unit_price                NUMERIC,
-  split_adjusted_unit_price NUMERIC(38, 12),
-  share_count_basis         DATE NOT NULL,
-  synthetic_purpose         TEXT CHECK (synthetic_purpose IS NULL OR synthetic_purpose = 'INITIALIZE'),
+
+  broker_ref                TEXT,
+  counterparty_account      TEXT,
+
   account_type              TEXT NOT NULL DEFAULT 'USER'
                               CHECK (account_type IN ('USER', 'EQUITY', 'INCOME', 'EXPENSE',
                                                       'IMBALANCE', 'TRANSFER_CLEARING',
                                                       'SOURCE_ROUNDING')),
+  synthetic_purpose         TEXT CHECK (synthetic_purpose IS NULL OR synthetic_purpose = 'INITIALIZE'),
+
+  group_id                  UUID NOT NULL REFERENCES tx_groups (id) ON DELETE CASCADE,
   weight                    NUMERIC NOT NULL,
   weight_commodity          TEXT NOT NULL,
-  group_id                  UUID NOT NULL REFERENCES tx_groups (id) ON DELETE CASCADE,
+
+  share_count_basis         DATE NOT NULL,
+  split_adjusted_quantity   NUMERIC(38, 12) NOT NULL,
+  split_adjusted_unit_price NUMERIC(38, 12),
+
   created_at                TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 
@@ -383,7 +432,10 @@ CREATE TABLE identification_errors (
 CREATE INDEX idx_identification_errors_job_id ON identification_errors (job_id);
 
 -- Link txs to instruments. Every tx has an instrument (plugin-resolved or broker description only).
-ALTER TABLE txs ADD COLUMN instrument_id UUID REFERENCES instruments (id);
+-- The column is declared with the rest of txs; only the foreign key waits until here,
+-- because instruments is created after txs.
+ALTER TABLE txs ADD CONSTRAINT txs_instrument_id_fkey
+  FOREIGN KEY (instrument_id) REFERENCES instruments (id);
 
 CREATE INDEX idx_txs_instrument_id ON txs (instrument_id);
 


### PR DESCRIPTION
First of five PRs for [0068](docs/issues/0068-match-in-flight-transfers.md). This one only stores the evidence; nothing reads it yet.

## Why

Matching the two sides of a transfer needs evidence that identifies the *occurrence*, and `txs` stores none: no broker reference, no counterparty account, no memo. On what is stored today matching reduces to equal-and-opposite amount within a date window between two accounts -- exactly the ambiguous case 0068 refuses to guess at. Fidelity's monthly fee transfers are the adversarial case: the same two small amounts move between the same account pair every month for the whole sample.

## What

Two nullable columns on `txs`, and the wire fields and CSV columns that feed them.

- **`broker_ref`** -- the source's own identifier for the row a posting was transcribed from: a Fidelity `Reference Number`, an OFX `FITID`. This is the signal that actually separates one month's fee transfer from another's, because a broker issues the two sides of one transfer adjacent references. In the sample the two sides of a hop differ by 1-8.
- **`counterparty_account`** -- the account the source names as the other side, in the same broker.

Neither is a natural key. Idempotency stays by replacement and nothing dedups on a reference, which one source transaction can spread across several postings. `counterparty_account` is advisory rather than authoritative: Fidelity puts the product account a service fee was charged for in the same field, which is attribution and not a transfer counterparty, so it is read as a pointer only where the group turns out to be a transfer.

Both are set only on postings **transcribed from a source row**. A converter's derived counter-leg and a server-routed residual carry neither, so a value that is present always names something the source itself issued. That invariant is why the `txs.go` inserts store NULL rather than `''` for an absent value, and it is asserted in the round-trip test.

## The `txs` comment and column order

The header comment above `CREATE TABLE txs` had grown by accretion into 45 undifferentiated lines -- `share_count_basis` sat between `account_type` and the split-adjusted pair, and the exactness argument was split across two places. Rather than append a 46th line it is now sectioned, and the columns are reordered to match, so the comment and the table read in step. Content-preserving: no fact dropped, no ADR reference lost.

`instrument_id` moves into the table body where it belongs; only its foreign key still waits at the old `ALTER` site for `instruments` to exist.

The reorder is safe -- nothing depends on the physical column order. There is no `SELECT *` or `RETURNING *` on `txs` anywhere in the tree, and every `INSERT INTO txs` (production, db-layer tests, e2e fixtures) names its columns. As with any edit to `001_initial.sql` it needs a fresh database, which the pre-release migration policy already assumes.

## Testing

`make check` and `make test` pass. New coverage:

- `client/lib/csv/standard.test.ts` -- both columns parse, a non-numeric reference survives verbatim, absent columns leave the fields empty.
- `server/db/postgres/txs_test.go` -- the two sides of the 2025-04-15 Fidelity hop round-trip, and the departure that names no counterparty stores NULL rather than an empty string.

## Next in the stack

PR2 makes the converters populate these; PR3 adds `transfer_matches`; PR4 the matcher; PR5 makes the transfers report mean something.

🤖 Generated with [Claude Code](https://claude.com/claude-code)