### PR TITLE
Emit the reference each converter was already parsing (0068)

### DIFF
--- a/client/lib/csv/converters/fidelity-csv.test.ts
+++ b/client/lib/csv/converters/fidelity-csv.test.ts
@@ -869,3 +869,59 @@ describe("trade cash legs", () => {
     expect(result.txs[1].quantity).toBe("7265.7");
   });
 });
+
+describe("source references", () => {
+  const HEAD =
+    "Order date,Completion date,Transaction type,Investments,Product Wrapper,Account Number,Source investment,Amount,Quantity,Price per unit,Reference Number,Status";
+  const convert = (rows: string[]) =>
+    convertFidelityToStandard([HEAD, ...rows].join("\n"), { currency: "GBP" });
+
+  // The two sides of one transfer hop, verbatim from the master export. Their
+  // references differ by 3, which is what tells this month's fee transfer from
+  // last month's when the amounts are identical.
+  it("carries the broker's reference onto every transcribed posting", () => {
+    const result = convert([
+      "2022-05-06,2022-05-06,Transfer To Cash Management Account For Fees,Cash,SIPP,AP1,,-2.19,2.19,1,603102266,Completed",
+      "2022-05-06,2022-05-06,Cash In Ring-fenced For Fees,Cash,Cash Management Account,AW1,,2.19,2.19,1,603102269,Completed",
+    ]);
+
+    expect(result.txs).toHaveLength(2);
+    expect(result.txs[0].brokerRef).toBe("603102266");
+    expect(result.txs[1].brokerRef).toBe("603102269");
+  });
+
+  // The export's "Source investment" column holds an asset name rather than an
+  // account, so this file names no counterparty anywhere and the converter must
+  // not pretend otherwise.
+  it("names no counterparty, because the CSV export carries none", () => {
+    const result = convert([
+      "8 Feb 2022,10 Feb 2022,Sell,\"WISE PLC (WISE)\",Investment Account,AG1,Cash,-7266.49,1242,5.85,563466569,Completed",
+    ]);
+
+    expect(result.txs[0].counterpartyAccount).toBe("");
+  });
+
+  it("leaves a posting the source gave no reference for unreferenced", () => {
+    const result = convert([
+      "8 Feb 2022,10 Feb 2022,Cash Interest,Cash,Investment Account,AG1,,1.18,1.18,1,,Completed",
+    ]);
+
+    expect(result.txs[0].brokerRef).toBe("");
+  });
+
+  // A dividend's income leg is the converter's invention: the source wrote one
+  // row and we write two. Handing the second the first's reference would make an
+  // invention indistinguishable from a transcription.
+  it("does not give a derived counter-leg a reference it never had", () => {
+    const result = convert([
+      "8 Feb 2022,10 Feb 2022,Cash Dividend,Cash,Investment Account,AG1,,23.40,23.40,1,563466600,Completed",
+    ]);
+
+    expect(result.txs).toHaveLength(2);
+    expect(result.txs[0].brokerRef).toBe("563466600");
+    expect(result.txs[1].accountType).toBe(AccountType.INCOME);
+    expect(result.txs[1].brokerRef).toBe("");
+    // Both legs still belong to one event.
+    expect(result.txs[1].groupRef).toBe(result.txs[0].groupRef);
+  });
+});

--- a/client/lib/csv/converters/fidelity-csv.ts
+++ b/client/lib/csv/converters/fidelity-csv.ts
@@ -651,6 +651,14 @@ export function convertFidelityToStandard(
       ref: refCol >= 0 ? parseInt(get(refCol), 10) : NaN,
       cashAsset,
     });
+    // The cell, not the parsed number the leg carries: broker_ref is opaque and a
+    // reference the source wrote in some other shape should survive rather than
+    // become NaN. Nothing here parses it -- that is the matcher's problem.
+    //
+    // No counterpartyAccount. The export's "Source investment" column holds an
+    // asset name, not an account, so this file names no counterparty anywhere.
+    // Only the JSON the extension reads does.
+    const brokerRef = refCol >= 0 ? get(refCol) : "";
     txs.push(
       create(TxSchema, {
         timestamp: timestampFromDate(date),
@@ -662,6 +670,7 @@ export function convertFidelityToStandard(
         ...(isCashTxType(ofxType) ? { tradingCurrency: currency } : {}),
         // Presence, not truthiness: a reported price of zero is a price.
         ...(unitPriceDec !== undefined ? { unitPrice: unitPriceDec.toString() } : {}),
+        ...(brokerRef ? { brokerRef } : {}),
         ...(identifierHints.length > 0 ? { identifierHints } : {}),
       })
     );

--- a/client/lib/csv/postings.ts
+++ b/client/lib/csv/postings.ts
@@ -60,6 +60,12 @@ export function counterLeg(tx: Tx): Tx | undefined {
   const leg = clone(TxSchema, tx);
   leg.quantity = new Big(tx.quantity).times(-1).toString();
   leg.accountType = accountType;
+  // A derived leg names no source row, because the source wrote none for it. The
+  // clone above would otherwise hand it the reference of the posting it mirrors,
+  // making an invention indistinguishable from a transcription. moneyLeg builds
+  // from scratch and needs no such reset. See docs/spec/postings.md.
+  leg.brokerRef = "";
+  leg.counterpartyAccount = "";
   return leg;
 }
 

--- a/client/lib/ofx/parser.test.ts
+++ b/client/lib/ofx/parser.test.ts
@@ -417,6 +417,15 @@ describe("groups and charges", () => {
     expect(refs).toEqual(new Set(["20251015U70330348371888432"]));
   });
 
+  // The same id says two different things: which postings are one event, and
+  // which statement record this one was transcribed from. Only the security leg
+  // is that record -- the cash and fee legs are derived from TOTAL and COMMISSION.
+  it("keeps the FITID as the transcribed leg's source reference", () => {
+    const result = parse(GBP_BUY);
+    const refs = result.txs.map((t) => t.brokerRef);
+    expect(refs.filter((r) => r !== "")).toEqual(["20251015U70330348371888432"]);
+  });
+
   it("splits the commission out of the netted total", () => {
     const result = parse(GBP_BUY);
 

--- a/client/lib/ofx/parser.ts
+++ b/client/lib/ofx/parser.ts
@@ -332,6 +332,11 @@ export function parseOfxStatement(text: string): OfxParseResult {
         tradingCurrency,
         settlementCurrency: tradingCurrency,
         groupRef: fitId,
+        // The same id in both fields, saying two different things: which postings
+        // are one event, and which statement record this one was transcribed from.
+        // Only this leg carries the reference -- the cash and fee legs below are
+        // derived from TOTAL and COMMISSION rather than from rows of their own.
+        ...(fitId ? { brokerRef: fitId } : {}),
         ...(unitPrice !== undefined ? { unitPrice } : {}),
         ...(hintProtos.length > 0 ? { identifierHints: hintProtos } : {}),
       });

--- a/extension/src/brokers/fidelity-json.test.ts
+++ b/extension/src/brokers/fidelity-json.test.ts
@@ -481,3 +481,78 @@ describe("convertFidelityJson grouping", () => {
     }
   });
 });
+
+describe("source references", () => {
+  const base = {
+    accountNumber: "AW10075724",
+    assetName: "Cash",
+    isin: "AA00K0000000",
+    currency: "GBP",
+    status: "Completed",
+    pricePerUnit: 1,
+    dealDate: "15/04/2025",
+    settlementDate: "15/04/2025",
+  };
+
+  it("carries the reference and the account the source names as the other side", () => {
+    const result = convertFidelityJson(
+      json({
+        ...base,
+        transactionType: "Transfer Into Account",
+        debitCreditIndicator: "CREDIT",
+        units: 20000,
+        valuation: 20000,
+        referenceId: "1093663531",
+        sourceOrTargetAccount: "AG10041188",
+      })
+    );
+
+    expect(result.errors).toEqual([]);
+    expect(result.txs[0]!.brokerRef).toBe("1093663531");
+    expect(result.txs[0]!.counterpartyAccount).toBe("AG10041188");
+  });
+
+  it("leaves the counterparty empty where the source names none", () => {
+    const result = convertFidelityJson(
+      json({
+        ...base,
+        transactionType: "Transfer Out From Cash Management Account",
+        debitCreditIndicator: "DEBIT",
+        units: 20000,
+        valuation: 20000,
+        referenceId: "1093663547",
+      })
+    );
+
+    expect(result.txs[0]!.brokerRef).toBe("1093663547");
+    expect(result.txs[0]!.counterpartyAccount).toBe("");
+  });
+
+  // Fidelity puts the product account a fee was charged for in the same field it
+  // names a transfer's source in. It is kept as the source wrote it: which of the
+  // two it means is not the converter's call, and a Service Fee is an INVEXPENSE
+  // whose group balances against an EXPENSE leg, so it never reaches the transfer
+  // matching that reads this as a pointer.
+  it("keeps a service fee's attribution, which is not a transfer counterparty", () => {
+    const result = convertFidelityJson(
+      json({
+        ...base,
+        assetName: "Relationship Cash Source",
+        transactionType: "Service Fee",
+        debitCreditIndicator: "DEBIT",
+        units: 5.13,
+        valuation: 5.13,
+        referenceId: "1299133228",
+        sourceOrTargetAccount: "AP10013127",
+      })
+    );
+
+    const fee = result.txs[0]!;
+    expect(fee.type).toBe(TxType.INVEXPENSE);
+    expect(fee.counterpartyAccount).toBe("AP10013127");
+    // The derived expense leg is the converter's own, so it names no source row.
+    const expense = result.txs.find((tx) => tx.accountType === AccountType.EXPENSE)!;
+    expect(expense.brokerRef).toBe("");
+    expect(expense.counterpartyAccount).toBe("");
+  });
+});

--- a/extension/src/brokers/fidelity-json.ts
+++ b/extension/src/brokers/fidelity-json.ts
@@ -50,6 +50,19 @@ interface FidelityRow {
   dealDate?: string;
   /** Completion date. Absent while a transaction has not settled. */
   settlementDate?: string | null;
+  /**
+   * The account Fidelity names as the other side of this row. Populated on a
+   * transfer arrival, naming where the money came from -- and also on a Service
+   * Fee, where it names the product account the fee was charged for, which is
+   * attribution rather than a transfer counterparty.
+   *
+   * Carried through either way, because the field says what the source said and
+   * which of the two it means is not the converter's call. A Service Fee is an
+   * INVEXPENSE whose group balances against an EXPENSE leg, so it never produces
+   * the TRANSFER_CLEARING residual that transfer matching reads a pointer for;
+   * the fee attribution is left for whatever wants it. See docs/spec/postings.md.
+   */
+  sourceOrTargetAccount?: string | null;
 }
 
 /**
@@ -218,6 +231,11 @@ export function convertFidelityJson(
         ...(row.pricePerUnit !== undefined
           ? { unitPrice: (decimalFromNumber(row.pricePerUnit) ?? ZERO).toString() }
           : {}),
+        // The string, not the number the leg carries: broker_ref is opaque, so a
+        // reference the source wrote in some other shape survives rather than
+        // becoming NaN.
+        ...(row.referenceId ? { brokerRef: row.referenceId } : {}),
+        ...(row.sourceOrTargetAccount ? { counterpartyAccount: row.sourceOrTargetAccount } : {}),
         ...(identifierHints.length > 0 ? { identifierHints } : {}),
       })
     );


### PR DESCRIPTION
Second of five PRs for [0068](docs/issues/0068-match-in-flight-transfers.md). **Stacked on #337** -- review that first; this PR is targeted at its branch and will retarget to `main` when it merges.

## Why

Every Fidelity leg has carried a broker reference since 0064 -- the buy pass ranks candidates by it, the deposit pass spans a run of it -- and the OFX parser has read `FITID` since it started naming groups. None of it survived the converter: the number decided grouping and was then dropped. #337 gave it somewhere to go; this sends it.

## What

| Converter | `broker_ref` | `counterparty_account` |
| --- | --- | --- |
| Fidelity CSV | `Reference Number` | none -- see below |
| Fidelity JSON | `referenceId` | `sourceOrTargetAccount` |
| IBKR OFX | `FITID`, security leg only | none -- OFX has no such field |

Both are taken as strings rather than as the parsed number the leg carries, so a reference written in some other shape survives instead of becoming `NaN`. Nothing here parses one; that is the matcher's problem.

The Fidelity **CSV names no counterparty** and the converter does not pretend it does: the export's `Source investment` column holds an asset name, not an account.

OFX stamps the security leg only. The cash and fee legs beside it are derived from `TOTAL` and `COMMISSION`, not transcribed from rows of their own.

`counterLeg` clears both fields after its `clone`. A dividend's income leg is the converter's invention -- the source wrote one row and we write two -- and handing the second the first's reference would make an invention indistinguishable from a transcription. `moneyLeg` builds from scratch and needed nothing.

## Measured against the masters

The invariant this PR maintains is *set only on postings transcribed from a source row*, so it is worth checking against real exports rather than only fixtures. Converting `local/masters/*-Fidelity-CWSY.csv` and `local/HAR/transactions-long-window.json`:

| source | transcribed | with a ref | derived | with a ref | counterparties |
| --- | --- | --- | --- | --- | --- |
| Lee-Fidelity-CWSY.csv | 674 | **674** | 358 | **0** | 0 |
| Helen-Fidelity-CWSY.csv | 739 | **739** | 401 | **0** | 0 |
| transactions-long-window.json | 416 | **416** | 221 | **0** | 40 |

## A finding worth recording

Of those 40 counterparties, **only 2 sit on a transfer**. The other 38 are `Service Fee` rows, where Fidelity reuses the field to name the product account a fee was charged *for*.

That matters for the rest of the stack. 0068 says storing this field makes Fidelity matching "a lookup rather than a heuristic"; on this sample it does not, because the pointer covers one transfer hop in the whole export. The broker reference is what actually separates one month's fee transfer from another's when the amounts are identical -- in the sample the two sides of a hop differ by 1-8. PR4's matcher will prefer the pointer and be calibrated on the reference.

The attribution is kept as the source wrote it rather than filtered out by transaction type: which of the two meanings applies is not the converter's call, and a `Service Fee` is an `INVEXPENSE` whose group balances against an `EXPENSE` leg, so it never produces the `TRANSFER_CLEARING` residual that matching reads a pointer for. The guard is structural, and there is a test asserting the behaviour so a later "fix" has to argue with it.

## Testing

`make check` and `make test` pass. New coverage in the Fidelity CSV, Fidelity JSON and OFX suites: references land on transcribed postings, a derived counter-leg carries none, a row the source gave no reference for stays unreferenced, and the service-fee attribution is preserved while its derived expense leg is not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)