### PR TITLE
Record which group holds the other side of a transfer (0068)

### DIFF
--- a/docs/adr/0021-converters-own-transaction-grouping.md
+++ b/docs/adr/0021-converters-own-transaction-grouping.md
@@ -31,3 +31,10 @@ converter, a CSV column and a server-side rule. The cost is that a converter whi
 supplies neither a cash row nor a unit price produces an unbalanced group; that
 residual is routed to an explicit imbalance account rather than rejected, so
 coverage tightens per broker over time instead of in a single cut-over.
+
+The rule against pairing is about ledger content, not about pairing as such. The
+server pairs the two sides of a transfer after the fact, which creates no posting and
+no group and spans uploads no converter can see. The premise above -- that the
+broker's reference numbers are gone by the time data reaches the standard format --
+no longer holds either: they are stored on the posting. See
+[0037](0037-transfer-matches-are-links-not-postings.md).

--- a/docs/adr/0022-typed-per-account-cash-flow-boundary.md
+++ b/docs/adr/0022-typed-per-account-cash-flow-boundary.md
@@ -62,7 +62,9 @@ place to say the same thing that can disagree with the first.
 Matching the two sides of a transfer becomes a correctness requirement rather than
 housekeeping. Until a pair is matched, a transfer between two accounts of one
 portfolio reads as a withdrawal and an unrelated deposit, so money-weighted return
-is wrong for any multi-account portfolio.
+is wrong for any multi-account portfolio. A match is recorded as a link between the
+two tx groups, which is what supplies the account identity the membership test above
+asks for; see [0037](0037-transfer-matches-are-links-not-postings.md).
 
 Converters, not the server, emit income and expense legs
 (see [0021](0021-converters-own-transaction-grouping.md)). The server cannot

--- a/docs/adr/0037-transfer-matches-are-links-not-postings.md
+++ b/docs/adr/0037-transfer-matches-are-links-not-postings.md
@@ -1,0 +1,114 @@
+# A transfer match is a link between groups, not a posting
+
+The two sides of a journal are balanced against `TRANSFER_CLEARING` and are
+deliberately not paired at ingest (see
+[0022](0022-typed-per-account-cash-flow-boundary.md)), because a broker reports them
+in separate statements and sometimes in separate imports. Pairing them afterwards is
+a correctness requirement rather than housekeeping: until a pair is matched, a
+transfer between two accounts of one portfolio reads as a withdrawal followed by an
+unrelated deposit, and money-weighted return is wrong for any multi-account
+portfolio. It is also what makes a residual clearing balance mean an unmatched
+transfer rather than any transfer at all.
+
+A match is recorded as a row in `transfer_matches` naming the two tx groups, the
+commodity, how they were matched and when.
+
+## It records which account holds the other side
+
+Not merely that a match exists. The portfolio membership test in
+[0022](0022-typed-per-account-cash-flow-boundary.md) asks whether *both* accounts are
+members before it nets a pair or values what is in transit, and only the identity of
+the other group answers that.
+
+## A link, not a status column and not a third group
+
+A status column on the posting could say a side was matched but not what it matched
+with, which is the one thing the consumer needs. A synthetic third group closing both
+sides out would fabricate an economic event that never happened and have to be
+unpicked on every rematch.
+
+Both are also unreachable rather than merely undesirable. `check_tx_group_balance()`
+enforces the group invariant at COMMIT, so a side cannot be cleared by mutating or
+deleting its clearing leg: that would leave its group unbalanced. Only a whole group
+deleted passes vacuously. The invariant that makes ingestion trustworthy is the same
+one that rules out every representation except a link beside the ledger.
+
+## Keyed per (group, commodity), and directed
+
+Balancing emits one residual per commodity, so an unpaired `JRNLSEC` group can have a
+security side and a cash side in flight independently, each pairing with a different
+group. "The two group ids" is therefore not a key; `(group, instrument)` is, which is
+what the two unique indexes -- one per direction -- state.
+
+The link is directed: `from_group_id` is the side the value left, whose clearing
+residual is positive because the group's own leg is negative. The direction costs
+nothing to record, being the sign of the residual, and a link without it would read
+identically for a transfer in either direction.
+
+## Derived and disposable
+
+A re-upload replaces one side's groups
+([0002](0002-transaction-ingestion-model.md)), the cascade takes the link with them,
+the surviving side reappears as unmatched, and the matcher pairs it again. Nothing
+has to know a re-upload happened. The link is never authoritative and is always cheap
+to rebuild, which is what licenses a heuristic to write one at all.
+
+The matcher only ever inserts. It never updates and never deletes, so a `MANUAL`
+match survives every rebuild.
+
+## Ambiguity is left unmatched
+
+Two transfers of the same amount between the same pair of accounts in the same window
+are not distinguishable, and surfacing both as unmatched is better than pairing them
+arbitrarily. A wrong pair is worse than no pair: it looks authoritative, it points at
+the wrong account, and the report that exists to find missing sides stops finding
+them.
+
+So a pair is matched only on evidence that identifies the *occurrence*: the source
+naming the other account, or the proximity of the two sides' broker references. There
+is no amount-and-window-alone rule. Every transfer in the sample data is intra-broker
+with both sides in one import; the cross-broker case that
+[0022](0022-typed-per-account-cash-flow-boundary.md) designed `TRANSFER_CLEARING` for
+is real in principle but has no sample, so it cannot be calibrated and stays
+unmatched and visible until one exists.
+
+An explicit pointer is narrowing evidence, not a decision. It names the counterparty
+*account*, not the occurrence, so it still needs the window and the ambiguity test:
+the sample's monthly fee transfers move the same two amounts between the same account
+pair every month, which a pointer plus an amount matches twelve times a year. It is
+also thinner than it looks -- in the sample the field is populated on 40 rows, of
+which 38 are service fees naming the account a fee was charged for, which is
+attribution and not a counterparty. The reference is what carries the data.
+
+## The server may pair groups, though it may not derive a leg
+
+[0021](0021-converters-own-transaction-grouping.md) says the converter owns grouping
+and the server never pairs rows. Matching does not contradict it.
+
+0021 is about the server fabricating *ledger content*: a derived cash leg that would
+double-count against a row the broker already reported. A match creates no posting and
+no group, and corrupts no balance if it is wrong -- it degrades a netting decision,
+and it is disposable. That asymmetry is what makes one acceptable server-side and the
+other not.
+
+0021's own argument for converter-owned pairing was that "by the time the data reaches
+the standard format the broker's own reference numbers have been discarded -- only the
+converter still has them." That premise no longer holds: the reference is stored on
+the posting. And the pairing it enables spans uploads, statements and accounts, which
+is a scope no single converter has. Where the evidence is within one file the
+converter still does the pairing; this is the residue it cannot see.
+
+## Consequences
+
+`TRANSFER_CLEARING` becomes a signal. An unmatched balance means a side whose pair has
+not arrived, its age is the age of something missing, and the transfers report can
+drop the caveat that it lists every imported transfer.
+
+What consumes a match is a separate change. Netting matched pairs in portfolio cash
+flows, and including matched in-flight value in valuation when both accounts are
+members, both read this table and neither lands with it.
+
+Matching is a post-ingest job rather than part of ingestion, because the second side
+can arrive in a later import: it is a function of all stored state, not of one job's
+payload. It is triggered by ingestion rather than scheduled, since nothing else
+changes the state it reads.

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -65,6 +65,7 @@ type DB interface {
 	InflationIndexDB
 	CorporateEventDB
 	ResidualBalanceDB
+	TransferMatchDB
 }
 
 // PriceFetchBlockDB manages permanently blocked (instrument, plugin) pairs.
@@ -1096,4 +1097,79 @@ type ResidualBalanceDB interface {
 	// history. The transfer count includes settled transfers, and will until
 	// matching (0068) makes the two distinguishable.
 	CountResidualBalances(ctx context.Context, staleBefore time.Time) (imbalances, staleTransfers int32, err error)
+}
+
+// Match methods for the transfer_matches table, mirroring its CHECK constraint.
+// There is no amount-and-window-alone method: a pair with no evidence beyond an
+// equal and opposite amount is left unmatched rather than guessed at.
+const (
+	// TransferMatchPointer -- the source named the other account outright.
+	TransferMatchPointer = "POINTER"
+	// TransferMatchReference -- the two sides' broker references are adjacent.
+	TransferMatchReference = "REFERENCE"
+	// TransferMatchManual -- a person said so. Nothing produces one yet; the
+	// matcher only ever inserts, so one will survive every rebuild.
+	TransferMatchManual = "MANUAL"
+)
+
+// TransferSide is one unmatched side of a transfer: the TRANSFER_CLEARING residual
+// of a journal group, carrying the evidence the rest of its group holds. One row per
+// (group, commodity), because balancing emits one residual per commodity and that
+// pair is what a match is keyed on.
+type TransferSide struct {
+	UserID       string
+	GroupID      string
+	Broker       apiv1.Broker
+	Account      string
+	InstrumentID string
+	TxType       apiv1.TxType
+	// Amount is the residual's split-adjusted quantity, signed. Positive means the
+	// value left this account -- the group's own leg is negative and the clearing
+	// leg holds what is owed out -- and negative means it arrived. A pair is two
+	// sides summing to exactly zero.
+	Amount    decimal.Decimal
+	Timestamp time.Time
+	// BrokerRefs are the distinct source references of the group's postings, and
+	// CounterpartyAccounts the distinct accounts they name as the other side. Sets
+	// rather than single values: a group is several source rows, the evidence can
+	// sit on any of them, and the nearest reference over the whole set is what the
+	// sample data supports. Either may be empty, for a source that supplied none.
+	BrokerRefs           []string
+	CounterpartyAccounts []string
+}
+
+// TransferMatch links the two sides of one transfer in one commodity. FromGroupID is
+// the side the value left and ToGroupID where it arrived.
+type TransferMatch struct {
+	UserID       string
+	FromGroupID  string
+	ToGroupID    string
+	InstrumentID string
+	Method       string
+}
+
+// TransferSideOpts filters the unmatched sides read for matching. An empty UserID
+// reads every user's, which is what a whole-corpus pass wants.
+type TransferSideOpts struct {
+	UserID string
+}
+
+// TransferMatchDB records which tx group holds the other side of a transfer.
+//
+// The links are derived and disposable: they cascade on group delete, so a re-upload
+// leaves the surviving side unmatched and the matcher rebuilds it. Nothing here
+// updates or deletes a link, which is what lets a MANUAL match survive a rebuild.
+type TransferMatchDB interface {
+	// ListUnmatchedTransferSides returns every TRANSFER_CLEARING residual that no
+	// match names, with the evidence its group carries. Ordered by
+	// (user_id, instrument_id, timestamp, group_id) so a matching pass is
+	// deterministic.
+	ListUnmatchedTransferSides(ctx context.Context, opts TransferSideOpts) ([]TransferSide, error)
+	// CreateTransferMatches inserts links and returns how many were written. It
+	// skips any link whose either side is already matched in that commodity, so a
+	// re-run over unchanged data writes nothing.
+	CreateTransferMatches(ctx context.Context, matches []TransferMatch) (int, error)
+	// ListTransferMatches returns one user's links, newest first. For the report
+	// and for tests; the matching path itself reads none.
+	ListTransferMatches(ctx context.Context, userID string) ([]TransferMatch, error)
 }

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -1122,7 +1122,6 @@ type TransferSide struct {
 	Broker       apiv1.Broker
 	Account      string
 	InstrumentID string
-	TxType       apiv1.TxType
 	// Amount is the residual's split-adjusted quantity, signed. Positive means the
 	// value left this account -- the group's own leg is negative and the clearing
 	// leg holds what is owed out -- and negative means it arrived. A pair is two

--- a/server/db/postgres/instruments.go
+++ b/server/db/postgres/instruments.go
@@ -44,6 +44,15 @@ func mergeInstruments(ctx context.Context, exec queryable, survivor, mergedAway 
 	// A transfer match is keyed on the commodity in flight, so it moves with the
 	// postings it links. Left behind it would point at an instrument the delete
 	// below is about to remove, and the pair would look unmatched again.
+	//
+	// This can in principle collide with idx_transfer_matches_from/_to, which are
+	// unique per (group, instrument): one group would have to hold matched
+	// residuals in both instruments being merged, which needs a JRNLSEC group whose
+	// two securities turn out to be the same one. No converter emits that. It is
+	// left to fail the merge loudly rather than resolved with ON CONFLICT DO
+	// NOTHING, because silently dropping one of the two links would leave a side
+	// unmatched with nothing to say why -- and a merge that aborts is recoverable,
+	// where a quietly wrong ledger is not.
 	if _, err := exec.ExecContext(ctx, `
 		UPDATE transfer_matches SET instrument_id = $1::uuid WHERE instrument_id = $2::uuid
 	`, survivor, mergedAway); err != nil {

--- a/server/db/postgres/instruments.go
+++ b/server/db/postgres/instruments.go
@@ -41,6 +41,14 @@ func mergeInstruments(ctx context.Context, exec queryable, survivor, mergedAway 
 	`, survivor, mergedAway); err != nil {
 		return fmt.Errorf("update txs: %w", err)
 	}
+	// A transfer match is keyed on the commodity in flight, so it moves with the
+	// postings it links. Left behind it would point at an instrument the delete
+	// below is about to remove, and the pair would look unmatched again.
+	if _, err := exec.ExecContext(ctx, `
+		UPDATE transfer_matches SET instrument_id = $1::uuid WHERE instrument_id = $2::uuid
+	`, survivor, mergedAway); err != nil {
+		return fmt.Errorf("update transfer matches: %w", err)
+	}
 	rows, err := exec.QueryContext(ctx, `SELECT identifier_type, domain, value, canonical FROM instrument_identifiers WHERE instrument_id = $1`, mergedAway)
 	if err != nil {
 		return fmt.Errorf("list identifiers: %w", err)

--- a/server/db/postgres/transfer_matches.go
+++ b/server/db/postgres/transfer_matches.go
@@ -35,7 +35,7 @@ import (
 // service fee is an INVEXPENSE whose group balances against an EXPENSE leg and
 // routes nothing to clearing.
 const unmatchedTransferSidesSQL = `
-	SELECT t.user_id, t.group_id, t.broker, t.account, t.instrument_id, t.tx_type,
+	SELECT t.user_id, t.group_id, t.broker, t.account, t.instrument_id,
 		-- The split-adjusted column, not the raw one: money never splits and the two
 		-- agree for it, but the two sides of a securities journal recorded either
 		-- side of a split are in different denominations and would not cancel.
@@ -72,7 +72,6 @@ type transferSideRow struct {
 	Broker               string          `db:"broker"`
 	Account              string          `db:"account"`
 	InstrumentID         string          `db:"instrument_id"`
-	TxType               string          `db:"tx_type"`
 	Amount               decimal.Decimal `db:"amount"`
 	Timestamp            time.Time       `db:"timestamp"`
 	BrokerRefs           pq.StringArray  `db:"broker_refs"`
@@ -86,7 +85,6 @@ func (r *transferSideRow) toDomain() db.TransferSide {
 		Broker:               strToBroker(r.Broker),
 		Account:              r.Account,
 		InstrumentID:         r.InstrumentID,
-		TxType:               strToTxType(r.TxType),
 		Amount:               r.Amount,
 		Timestamp:            r.Timestamp,
 		BrokerRefs:           []string(r.BrokerRefs),
@@ -154,31 +152,38 @@ func (p *Postgres) CreateTransferMatches(ctx context.Context, matches []db.Trans
 	return written, nil
 }
 
+// transferMatchRow is the sqlx-scannable shape for one link.
+type transferMatchRow struct {
+	UserID       string `db:"user_id"`
+	FromGroupID  string `db:"from_group_id"`
+	ToGroupID    string `db:"to_group_id"`
+	InstrumentID string `db:"instrument_id"`
+	Method       string `db:"method"`
+}
+
+func (r *transferMatchRow) toDomain() db.TransferMatch {
+	return db.TransferMatch{
+		UserID:       r.UserID,
+		FromGroupID:  r.FromGroupID,
+		ToGroupID:    r.ToGroupID,
+		InstrumentID: r.InstrumentID,
+		Method:       r.Method,
+	}
+}
+
 // ListTransferMatches implements db.TransferMatchDB.
 func (p *Postgres) ListTransferMatches(ctx context.Context, userID string) ([]db.TransferMatch, error) {
-	var rows []struct {
-		UserID       string `db:"user_id"`
-		FromGroupID  string `db:"from_group_id"`
-		ToGroupID    string `db:"to_group_id"`
-		InstrumentID string `db:"instrument_id"`
-		Method       string `db:"method"`
-	}
 	q := `
 		SELECT user_id, from_group_id, to_group_id, instrument_id, method
 		FROM transfer_matches WHERE user_id = $1::uuid
 		ORDER BY matched_at DESC, id`
+	var rows []transferMatchRow
 	if err := p.q.SelectContext(ctx, &rows, q, userID); err != nil {
 		return nil, fmt.Errorf("list transfer matches: %w", err)
 	}
 	out := make([]db.TransferMatch, len(rows))
-	for i, r := range rows {
-		out[i] = db.TransferMatch{
-			UserID:       r.UserID,
-			FromGroupID:  r.FromGroupID,
-			ToGroupID:    r.ToGroupID,
-			InstrumentID: r.InstrumentID,
-			Method:       r.Method,
-		}
+	for i := range rows {
+		out[i] = rows[i].toDomain()
 	}
 	return out, nil
 }

--- a/server/db/postgres/transfer_matches.go
+++ b/server/db/postgres/transfer_matches.go
@@ -1,0 +1,184 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/shopspring/decimal"
+
+	"github.com/leedenison/portfoliodb/server/db"
+)
+
+// unmatchedTransferSidesSQL reads the TRANSFER_CLEARING residuals no match names,
+// each carrying the evidence its whole group holds. $1 is a user id, or the empty
+// string for every user.
+//
+// The evidence is aggregated here rather than stored on the residual. A routed
+// posting is arithmetic on the legs supplied, so stamping it with a broker's
+// reference would make a derived row indistinguishable from a transcribed one; and
+// a group carries a set of references, of which the residual could only carry one.
+// The two sides of the sample's lump-sum transfer are refs 545/546/548 against 547,
+// where the nearest over the set is 1 and the first leg's alone is 2 -- and it is
+// the nearest that decides a match. The counterparty has the same problem from the
+// other direction: it sits on whichever leg the source named it on, which need not
+// be the leg a residual is built from.
+//
+// A group whose residual is in a security and one whose residual is money are
+// separate rows, because balancing emits one residual per commodity and a match is
+// keyed on the pair.
+//
+// Only a group that produced a TRANSFER_CLEARING residual is read, which is also
+// what keeps a counterparty that is not one out of the matcher's reach: Fidelity
+// names the product account a service fee was charged for in the same field, but a
+// service fee is an INVEXPENSE whose group balances against an EXPENSE leg and
+// routes nothing to clearing.
+const unmatchedTransferSidesSQL = `
+	SELECT t.user_id, t.group_id, t.broker, t.account, t.instrument_id, t.tx_type,
+		-- The split-adjusted column, not the raw one: money never splits and the two
+		-- agree for it, but the two sides of a securities journal recorded either
+		-- side of a split are in different denominations and would not cancel.
+		t.split_adjusted_quantity AS amount,
+		t.timestamp,
+		COALESCE(e.refs, '{}')           AS broker_refs,
+		COALESCE(e.counterparties, '{}') AS counterparty_accounts
+	FROM txs t
+	LEFT JOIN LATERAL (
+		SELECT array_agg(DISTINCT p.broker_ref)
+			FILTER (WHERE p.broker_ref IS NOT NULL) AS refs,
+		       array_agg(DISTINCT p.counterparty_account)
+			FILTER (WHERE p.counterparty_account IS NOT NULL) AS counterparties
+		FROM txs p
+		WHERE p.group_id = t.group_id
+	) e ON true
+	WHERE t.account_type = 'TRANSFER_CLEARING'
+		-- Routing drops a residual it cannot resolve an instrument for, so this
+		-- excludes nothing in practice; it is here so a NULL commodity cannot reach
+		-- the scan, and because instrument_id is half of a match's key.
+		AND t.instrument_id IS NOT NULL
+		AND ($1 = '' OR t.user_id = $1::uuid)
+		AND NOT EXISTS (
+			SELECT 1 FROM transfer_matches m
+			WHERE m.instrument_id = t.instrument_id
+				AND (m.from_group_id = t.group_id OR m.to_group_id = t.group_id)
+		)
+	ORDER BY t.user_id, t.instrument_id, t.timestamp, t.group_id`
+
+// transferSideRow is the sqlx-scannable shape for one unmatched side.
+type transferSideRow struct {
+	UserID               string          `db:"user_id"`
+	GroupID              string          `db:"group_id"`
+	Broker               string          `db:"broker"`
+	Account              string          `db:"account"`
+	InstrumentID         string          `db:"instrument_id"`
+	TxType               string          `db:"tx_type"`
+	Amount               decimal.Decimal `db:"amount"`
+	Timestamp            time.Time       `db:"timestamp"`
+	BrokerRefs           pq.StringArray  `db:"broker_refs"`
+	CounterpartyAccounts pq.StringArray  `db:"counterparty_accounts"`
+}
+
+func (r *transferSideRow) toDomain() db.TransferSide {
+	return db.TransferSide{
+		UserID:               r.UserID,
+		GroupID:              r.GroupID,
+		Broker:               strToBroker(r.Broker),
+		Account:              r.Account,
+		InstrumentID:         r.InstrumentID,
+		TxType:               strToTxType(r.TxType),
+		Amount:               r.Amount,
+		Timestamp:            r.Timestamp,
+		BrokerRefs:           []string(r.BrokerRefs),
+		CounterpartyAccounts: []string(r.CounterpartyAccounts),
+	}
+}
+
+// ListUnmatchedTransferSides implements db.TransferMatchDB.
+func (p *Postgres) ListUnmatchedTransferSides(ctx context.Context, opts db.TransferSideOpts) ([]db.TransferSide, error) {
+	var rows []transferSideRow
+	if err := p.q.SelectContext(ctx, &rows, unmatchedTransferSidesSQL, opts.UserID); err != nil {
+		return nil, fmt.Errorf("list unmatched transfer sides: %w", err)
+	}
+	out := make([]db.TransferSide, len(rows))
+	for i := range rows {
+		out[i] = rows[i].toDomain()
+	}
+	return out, nil
+}
+
+// insertTransferMatchSQL writes one link unless either side is already matched in
+// that commodity.
+//
+// A guarded insert rather than ON CONFLICT, which can infer only one index and there
+// are two -- one per direction. The guard also covers the case the indexes cannot:
+// a group arriving as the *from* side of one proposed link and the *to* side of
+// another within the same batch.
+//
+// This is what makes a matching pass re-runnable. A cycle over unchanged data
+// proposes the links that already exist and writes none of them.
+const insertTransferMatchSQL = `
+	INSERT INTO transfer_matches (user_id, from_group_id, to_group_id, instrument_id, method)
+	SELECT $1::uuid, $2::uuid, $3::uuid, $4::uuid, $5
+	WHERE NOT EXISTS (
+		SELECT 1 FROM transfer_matches m
+		WHERE m.instrument_id = $4::uuid
+			AND (m.from_group_id IN ($2::uuid, $3::uuid)
+			  OR m.to_group_id   IN ($2::uuid, $3::uuid))
+	)`
+
+// CreateTransferMatches implements db.TransferMatchDB.
+func (p *Postgres) CreateTransferMatches(ctx context.Context, matches []db.TransferMatch) (int, error) {
+	if len(matches) == 0 {
+		return 0, nil
+	}
+	written := 0
+	err := p.runInTx(ctx, func(exec queryable) error {
+		for _, m := range matches {
+			res, err := exec.ExecContext(ctx, insertTransferMatchSQL,
+				m.UserID, m.FromGroupID, m.ToGroupID, m.InstrumentID, m.Method)
+			if err != nil {
+				return fmt.Errorf("insert transfer match: %w", err)
+			}
+			n, err := res.RowsAffected()
+			if err != nil {
+				return fmt.Errorf("insert transfer match: %w", err)
+			}
+			written += int(n)
+		}
+		return nil
+	})
+	if err != nil {
+		return 0, err
+	}
+	return written, nil
+}
+
+// ListTransferMatches implements db.TransferMatchDB.
+func (p *Postgres) ListTransferMatches(ctx context.Context, userID string) ([]db.TransferMatch, error) {
+	var rows []struct {
+		UserID       string `db:"user_id"`
+		FromGroupID  string `db:"from_group_id"`
+		ToGroupID    string `db:"to_group_id"`
+		InstrumentID string `db:"instrument_id"`
+		Method       string `db:"method"`
+	}
+	q := `
+		SELECT user_id, from_group_id, to_group_id, instrument_id, method
+		FROM transfer_matches WHERE user_id = $1::uuid
+		ORDER BY matched_at DESC, id`
+	if err := p.q.SelectContext(ctx, &rows, q, userID); err != nil {
+		return nil, fmt.Errorf("list transfer matches: %w", err)
+	}
+	out := make([]db.TransferMatch, len(rows))
+	for i, r := range rows {
+		out[i] = db.TransferMatch{
+			UserID:       r.UserID,
+			FromGroupID:  r.FromGroupID,
+			ToGroupID:    r.ToGroupID,
+			InstrumentID: r.InstrumentID,
+			Method:       r.Method,
+		}
+	}
+	return out, nil
+}

--- a/server/db/postgres/transfer_matches_test.go
+++ b/server/db/postgres/transfer_matches_test.go
@@ -1,0 +1,226 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// transferFixture stands up the two sides of one transfer hop as ingestion would
+// leave them: a journal posting in each account, each balanced by a
+// TRANSFER_CLEARING counterparty holding the value in transit. It returns the group
+// ids of the departure and the arrival.
+//
+// The rows are the 2025-04-15 lump sum from the Fidelity master, whose references
+// differ by 3.
+func transferFixture(t *testing.T, p *Postgres, userID, instID string) (from, to string) {
+	t.Helper()
+	ctx := context.Background()
+	base := time.Date(2025, 4, 15, 0, 0, 0, 0, time.UTC)
+	period := func() (*timestamppb.Timestamp, *timestamppb.Timestamp) {
+		return timestamppb.New(base), timestamppb.New(base.Add(24 * time.Hour))
+	}
+	side := func(account, qty, ref, counterparty string) []*apiv1.Tx {
+		return []*apiv1.Tx{
+			{Timestamp: timestamppb.New(base), InstrumentDescription: "GBP", Type: apiv1.TxType_TRANSFER,
+				Quantity: qty, Account: account, GroupRef: ref, BrokerRef: ref,
+				CounterpartyAccount: counterparty},
+			// The clearing counterparty, equal and opposite, as routing writes it:
+			// no reference of its own, because it was transcribed from no row.
+			{Timestamp: timestamppb.New(base), InstrumentDescription: "GBP", Type: apiv1.TxType_TRANSFER,
+				Quantity: negate(t, qty), Account: account, GroupRef: ref,
+				AccountType: apiv1.AccountType_ACCOUNT_TYPE_TRANSFER_CLEARING},
+		}
+	}
+	f, b := period()
+	txs := append(side("AG10041188", "-20000", "1093663528", ""),
+		side("AW10075724", "20000", "1093663531", "AG10041188")...)
+	ids := []string{instID, instID, instID, instID}
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "FIDELITY", "", f, b, txs, ids, nil, nil); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+	// The departure's clearing leg is positive: the account's own leg is negative
+	// and the clearing leg holds what is owed out.
+	if err := p.q.QueryRowContext(ctx, `
+		SELECT group_id FROM txs
+		WHERE user_id = $1::uuid AND account_type = 'TRANSFER_CLEARING' AND quantity > 0
+	`, userID).Scan(&from); err != nil {
+		t.Fatalf("departure group: %v", err)
+	}
+	if err := p.q.QueryRowContext(ctx, `
+		SELECT group_id FROM txs
+		WHERE user_id = $1::uuid AND account_type = 'TRANSFER_CLEARING' AND quantity < 0
+	`, userID).Scan(&to); err != nil {
+		t.Fatalf("arrival group: %v", err)
+	}
+	return from, to
+}
+
+func negate(t *testing.T, qty string) string {
+	t.Helper()
+	if qty[0] == '-' {
+		return qty[1:]
+	}
+	return "-" + qty
+}
+
+func transferUser(t *testing.T, p *Postgres, sub string) (userID, instID string) {
+	t.Helper()
+	ctx := context.Background()
+	userID, _ = p.GetOrCreateUser(ctx, sub, "U", sub+"@t.com")
+	instID, err := p.EnsureInstrument(ctx, "", "", "", "", "", "",
+		[]db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: sub, Value: "GBP", Canonical: false}}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+	return userID, instID
+}
+
+// TestListUnmatchedTransferSides_ReadsBothSidesWithTheirEvidence verifies the shape
+// the matcher works on: one row per clearing residual, signed by direction, carrying
+// the references and counterparties of its whole group rather than of the residual,
+// which was transcribed from no row and carries neither.
+func TestListUnmatchedTransferSides_ReadsBothSidesWithTheirEvidence(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, instID := transferUser(t, p, "sub|tm-sides")
+	transferFixture(t, p, userID, instID)
+
+	sides, err := p.ListUnmatchedTransferSides(ctx, db.TransferSideOpts{UserID: userID})
+	if err != nil {
+		t.Fatalf("list sides: %v", err)
+	}
+	if len(sides) != 2 {
+		t.Fatalf("got %d unmatched sides, want 2", len(sides))
+	}
+	byAccount := map[string]db.TransferSide{}
+	for _, s := range sides {
+		byAccount[s.Account] = s
+	}
+	departure, arrival := byAccount["AG10041188"], byAccount["AW10075724"]
+	if !departure.Amount.Add(arrival.Amount).IsZero() {
+		t.Errorf("sides sum to %v, want a pair summing to exactly zero",
+			departure.Amount.Add(arrival.Amount))
+	}
+	if !departure.Amount.IsPositive() {
+		t.Errorf("departure amount = %v, want positive: the value left this account", departure.Amount)
+	}
+	// The evidence comes from the journal leg, not from the residual beside it.
+	if len(departure.BrokerRefs) != 1 || departure.BrokerRefs[0] != "1093663528" {
+		t.Errorf("departure broker refs = %v, want [1093663528]", departure.BrokerRefs)
+	}
+	if len(departure.CounterpartyAccounts) != 0 {
+		t.Errorf("departure counterparties = %v, want none: only the receiving side names one",
+			departure.CounterpartyAccounts)
+	}
+	if len(arrival.CounterpartyAccounts) != 1 || arrival.CounterpartyAccounts[0] != "AG10041188" {
+		t.Errorf("arrival counterparties = %v, want [AG10041188]", arrival.CounterpartyAccounts)
+	}
+}
+
+// TestCreateTransferMatches_ClearsBothSides verifies a match takes both sides out of
+// the unmatched set, which is what makes a residual TRANSFER_CLEARING balance mean
+// an unmatched transfer rather than any transfer.
+func TestCreateTransferMatches_ClearsBothSides(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, instID := transferUser(t, p, "sub|tm-clear")
+	from, to := transferFixture(t, p, userID, instID)
+
+	n, err := p.CreateTransferMatches(ctx, []db.TransferMatch{{
+		UserID: userID, FromGroupID: from, ToGroupID: to,
+		InstrumentID: instID, Method: db.TransferMatchReference,
+	}})
+	if err != nil {
+		t.Fatalf("create match: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("wrote %d matches, want 1", n)
+	}
+	sides, err := p.ListUnmatchedTransferSides(ctx, db.TransferSideOpts{UserID: userID})
+	if err != nil {
+		t.Fatalf("list sides: %v", err)
+	}
+	if len(sides) != 0 {
+		t.Errorf("got %d unmatched sides after matching, want none", len(sides))
+	}
+	matches, err := p.ListTransferMatches(ctx, userID)
+	if err != nil {
+		t.Fatalf("list matches: %v", err)
+	}
+	if len(matches) != 1 || matches[0].FromGroupID != from || matches[0].ToGroupID != to {
+		t.Errorf("stored match = %+v, want %s -> %s", matches, from, to)
+	}
+}
+
+// TestCreateTransferMatches_IsIdempotent verifies a second pass over unchanged data
+// writes nothing. The matcher is re-runnable because the second side of a transfer
+// can arrive in a later import, so every cycle re-proposes what it already decided.
+func TestCreateTransferMatches_IsIdempotent(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, instID := transferUser(t, p, "sub|tm-idem")
+	from, to := transferFixture(t, p, userID, instID)
+	m := db.TransferMatch{UserID: userID, FromGroupID: from, ToGroupID: to,
+		InstrumentID: instID, Method: db.TransferMatchReference}
+
+	if _, err := p.CreateTransferMatches(ctx, []db.TransferMatch{m}); err != nil {
+		t.Fatalf("first pass: %v", err)
+	}
+	n, err := p.CreateTransferMatches(ctx, []db.TransferMatch{m})
+	if err != nil {
+		t.Fatalf("second pass: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("second pass wrote %d matches, want 0", n)
+	}
+
+	// The same guard rejects a side being matched again against a different group,
+	// which is what stops one arrival satisfying two departures.
+	other := newTxGroup(t, p, userID)
+	n, err = p.CreateTransferMatches(ctx, []db.TransferMatch{{
+		UserID: userID, FromGroupID: other, ToGroupID: to,
+		InstrumentID: instID, Method: db.TransferMatchReference,
+	}})
+	if err != nil {
+		t.Fatalf("second claim on the arrival: %v", err)
+	}
+	if n != 0 {
+		t.Errorf("a second claim on an already-matched side wrote %d, want 0", n)
+	}
+}
+
+// TestTransferMatches_CascadeOnReupload verifies the link is disposable. Re-uploading
+// a period replaces one side's groups; the link goes with them and the surviving side
+// reappears as unmatched, so the matcher can pair it again without anything having to
+// know a re-upload happened.
+func TestTransferMatches_CascadeOnReupload(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, instID := transferUser(t, p, "sub|tm-cascade")
+	from, to := transferFixture(t, p, userID, instID)
+	if _, err := p.CreateTransferMatches(ctx, []db.TransferMatch{{
+		UserID: userID, FromGroupID: from, ToGroupID: to,
+		InstrumentID: instID, Method: db.TransferMatchReference,
+	}}); err != nil {
+		t.Fatalf("create match: %v", err)
+	}
+
+	// Replacing the period deletes both sides' groups, so both links and postings go.
+	base := time.Date(2025, 4, 15, 0, 0, 0, 0, time.UTC)
+	f, b := timestamppb.New(base), timestamppb.New(base.Add(24*time.Hour))
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "FIDELITY", "", f, b, nil, nil, nil, nil); err != nil {
+		t.Fatalf("replace with nothing: %v", err)
+	}
+	matches, err := p.ListTransferMatches(ctx, userID)
+	if err != nil {
+		t.Fatalf("list matches: %v", err)
+	}
+	if len(matches) != 0 {
+		t.Errorf("got %d matches after the groups were replaced, want none", len(matches))
+	}
+}

--- a/server/db/postgres/transfer_matches_test.go
+++ b/server/db/postgres/transfer_matches_test.go
@@ -224,3 +224,65 @@ func TestTransferMatches_CascadeOnReupload(t *testing.T) {
 		t.Errorf("got %d matches after the groups were replaced, want none", len(matches))
 	}
 }
+
+// TestTransferMatches_SurviveAnInstrumentMerge verifies the link moves with the
+// postings it names. A match is keyed on the commodity in flight, so one left behind
+// would point at the instrument the merge deletes and the settled pair would surface
+// as unmatched again.
+func TestTransferMatches_SurviveAnInstrumentMerge(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|tm-merge", "U", "u@merge.com")
+	// Two instruments that turn out to be one security. The transfer is posted
+	// against the one that loses the merge -- the survivor is whichever carries more
+	// identifiers -- so the rewrite is the thing under test rather than a no-op.
+	mergedAway, err := p.EnsureInstrument(ctx, "", "", "", "", "", "",
+		[]db.IdentifierInput{{Type: "ISIN", Value: "TM1", Canonical: true}}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure merged-away: %v", err)
+	}
+	if _, err := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{
+		{Type: "CUSIP", Value: "TM1", Canonical: true},
+		{Type: "SEDOL", Value: "TM1", Canonical: true},
+	}, "", nil, nil, nil); err != nil {
+		t.Fatalf("ensure survivor: %v", err)
+	}
+	from, to := transferFixture(t, p, userID, mergedAway)
+	if _, err := p.CreateTransferMatches(ctx, []db.TransferMatch{{
+		UserID: userID, FromGroupID: from, ToGroupID: to,
+		InstrumentID: mergedAway, Method: db.TransferMatchReference,
+	}}); err != nil {
+		t.Fatalf("create match: %v", err)
+	}
+
+	// Naming both identifiers at once is what merges them.
+	survivor, err := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{
+		{Type: "ISIN", Value: "TM1", Canonical: true},
+		{Type: "CUSIP", Value: "TM1", Canonical: true},
+	}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("merge: %v", err)
+	}
+	if survivor == mergedAway {
+		t.Fatal("fixture did not merge away the instrument the match was keyed on")
+	}
+
+	matches, err := p.ListTransferMatches(ctx, userID)
+	if err != nil {
+		t.Fatalf("list matches: %v", err)
+	}
+	if len(matches) != 1 {
+		t.Fatalf("got %d matches after the merge, want the pair to survive it", len(matches))
+	}
+	if matches[0].InstrumentID != survivor {
+		t.Errorf("match instrument = %s, want the survivor %s", matches[0].InstrumentID, survivor)
+	}
+	// And the pair is still settled, which is the thing the report reads.
+	sides, err := p.ListUnmatchedTransferSides(ctx, db.TransferSideOpts{UserID: userID})
+	if err != nil {
+		t.Fatalf("list sides: %v", err)
+	}
+	if len(sides) != 0 {
+		t.Errorf("got %d unmatched sides after the merge, want none", len(sides))
+	}
+}

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -456,6 +456,62 @@ CREATE UNIQUE INDEX idx_txs_initialize_unique
   ON txs (user_id, broker, account, instrument_id, account_type)
   WHERE synthetic_purpose = 'INITIALIZE';
 
+-- The two sides of a transfer, paired after the fact.
+--
+-- Each side of a journal is balanced by a TRANSFER_CLEARING counterparty and the two
+-- are deliberately not paired at ingest, because brokers report them in separate
+-- statements and sometimes in separate imports. This is the pairing. It records which
+-- group -- and so which account -- holds the other side, because that identity is what
+-- the portfolio membership test in docs/adr/0022-typed-per-account-cash-flow-boundary.md
+-- consumes; that a match merely exists would not answer it.
+--
+-- A link rather than a status column on the posting, which could say that a side was
+-- matched but not what it matched with. And not a synthetic third group closing both
+-- sides out, which would fabricate an economic event that never happened and have to be
+-- unpicked on rematch. Both alternatives are also unreachable: check_tx_group_balance()
+-- rejects mutating or deleting a single leg of a group.
+--
+-- Derived and disposable. A re-upload replaces one side's groups
+-- (docs/adr/0002-transaction-ingestion-model.md), the cascade takes the link with them,
+-- the surviving side reappears as unmatched and the matcher runs again. It is never
+-- authoritative and is always cheap to rebuild.
+--
+-- Directed. from_group_id is the side the value left: its TRANSFER_CLEARING residual is
+-- positive, because the group's own leg is negative and the clearing leg holds what is
+-- owed out. to_group_id is where it arrived. The direction costs nothing to record --
+-- it is the sign of the residual -- and a link that did not carry it would read the
+-- same for a transfer in either direction.
+--
+-- Keyed per (group, commodity) rather than per group, which is what the two unique
+-- indexes say. Balancing emits one residual per commodity, so an unpaired JRNLSEC group
+-- can have a security side and a cash side in flight independently and each pairs with
+-- a different group. instrument_id moves with an instrument merge, alongside
+-- txs.instrument_id.
+--
+-- Neither the quantity nor the ingestion job is stored. The two sides are equal and
+-- opposite by construction, so a stored amount could only disagree with them, and a
+-- match is not made by an ingestion job.
+CREATE TABLE transfer_matches (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID NOT NULL REFERENCES users (id) ON DELETE CASCADE,
+  from_group_id UUID NOT NULL REFERENCES tx_groups (id) ON DELETE CASCADE,
+  to_group_id   UUID NOT NULL REFERENCES tx_groups (id) ON DELETE CASCADE,
+  instrument_id UUID NOT NULL REFERENCES instruments (id),
+  -- How the pair was found. POINTER is the source naming the other account outright;
+  -- REFERENCE is the proximity of the two sides' broker references; MANUAL is a person
+  -- saying so. There is no amount-and-window-alone value: a pair with no evidence
+  -- beyond an equal and opposite amount is left unmatched rather than guessed at.
+  method        TEXT NOT NULL CHECK (method IN ('POINTER', 'REFERENCE', 'MANUAL')),
+  matched_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CHECK (from_group_id <> to_group_id)
+);
+
+-- One match per side per commodity, in both directions. These are the uniqueness
+-- constraint and the lookup index at once: what holds the other side of a group is
+-- (from_group_id = g OR to_group_id = g), and neither side can be matched twice.
+CREATE UNIQUE INDEX idx_transfer_matches_from ON transfer_matches (from_group_id, instrument_id);
+CREATE UNIQUE INDEX idx_transfer_matches_to   ON transfer_matches (to_group_id, instrument_id);
+
 -- Portfolio filter matching view: returns (portfolio_id, tx_id) pairs for txs
 -- matching the portfolio's filters. Semantics: AND between categories (broker,
 -- account, instrument), OR within each category. Categories with no filters are

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -491,6 +491,13 @@ CREATE UNIQUE INDEX idx_txs_initialize_unique
 -- Neither the quantity nor the ingestion job is stored. The two sides are equal and
 -- opposite by construction, so a stored amount could only disagree with them, and a
 -- match is not made by an ingestion job.
+--
+-- user_id must be the owner of both groups, and both groups must have the same owner.
+-- Neither is checked here: a CHECK cannot reach another table and a trigger to enforce
+-- it would run on every insert to catch a case no caller can produce. The matcher
+-- partitions its candidates by user before proposing anything, so a cross-user pair
+-- cannot be built. The column is a denormalisation for query scoping -- deleting a
+-- user already cascades through tx_groups -- and the invariant is the caller's.
 CREATE TABLE transfer_matches (
   id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id       UUID NOT NULL REFERENCES users (id) ON DELETE CASCADE,


### PR DESCRIPTION
Third of five PRs for [0068](docs/issues/0068-match-in-flight-transfers.md). **Stacked on #337**, alongside #338 -- both branch off it and neither depends on the other. This adds the table and its db layer; the matcher that fills it is PR4.

## Why

Each side of a journal is balanced against `TRANSFER_CLEARING` and the two are deliberately not paired at ingest, because a broker reports them in separate statements and sometimes in separate imports. Nothing has ever paired them afterwards either, so the clearing account only grows and a residual balance says *a transfer was imported* rather than *a side is missing*.

## The shape

`transfer_matches` names the two groups, the commodity, how they were matched and when. It records **which group holds the other side**, not merely that a match exists, because the portfolio membership test in ADR 0022 asks whether *both* accounts are members before it nets a pair, and only the other group's identity answers that.

A link rather than a status column on the posting -- which could say a side was matched but not what it matched with -- and rather than a synthetic third group closing both sides out, which fabricates an economic event that never happened. Both are unreachable anyway: `check_tx_group_balance()` rejects mutating or deleting a single leg, so only a whole group deleted passes. The invariant that makes ingestion trustworthy is the same one that rules out every representation except a link beside the ledger.

Two details the issue under-specifies:

- **Keyed per `(group, commodity)`**, not per group. Balancing emits one residual per commodity, so an unpaired `JRNLSEC` group can have a security side and a cash side in flight independently, each pairing with a different group. Hence two unique indexes, one per direction.
- **Directed.** `from_group_id` is the side the value left, whose clearing residual is positive because the group's own leg is negative. The direction is free -- it is the sign of the residual -- and a link without it reads identically for a transfer either way.

`method` has no `AMOUNT_WINDOW` value: a pair with no evidence beyond an equal and opposite amount is left unmatched rather than guessed at. `MANUAL` is there and nothing produces one yet; the matcher only ever inserts, so one will survive every rebuild.

## The candidate query

`ListUnmatchedTransferSides` aggregates each group's references and counterparties through a lateral rather than reading them off the residual. Two reasons:

1. A routed residual is arithmetic on the legs supplied and was transcribed from no row, so it carries neither field -- and stamping it with a broker's reference would make a derived row indistinguishable from a transcribed one.
2. A group carries a *set* of references and it is the **nearest over the set** that decides a match. The sample's lump sum is refs 545/546/548 against 547: nearest over the set is 1, the first leg's alone is 2. Collapsing to one value throws away the signal PR1 paid a schema change to capture.

Reading only groups that produced a clearing residual is also what keeps a counterparty that is not one out of the matcher's reach: Fidelity names a service fee's product account in the same field, and a service fee is an `INVEXPENSE` whose group balances against an `EXPENSE` leg and routes nothing to clearing. That guard is a comment and a test, not folklore.

## Idempotency

`CreateTransferMatches` uses a guarded insert rather than `ON CONFLICT`, which can infer only one of the two indexes and cannot see a group appearing on both sides within one batch. A pass over unchanged data writes nothing, which is what makes the matcher re-runnable when the second side arrives in a later import.

## Instrument merge

`mergeInstruments` now rewrites `transfer_matches.instrument_id` alongside `txs.instrument_id`, in the same transaction. Left behind, a link would point at an instrument the merge is about to delete and the pair would look unmatched again.

## Docs

New ADR [0037](docs/adr/0037-transfer-matches-are-links-not-postings.md), cross-referenced from 0021 and 0022. Its load-bearing section is why a post-ingest matcher does not contradict 0021: a match creates no posting and no group, corrupts no balance if wrong, and is disposable; and 0021's own premise for converter-owned pairing -- that the references are discarded before the server sees them -- stopped holding in #337.

## Testing

`make check` and `make test` pass. Four integration tests against real postgres: both sides surface with the right signs and evidence sets, a match clears both, a second pass writes nothing (and a second claim on a matched side is refused), and replacing a period cascades the link away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)