### PR TITLE
Open the archive proto package with its envelope and shared types (0078)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,7 +101,10 @@ Whenever you begin work in a new worktree you should:
 
 The informantion architecture of the user interface is described in docs/spec/information-architecture.md.  It describes key concepts for users (and admin users), how they relate to each other, the relative importance they carry for the user and gives the example of how the information architecture should impact global navigation.
 
-The file formats for transaction, price and corporate event imports are documented in docs/spec/csv-format.md.
+The archive format -- the single import and export format that replaces the
+transaction CSV, the price CSV, the instrument JSON and the corporate event JSON
+-- is documented in docs/spec/archive-format.md. The formats it has not yet
+replaced are documented in docs/spec/csv-format.md.
 
 Automated transaction import via the browser extension is specified in docs/spec/broker-import-extension.md.
 

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -38,7 +38,9 @@ Protobuf source only; generated `.pb.go` files under `proto/` are build outputs 
   These define the gRPC services used by the front end and by transaction ingestion.  
   `proto/type/v1/type.proto` holds the controlled vocabularies shared by every
   other package; unlike the rest of `proto/` it is not free to break, and
-  `docs/adr/0038-controlled-vocabularies-are-shared.md` says why.
+  `docs/adr/0038-controlled-vocabularies-are-shared.md` says why.  
+  `proto/archive/v1/` defines the import and export file format rather than a
+  gRPC service; it is specified in `docs/spec/archive-format.md`.
 
 Generated bindings are produced by buf/protoc: Go code under **proto/** (e.g. `proto/api/v1/*.pb.go`), TypeScript under **client/gen**. Those outputs are in `.gitignore`. See the `protobuf` skill (`.claude/skills/protobuf/`) for generation rules.
 

--- a/docs/spec/archive-format.md
+++ b/docs/spec/archive-format.md
@@ -1,0 +1,175 @@
+# Archive format
+
+The archive is the single import and export format. One schema, defined in
+`proto/archive/v1/` and serialised as protojson, replaces the standard
+transaction CSV, the price CSV, the instrument JSON and the corporate event
+JSON.
+
+Broker-specific files -- the Fidelity CSV, the IBKR OFX, the Schwab CSV -- are
+not affected. They are the broker's own output and PortfolioDB does not define
+them; converters read them into archive messages directly. Only the formats
+PortfolioDB itself defines are replaced.
+
+## What an archive is
+
+An archive exists to rebuild an instance on a new server without losing data and
+without re-running expensive external operations, identifier lookup above all.
+It is neither a general interchange format nor a full database backup, and the
+difference decides what it carries.
+
+It carries two kinds of thing:
+
+- **Irreplaceable data.** Transactions and their grouping, holding declarations,
+  portfolios, preferences, plugin configuration, fetch-block reasons, resolved
+  corporate events, and hand-recovered prices no provider still serves. Nothing
+  can reconstruct these.
+- **Data that is expensive to reacquire.** Instruments and their identifiers,
+  provider identifiers, prices with their coverage, corporate events with their
+  coverage, and inflation indices. These are refetchable in principle, at the
+  cost of the paid, rate-limited lookups the archive exists to avoid.
+
+It does not carry anything the importing instance recomputes: split-adjusted
+quantities and prices, posting weights, synthetic opening postings, lots and
+realised gains, identification and validation errors, ingestion jobs, or
+computed holdings and valuations. Exporting derived state would invite a round
+trip to change a number -- to carry a rounding, or to mix share counts -- which
+`docs/spec/bitemporality.md` forbids.
+
+Full reasoning: `docs/adr/0032-archive-preserves-inputs-not-derived-state.md`.
+
+## The two archives
+
+Export and import split by data ownership rather than bundling everything into
+one file.
+
+- The **admin archive** carries shared data and no user data: instruments and
+  their identifiers, prices and coverage, corporate events and coverage,
+  inflation indices, fetch blocks, unhandled event resolutions and plugin
+  configuration.
+- The **user archive** carries one user's own data and no admin data:
+  transactions and their grouping, holding declarations, and preferences.
+
+They have different owners, different authorisation and different lifecycles.
+Shared reference data is curated by an admin and refetchable in principle; user
+data is authoritative and recoverable from nowhere. Bundling them would put one
+user's transactions in an artefact an admin exports, and force an ordinary user
+to hold reference data they have no business owning.
+
+Restoring a user archive into an instance with no instruments loaded leaves its
+postings to resolve from scratch. That is working as intended: the normal
+identifier resolution path handles it and the result is correct, merely
+expensive. **Restoring the admin archive first is a recommendation, not a
+constraint** -- avoiding that cost is what the archive buys, not a mechanism it
+depends on.
+
+Full reasoning: `docs/adr/0033-admin-and-user-archives-are-separate.md`.
+
+## The three levels
+
+A file has three levels, and each states its own scope in full.
+
+- **File.** The `envelope`, and nothing else. It carries `format_version`,
+  `exported_at`, the source instance and which of the two archives this is.
+- **Group.** The entity's aggregate root: the instrument for prices and
+  corporate events, the transaction window and group for transactions, the
+  statement for holding declarations. Coverage, `share_count_basis`, asset class
+  and currency live here.
+- **Row.** Only what varies per row. A price row is a date and a bar.
+
+A field belongs at the file level only if it **cannot** differ between two rows
+of a valid file. Being constant in practice is not enough. The flat formats got
+this wrong in both directions: `prices-recovered.csv` carries ninety coverage
+declarations and every one of them is instrument-scoped, so the file-wide slot
+the format was designed around goes unused -- coverage diverges exactly when
+instruments have different lifetimes, which is the case it exists to record.
+Meanwhile `ExportPriceRow.exported_at` stamps one value onto every row, because
+the stream has nowhere else to put it.
+
+**There is no inheritance or override between levels.** Repetition is cheap in a
+machine format and compresses away; precedence rules are expensive, because
+every reader has to implement them identically and a disagreement between two
+readers is silent. The price CSV needs four rules to rebuild nesting from
+flatness -- at most one global declaration, a specific one overrides rather than
+adds, several specifics all apply, a partial identifier is an error -- plus two
+cases the export must always write out in full. The cost of getting one of them
+wrong is not an error but a wrong number: a missing share count basis reads as
+as-traded, and back-adjusted prices are then adjusted a second time.
+
+Full reasoning: `docs/adr/0035-archive-nests-by-aggregate-root.md`.
+
+## Shared conventions
+
+These hold everywhere in the format, and are stated here rather than repeated
+per part.
+
+**Dates** are `"YYYY-MM-DD"` strings. **Instants** are RFC 3339, as protojson
+writes a `google.protobuf.Timestamp`: `"2026-07-30T00:00:00Z"`.
+
+**Date intervals** are half-open `[from, before)` and always name the exclusive
+bound `before`. To cover through 31 December 2024, write
+`{"from": "2024-01-01", "before": "2025-01-01"}`. See
+`docs/adr/0018-half-open-date-intervals.md`.
+
+**Decimals** -- quantities, prices, money, split factors -- are canonical
+decimal strings, never JSON numbers: `"185.9"`, not `185.9`. A `double` cannot
+carry an exact decimal, and a value that does not reimport identically is a bug.
+Trailing zeroes are the only thing not preserved: `"1.50"` and `"1.5"` are the
+same price. See `docs/adr/0027-decimal-values-cross-the-wire-as-strings.md`.
+
+**Absent is not zero.** A field is written only when it has a value, and a field
+that is absent means the file does not state it. An absent `unit_price` is not a
+price of zero -- an option expiring worthless has a declared price of zero and
+its group balances, while a posting with no price cannot be converted at all.
+Readers must not substitute a zero for an absent value.
+
+**Instruments are named by identifier, never by id.** A server UUID means
+nothing in another instance and is never written. One instrument reference is a
+triple:
+
+```json
+{"type": "MIC_TICKER", "value": "AAPL", "domain": "XNAS"}
+```
+
+`domain` is the MIC for `MIC_TICKER`, the exchange code for `OPENFIGI_TICKER`,
+and the source for `BROKER_DESCRIPTION`; it is empty for everything else, and
+absent and empty mean the same thing. Where a file states an instrument's whole
+identifier set rather than referring to it, each entry carries `canonical` as
+well, which is false only for broker-description identifiers.
+
+**Coverage** is a list of intervals on the group, saying which dates were
+authoritatively answered for. An interval holding no rows is meaningful, and is
+the only way a file can record that a provider was asked about those dates and
+had nothing; dropping it leaves valuation treating the days between reported
+bars as unpriced. See `docs/adr/0023-price-coverage-is-stored-not-inferred.md`.
+
+**Vocabularies** -- asset classes, identifier types, transaction types, account
+types, brokers -- are written by name, and the names are the same strings the
+database stores: `"STOCK"`, `"ISIN"`, `"BUYSTOCK"`. They come from
+`proto/type/v1/type.proto`, which does not remove or rename a value. See
+`docs/adr/0038-controlled-vocabularies-are-shared.md`.
+
+## The envelope
+
+Every archive is one protojson object whose first member is the envelope:
+
+```json
+{"envelope": {"format_version": 1,
+              "exported_at": "2026-07-30T00:00:00Z",
+              "source_instance": "portfoliodb.example.com",
+              "kind": "ARCHIVE_KIND_ADMIN"}}
+```
+
+- `format_version` is bumped only by a change an older reader cannot survive: a
+  field removed, renamed or retyped, or a semantic change to one that stays.
+  Adding a field does not bump it.
+- `exported_at` is knowledge time: when the data in the file was current.
+  Imported price rows and coverage record it as `last_fetched_at`, and corporate
+  events with no `first_known_at` of their own fall back to it. It says nothing
+  about which share count a value is denominated in; that is
+  `share_count_basis`, and it is a different question entirely.
+- `source_instance` is an opaque label for whatever produced the file, for a
+  reader's benefit only. Nothing keys off it.
+- `kind` is `ARCHIVE_KIND_ADMIN` or `ARCHIVE_KIND_USER`. The document's message
+  type says the same thing, but protojson records no type name, so the envelope
+  has to carry it -- without it, an importer cannot refuse a user archive handed
+  to the admin page.

--- a/proto/archive/v1/archive.proto
+++ b/proto/archive/v1/archive.proto
@@ -1,0 +1,43 @@
+syntax = "proto3";
+
+package portfoliodb.archive.v1;
+
+import "archive/v1/common.proto";
+import "buf/validate/validate.proto";
+
+option go_package = "github.com/leedenison/portfoliodb/proto/archive/v1;archivev1";
+
+// AdminArchive is one admin archive document: shared reference data, and no
+// user data at all. It is one protojson object, and it is the whole file.
+//
+// Every section is optional, because an export is a menu. Each is wrapped in
+// its own message so that a section present but empty -- included, and there
+// was nothing -- is distinguishable from a section absent, which says it was
+// not included at all.
+//
+// Field numbers run in restore order, which is also the order protojson emits
+// them in, so a document reads top to bottom in the order it is applied.
+// Instruments come first because every other part refers to them.
+// See docs/adr/0033-admin-and-user-archives-are-separate.md.
+message AdminArchive {
+  Envelope envelope = 1 [(buf.validate.field).required = true];
+  // 2 to 9 are the parts: instruments, prices, corporate events, fetch blocks
+  // and resolutions, plugin config, inflation indices.
+}
+
+// UserArchive is one user archive document: one user's own data, and no admin
+// data at all.
+//
+// Restoring into an instance whose instruments are not loaded is supported and
+// correct: postings resolve through the normal identifier path. It is merely
+// slower, which is the cost restoring the admin archive first avoids -- a
+// recommendation, not a constraint.
+//
+// Field numbers run in restore order. Preferences come first because which
+// asset classes are ignored changes what a later transaction import keeps.
+// Declarations come last because an assertion is checked against what the
+// transactions add up to.
+message UserArchive {
+  Envelope envelope = 1 [(buf.validate.field).required = true];
+  // 2 to 9 are the parts: preferences, transactions, declarations, portfolios.
+}

--- a/proto/archive/v1/common.proto
+++ b/proto/archive/v1/common.proto
@@ -1,0 +1,115 @@
+syntax = "proto3";
+
+// The archive format: the one file schema every PortfolioDB export writes and
+// every import reads. It replaces the standard transaction CSV, the price CSV,
+// the instrument JSON and the corporate event JSON, and is serialised as
+// protojson.
+//
+// It is deliberately separate from portfoliodb.api.v1 and imports nothing from
+// it. An archive is written today and read by a server that does not exist yet,
+// so it cannot be bound to a schema that is free to break while the project is
+// pre-release. The controlled vocabularies it shares with the API come from
+// portfoliodb.type.v1, which is not free to break either. See
+// docs/adr/0034-archive-format-is-its-own-proto-package.md and
+// docs/adr/0038-controlled-vocabularies-are-shared.md.
+//
+// Conventions holding for every message in this package:
+//
+//   - Encoding is protojson written with proto field names, so keys are
+//     snake_case and enums are written by name. docs/spec/archive-format.md
+//     states the options in full.
+//   - Dates are "YYYY-MM-DD" strings; instants are google.protobuf.Timestamp,
+//     which protojson writes as RFC 3339.
+//   - Every date interval is half-open [from, before) and names its exclusive
+//     bound "before". See docs/adr/0018-half-open-date-intervals.md.
+//   - Quantities, prices and money are exact decimals carried as canonical
+//     decimal strings, never as double. See
+//     docs/adr/0027-decimal-values-cross-the-wire-as-strings.md.
+//   - A field is `optional` wherever absent differs from zero: an absent unit
+//     price is not a price of zero.
+//   - An archive carries inputs, not derived state. Anything the importing
+//     instance recomputes is left out. See
+//     docs/adr/0032-archive-preserves-inputs-not-derived-state.md.
+//   - There is no inheritance or override between the file, group and row
+//     levels. Each states its own scope in full, because a precedence rule has
+//     to be implemented identically by every reader and a disagreement between
+//     two readers is silent. See
+//     docs/adr/0035-archive-nests-by-aggregate-root.md.
+package portfoliodb.archive.v1;
+
+import "buf/validate/validate.proto";
+import "google/protobuf/timestamp.proto";
+import "type/v1/type.proto";
+
+option go_package = "github.com/leedenison/portfoliodb/proto/archive/v1;archivev1";
+
+// ArchiveKind says which of the two archives a document is, so a reader can
+// refuse a user archive handed to the admin importer. The document's message
+// type says the same thing, but protojson records no type name, so the envelope
+// has to carry it.
+// See docs/adr/0033-admin-and-user-archives-are-separate.md.
+enum ArchiveKind {
+  ARCHIVE_KIND_UNSPECIFIED = 0;
+  ARCHIVE_KIND_ADMIN = 1; // shared reference data; no user data
+  ARCHIVE_KIND_USER = 2;  // one user's own data; no admin data
+}
+
+// Envelope carries only what cannot differ between two rows of a valid file.
+// Anything that can differ between rows belongs on a group or on a row.
+message Envelope {
+  // The schema version this document was written against. It is bumped only by
+  // a change an older reader cannot survive -- a field removed, renamed or
+  // retyped, or a semantic change to one that stays. Adding a field does not
+  // bump it. A reader refuses a document whose format_version exceeds its own
+  // and accepts any lower one, which turns "written by a later PortfolioDB"
+  // from a confusing parse error into a sentence the user can act on.
+  uint32 format_version = 1 [(buf.validate.field).uint32.gte = 1];
+  // Knowledge time: when the data in this file was current. Imported price rows
+  // and coverage record it as last_fetched_at, corporate events without their
+  // own first_known_at fall back to it, and option identity is adjusted to it
+  // during instrument resolution. It says nothing about which share count a
+  // value is denominated in -- that is share_count_basis, and it is a different
+  // question. See docs/spec/bitemporality.md.
+  google.protobuf.Timestamp exported_at = 2 [(buf.validate.field).required = true];
+  // Opaque label for whatever produced the file, for a reader's benefit only.
+  // Nothing keys off it. e.g. "portfoliodb.example.com" or "recover-prices.py".
+  string source_instance = 3;
+  ArchiveKind kind = 4 [(buf.validate.field).enum = {defined_only: true, not_in: [0]}];
+}
+
+// InstrumentRef names one instrument by a single identifier. It is the only way
+// an archive refers to an instrument: a server UUID means nothing in another
+// instance and is never written.
+//
+// An export writes the identifier chosen by bestIdentifierJoin (see
+// server/db/postgres/identifier_priority.go), so every export that surfaces one
+// identifier per instrument agrees on which one it is.
+message InstrumentRef {
+  portfoliodb.type.v1.IdentifierType type = 1 [(buf.validate.field).enum = {defined_only: true, not_in: [0]}];
+  string value = 2 [(buf.validate.field).string.min_len = 1];
+  // MIC for MIC_TICKER, exchange code for OPENFIGI_TICKER, source for
+  // BROKER_DESCRIPTION; empty otherwise. Absent and empty mean the same thing.
+  string domain = 3;
+}
+
+// Identifier is an InstrumentRef plus the canonical flag, used where a file
+// states an instrument's whole identifier set rather than referring to it.
+// canonical is false only for broker-description identifiers.
+message Identifier {
+  portfoliodb.type.v1.IdentifierType type = 1 [(buf.validate.field).enum = {defined_only: true, not_in: [0]}];
+  string value = 2 [(buf.validate.field).string.min_len = 1];
+  string domain = 3;
+  bool canonical = 4;
+}
+
+// DateInterval is a half-open [from, before) interval of calendar days. To cover
+// through 31 December 2024, write before = "2025-01-01".
+message DateInterval {
+  option (buf.validate.message).cel = {
+    id: "date_interval.before_after_from"
+    message: "before must be after from; the interval is half-open [from, before)"
+    expression: "this.before > this.from"
+  };
+  string from = 1 [(buf.validate.field).string.pattern = "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"];   // inclusive
+  string before = 2 [(buf.validate.field).string.pattern = "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"]; // exclusive
+}


### PR DESCRIPTION
First of four PRs for 0078. **Stacked on #343**, which is stacked on #342 -- review those first.

`proto/archive/v1/` exists, with the pieces every part will compose:

- `common.proto` -- `ArchiveKind`, `Envelope`, `InstrumentRef`, `Identifier`, `DateInterval`.
- `archive.proto` -- `AdminArchive` and `UserArchive`, carrying nothing yet but the envelope. Field numbers 2 to 9 are reserved in restore order, so a document reads top to bottom in the order it is applied.

The package imports `portfoliodb.type.v1` for the vocabularies and nothing from `portfoliodb.api.v1`. That is the whole point of it being a separate package: an archive is written today and read by a server that does not exist yet, so it cannot be bound to a schema that is deliberately free to break.

## Documentation

`docs/spec/archive-format.md` sections 1-5: what an archive is and is not, the two archives, the three levels and the rule for placing a field among them, the conventions that hold everywhere (dates, half-open intervals, decimal strings, absent-is-not-zero, identifier triples, coverage, vocabularies), and the envelope. The per-part sections land with the parts.

## Nothing consumes this yet

No existing format changes here, and no import or export path is touched. 0081, 0082, 0084, 0076 and 0085 migrate the four current formats onto this schema one at a time; `docs/spec/csv-format.md` shrinks as they do.

## Testing

`make generate` emits `proto/archive/v1/*.pb.go` and `client/gen/archive/v1/*_pb.ts` with no buf config change. `make lint-proto` and `make check` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)