### PR TITLE
Add the admin archive parts: instruments, prices, corporate events (0078)

### DIFF
--- a/docs/spec/archive-format.md
+++ b/docs/spec/archive-format.md
@@ -173,3 +173,123 @@ Every archive is one protojson object whose first member is the envelope:
   type says the same thing, but protojson records no type name, so the envelope
   has to carry it -- without it, an importer cannot refuse a user archive handed
   to the admin page.
+
+## The admin archive
+
+`AdminArchive` is one protojson object: the envelope, then one optional section
+per entity. A section present but empty means the export included it and there
+was nothing; a section absent means it was not included at all. Sections are
+written in restore order -- instruments first, because every other part refers
+to them.
+
+```json
+{"envelope": {"format_version": 1, "exported_at": "2026-07-30T00:00:00Z",
+              "source_instance": "portfoliodb.example.com",
+              "kind": "ARCHIVE_KIND_ADMIN"},
+ "instruments": {"instruments": [...]},
+ "prices": {"groups": [...]},
+ "corporate_events": {"groups": [...]}}
+```
+
+### Instruments
+
+`instruments.instruments[]` is a flat list. A derivative names its underlying by
+identifier rather than by position, so a shared underlying appears once and the
+order the list is written in carries no meaning.
+
+| Field | Notes |
+| --- | --- |
+| `asset_class` | |
+| `name` | optional; advisory, see below |
+| `currency` | ISO 4217 |
+| `exchange_mic` | optional; ISO 10383 |
+| `identifiers[]` | at least one; `{type, value, domain, canonical}` |
+| `provider_identifiers[]` | `{provider, identifier_type, value, domain}`; `identifier_type` is the provider's own vocabulary, not `IdentifierType` |
+| `underlying` | optional; an identifier triple naming an instrument in the same part |
+| `cik`, `sic_code` | optional |
+| `valid_from`, `valid_before` | optional; half-open, either bound open-ended |
+| `strike`, `expiry`, `put_call`, `contract_multiplier` | optional; options only |
+| `identity_as_of` | optional; the point in market time the identity reflects |
+
+`name` is advisory because the importing instance recomputes it from the
+identifiers. It survives only where no ticker-like identifier exists to derive
+one from, which is exactly the case where a plugin-supplied name would otherwise
+be lost.
+
+`provider_identifiers` are the recorded output of the paid, rate-limited lookups
+the archive exists to avoid repeating. An instrument restored with them is
+indistinguishable from a resolved one, and no plugin is called for it.
+
+**Not carried:** the server UUID, which means nothing in another instance; the
+`exchange` column, which is derived from `exchange_mic` and the identifiers; the
+nested underlying subtree and the joined exchange reference data, both of which
+exist so the SPA need not fetch them separately and neither of which belongs in
+a file.
+
+### Prices
+
+`prices.groups[]` is one group per instrument, or one group per
+`share_count_basis` where an instrument's rows are not all denominated in one
+share count -- which is how a single file carries a back-adjusted series
+alongside an as-traded one.
+
+| Level | Field | Notes |
+| --- | --- | --- |
+| group | `instrument` | identifier triple |
+| group | `asset_class` | hint for identifier plugin routing on an unknown instrument |
+| group | `currency` | ISO 4217; validation hint |
+| group | `share_count_basis` | optional; absent means as-traded |
+| group | `coverage[]` | half-open intervals |
+| row | `price_date` | |
+| row | `open`, `high`, `low`, `adjusted_close`, `volume` | optional |
+| row | `close` | |
+
+```json
+{"instrument": {"type": "MIC_TICKER", "value": "AAPL", "domain": "XNAS"},
+ "asset_class": "STOCK", "currency": "USD",
+ "coverage": [{"from": "2022-01-01", "before": "2025-07-07"}],
+ "rows": [{"price_date": "2024-01-15", "close": "185.9", "volume": "48088700"}]}
+```
+
+That group is what the price CSV spelled as a `# coverage=` comment line plus a
+row, and it is why the comment syntax goes. Coverage is a field of the group it
+applies to, so a file needs no global declaration, no rule for a specific
+declaration overriding a global one, no rule for several specifics applying at
+once, and no error case for a half-written identifier. An instrument that was
+covered but has no rows is simply a group with an empty `rows`.
+
+**Not carried:** the split-adjusted close, which the importing instance derives;
+`last_fetched_at`, which comes from the envelope's `exported_at`; and the
+originating data provider, because an import records every row and every span
+against the `import` sentinel, so provenance cannot survive a round trip.
+
+`share_count_basis` on the group is new. The price CSV could state it on import
+but not on export, so a back-adjusted series exported and reimported came back
+as as-traded and was adjusted a second time.
+
+### Corporate events
+
+`corporate_events.groups[]` is one group per instrument, carrying coverage and a
+list of events, each of which is a `split` or a `dividend`.
+
+| Level | Field | Notes |
+| --- | --- | --- |
+| group | `instrument`, `asset_class` | |
+| group | `coverage[]` | merged across plugins; see below |
+| split | `ex_date`, `split_from`, `split_to` | factor is `split_to / split_from` |
+| split | `first_known_at` | optional; knowledge time |
+| dividend | `ex_date`, `amount`, `currency`, `type` | `type` is `CD` or `SC` |
+| dividend | `pay_date`, `record_date`, `declaration_date`, `frequency`, `first_known_at` | optional |
+
+Events are sparse, so the absence of an event says nothing about whether a range
+was queried. Only coverage says that, which is why a group with no events is
+still worth writing.
+
+`first_known_at` gates retroactive adjustment of options on the underlying: a
+round trip that dropped it would re-adjust symbols that were already correct. It
+falls back to the envelope's `exported_at` and then to storage time, and a
+stored value only ever moves backwards.
+
+Coverage is stored per instrument and plugin, but an import records every span
+against the `import` sentinel, so the file carries spans merged across plugins.
+The per-plugin distinction cannot survive a round trip and is not written.

--- a/proto/archive/v1/archive.proto
+++ b/proto/archive/v1/archive.proto
@@ -3,6 +3,9 @@ syntax = "proto3";
 package portfoliodb.archive.v1;
 
 import "archive/v1/common.proto";
+import "archive/v1/corporate_events.proto";
+import "archive/v1/instruments.proto";
+import "archive/v1/prices.proto";
 import "buf/validate/validate.proto";
 
 option go_package = "github.com/leedenison/portfoliodb/proto/archive/v1;archivev1";
@@ -21,8 +24,11 @@ option go_package = "github.com/leedenison/portfoliodb/proto/archive/v1;archivev
 // See docs/adr/0033-admin-and-user-archives-are-separate.md.
 message AdminArchive {
   Envelope envelope = 1 [(buf.validate.field).required = true];
-  // 2 to 9 are the parts: instruments, prices, corporate events, fetch blocks
-  // and resolutions, plugin config, inflation indices.
+  InstrumentPart instruments = 2;
+  PricePart prices = 3;
+  CorporateEventPart corporate_events = 4;
+  // 5 to 9 are the remaining parts: fetch blocks and resolutions, plugin
+  // config, inflation indices.
 }
 
 // UserArchive is one user archive document: one user's own data, and no admin

--- a/proto/archive/v1/corporate_events.proto
+++ b/proto/archive/v1/corporate_events.proto
@@ -1,0 +1,83 @@
+syntax = "proto3";
+
+package portfoliodb.archive.v1;
+
+import "archive/v1/common.proto";
+import "buf/validate/validate.proto";
+import "google/protobuf/timestamp.proto";
+import "type/v1/type.proto";
+
+option go_package = "github.com/leedenison/portfoliodb/proto/archive/v1;archivev1";
+
+// CorporateEventPart is the corporate-event section of an admin archive.
+message CorporateEventPart {
+  repeated CorporateEventGroup groups = 1;
+}
+
+// CorporateEventGroup is one instrument's events with the coverage saying which
+// dates were asked about. Events are sparse, so the absence of an event says
+// nothing about whether the range was ever queried; only coverage does.
+message CorporateEventGroup {
+  InstrumentRef instrument = 1 [(buf.validate.field).required = true];
+  // Security type hint for identifier plugin routing when the importing
+  // instance does not know the instrument.
+  portfoliodb.type.v1.AssetClass asset_class = 2 [(buf.validate.field).enum.defined_only = true];
+  // Coverage is stored per (instrument, plugin), but an import records every
+  // span against the "import" sentinel, so these are merged across plugins: the
+  // per-plugin distinction cannot survive a round trip and is not written.
+  repeated DateInterval coverage = 3;
+  repeated CorporateEvent events = 4;
+}
+
+// CorporateEvent is one event on the group's instrument.
+message CorporateEvent {
+  oneof event {
+    Split split = 1;
+    CashDividend dividend = 2;
+  }
+}
+
+// Split is one stock split. The factor is split_to / split_from, so a 2:1 split
+// is split_from = "1", split_to = "2".
+message Split {
+  // Valid time: when the split took effect, not when it was announced or learned
+  // of.
+  string ex_date = 1 [(buf.validate.field).string.pattern = "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"];
+  // Positive decimals; the stored columns carry CHECK (> 0).
+  string split_from = 2 [(buf.validate.field).string.pattern = "^[0-9]+(\\.[0-9]+)?$"];
+  string split_to = 3 [(buf.validate.field).string.pattern = "^[0-9]+(\\.[0-9]+)?$"];
+  // Knowledge time: when the exporting instance first learned of this split. It
+  // gates retroactive adjustment of options on the underlying, so a round trip
+  // that drops it re-adjusts symbols that were already correct. Absent falls
+  // back to the envelope's exported_at and then to storage time; a stored value
+  // only ever moves backwards.
+  optional google.protobuf.Timestamp first_known_at = 4;
+}
+
+// CashDividend is one cash dividend. amount is per share, in currency, which may
+// differ from the instrument's own currency for a cross-listed security.
+message CashDividend {
+  string ex_date = 1 [(buf.validate.field).string.pattern = "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"];
+  optional string pay_date = 2 [(buf.validate.field).string.pattern = "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"];
+  optional string record_date = 3 [(buf.validate.field).string.pattern = "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"];
+  // The issuer's announcement date. The world's knowledge time, but
+  // PortfolioDB's valid time: what is known is that the announcement happened on
+  // that date.
+  optional string declaration_date = 4 [(buf.validate.field).string.pattern = "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"];
+  string amount = 5 [(buf.validate.field).string.pattern = "^[0-9]+(\\.[0-9]+)?$"];
+  string currency = 6; // ISO 4217
+  // Provider-supplied and often absent: "annual", "semi-annual", "quarterly",
+  // "monthly". Free-form because it is transcribed rather than interpreted.
+  optional string frequency = 7;
+  DividendType type = 8 [(buf.validate.field).enum.defined_only = true];
+  optional google.protobuf.Timestamp first_known_at = 9;
+}
+
+// DividendType uses the stored two-letter vocabulary rather than a friendlier
+// name, so the file and the column agree without a mapping table. It is local to
+// this package because the API carries dividend type as a bare string.
+enum DividendType {
+  DIVIDEND_TYPE_UNSPECIFIED = 0; // read as CD
+  CD = 1;                        // regular cash dividend
+  SC = 2;                        // special cash dividend
+}

--- a/proto/archive/v1/instruments.proto
+++ b/proto/archive/v1/instruments.proto
@@ -1,0 +1,75 @@
+syntax = "proto3";
+
+package portfoliodb.archive.v1;
+
+import "archive/v1/common.proto";
+import "buf/validate/validate.proto";
+import "google/protobuf/timestamp.proto";
+import "type/v1/type.proto";
+
+option go_package = "github.com/leedenison/portfoliodb/proto/archive/v1;archivev1";
+
+// InstrumentPart is the security-master section of an admin archive.
+message InstrumentPart {
+  repeated Instrument instruments = 1;
+}
+
+// Instrument is security-master data as a file carries it: no server UUIDs, no
+// joined exchange reference data, and no nested underlying subtree. A derivative
+// names its underlying by identifier, so a shared underlying appears once and
+// the order instruments are written in carries no meaning.
+message Instrument {
+  portfoliodb.type.v1.AssetClass asset_class = 1 [(buf.validate.field).enum.defined_only = true];
+  // Display name. The importing instance recomputes it from the identifiers, so
+  // this is advisory: it survives only where no ticker-like identifier exists to
+  // derive one from, which is the case a plugin-supplied name would otherwise be
+  // lost in.
+  optional string name = 2;
+  string currency = 3; // ISO 4217
+  // ISO 10383 MIC. The instruments.exchange column is derived from this and from
+  // the identifiers, and is not carried.
+  optional string exchange_mic = 4;
+  repeated Identifier identifiers = 5 [(buf.validate.field).repeated.min_items = 1];
+  // Provider-scoped identifiers recorded by the identifier plugins. These are
+  // the output of the paid, rate-limited lookups the archive exists to avoid
+  // repeating, so an instrument restored with them is indistinguishable from a
+  // resolved one and no plugin is called for it.
+  repeated ProviderIdentifier provider_identifiers = 6;
+  // The underlying of an OPTION or FUTURE, which must itself appear in this
+  // part. Absent for everything else.
+  optional InstrumentRef underlying = 7;
+  optional string cik = 8;      // SEC Central Index Key; an identifier plugin lookup result
+  optional string sic_code = 9; // SIC industry classification; likewise
+  // The half-open [valid_from, valid_before) interval the instrument was
+  // available to trade in; an absent bound is open-ended. Descriptive -- no
+  // query filters on it -- and derivable from nothing, so a file that drops it
+  // loses it for good.
+  optional string valid_from = 10 [(buf.validate.field).string.pattern = "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"];
+  optional string valid_before = 11 [(buf.validate.field).string.pattern = "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"];
+  // Option terms, denormalized from the OCC identifier and absent for anything
+  // that is not an option. strike is a component of option identity, decoded
+  // from the symbol's eight digits of thousandths, so it is an exact decimal:
+  // comparing identity components as floats is a latent bug.
+  optional string strike = 12 [(buf.validate.field).string.pattern = "^-?[0-9]+(\\.[0-9]+)?$"];
+  optional string expiry = 13 [(buf.validate.field).string.pattern = "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"];
+  optional string put_call = 14 [(buf.validate.field).string = {in: ["C", "P"]}];
+  // Deliverable multiplier; absent means the column default of 1. A non-standard
+  // split leaves a fraction here -- 3:2 gives 1.5 -- and it multiplies a
+  // posting's weight, so it stays exact.
+  optional string contract_multiplier = 15 [(buf.validate.field).string.pattern = "^-?[0-9]+(\\.[0-9]+)?$"];
+  // The point in market time this identity reflects. Restored on import so that
+  // a round trip cannot make an already-adjusted option look unadjusted; absent
+  // means the identity predates every split.
+  // See docs/adr/0017-option-identity-reflects-ex-date.md.
+  optional google.protobuf.Timestamp identity_as_of = 16;
+}
+
+// ProviderIdentifier is one provider-scoped identifier for an instrument.
+// identifier_type is free-form and specific to the provider, so it is not the
+// IdentifierType vocabulary.
+message ProviderIdentifier {
+  string provider = 1 [(buf.validate.field).string.min_len = 1];
+  string identifier_type = 2 [(buf.validate.field).string.min_len = 1];
+  string value = 3 [(buf.validate.field).string.min_len = 1];
+  string domain = 4; // optional; absent and empty mean the same thing
+}

--- a/proto/archive/v1/prices.proto
+++ b/proto/archive/v1/prices.proto
@@ -1,0 +1,69 @@
+syntax = "proto3";
+
+package portfoliodb.archive.v1;
+
+import "archive/v1/common.proto";
+import "buf/validate/validate.proto";
+import "type/v1/type.proto";
+
+option go_package = "github.com/leedenison/portfoliodb/proto/archive/v1;archivev1";
+
+// PricePart is the price section of an admin archive: end-of-day bars grouped
+// by the instrument they belong to.
+message PricePart {
+  repeated PriceGroup groups = 1;
+}
+
+// PriceGroup is one instrument's prices together with the coverage saying which
+// dates were answered for.
+//
+// A group is not unique per instrument. An instrument whose rows are not all
+// denominated in one share count is written as one group per basis, which is
+// how a single file carries a back-adjusted series alongside an as-traded one
+// -- the case the price CSV could only meet by writing two separate files.
+message PriceGroup {
+  InstrumentRef instrument = 1 [(buf.validate.field).required = true];
+  // Security type hint, used to route the identifier plugins when the importing
+  // instance does not know the instrument. ASSET_CLASS_UNSPECIFIED skips them
+  // and creates the instrument from the supplied identifier alone.
+  portfoliodb.type.v1.AssetClass asset_class = 2 [(buf.validate.field).enum.defined_only = true];
+  string currency = 3; // ISO 4217; a validation hint, denormalized from the instrument
+  // The share count every row in this group is denominated in, as
+  // "YYYY-MM-DD". Absent means each row is denominated in its own price_date --
+  // the as-traded convention, and what an ordinary export writes. Set it only
+  // for a back-adjusted series, where it is the date the provider adjusted to.
+  // Getting this wrong is not an error but a wrong number: a back-adjusted
+  // series read as as-traded is adjusted a second time.
+  // See docs/spec/bitemporality.md.
+  optional string share_count_basis = 4 [(buf.validate.field).string.pattern = "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"];
+  // The intervals this instrument was authoritatively answered for. An interval
+  // holding no rows is meaningful and is the only way a file can say a provider
+  // was asked about those dates and had nothing; dropping it leaves valuation
+  // treating the days between reported bars as unpriced. An empty list means
+  // each row covers only its own date.
+  // See docs/adr/0023-price-coverage-is-stored-not-inferred.md.
+  repeated DateInterval coverage = 5;
+  repeated PriceRow rows = 6;
+}
+
+// PriceRow is one end-of-day bar. It carries only what varies per day: the
+// identifier, asset class, currency and share count basis are on the group.
+message PriceRow {
+  // Valid time: the trading date this bar describes.
+  string price_date = 1 [(buf.validate.field).string.pattern = "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"];
+  // OHLC are decimal strings in the group's currency, as the source supplied
+  // them. Export and import are a round-trip pair, and a row that does not
+  // reimport identically is a bug; trailing zeroes are the only thing not
+  // preserved, since "1.50" and "1.5" are the same price.
+  optional string open = 2 [(buf.validate.field).string.pattern = "^-?[0-9]+(\\.[0-9]+)?$"];
+  optional string high = 3 [(buf.validate.field).string.pattern = "^-?[0-9]+(\\.[0-9]+)?$"];
+  optional string low = 4 [(buf.validate.field).string.pattern = "^-?[0-9]+(\\.[0-9]+)?$"];
+  string close = 5 [(buf.validate.field).string.pattern = "^-?[0-9]+(\\.[0-9]+)?$"];
+  // The provider's own adjusted close, on the provider's basis and typically
+  // including dividend adjustment. Never an input to valuation; it exists to
+  // cross-check the split-adjusted close PortfolioDB derives for itself, which
+  // is why that derived value is not carried.
+  optional string adjusted_close = 6 [(buf.validate.field).string.pattern = "^-?[0-9]+(\\.[0-9]+)?$"];
+  // protojson writes a 64-bit integer as a quoted string: "1234567".
+  optional int64 volume = 7;
+}


### PR DESCRIPTION
Second of four PRs for 0078. **Stacked on #344.**

Three parts wired into `AdminArchive`, each grouped by its aggregate root -- the instrument -- with coverage and `share_count_basis` on the group rather than repeated per row or hidden in a comment line.

## What the price group replaces

Coverage is a field of the group it applies to. That deletes the `# coverage=` comment syntax along with all four of its precedence rules: at most one global declaration, a specific one overriding rather than adding, several specifics all applying, a partial identifier being an error. It also deletes the two cases the export had to always write out in full -- an instrument with more than one span, and a covered instrument with no rows -- because a covered instrument with no rows is now just a group with an empty `rows`.

`prices-recovered.csv` carries ninety coverage declarations and every one is instrument-scoped, so the file-wide slot the CSV was designed around goes unused. This is that shape, typed.

## share_count_basis on the price group

New on the export side. The CSV could state it on import but not on export, so a back-adjusted series exported and reimported came back as as-traded and was adjusted a second time. A group is per (instrument, basis), so one file can now carry a back-adjusted series alongside an as-traded one -- today that needs two files.

## What the instrument part gains and loses

Gains what `instrumentsToJson` silently drops: `cik`, `sic_code`, the validity interval, the option terms (`strike`, `expiry`, `put_call`, `contract_multiplier`), `identity_as_of`, `exchange_mic`, and `provider_identifiers` -- the recorded output of the paid, rate-limited lookups an archive exists to avoid repeating.

Loses the server UUID, the joined `exchange_info`, the nested `underlying` subtree, and the derived `exchange` column. An underlying is named by identifier rather than by position, so a shared underlying appears once and list order carries no meaning.

## Documentation

`docs/spec/archive-format.md` gains the admin archive section: a field table, a worked example and a "not carried, and why" list per part.

## Testing

`make generate`, `make lint-proto` and `make check` are clean. Nothing consumes these messages yet -- 0081 and 0082 move the price and instrument/corporate-event paths onto them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)