### PR TITLE
Export prices as an admin archive price part (0081)

### DIFF
--- a/client/app/admin/prices/page.tsx
+++ b/client/app/admin/prices/page.tsx
@@ -14,11 +14,13 @@ import {
   deletePriceFetchBlock,
   exportPrices,
 } from "@/lib/portfolio-api";
-import { pricesToCsv } from "@/lib/csv/prices";
+import { marshalAdmin } from "@/lib/archive/codec";
 import { dayAfter } from "@/lib/dates";
 import { useDebounce } from "@/hooks/use-debounce";
 import { ImportPricesModal } from "./import-modal";
-import type { EODPriceProto, ExportCoverage, ExportPriceRow, PriceFetchBlock } from "@/gen/api/v1/api_pb";
+import type { EODPriceProto, PriceFetchBlock } from "@/gen/api/v1/api_pb";
+import type { Envelope } from "@/gen/archive/v1/common_pb";
+import type { PriceGroup } from "@/gen/archive/v1/prices_pb";
 import { timestampDate } from "@bufbuild/protobuf/wkt";
 
 type Tab = "prices" | "blocks";
@@ -96,31 +98,29 @@ function PriceListTab() {
   const [importOpen, setImportOpen] = useState(false);
   const queryClient = useQueryClient();
 
+  // The file is an admin archive carrying only its price part. The stream sends
+  // the envelope first because exported_at is knowledge time and belongs to the
+  // server's clock, not the browser's.
   async function handleExport() {
     setExportLoading(true);
     setExportError(null);
     try {
-      const rows: ExportPriceRow[] = [];
-      const coverage: ExportCoverage[] = [];
-      let exportedAt: Date | undefined;
+      let envelope: Envelope | undefined;
+      const groups: PriceGroup[] = [];
       for await (const item of exportPrices()) {
-        if (item.item.case === "coverage") {
-          coverage.push(item.item.value);
-          continue;
+        if (item.item.case === "envelope") {
+          envelope = item.item.value;
+        } else if (item.item.case === "group") {
+          groups.push(item.item.value);
         }
-        if (item.item.case !== "row") continue;
-        const row = item.item.value;
-        if (!exportedAt && row.exportedAt) {
-          exportedAt = timestampDate(row.exportedAt);
-        }
-        rows.push(row);
       }
-      const csv = pricesToCsv(rows, exportedAt, coverage);
-      const blob = new Blob([csv], { type: "text/csv" });
+      if (!envelope) throw new Error("export stream sent no envelope");
+      const json = marshalAdmin({ envelope, prices: { groups } });
+      const blob = new Blob([json], { type: "application/json" });
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download = "prices.csv";
+      a.download = "prices.json";
       a.click();
       URL.revokeObjectURL(url);
     } catch (err) {
@@ -166,7 +166,7 @@ function PriceListTab() {
             disabled={exportLoading}
             className="rounded-md border border-border bg-surface px-3 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-primary-light/15 disabled:cursor-not-allowed disabled:opacity-50"
           >
-            {exportLoading ? "Exporting..." : "Export CSV"}
+            {exportLoading ? "Exporting..." : "Export archive"}
           </button>
           <button
             type="button"

--- a/client/lib/csv/prices.test.ts
+++ b/client/lib/csv/prices.test.ts
@@ -1,91 +1,6 @@
 import { describe, expect, it } from "vitest";
-import { create } from "@bufbuild/protobuf";
-import type { MessageInitShape } from "@bufbuild/protobuf";
-import { ExportCoverageSchema, ExportPriceRowSchema } from "@/gen/api/v1/api_pb";
 import { AssetClass } from "@/gen/type/v1/type_pb";
-import type { ExportPriceRow } from "@/gen/api/v1/api_pb";
-import { pricesToCsv, csvToPrices } from "./prices";
-
-// Overrides are typed against the init shape, not Partial<ExportPriceRow>: the
-// latter makes $typeName optional, which create() will not accept.
-function makeRow(
-  overrides: MessageInitShape<typeof ExportPriceRowSchema> = {},
-): ExportPriceRow {
-  return create(ExportPriceRowSchema, {
-    identifierType: "ISIN",
-    identifierValue: "US0378331005",
-    identifierDomain: "",
-    priceDate: "2024-01-15",
-    close: "185.9",
-    ...overrides,
-  });
-}
-
-describe("pricesToCsv", () => {
-  it("produces header + data rows", () => {
-    const csv = pricesToCsv([makeRow()]);
-    const lines = csv.trim().split("\n");
-    expect(lines).toHaveLength(2);
-    expect(lines[0]).toBe(
-      "identifier_type,identifier_value,identifier_domain,price_date,open,high,low,close,adjusted_close,volume,asset_class,currency"
-    );
-    expect(lines[1]).toContain("ISIN");
-    expect(lines[1]).toContain("US0378331005");
-    expect(lines[1]).toContain("2024-01-15");
-    expect(lines[1]).toContain("185.9");
-  });
-
-  it("prepends exported_at comment line when date provided", () => {
-    const exportedAt = new Date("2025-07-15T10:30:00.000Z");
-    const csv = pricesToCsv([makeRow()], exportedAt);
-    const lines = csv.split("\n");
-    expect(lines[0]).toBe("# exported_at=2025-07-15T10:30:00.000Z");
-    expect(lines[1]).toBe(
-      "identifier_type,identifier_value,identifier_domain,price_date,open,high,low,close,adjusted_close,volume,asset_class,currency"
-    );
-  });
-
-  it("omits comment line when no exportedAt provided", () => {
-    const csv = pricesToCsv([makeRow()]);
-    expect(csv.startsWith("#")).toBe(false);
-  });
-
-  it("includes optional fields when present", () => {
-    const csv = pricesToCsv([
-      makeRow({ open: "185.5", high: "186.2", low: "184.8", adjustedClose: "185.9", volume: 50000000n, assetClass: AssetClass.STOCK, currency: "USD" }),
-    ]);
-    const lines = csv.trim().split("\n");
-    const fields = lines[1].split(",");
-    expect(fields[4]).toBe("185.5"); // open
-    expect(fields[5]).toBe("186.2"); // high
-    expect(fields[6]).toBe("184.8"); // low
-    expect(fields[8]).toBe("185.9"); // adjusted_close
-    expect(fields[9]).toBe("50000000"); // volume
-    expect(fields[10]).toBe("STOCK"); // asset_class
-    expect(fields[11]).toBe("USD"); // currency
-  });
-
-  it("leaves optional fields empty when absent", () => {
-    const csv = pricesToCsv([makeRow()]);
-    const fields = csv.trim().split("\n")[1].split(",");
-    expect(fields[4]).toBe(""); // open
-    expect(fields[5]).toBe(""); // high
-    expect(fields[6]).toBe(""); // low
-    expect(fields[8]).toBe(""); // adjusted_close
-    expect(fields[9]).toBe(""); // volume
-  });
-
-  it("quotes fields containing commas", () => {
-    const csv = pricesToCsv([makeRow({ identifierValue: "APPLE, INC" })]);
-    expect(csv).toContain('"APPLE, INC"');
-  });
-
-  it("handles empty array", () => {
-    const csv = pricesToCsv([]);
-    const lines = csv.trim().split("\n");
-    expect(lines).toHaveLength(1); // header only
-  });
-});
+import { csvToPrices } from "./prices";
 
 describe("csvToPrices", () => {
   const HEADER = "identifier_type,identifier_value,identifier_domain,price_date,open,high,low,close,adjusted_close,volume,asset_class,currency";
@@ -201,14 +116,14 @@ describe("csvToPrices", () => {
     expect(result.prices[0].currency).toBe("");
   });
 
-  it("round-trips a decimal too precise for a float64", () => {
+  it("keeps a decimal too precise for a float64", () => {
     // 0.1 + 0.2 is the textbook case, but a price column is worse: these values
     // have more significant digits than a float64 carries, so parsing them into
     // a JS number and printing them back changes the digits. Export and import
     // are a round-trip pair, so that is a bug rather than a rounding preference.
     const precise = "185.90000000000012345";
     const tiny = "0.000000000000001";
-    const csv = pricesToCsv([makeRow({ close: precise, open: tiny })]);
+    const csv = `${HEADER}\nISIN,US0378331005,,2024-01-15,${tiny},,,${precise},,`;
     const result = csvToPrices(csv);
 
     expect(result.errors).toHaveLength(0);
@@ -218,29 +133,6 @@ describe("csvToPrices", () => {
     // exponent notation, which the wire format does not even accept.
     expect(String(Number(precise))).toBe("185.90000000000012");
     expect(String(Number(tiny))).toBe("1e-15");
-  });
-
-  it("round-trips through pricesToCsv and csvToPrices", () => {
-    const original = [
-      makeRow({ open: "185.5", high: "186.2", low: "184.8", adjustedClose: "185.9", volume: 50000000n, currency: "USD" }),
-      makeRow({ identifierType: "MIC_TICKER", identifierValue: "AAPL", identifierDomain: "XNAS", priceDate: "2024-01-16", close: "186.5", currency: "GBP" }),
-    ];
-    const exportedAt = new Date("2025-07-15T10:30:00.000Z");
-    const csv = pricesToCsv(original, exportedAt);
-    const result = csvToPrices(csv);
-    expect(result.errors).toHaveLength(0);
-    expect(result.prices).toHaveLength(2);
-    expect(result.exportedAt).toEqual(exportedAt);
-    expect(result.prices[0].identifierType).toBe("ISIN");
-    expect(result.prices[0].close).toBe("185.9");
-    expect(result.prices[0].open).toBe("185.5");
-    expect(result.prices[0].volume).toBe(50000000n);
-    expect(result.prices[0].currency).toBe("USD");
-    expect(result.prices[1].identifierType).toBe("MIC_TICKER");
-    expect(result.prices[1].identifierDomain).toBe("XNAS");
-    expect(result.prices[1].close).toBe("186.5");
-    expect(result.prices[1].open).toBeUndefined();
-    expect(result.prices[1].currency).toBe("GBP");
   });
 
   it("extracts exported_at from comment line", () => {
@@ -379,136 +271,5 @@ describe("csvToPrices coverage headers", () => {
     expect(result.errors[0].field).toBe("before");
     expect(result.prices).toHaveLength(2);
     expect(result.coverage).toEqual([]);
-  });
-});
-
-describe("price CSV coverage round trip", () => {
-  it("carries coverage spans through serialize and parse", () => {
-    const coverage = [
-      create(ExportCoverageSchema, {
-        identifierType: "ISIN",
-        identifierValue: "US0378331005",
-        identifierDomain: "",
-        from: "2024-01-15",
-        before: "2024-02-01",
-      }),
-    ];
-    const csv = pricesToCsv([makeRow()], new Date("2026-07-30T00:00:00.000Z"), coverage);
-    const result = csvToPrices(csv);
-    expect(result.errors).toEqual([]);
-    expect(result.exportedAt?.toISOString()).toBe("2026-07-30T00:00:00.000Z");
-    expect(result.coverage).toEqual([
-      expect.objectContaining({
-        identifierType: "ISIN",
-        identifierValue: "US0378331005",
-        identifierDomain: "",
-        from: "2024-01-15",
-        before: "2024-02-01",
-      }),
-    ]);
-  });
-
-  it("writes no coverage header when the export supplied none", () => {
-    expect(pricesToCsv([makeRow()])).not.toContain("# coverage=");
-  });
-});
-
-describe("pricesToCsv coverage compression", () => {
-  const span = (value: string, from: string, before: string) =>
-    create(ExportCoverageSchema, {
-      identifierType: "MIC_TICKER",
-      identifierValue: value,
-      identifierDomain: "XNAS",
-      from,
-      before,
-    });
-  const row = (value: string, priceDate = "2024-02-01") =>
-    makeRow({ identifierType: "MIC_TICKER", identifierValue: value, identifierDomain: "XNAS", priceDate });
-
-  const coverageLines = (csv: string) =>
-    csv.split("\n").filter((l) => l.startsWith("# coverage="));
-
-  it("collapses a shared span to one global line", () => {
-    const csv = pricesToCsv(
-      [row("AAPL"), row("MSFT"), row("GOOG")],
-      undefined,
-      [span("AAPL", "2022-01-01", "2025-07-07"),
-       span("MSFT", "2022-01-01", "2025-07-07"),
-       span("GOOG", "2022-01-01", "2025-07-07")],
-    );
-    expect(coverageLines(csv)).toEqual(["# coverage=2022-01-01,2025-07-07"]);
-  });
-
-  it("writes the odd one out as an exception beside the global", () => {
-    const csv = pricesToCsv(
-      [row("AAPL"), row("MSFT"), row("ATVI")],
-      undefined,
-      [span("AAPL", "2022-01-01", "2025-07-07"),
-       span("MSFT", "2022-01-01", "2025-07-07"),
-       span("ATVI", "2021-12-31", "2023-10-14")],
-    );
-    expect(coverageLines(csv)).toEqual([
-      "# coverage=2022-01-01,2025-07-07",
-      "# coverage=MIC_TICKER,ATVI,XNAS,2021-12-31,2023-10-14",
-    ]);
-  });
-
-  it("keeps both spans of a two-period instrument explicit, since a specific overrides the global outright", () => {
-    const csv = pricesToCsv(
-      [row("AAPL"), row("MSFT"), row("TSLA")],
-      undefined,
-      [span("AAPL", "2022-01-01", "2025-07-07"),
-       span("MSFT", "2022-01-01", "2025-07-07"),
-       span("TSLA", "2022-01-01", "2022-06-01"),
-       span("TSLA", "2024-01-01", "2024-06-01")],
-    );
-    expect(coverageLines(csv)).toEqual([
-      "# coverage=2022-01-01,2025-07-07",
-      "# coverage=MIC_TICKER,TSLA,XNAS,2022-01-01,2022-06-01",
-      "# coverage=MIC_TICKER,TSLA,XNAS,2024-01-01,2024-06-01",
-    ]);
-  });
-
-  it("keeps a covered instrument with no rows explicit, since the global never reaches it", () => {
-    const csv = pricesToCsv(
-      [row("AAPL"), row("MSFT")],
-      undefined,
-      [span("AAPL", "2022-01-01", "2025-07-07"),
-       span("MSFT", "2022-01-01", "2025-07-07"),
-       span("DELISTED", "2022-01-01", "2025-07-07")],
-    );
-    expect(coverageLines(csv)).toEqual([
-      "# coverage=2022-01-01,2025-07-07",
-      "# coverage=MIC_TICKER,DELISTED,XNAS,2022-01-01,2025-07-07",
-    ]);
-  });
-
-  it("writes no global when no span is shared, which would save nothing", () => {
-    const csv = pricesToCsv(
-      [row("AAPL"), row("MSFT")],
-      undefined,
-      [span("AAPL", "2022-01-01", "2023-01-01"),
-       span("MSFT", "2024-01-01", "2025-01-01")],
-    );
-    expect(coverageLines(csv)).toEqual([
-      "# coverage=MIC_TICKER,AAPL,XNAS,2022-01-01,2023-01-01",
-      "# coverage=MIC_TICKER,MSFT,XNAS,2024-01-01,2025-01-01",
-    ]);
-  });
-
-  it("round trips the compressed form back to one entry per instrument per span", () => {
-    const coverage = [
-      span("AAPL", "2022-01-01", "2025-07-07"),
-      span("MSFT", "2022-01-01", "2025-07-07"),
-      span("ATVI", "2021-12-31", "2023-10-14"),
-    ];
-    const csv = pricesToCsv([row("AAPL"), row("MSFT"), row("ATVI")], undefined, coverage);
-    const result = csvToPrices(csv);
-    expect(result.errors).toEqual([]);
-    expect(result.coverage).toEqual([
-      expect.objectContaining({ identifierValue: "AAPL", from: "2022-01-01", before: "2025-07-07" }),
-      expect.objectContaining({ identifierValue: "MSFT", from: "2022-01-01", before: "2025-07-07" }),
-      expect.objectContaining({ identifierValue: "ATVI", from: "2021-12-31", before: "2023-10-14" }),
-    ]);
   });
 });

--- a/client/lib/csv/prices.ts
+++ b/client/lib/csv/prices.ts
@@ -1,18 +1,19 @@
 /**
- * CSV serializer/parser for EOD price export/import.
+ * CSV parser for EOD price import.
+ *
+ * The export side is gone: it writes an archive document now. This goes with it
+ * when the import follows.
  */
 
 import Papa from "papaparse";
 import { create } from "@bufbuild/protobuf";
 import { ImportPriceRowSchema, ImportCoverageSchema } from "@/gen/api/v1/api_pb";
-import type { ExportCoverage, ExportPriceRow, ImportPriceRow, ImportCoverage } from "@/gen/api/v1/api_pb";
+import type { ImportPriceRow, ImportCoverage } from "@/gen/api/v1/api_pb";
 import type { ParseError } from "./standard";
-import { assetClassToStr, assetClassFromStr } from "@/lib/asset-class";
+import { assetClassFromStr } from "@/lib/asset-class";
 import { VALID_IDENTIFIER_TYPES } from "@/lib/identifiers";
 import { expandCoverage, validateCoverage } from "@/lib/coverage";
 import type { CoverageDecl, InstrumentRef } from "@/lib/coverage";
-
-const HEADER = "identifier_type,identifier_value,identifier_domain,price_date,open,high,low,close,adjusted_close,volume,asset_class,currency";
 
 /** Comment line carrying the export's knowledge time. */
 const EXPORTED_AT_PREFIX = "# exported_at=";
@@ -32,121 +33,8 @@ const COVERAGE_PREFIX = "# coverage=";
 
 const REQUIRED_COLUMNS = new Set(["identifier_type", "identifier_value", "price_date", "close"]);
 
-/**
- * Decimal fields arrive as strings and are written back unchanged, so export and
- * import round-trip byte for byte. An absent optional field is an empty cell.
- */
-function fmtOptDec(v: string | undefined): string {
-  return v ?? "";
-}
-
 /** Matches the protovalidate pattern the decimal wire fields carry. */
 const DECIMAL_RE = /^-?[0-9]+(\.[0-9]+)?$/;
-
-function fmtOptBigint(v: bigint | undefined): string {
-  return v === undefined ? "" : String(v);
-}
-
-function coverageKey(c: { identifierType: string; identifierValue: string; identifierDomain: string }): string {
-  return `${c.identifierType}\x00${c.identifierValue}\x00${c.identifierDomain}`;
-}
-
-/**
- * Choose the global declaration and the instruments it covers.
- *
- * A global is only a saving where many instruments share one span, which is the
- * common case: a file exported from one instance covers the same period for
- * everything except instruments that started or stopped trading partway through.
- *
- * Two constraints come from how a global is read back (see expandCoverage):
- *
- * - A specific declaration overrides the global outright rather than adding to
- *   it, so only an instrument whose whole span list is exactly the global can be
- *   left implicit. One with two spans always writes both.
- * - The global is expanded against the instruments the file has rows for, so an
- *   instrument covered but carrying no rows would never receive it. Those keep
- *   an explicit declaration.
- */
-function chooseGlobal(
-  coverage: ExportCoverage[],
-  withRows: Set<string>,
-): { global?: ExportCoverage; implicit: Set<string> } {
-  const byInstrument = new Map<string, ExportCoverage[]>();
-  for (const c of coverage) {
-    const key = coverageKey(c);
-    const existing = byInstrument.get(key);
-    if (existing) existing.push(c);
-    else byInstrument.set(key, [c]);
-  }
-
-  // Only single-span instruments that the file has rows for can be implicit.
-  const candidates = new Map<string, string[]>();
-  for (const [key, spans] of byInstrument) {
-    if (spans.length !== 1 || !withRows.has(key)) continue;
-    const span = `${spans[0].from},${spans[0].before}`;
-    const keys = candidates.get(span);
-    if (keys) keys.push(key);
-    else candidates.set(span, [key]);
-  }
-
-  let bestSpan: string | undefined;
-  let bestKeys: string[] = [];
-  for (const [span, keys] of candidates) {
-    if (keys.length > bestKeys.length) {
-      bestSpan = span;
-      bestKeys = keys;
-    }
-  }
-  // One instrument sharing the span saves nothing: the global line replaces
-  // exactly one specific line.
-  if (bestSpan === undefined || bestKeys.length < 2) return { implicit: new Set() };
-
-  const [from, before] = bestSpan.split(",");
-  const global = byInstrument.get(bestKeys[0])![0];
-  return {
-    global: { ...global, from, before },
-    implicit: new Set(bestKeys),
-  };
-}
-
-/**
- * Serialize ExportPriceRow[] to CSV text.
- *
- * Coverage spans are written as "# coverage=" headers: one global for the span
- * most instruments share, then the exceptions. They are not derivable from the
- * rows -- a span holding no rows records that a provider was asked and had
- * nothing -- so dropping them loses information the rows cannot carry.
- */
-export function pricesToCsv(rows: ExportPriceRow[], exportedAt?: Date, coverage?: ExportCoverage[]): string {
-  const data = rows.map((r) => [
-    r.identifierType,
-    r.identifierValue,
-    r.identifierDomain,
-    r.priceDate,
-    fmtOptDec(r.open),
-    fmtOptDec(r.high),
-    fmtOptDec(r.low),
-    r.close,
-    fmtOptDec(r.adjustedClose),
-    fmtOptBigint(r.volume),
-    assetClassToStr(r.assetClass),
-    r.currency,
-  ]);
-  const csv = Papa.unparse({ fields: HEADER.split(","), data }, { newline: "\n" }) + "\n";
-  const headers: string[] = [];
-  if (exportedAt) headers.push(`${EXPORTED_AT_PREFIX}${exportedAt.toISOString()}`);
-
-  const withRows = new Set(rows.map(coverageKey));
-  const { global, implicit } = chooseGlobal(coverage ?? [], withRows);
-  if (global) headers.push(`${COVERAGE_PREFIX}${global.from},${global.before}`);
-  for (const c of coverage ?? []) {
-    if (implicit.has(coverageKey(c))) continue;
-    headers.push(
-      `${COVERAGE_PREFIX}${c.identifierType},${c.identifierValue},${c.identifierDomain},${c.from},${c.before}`,
-    );
-  }
-  return headers.length > 0 ? `${headers.join("\n")}\n${csv}` : csv;
-}
 
 export interface PriceParseResult {
   prices: ImportPriceRow[];

--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -2,6 +2,8 @@ syntax = "proto3";
 
 package portfoliodb.api.v1;
 
+import "archive/v1/common.proto";
+import "archive/v1/prices.proto";
 import "buf/validate/validate.proto";
 import "google/protobuf/timestamp.proto";
 import "google/type/date.proto";
@@ -207,7 +209,8 @@ service ApiService {
   // EOD prices (admin-only). Browse cached price data.
   rpc ListPrices(ListPricesRequest) returns (ListPricesResponse);
 
-  // Price export/import (admin-only). Export streams all cached EOD prices with best identifier per instrument; import upserts with data_provider = "import".
+  // Price export/import (admin-only). Export streams the price part of an admin
+  // archive; import upserts it with data_provider = "import".
   rpc ExportPrices(ExportPricesRequest) returns (stream ExportPricesResponse);
   rpc ImportPrices(ImportPricesRequest) returns (ImportPricesResponse);
 
@@ -689,14 +692,18 @@ message ListPricesResponse {
   int32 total_count = 3;
 }
 
-// ExportPrices streams all cached EOD prices. Each row carries the best identifier for the instrument.
+// ExportPrices streams the price part of an admin archive: one group per
+// instrument, carrying the best identifier for it.
 message ExportPricesRequest {}
 
-// ExportCoverage is one half-open [from, before) coverage span for an
-// instrument, streamed alongside the rows it covers. It records that a provider
-// answered for the range, which the rows cannot say on their own: a span with no
-// rows in it means the provider was asked and had nothing. Re-importing rows
-// without their coverage loses that.
+// ExportCoverage is one half-open [from, before) corporate event coverage span
+// for an instrument, streamed alongside the events it covers. It records that a
+// provider answered for the range, which the events cannot say on their own: a
+// span with no events in it means the provider was asked and had nothing.
+// Re-importing events without their coverage loses that.
+//
+// Prices state the same thing as archive.v1.PriceGroup.coverage; this goes the
+// same way when corporate events move to the archive schema.
 message ExportCoverage {
   string identifier_type = 1;
   string identifier_value = 2;
@@ -705,33 +712,17 @@ message ExportCoverage {
   string before = 5; // YYYY-MM-DD, exclusive
 }
 
-// ExportPricesResponse is one element of the export stream. Coverage spans are
-// sent before the rows they cover.
+// ExportPricesResponse is one element of the export stream: the envelope first,
+// exactly once, then one message per instrument group.
+//
+// The envelope travels on the stream rather than being built by the caller
+// because exported_at is knowledge time and has to be the server's clock, and
+// source_instance is a server property the browser does not know.
 message ExportPricesResponse {
   oneof item {
-    ExportPriceRow row = 1;
-    ExportCoverage coverage = 2;
+    portfoliodb.archive.v1.Envelope envelope = 1;
+    portfoliodb.archive.v1.PriceGroup group = 2;
   }
-}
-
-// ExportPriceRow is one price row with instrument identifier context.
-message ExportPriceRow {
-  string identifier_type = 1;    // IdentifierType name (e.g. "ISIN", "MIC_TICKER", "OPENFIGI_TICKER")
-  string identifier_value = 2;
-  string identifier_domain = 3;  // MIC for MIC_TICKER, exchange code for OPENFIGI_TICKER, source for BROKER_DESCRIPTION, empty otherwise
-  string price_date = 4;         // "YYYY-MM-DD"
-  // OHLC are decimal strings in the instrument's own currency. Export and import
-  // are a round-trip pair: a row that does not reimport identically is a bug, and
-  // a double on either side loses digits a NUMERIC column holds.
-  optional string open = 5 [(buf.validate.field).string.pattern = "^-?[0-9]+(\\.[0-9]+)?$"];
-  optional string high = 6 [(buf.validate.field).string.pattern = "^-?[0-9]+(\\.[0-9]+)?$"];
-  optional string low = 7 [(buf.validate.field).string.pattern = "^-?[0-9]+(\\.[0-9]+)?$"];
-  string close = 8 [(buf.validate.field).string.pattern = "^-?[0-9]+(\\.[0-9]+)?$"];
-  optional string adjusted_close = 9 [(buf.validate.field).string.pattern = "^-?[0-9]+(\\.[0-9]+)?$"];
-  optional int64 volume = 10;
-  portfoliodb.type.v1.AssetClass asset_class = 11;   // denormalized from instrument
-  google.protobuf.Timestamp exported_at = 12; // when the export was generated
-  string currency = 13;          // ISO 4217 currency code; denormalized from instrument
 }
 
 // ImportPriceRow is one price row to import. When the instrument is unknown, asset_class

--- a/server/archive/codec.go
+++ b/server/archive/codec.go
@@ -18,6 +18,7 @@ import (
 	"buf.build/go/protovalidate"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
 )
@@ -64,6 +65,21 @@ type KindError struct {
 
 func (e *KindError) Error() string {
 	return fmt.Sprintf("archive is %s, expected %s", e.Got, e.Want)
+}
+
+// NewEnvelope builds the envelope an export stamps onto its own document. The
+// format version and the kind come from this build rather than from a caller,
+// for the same reason MarshalAdmin overwrites them.
+//
+// exported_at is knowledge time -- when the data being exported was current --
+// so it is the exporting server's clock and nothing else's.
+func NewEnvelope(sourceInstance string, kind archivev1.ArchiveKind) *archivev1.Envelope {
+	return &archivev1.Envelope{
+		FormatVersion:  FormatVersion,
+		ExportedAt:     timestamppb.Now(),
+		SourceInstance: sourceInstance,
+		Kind:           kind,
+	}
 }
 
 // MarshalAdmin writes an admin archive. It stamps the envelope's format_version

--- a/server/archive/codec_test.go
+++ b/server/archive/codec_test.go
@@ -102,6 +102,24 @@ func userFixture() *archivev1.UserArchive {
 	}
 }
 
+// The version and the kind come from the build, so an export cannot produce a
+// document that misdescribes itself even if the caller never touches them.
+func TestNewEnvelope_StampsVersionAndKind(t *testing.T) {
+	e := archive.NewEnvelope("portfoliodb.example.com", archivev1.ArchiveKind_ADMIN)
+	if e.GetFormatVersion() != archive.FormatVersion {
+		t.Errorf("format_version = %d, want %d", e.GetFormatVersion(), archive.FormatVersion)
+	}
+	if e.GetKind() != archivev1.ArchiveKind_ADMIN {
+		t.Errorf("kind = %s, want ADMIN", e.GetKind())
+	}
+	if e.GetSourceInstance() != "portfoliodb.example.com" {
+		t.Errorf("source_instance = %q", e.GetSourceInstance())
+	}
+	if e.GetExportedAt() == nil {
+		t.Error("expected exported_at to be stamped")
+	}
+}
+
 // The keys are snake_case and the enums are names, because that is what makes a
 // file written by one version readable by another. A regression here is a
 // wholesale format change, so it is asserted on the bytes rather than through a

--- a/server/service/api/export_import_prices_test.go
+++ b/server/service/api/export_import_prices_test.go
@@ -3,7 +3,9 @@ package api
 import (
 	"context"
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
 	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
+	"github.com/leedenison/portfoliodb/server/archive"
 	dbpkg "github.com/leedenison/portfoliodb/server/db"
 	"github.com/leedenison/portfoliodb/server/testutil"
 	"github.com/shopspring/decimal"
@@ -24,6 +26,7 @@ func TestExportPrices_Success(t *testing.T) {
 	srv, db := newAPIServerWithMock(t)
 	open := decimal.RequireFromString("185.5")
 	vol := int64(50000000)
+	basis := time.Date(2024, 6, 10, 0, 0, 0, 0, time.UTC)
 	rows := []dbpkg.ExportPriceRow{
 		{
 			IdentifierType:   "MIC_TICKER",
@@ -36,6 +39,16 @@ func TestExportPrices_Success(t *testing.T) {
 			Close:            decimal.RequireFromString("185.90"),
 			Volume:           &vol,
 		},
+		{
+			IdentifierType:   "MIC_TICKER",
+			IdentifierValue:  "AAPL",
+			IdentifierDomain: "US",
+			AssetClass:       "STOCK",
+			Currency:         "USD",
+			PriceDate:        time.Date(2024, 1, 16, 0, 0, 0, 0, time.UTC),
+			ShareCountBasis:  &basis,
+			Close:            decimal.RequireFromString("18.59"),
+		},
 	}
 	db.EXPECT().
 		ListPriceCoverageForExport(gomock.Any()).
@@ -43,8 +56,10 @@ func TestExportPrices_Success(t *testing.T) {
 			IdentifierType:   "MIC_TICKER",
 			IdentifierValue:  "AAPL",
 			IdentifierDomain: "US",
+			AssetClass:       "STOCK",
+			Currency:         "USD",
 			From:             time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
-			Before:           time.Date(2024, 1, 16, 0, 0, 0, 0, time.UTC),
+			Before:           time.Date(2024, 1, 17, 0, 0, 0, 0, time.UTC),
 		}}, nil)
 	db.EXPECT().
 		ListPricesForExport(gomock.Any()).
@@ -54,16 +69,29 @@ func TestExportPrices_Success(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ExportPrices: %v", err)
 	}
-	if len(stream.rows()) != 1 {
-		t.Fatalf("expected 1 row streamed, got %d", len(stream.rows()))
+	if len(stream.groups()) != 1 {
+		t.Fatalf("expected 1 group streamed, got %d", len(stream.groups()))
 	}
-	row := stream.rows()[0]
-	if row.GetIdentifierType() != "MIC_TICKER" || row.GetIdentifierValue() != "AAPL" {
-		t.Fatalf("got identifier %s %s", row.GetIdentifierType(), row.GetIdentifierValue())
+	g := stream.groups()[0]
+	if g.GetInstrument().GetType() != typev1.IdentifierType_MIC_TICKER || g.GetInstrument().GetValue() != "AAPL" {
+		t.Fatalf("got identifier %s %s", g.GetInstrument().GetType(), g.GetInstrument().GetValue())
 	}
-	if row.GetAssetClass() != typev1.AssetClass_STOCK {
-		t.Fatalf("expected asset_class=ASSET_CLASS_STOCK, got %s", row.GetAssetClass())
+	if g.GetInstrument().GetDomain() != "US" {
+		t.Fatalf("expected domain US, got %s", g.GetInstrument().GetDomain())
 	}
+	if g.GetAssetClass() != typev1.AssetClass_STOCK {
+		t.Fatalf("expected asset_class=ASSET_CLASS_STOCK, got %s", g.GetAssetClass())
+	}
+	if g.GetCurrency() != "USD" {
+		t.Fatalf("expected currency=USD, got %s", g.GetCurrency())
+	}
+	if len(g.GetCoverage()) != 1 || g.GetCoverage()[0].GetFrom() != "2024-01-15" || g.GetCoverage()[0].GetBefore() != "2024-01-17" {
+		t.Fatalf("got coverage %+v", g.GetCoverage())
+	}
+	if len(g.GetRows()) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(g.GetRows()))
+	}
+	row := g.GetRows()[0]
 	if row.GetPriceDate() != "2024-01-15" {
 		t.Fatalf("expected date 2024-01-15, got %s", row.GetPriceDate())
 	}
@@ -79,8 +107,123 @@ func TestExportPrices_Success(t *testing.T) {
 	if row.Volume == nil || *row.Volume != 50000000 {
 		t.Fatalf("expected volume=50000000, got %v", row.Volume)
 	}
-	if row.GetCurrency() != "USD" {
-		t.Fatalf("expected currency=USD, got %s", row.GetCurrency())
+	// An as-traded bar says nothing; only the restated one carries a basis.
+	if row.ShareCountBasis != nil {
+		t.Fatalf("expected no share_count_basis on the as-traded row, got %v", row.ShareCountBasis)
+	}
+	if g.GetRows()[1].GetShareCountBasis() != "2024-06-10" {
+		t.Fatalf("expected share_count_basis=2024-06-10, got %v", g.GetRows()[1].ShareCountBasis)
+	}
+}
+
+// The envelope carries the knowledge time the whole file is stamped with, so it
+// has to arrive before anything a reader would attribute to it.
+func TestExportPrices_SendsEnvelopeFirst(t *testing.T) {
+	srv, db := newAPIServerWithMock(t)
+	db.EXPECT().
+		ListPriceCoverageForExport(gomock.Any()).
+		Return(nil, nil)
+	db.EXPECT().
+		ListPricesForExport(gomock.Any()).
+		Return([]dbpkg.ExportPriceRow{{
+			IdentifierType:  "MIC_TICKER",
+			IdentifierValue: "AAPL",
+			PriceDate:       time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
+			Close:           decimal.RequireFromString("185.90"),
+		}}, nil)
+	stream := &exportPriceStreamMock{ctx: adminCtx("user-1", "sub|1")}
+	if err := srv.ExportPrices(&apiv1.ExportPricesRequest{}, stream); err != nil {
+		t.Fatalf("ExportPrices: %v", err)
+	}
+	if len(stream.sent) != 2 {
+		t.Fatalf("expected 2 stream items, got %d", len(stream.sent))
+	}
+	env := stream.sent[0].GetEnvelope()
+	if env == nil {
+		t.Fatalf("expected the envelope first, got %+v", stream.sent[0])
+	}
+	if env.GetFormatVersion() != archive.FormatVersion {
+		t.Fatalf("expected format_version=%d, got %d", archive.FormatVersion, env.GetFormatVersion())
+	}
+	if env.GetKind() != archivev1.ArchiveKind_ADMIN {
+		t.Fatalf("expected kind=ADMIN, got %s", env.GetKind())
+	}
+	if env.GetExportedAt() == nil {
+		t.Fatal("expected exported_at to be stamped")
+	}
+	if stream.sent[1].GetGroup() == nil {
+		t.Fatalf("expected a group second, got %+v", stream.sent[1])
+	}
+}
+
+// A provider asked about a range and reporting nothing is the one fact rows
+// cannot carry, so a covered instrument with no bars is still a group.
+func TestExportPrices_CoveredInstrumentWithNoRows(t *testing.T) {
+	srv, db := newAPIServerWithMock(t)
+	db.EXPECT().
+		ListPriceCoverageForExport(gomock.Any()).
+		Return([]dbpkg.ExportPriceCoverageRow{{
+			IdentifierType:  "MIC_TICKER",
+			IdentifierValue: "DELISTED",
+			AssetClass:      "STOCK",
+			Currency:        "USD",
+			From:            time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
+			Before:          time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC),
+		}}, nil)
+	db.EXPECT().
+		ListPricesForExport(gomock.Any()).
+		Return(nil, nil)
+	stream := &exportPriceStreamMock{ctx: adminCtx("user-1", "sub|1")}
+	if err := srv.ExportPrices(&apiv1.ExportPricesRequest{}, stream); err != nil {
+		t.Fatalf("ExportPrices: %v", err)
+	}
+	groups := stream.groups()
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(groups))
+	}
+	if len(groups[0].GetRows()) != 0 {
+		t.Fatalf("expected no rows, got %d", len(groups[0].GetRows()))
+	}
+	if len(groups[0].GetCoverage()) != 1 {
+		t.Fatalf("expected 1 coverage span, got %d", len(groups[0].GetCoverage()))
+	}
+	if groups[0].GetAssetClass() != typev1.AssetClass_STOCK || groups[0].GetCurrency() != "USD" {
+		t.Fatalf("expected the coverage row to supply the plugin hints, got %s %s",
+			groups[0].GetAssetClass(), groups[0].GetCurrency())
+	}
+}
+
+// Two venues can list one ticker, and they are two instruments with two groups.
+func TestExportPrices_SplitsGroupsOnDomain(t *testing.T) {
+	srv, db := newAPIServerWithMock(t)
+	db.EXPECT().
+		ListPriceCoverageForExport(gomock.Any()).
+		Return(nil, nil)
+	db.EXPECT().
+		ListPricesForExport(gomock.Any()).
+		Return([]dbpkg.ExportPriceRow{
+			{
+				IdentifierType: "MIC_TICKER", IdentifierValue: "VOD", IdentifierDomain: "XLON",
+				PriceDate: time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
+				Close:     decimal.RequireFromString("70"),
+			},
+			{
+				IdentifierType: "MIC_TICKER", IdentifierValue: "VOD", IdentifierDomain: "XNAS",
+				PriceDate: time.Date(2024, 1, 16, 0, 0, 0, 0, time.UTC),
+				Close:     decimal.RequireFromString("9"),
+			},
+		}, nil)
+	stream := &exportPriceStreamMock{ctx: adminCtx("user-1", "sub|1")}
+	if err := srv.ExportPrices(&apiv1.ExportPricesRequest{}, stream); err != nil {
+		t.Fatalf("ExportPrices: %v", err)
+	}
+	groups := stream.groups()
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 groups, got %d", len(groups))
+	}
+	if groups[0].GetInstrument().GetDomain() != "XLON" || groups[1].GetInstrument().GetDomain() != "XNAS" {
+		t.Fatalf("got domains %s and %s",
+			groups[0].GetInstrument().GetDomain(), groups[1].GetInstrument().GetDomain())
 	}
 }
 
@@ -97,54 +240,10 @@ func TestExportPrices_Empty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ExportPrices: %v", err)
 	}
-	if len(stream.rows()) != 0 {
-		t.Fatalf("expected 0 rows, got %d", len(stream.rows()))
-	}
-	if len(stream.coverage()) != 0 {
-		t.Fatalf("expected 0 coverage spans, got %d", len(stream.coverage()))
-	}
-}
-
-// Only real bars are exported, so the coverage spans are what let an import
-// regenerate the synthetic days between them. They precede the rows.
-func TestExportPrices_SendsCoverageBeforeRows(t *testing.T) {
-	srv, db := newAPIServerWithMock(t)
-	db.EXPECT().
-		ListPriceCoverageForExport(gomock.Any()).
-		Return([]dbpkg.ExportPriceCoverageRow{{
-			IdentifierType:   "MIC_TICKER",
-			IdentifierValue:  "AAPL",
-			IdentifierDomain: "US",
-			From:             time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
-			Before:           time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC),
-		}}, nil)
-	db.EXPECT().
-		ListPricesForExport(gomock.Any()).
-		Return([]dbpkg.ExportPriceRow{{
-			IdentifierType:  "MIC_TICKER",
-			IdentifierValue: "AAPL",
-			PriceDate:       time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
-			Close:           decimal.RequireFromString("185.90"),
-		}}, nil)
-	stream := &exportPriceStreamMock{ctx: adminCtx("user-1", "sub|1")}
-	if err := srv.ExportPrices(&apiv1.ExportPricesRequest{}, stream); err != nil {
-		t.Fatalf("ExportPrices: %v", err)
-	}
-	if len(stream.sent) != 2 {
-		t.Fatalf("expected 2 stream items, got %d", len(stream.sent))
-	}
-	cov := stream.sent[0].GetCoverage()
-	if cov == nil {
-		t.Fatalf("expected coverage first, got %+v", stream.sent[0])
-	}
-	if cov.GetFrom() != "2024-01-15" || cov.GetBefore() != "2024-02-01" {
-		t.Fatalf("got span [%s, %s)", cov.GetFrom(), cov.GetBefore())
-	}
-	if cov.GetIdentifierValue() != "AAPL" || cov.GetIdentifierDomain() != "US" {
-		t.Fatalf("got identifier %s %s", cov.GetIdentifierValue(), cov.GetIdentifierDomain())
-	}
-	if stream.sent[1].GetRow() == nil {
-		t.Fatalf("expected a row second, got %+v", stream.sent[1])
+	// The envelope goes out even when there is nothing to say: an empty archive
+	// is a statement, and a reader still has to see the version and the kind.
+	if len(stream.sent) != 1 || stream.sent[0].GetEnvelope() == nil {
+		t.Fatalf("expected the envelope alone, got %+v", stream.sent)
 	}
 }
 

--- a/server/service/api/prices.go
+++ b/server/service/api/prices.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
+	"github.com/leedenison/portfoliodb/server/archive"
 	"github.com/leedenison/portfoliodb/server/auth"
 	"github.com/leedenison/portfoliodb/server/db"
 	"google.golang.org/grpc/codes"
@@ -63,10 +65,12 @@ func (s *Server) ListPrices(ctx context.Context, req *apiv1.ListPricesRequest) (
 	}, nil
 }
 
-// ExportPrices streams all cached EOD prices with the best identifier per
-// instrument. Coverage spans come first, then the rows. The spans are not
-// derivable from the rows: one covering dates with no rows records that a
-// provider was asked and had nothing. Admin only.
+// ExportPrices streams the price part of an admin archive: the envelope first,
+// then one group per instrument. Admin only.
+//
+// The coverage nested in each group is not derivable from its rows: a span
+// covering dates with no rows records that a provider was asked and had
+// nothing.
 func (s *Server) ExportPrices(req *apiv1.ExportPricesRequest, stream apiv1.ApiService_ExportPricesServer) error {
 	ctx := stream.Context()
 	if _, authErr := auth.RequireAdmin(ctx); authErr != nil {
@@ -76,49 +80,117 @@ func (s *Server) ExportPrices(req *apiv1.ExportPricesRequest, stream apiv1.ApiSe
 	if err != nil {
 		return status.Error(codes.Internal, err.Error())
 	}
-	for _, c := range coverage {
-		if err := stream.Send(&apiv1.ExportPricesResponse{
-			Item: &apiv1.ExportPricesResponse_Coverage{Coverage: &apiv1.ExportCoverage{
-				IdentifierType:   c.IdentifierType,
-				IdentifierValue:  c.IdentifierValue,
-				IdentifierDomain: c.IdentifierDomain,
-				From:             c.From.Format("2006-01-02"),
-				Before:           c.Before.Format("2006-01-02"),
-			}},
-		}); err != nil {
-			return err
-		}
-	}
 	rows, err := s.db.ListPricesForExport(ctx)
 	if err != nil {
 		return status.Error(codes.Internal, err.Error())
 	}
-	now := timestamppb.Now()
-	for _, r := range rows {
-		row := &apiv1.ExportPriceRow{
-			ExportedAt:       now,
-			IdentifierType:   r.IdentifierType,
-			IdentifierValue:  r.IdentifierValue,
-			IdentifierDomain: r.IdentifierDomain,
-			AssetClass:       db.StrToAssetClass(r.AssetClass),
-			Currency:         r.Currency,
-			PriceDate:        r.PriceDate.Format("2006-01-02"),
-			Close:            decStr(r.Close),
-		}
-		row.Open = decStrPtr(r.Open)
-		row.High = decStrPtr(r.High)
-		row.Low = decStrPtr(r.Low)
-		row.AdjustedClose = decStrPtr(r.AdjustedClose)
-		if r.Volume != nil {
-			row.Volume = r.Volume
-		}
+	// source_instance is left empty: nothing keys off it, and this build has no
+	// configured identity to put there.
+	if err := stream.Send(&apiv1.ExportPricesResponse{
+		Item: &apiv1.ExportPricesResponse_Envelope{
+			Envelope: archive.NewEnvelope("", archivev1.ArchiveKind_ADMIN),
+		},
+	}); err != nil {
+		return err
+	}
+	for _, g := range priceGroups(rows, coverage) {
 		if err := stream.Send(&apiv1.ExportPricesResponse{
-			Item: &apiv1.ExportPricesResponse_Row{Row: row},
+			Item: &apiv1.ExportPricesResponse_Group{Group: g},
 		}); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// instKey is an instrument named the way a file names it: the identifier triple
+// bestIdentifierJoin picked, and no server UUID.
+type instKey struct{ typ, value, domain string }
+
+// priceGroups turns the flat export rows and the per-instrument coverage spans
+// into archive groups, one per instrument.
+//
+// An instrument that was covered and has no rows still gets a group, with empty
+// rows. It is the only way a file can say a provider was asked about those
+// dates and had nothing, and the coverage row is where such a group's asset
+// class and currency come from.
+//
+// Both inputs arrive ordered by identifier, so the rows are grouped by a scan
+// and the output order follows the query's.
+func priceGroups(rows []db.ExportPriceRow, coverage []db.ExportPriceCoverageRow) []*archivev1.PriceGroup {
+	spans := make(map[instKey][]*archivev1.DateInterval, len(coverage))
+	for _, c := range coverage {
+		k := instKey{c.IdentifierType, c.IdentifierValue, c.IdentifierDomain}
+		spans[k] = append(spans[k], &archivev1.DateInterval{
+			From:   c.From.Format("2006-01-02"),
+			Before: c.Before.Format("2006-01-02"),
+		})
+	}
+
+	var out []*archivev1.PriceGroup
+	var cur *archivev1.PriceGroup
+	var curKey instKey
+	for _, r := range rows {
+		k := instKey{r.IdentifierType, r.IdentifierValue, r.IdentifierDomain}
+		if cur == nil || k != curKey {
+			cur = &archivev1.PriceGroup{
+				Instrument: &archivev1.InstrumentRef{
+					Type:   identifierTypeFromString(r.IdentifierType),
+					Value:  r.IdentifierValue,
+					Domain: r.IdentifierDomain,
+				},
+				AssetClass: db.StrToAssetClass(r.AssetClass),
+				Currency:   r.Currency,
+				Coverage:   spans[k],
+			}
+			delete(spans, k)
+			curKey = k
+			out = append(out, cur)
+		}
+		cur.Rows = append(cur.Rows, priceRow(r))
+	}
+
+	// Whatever coverage is left names an instrument with no rows at all.
+	for _, c := range coverage {
+		k := instKey{c.IdentifierType, c.IdentifierValue, c.IdentifierDomain}
+		cov, ok := spans[k]
+		if !ok {
+			continue
+		}
+		delete(spans, k)
+		out = append(out, &archivev1.PriceGroup{
+			Instrument: &archivev1.InstrumentRef{
+				Type:   identifierTypeFromString(c.IdentifierType),
+				Value:  c.IdentifierValue,
+				Domain: c.IdentifierDomain,
+			},
+			AssetClass: db.StrToAssetClass(c.AssetClass),
+			Currency:   c.Currency,
+			Coverage:   cov,
+		})
+	}
+	return out
+}
+
+// priceRow converts one export row to its archive form. The share count basis
+// is written only when the row has one: absent means the bar's own date, which
+// is the as-traded convention and what the query reports as nil.
+func priceRow(r db.ExportPriceRow) *archivev1.PriceRow {
+	row := &archivev1.PriceRow{
+		PriceDate: r.PriceDate.Format("2006-01-02"),
+		Close:     decStr(r.Close),
+	}
+	if r.ShareCountBasis != nil {
+		row.ShareCountBasis = proto.String(r.ShareCountBasis.Format("2006-01-02"))
+	}
+	row.Open = decStrPtr(r.Open)
+	row.High = decStrPtr(r.High)
+	row.Low = decStrPtr(r.Low)
+	row.AdjustedClose = decStrPtr(r.AdjustedClose)
+	if r.Volume != nil {
+		row.Volume = r.Volume
+	}
+	return row
 }
 
 // ImportPrices creates an async job to upsert EOD prices. Admin only.

--- a/server/service/api/server_test.go
+++ b/server/service/api/server_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
 	"github.com/leedenison/portfoliodb/server/auth"
 	"github.com/leedenison/portfoliodb/server/db/mock"
 	"github.com/leedenison/portfoliodb/server/testutil"
@@ -80,23 +81,12 @@ func (e *exportPriceStreamMock) SendMsg(m interface{}) error {
 	return nil
 }
 
-// rows returns the price rows in send order, dropping coverage envelopes.
-func (e *exportPriceStreamMock) rows() []*apiv1.ExportPriceRow {
-	var out []*apiv1.ExportPriceRow
+// groups returns the price groups in send order, dropping the envelope.
+func (e *exportPriceStreamMock) groups() []*archivev1.PriceGroup {
+	var out []*archivev1.PriceGroup
 	for _, m := range e.sent {
-		if r := m.GetRow(); r != nil {
-			out = append(out, r)
-		}
-	}
-	return out
-}
-
-// coverage returns the coverage spans in send order.
-func (e *exportPriceStreamMock) coverage() []*apiv1.ExportCoverage {
-	var out []*apiv1.ExportCoverage
-	for _, m := range e.sent {
-		if c := m.GetCoverage(); c != nil {
-			out = append(out, c)
+		if g := m.GetGroup(); g != nil {
+			out = append(out, g)
 		}
 	}
 	return out


### PR DESCRIPTION
Second of four PRs for [0081](docs/issues/0081-price-import-export-to-archive.md). **Stacked on #348** -- review that one first.

## What changes

`ExportPrices` stops streaming flat rows plus a parallel coverage channel:

```proto
message ExportPricesResponse {
  oneof item {
    portfoliodb.archive.v1.Envelope envelope = 1;
    portfoliodb.archive.v1.PriceGroup group = 2;
  }
}
```

The envelope goes first, exactly once, then one group per instrument with its coverage and rows nested inside it. It travels on the stream rather than being built by the browser because `exported_at` is knowledge time and has to be the server's clock.

The client accumulates the groups and calls `marshalAdmin({ envelope, prices: { groups } })`, so the downloaded file is an admin archive document, `prices.json`, and the encoding decisions stay in `client/lib/archive/codec.ts` where they belong.

## What the group buys

That group is exactly what the price CSV spelled as a `# coverage=` comment line plus a row, so the export half of the comment syntax goes: `pricesToCsv`, `chooseGlobal`, and the four global-versus-specific precedence rules `chooseGlobal` existed to satisfy.

Two facts the flat stream could not carry:

- **`share_count_basis` now reaches a file on the way out**, not just on the way in. A back-adjusted series exported and reimported used to come back as as-traded and get adjusted a second time -- the bug in 0057.
- **A covered instrument holding no bars is a group with empty `rows`.** It was previously a coverage message with no row to attach it to.

And `exported_at` moves off every row onto the envelope, stamped by the new `archive.NewEnvelope`.

## Scope

The import path is deliberately untouched -- `csvToPrices` and `ImportPriceRow` still stand, so CI stays green on this commit. They go in the next PR.

`ExportCoverage` stays in `api.proto`: `ExportCorporateEventsResponse` still uses it, and it goes with 0082.

## Testing

`make check`, `make server-test`, `make client-test` pass. New Go cases cover the envelope arriving first, a covered instrument with no rows becoming an empty group, two venues sharing a ticker splitting into two groups, and the basis being written only for a restated bar. The client's `csvToPrices` tests are untouched apart from the two that drove the serialiser.

🤖 Generated with [Claude Code](https://claude.com/claude-code)