### PR TITLE
Export corporate events as an admin archive corporate event part (0082)

### DIFF
--- a/client/app/admin/corporate-events/splits-tab.tsx
+++ b/client/app/admin/corporate-events/splits-tab.tsx
@@ -7,18 +7,17 @@ import { errorMessage } from "@/lib/errors";
 import { qk } from "@/lib/query-keys";
 import { ErrorAlert } from "@/app/components/error-alert";
 import { exportCorporateEvents } from "@/lib/portfolio-api";
-import { splitsToJson } from "@/lib/json/corporate-events";
-import type { ExportCorporateEventRow, ExportCoverage } from "@/gen/api/v1/api_pb";
+import { marshalAdmin } from "@/lib/archive/codec";
+import type { Envelope } from "@/gen/archive/v1/common_pb";
+import type { CorporateEventGroup } from "@/gen/archive/v1/corporate_events_pb";
 import { ImportSplitsModal } from "./import-splits-modal";
 
 interface SplitDisplay {
-  identifierType: string;
   identifierValue: string;
   identifierDomain: string;
   exDate: string;
   splitFrom: string;
   splitTo: string;
-  dataProvider: string;
 }
 
 export function SplitsTab() {
@@ -27,8 +26,9 @@ export function SplitsTab() {
   const [exportError, setExportError] = useState<string | null>(null);
   const [importOpen, setImportOpen] = useState(false);
 
-  // The export is a streaming generator, so the queryFn drains it and returns
-  // the accumulated rows. The generator itself is unchanged.
+  // The export is a streaming generator, so the queryFn drains it and flattens
+  // the groups back out. This tab lists splits; the dividends the same file
+  // carries have a tab of their own that is not built yet.
   const {
     data: splits = [],
     isPending: loading,
@@ -38,17 +38,16 @@ export function SplitsTab() {
     queryFn: async () => {
       const rows: SplitDisplay[] = [];
       for await (const item of exportCorporateEvents()) {
-        if (item.item.case !== "row") continue;
-        const row = item.item.value;
-        if (row.event.case === "split") {
+        if (item.item.case !== "group") continue;
+        const group = item.item.value;
+        for (const event of group.events) {
+          if (event.event.case !== "split") continue;
           rows.push({
-            identifierType: row.identifierType,
-            identifierValue: row.identifierValue,
-            identifierDomain: row.identifierDomain,
-            exDate: row.event.value.exDate,
-            splitFrom: row.event.value.splitFrom,
-            splitTo: row.event.value.splitTo,
-            dataProvider: row.dataProvider,
+            identifierValue: group.instrument?.value ?? "",
+            identifierDomain: group.instrument?.domain ?? "",
+            exDate: event.event.value.exDate,
+            splitFrom: event.event.value.splitFrom,
+            splitTo: event.event.value.splitTo,
           });
         }
       }
@@ -61,25 +60,29 @@ export function SplitsTab() {
 
   const error = exportError ?? (loadError ? errorMessage(loadError, "Failed to load splits") : null);
 
+  // The file is an admin archive carrying only its corporate event part. The
+  // stream sends the envelope first because exported_at is knowledge time and
+  // belongs to the server's clock, not the browser's.
   async function handleExport() {
     setExportLoading(true);
     setExportError(null);
     try {
-      const rows: ExportCorporateEventRow[] = [];
-      const coverage: ExportCoverage[] = [];
+      let envelope: Envelope | undefined;
+      const groups: CorporateEventGroup[] = [];
       for await (const item of exportCorporateEvents()) {
-        if (item.item.case === "coverage") {
-          coverage.push(item.item.value);
-        } else if (item.item.case === "row" && item.item.value.event.case === "split") {
-          rows.push(item.item.value);
+        if (item.item.case === "envelope") {
+          envelope = item.item.value;
+        } else if (item.item.case === "group") {
+          groups.push(item.item.value);
         }
       }
-      const json = splitsToJson(rows, coverage);
+      if (!envelope) throw new Error("export stream sent no envelope");
+      const json = marshalAdmin({ envelope, corporateEvents: { groups } });
       const blob = new Blob([json], { type: "application/json" });
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download = "splits.json";
+      a.download = "corporate-events.json";
       a.click();
       URL.revokeObjectURL(url);
     } catch (e) {
@@ -99,14 +102,14 @@ export function SplitsTab() {
             disabled={exportLoading}
             className="rounded-md border border-border bg-surface px-3 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-primary-light/15 disabled:cursor-not-allowed disabled:opacity-50"
           >
-            {exportLoading ? "Exporting..." : "Export JSON"}
+            {exportLoading ? "Exporting..." : "Export archive"}
           </button>
           <button
             type="button"
             onClick={() => setImportOpen(true)}
             className="rounded-md border border-border bg-surface px-3 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-primary-light/15"
           >
-            Import JSON
+            Import archive
           </button>
         </div>
       </div>
@@ -135,7 +138,6 @@ export function SplitsTab() {
               <th className="py-2 pr-4 font-medium">Ex Date</th>
               <th className="py-2 pr-4 font-medium">From</th>
               <th className="py-2 pr-4 font-medium">To</th>
-              <th className="py-2 pr-4 font-medium">Provider</th>
             </tr>
           </thead>
           <tbody>
@@ -148,7 +150,6 @@ export function SplitsTab() {
                 <td className="py-2 pr-4 text-text-muted">{s.exDate}</td>
                 <td className="py-2 pr-4 text-text-muted">{s.splitFrom}</td>
                 <td className="py-2 pr-4 text-text-muted">{s.splitTo}</td>
-                <td className="py-2 pr-4 text-text-muted">{s.dataProvider}</td>
               </tr>
             ))}
           </tbody>

--- a/client/lib/json/corporate-events.test.ts
+++ b/client/lib/json/corporate-events.test.ts
@@ -1,54 +1,30 @@
 import { describe, expect, it } from "vitest";
-import { create } from "@bufbuild/protobuf";
-import { timestampFromDate } from "@bufbuild/protobuf/wkt";
-import { ExportCorporateEventRowSchema, ExportCoverageSchema, SplitRowSchema } from "@/gen/api/v1/api_pb";
-import { AssetClass } from "@/gen/type/v1/type_pb";
-import type { ExportCorporateEventRow } from "@/gen/api/v1/api_pb";
-import { splitsToJson, parseSplitsJson } from "./corporate-events";
+import { parseSplitsJson } from "./corporate-events";
 
-function makeSplitRow(firstKnownAt?: Date): ExportCorporateEventRow {
-  return create(ExportCorporateEventRowSchema, {
-    identifierType: "MIC_TICKER",
-    identifierValue: "AAPL",
-    identifierDomain: "XNAS",
-    assetClass: AssetClass.STOCK,
-    dataProvider: "massive",
-    event: {
-      case: "split",
-      value: create(SplitRowSchema, {
-        exDate: "2020-08-31",
-        splitFrom: "1",
-        splitTo: "4",
-        firstKnownAt: firstKnownAt ? timestampFromDate(firstKnownAt) : undefined,
-      }),
-    },
-  });
-}
-
-describe("splitsToJson", () => {
-  it("serializes knowledge time as an ISO 8601 instant", () => {
-    const knownAt = new Date("2015-03-04T09:30:00.000Z");
-    const out = JSON.parse(splitsToJson([makeSplitRow(knownAt)]));
-    expect(out.events[0].first_known_at).toBe("2015-03-04T09:30:00.000Z");
-  });
-
-  it("omits knowledge time when the row carries none", () => {
-    const out = JSON.parse(splitsToJson([makeSplitRow()]));
-    expect(out.events[0]).not.toHaveProperty("first_known_at");
-  });
-});
+// The exporter that produced these files is gone -- corporate events export as
+// an admin archive part -- so the fixtures are written by hand, which is what a
+// file this parser still has to read now looks like.
+const SPLIT = {
+  identifier_type: "MIC_TICKER",
+  identifier_value: "AAPL",
+  identifier_domain: "XNAS",
+  asset_class: "STOCK",
+  ex_date: "2020-08-31",
+  split_from: "1",
+  split_to: "4",
+};
 
 describe("parseSplitsJson", () => {
   it("round-trips knowledge time", () => {
-    const knownAt = new Date("2015-03-04T09:30:00.000Z");
-    const { splits, errors } = parseSplitsJson(splitsToJson([makeSplitRow(knownAt)]));
+    const knownAt = "2015-03-04T09:30:00.000Z";
+    const { splits, errors } = parseSplitsJson(JSON.stringify({ events: [{ ...SPLIT, first_known_at: knownAt }] }));
     expect(errors).toEqual([]);
     expect(splits).toHaveLength(1);
-    expect(splits[0].firstKnownAt?.toISOString()).toBe(knownAt.toISOString());
+    expect(splits[0].firstKnownAt?.toISOString()).toBe(knownAt);
   });
 
   it("accepts a file with no knowledge time, leaving the server to stamp it", () => {
-    const { splits, errors } = parseSplitsJson(splitsToJson([makeSplitRow()]));
+    const { splits, errors } = parseSplitsJson(JSON.stringify({ events: [SPLIT] }));
     expect(errors).toEqual([]);
     expect(splits[0].firstKnownAt).toBeUndefined();
   });
@@ -131,35 +107,5 @@ describe("parseSplitsJson coverage", () => {
     const { errors } = parseSplitsJson(JSON.stringify({ coverage: [] }));
     expect(errors).toHaveLength(1);
     expect(errors[0].field).toBe("file");
-  });
-});
-
-describe("corporate event JSON coverage round trip", () => {
-  it("carries coverage spans through serialize and parse", () => {
-    const coverage = [
-      create(ExportCoverageSchema, {
-        identifierType: "MIC_TICKER",
-        identifierValue: "AAPL",
-        identifierDomain: "XNAS",
-        from: "2020-01-01",
-        before: "2025-01-01",
-      }),
-    ];
-    const json = splitsToJson([makeSplitRow()], coverage);
-    const result = parseSplitsJson(json);
-    expect(result.errors).toEqual([]);
-    expect(result.coverage).toEqual([
-      expect.objectContaining({
-        identifierType: "MIC_TICKER",
-        identifierValue: "AAPL",
-        identifierDomain: "XNAS",
-        from: "2020-01-01",
-        before: "2025-01-01",
-      }),
-    ]);
-  });
-
-  it("omits the coverage key when the export supplied none", () => {
-    expect(JSON.parse(splitsToJson([makeSplitRow()]))).not.toHaveProperty("coverage");
   });
 });

--- a/client/lib/json/corporate-events.ts
+++ b/client/lib/json/corporate-events.ts
@@ -1,81 +1,22 @@
 /**
- * JSON serialization for corporate event (split) export/import.
+ * JSON parsing for the retired corporate event import format.
  *
- * The canonical import shape is an object with "events" -- split objects with
- * identifier context -- and an optional "coverage". A bare array of events is
- * still accepted, and is what the exporter writes until it has coverage to
- * serialize. See docs/spec/csv-format.md.
+ * The export half is gone: corporate events export as an admin archive part.
+ * This is what remains until the import follows it. The shape is an object with
+ * "events" -- split objects with identifier context -- and an optional
+ * "coverage"; a bare array of events is also accepted.
+ * See docs/spec/csv-format.md.
  */
 
 import { create } from "@bufbuild/protobuf";
-import { timestampDate } from "@bufbuild/protobuf/wkt";
 import { ImportCorporateEventCoverageSchema } from "@/gen/api/v1/api_pb";
 import { AssetClass } from "@/gen/type/v1/type_pb";
-import type { ExportCorporateEventRow, ExportCoverage, ImportCorporateEventCoverage, SplitRow } from "@/gen/api/v1/api_pb";
+import type { ImportCorporateEventCoverage } from "@/gen/api/v1/api_pb";
 import type { CorporateSplitImportRow } from "@/lib/portfolio-api";
-import { assetClassToStr, assetClassFromStr } from "@/lib/asset-class";
+import { assetClassFromStr } from "@/lib/asset-class";
 import type { ParseError } from "@/lib/csv/standard";
 import { expandCoverage, validateCoverage } from "@/lib/coverage";
 import type { CoverageDecl, InstrumentRef } from "@/lib/coverage";
-
-interface SerializedSplit {
-  identifier_type: string;
-  identifier_value: string;
-  identifier_domain?: string;
-  asset_class?: string;
-  ex_date: string;
-  split_from: string;
-  split_to: string;
-  // Knowledge time as an ISO 8601 instant: when the exporting instance first
-  // learned of the split. Absent in files written before it was recorded.
-  first_known_at?: string;
-}
-
-interface SerializedCoverage {
-  identifier_type: string;
-  identifier_value: string;
-  identifier_domain?: string;
-  from: string;
-  before: string;
-}
-
-/**
- * Serialize split export rows to a JSON string in the canonical object form.
- * Coverage is written in the specific form, one entry per instrument.
- */
-export function splitsToJson(rows: ExportCorporateEventRow[], coverage?: ExportCoverage[]): string {
-  const serialized: SerializedSplit[] = rows
-    .filter((r) => r.event.case === "split")
-    .map((r) => {
-      const split = r.event.value as SplitRow;
-      const obj: SerializedSplit = {
-        identifier_type: r.identifierType,
-        identifier_value: r.identifierValue,
-        ex_date: split.exDate,
-        split_from: split.splitFrom,
-        split_to: split.splitTo,
-      };
-      if (r.identifierDomain) obj.identifier_domain = r.identifierDomain;
-      const ac = assetClassToStr(r.assetClass);
-      if (ac) obj.asset_class = ac;
-      if (split.firstKnownAt) obj.first_known_at = timestampDate(split.firstKnownAt).toISOString();
-      return obj;
-    });
-  const out: { events: SerializedSplit[]; coverage?: SerializedCoverage[] } = { events: serialized };
-  if (coverage && coverage.length > 0) {
-    out.coverage = coverage.map((c) => {
-      const obj: SerializedCoverage = {
-        identifier_type: c.identifierType,
-        identifier_value: c.identifierValue,
-        from: c.from,
-        before: c.before,
-      };
-      if (c.identifierDomain) obj.identifier_domain = c.identifierDomain;
-      return obj;
-    });
-  }
-  return JSON.stringify(out, null, 2) + "\n";
-}
 
 export interface SplitParseResult {
   splits: CorporateSplitImportRow[];

--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -3,6 +3,7 @@ syntax = "proto3";
 package portfoliodb.api.v1;
 
 import "archive/v1/common.proto";
+import "archive/v1/corporate_events.proto";
 import "archive/v1/instruments.proto";
 import "archive/v1/prices.proto";
 import "buf/validate/validate.proto";
@@ -713,22 +714,6 @@ message ListPricesResponse {
 // instrument, carrying the best identifier for it.
 message ExportPricesRequest {}
 
-// ExportCoverage is one half-open [from, before) corporate event coverage span
-// for an instrument, streamed alongside the events it covers. It records that a
-// provider answered for the range, which the events cannot say on their own: a
-// span with no events in it means the provider was asked and had nothing.
-// Re-importing events without their coverage loses that.
-//
-// Prices state the same thing as archive.v1.PriceGroup.coverage; this goes the
-// same way when corporate events move to the archive schema.
-message ExportCoverage {
-  string identifier_type = 1;
-  string identifier_value = 2;
-  string identifier_domain = 3;
-  string from = 4;   // YYYY-MM-DD, inclusive
-  string before = 5; // YYYY-MM-DD, exclusive
-}
-
 // ExportPricesResponse is one element of the export stream: the envelope first,
 // exactly once, then one message per instrument group.
 //
@@ -1086,32 +1071,20 @@ message CashDividendRow {
   google.protobuf.Timestamp first_known_at = 9;
 }
 
-// ExportCorporateEventRow is one corporate event with its instrument
-// identifier context. Each row is either a stock split or a cash dividend
-// (oneof event). The best identifier per instrument is selected on the
-// server using the same priority as ExportPriceRow.
-message ExportCorporateEventRow {
-  string identifier_type = 1;
-  string identifier_value = 2;
-  string identifier_domain = 3;
-  portfoliodb.type.v1.AssetClass asset_class = 4;
-  string data_provider = 5;
-  oneof event {
-    SplitRow split = 10;
-    CashDividendRow dividend = 11;
-  }
-}
-
+// ExportCorporateEvents streams the corporate event part of an admin archive:
+// one group per instrument, carrying the best identifier for it.
 message ExportCorporateEventsRequest {}
 
-// ExportCorporateEventsResponse is one element of the export stream. Coverage
-// spans are sent before the rows they cover, merged across plugins: an import
-// records them all as data_provider = "import", so the per-plugin split does
-// not survive a round trip anyway.
+// ExportCorporateEventsResponse is one element of the export stream: the
+// envelope first, exactly once, then one message per instrument group.
+//
+// The envelope travels on the stream rather than being built by the caller
+// because exported_at is knowledge time and has to be the server's clock, and
+// source_instance is a server property the browser does not know.
 message ExportCorporateEventsResponse {
   oneof item {
-    ExportCorporateEventRow row = 1;
-    ExportCoverage coverage = 2;
+    portfoliodb.archive.v1.Envelope envelope = 1;
+    portfoliodb.archive.v1.CorporateEventGroup group = 2;
   }
 }
 

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -445,10 +445,15 @@ type ExportPriceCoverageRow struct {
 
 // ExportCoverageRow is one half-open [From, Before) corporate event coverage
 // span with the best instrument identifier for export.
+//
+// AssetClass rides along because an instrument that was covered and has no
+// events is still a group, and the asset class is what routes the identifier
+// plugins when the importing instance does not know the instrument.
 type ExportCoverageRow struct {
 	IdentifierType   string
 	IdentifierValue  string
 	IdentifierDomain string
+	AssetClass       string
 	From             time.Time
 	Before           time.Time
 }

--- a/server/db/postgres/corporate_events.go
+++ b/server/db/postgres/corporate_events.go
@@ -427,7 +427,7 @@ func (p *Postgres) ListStockSplitsForExport(ctx context.Context) ([]db.ExportSto
 		FROM stock_splits s
 		JOIN instruments i ON i.id = s.instrument_id
 		` + bestIdentifierJoin + `
-		ORDER BY best_id.identifier_type, best_id.value, s.ex_date
+		ORDER BY best_id.identifier_type, best_id.value, COALESCE(best_id.domain, ''), s.ex_date
 	`
 	rows, err := p.q.QueryContext(ctx, q)
 	if err != nil {
@@ -457,7 +457,7 @@ func (p *Postgres) ListCashDividendsForExport(ctx context.Context) ([]db.ExportC
 		FROM cash_dividends d
 		JOIN instruments i ON i.id = d.instrument_id
 		` + bestIdentifierJoin + `
-		ORDER BY best_id.identifier_type, best_id.value, d.ex_date
+		ORDER BY best_id.identifier_type, best_id.value, COALESCE(best_id.domain, ''), d.ex_date
 	`
 	rows, err := p.q.QueryContext(ctx, q)
 	if err != nil {
@@ -867,6 +867,7 @@ type exportCoverageRow struct {
 	IdentifierType   string    `db:"identifier_type"`
 	IdentifierValue  string    `db:"value"`
 	IdentifierDomain string    `db:"domain"`
+	AssetClass       string    `db:"asset_class"`
 	From             time.Time `db:"covered_from"`
 	Before           time.Time `db:"covered_before"`
 }
@@ -878,6 +879,7 @@ func toExportCoverageRows(rows []exportCoverageRow) []db.ExportCoverageRow {
 			IdentifierType:   r.IdentifierType,
 			IdentifierValue:  r.IdentifierValue,
 			IdentifierDomain: r.IdentifierDomain,
+			AssetClass:       r.AssetClass,
 			From:             r.From,
 			Before:           r.Before,
 		}
@@ -889,6 +891,7 @@ func toExportCoverageRows(rows []exportCoverageRow) []db.ExportCoverageRow {
 func (p *Postgres) ListCorporateEventCoverageForExport(ctx context.Context) ([]db.ExportCoverageRow, error) {
 	q := `
 		SELECT best_id.identifier_type, best_id.value, COALESCE(best_id.domain, '') AS domain,
+			COALESCE(i.asset_class, '') AS asset_class,
 			lower(sub.r) AS covered_from, upper(sub.r) AS covered_before
 		FROM (
 			SELECT instrument_id,
@@ -898,7 +901,7 @@ func (p *Postgres) ListCorporateEventCoverageForExport(ctx context.Context) ([]d
 		) sub
 		JOIN instruments i ON i.id = sub.instrument_id
 		` + bestIdentifierJoin + `
-		ORDER BY best_id.identifier_type, best_id.value, covered_from
+		ORDER BY best_id.identifier_type, best_id.value, COALESCE(best_id.domain, ''), covered_from
 	`
 	var rows []exportCoverageRow
 	if err := p.q.SelectContext(ctx, &rows, q); err != nil {

--- a/server/service/api/corporate_events.go
+++ b/server/service/api/corporate_events.go
@@ -3,8 +3,11 @@ package api
 import (
 	"context"
 	"fmt"
+	"sort"
 
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
+	"github.com/leedenison/portfoliodb/server/archive"
 	"github.com/leedenison/portfoliodb/server/auth"
 	"github.com/leedenison/portfoliodb/server/db"
 	"google.golang.org/grpc/codes"
@@ -13,103 +16,159 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-// exportCoverage converts a db coverage span to its wire form.
-func exportCoverage(c db.ExportCoverageRow) *apiv1.ExportCoverage {
-	return &apiv1.ExportCoverage{
-		IdentifierType:   c.IdentifierType,
-		IdentifierValue:  c.IdentifierValue,
-		IdentifierDomain: c.IdentifierDomain,
-		From:             c.From.Format("2006-01-02"),
-		Before:           c.Before.Format("2006-01-02"),
-	}
-}
-
-// ExportCorporateEvents streams every stored stock split and cash dividend
-// with the best identifier per instrument. Coverage spans come first, then
-// splits, then dividends; within each block rows are ordered by
-// (identifier_type, identifier_value, ex_date). Admin only.
+// ExportCorporateEvents streams the corporate event part of an admin archive:
+// the envelope first, then one group per instrument. Admin only.
+//
+// The coverage nested in each group is not derivable from its events: events are
+// sparse, so a span holding none of them records that a provider was asked and
+// had nothing, which is a different statement from never having asked.
 func (s *Server) ExportCorporateEvents(req *apiv1.ExportCorporateEventsRequest, stream apiv1.ApiService_ExportCorporateEventsServer) error {
 	ctx := stream.Context()
 	if _, authErr := auth.RequireAdmin(ctx); authErr != nil {
 		return authErr
 	}
-
 	coverage, err := s.db.ListCorporateEventCoverageForExport(ctx)
 	if err != nil {
 		return status.Error(codes.Internal, err.Error())
 	}
-	for _, c := range coverage {
-		if err := stream.Send(&apiv1.ExportCorporateEventsResponse{
-			Item: &apiv1.ExportCorporateEventsResponse_Coverage{Coverage: exportCoverage(c)},
-		}); err != nil {
-			return err
-		}
-	}
-
 	splits, err := s.db.ListStockSplitsForExport(ctx)
 	if err != nil {
 		return status.Error(codes.Internal, err.Error())
 	}
-	for _, r := range splits {
-		row := &apiv1.ExportCorporateEventRow{
-			IdentifierType:   r.IdentifierType,
-			IdentifierValue:  r.IdentifierValue,
-			IdentifierDomain: r.IdentifierDomain,
-			AssetClass:       db.StrToAssetClass(r.AssetClass),
-			DataProvider:     r.DataProvider,
-			Event: &apiv1.ExportCorporateEventRow_Split{
-				Split: &apiv1.SplitRow{
-					ExDate:       r.ExDate.Format("2006-01-02"),
-					SplitFrom:    r.SplitFrom,
-					SplitTo:      r.SplitTo,
-					FirstKnownAt: timestamppb.New(r.FirstKnownAt),
-				},
-			},
-		}
-		if err := stream.Send(&apiv1.ExportCorporateEventsResponse{
-			Item: &apiv1.ExportCorporateEventsResponse_Row{Row: row},
-		}); err != nil {
-			return err
-		}
-	}
-
 	dividends, err := s.db.ListCashDividendsForExport(ctx)
 	if err != nil {
 		return status.Error(codes.Internal, err.Error())
 	}
-	for _, r := range dividends {
-		div := &apiv1.CashDividendRow{
-			ExDate:       r.ExDate.Format("2006-01-02"),
-			Amount:       r.Amount,
-			Currency:     r.Currency,
-			Frequency:    r.Frequency,
-			Type:         r.Type,
-			FirstKnownAt: timestamppb.New(r.FirstKnownAt),
-		}
-		if r.PayDate != nil {
-			div.PayDate = r.PayDate.Format("2006-01-02")
-		}
-		if r.RecordDate != nil {
-			div.RecordDate = r.RecordDate.Format("2006-01-02")
-		}
-		if r.DeclarationDate != nil {
-			div.DeclarationDate = r.DeclarationDate.Format("2006-01-02")
-		}
-		row := &apiv1.ExportCorporateEventRow{
-			IdentifierType:   r.IdentifierType,
-			IdentifierValue:  r.IdentifierValue,
-			IdentifierDomain: r.IdentifierDomain,
-			AssetClass:       db.StrToAssetClass(r.AssetClass),
-			DataProvider:     r.DataProvider,
-			Event:            &apiv1.ExportCorporateEventRow_Dividend{Dividend: div},
-		}
+	// source_instance is left empty: nothing keys off it, and this build has no
+	// configured identity to put there.
+	if err := stream.Send(&apiv1.ExportCorporateEventsResponse{
+		Item: &apiv1.ExportCorporateEventsResponse_Envelope{
+			Envelope: archive.NewEnvelope("", archivev1.ArchiveKind_ADMIN),
+		},
+	}); err != nil {
+		return err
+	}
+	for _, g := range corporateEventGroups(splits, dividends, coverage) {
 		if err := stream.Send(&apiv1.ExportCorporateEventsResponse{
-			Item: &apiv1.ExportCorporateEventsResponse_Row{Row: row},
+			Item: &apiv1.ExportCorporateEventsResponse_Group{Group: g},
 		}); err != nil {
 			return err
 		}
 	}
 	return nil
+}
+
+// corporateEventGroups turns the three flat export queries into archive groups,
+// one per instrument.
+//
+// An instrument that was covered and has no events still gets a group, with
+// empty events. It is the only way a file can say a provider was asked about
+// those dates and had nothing, and the coverage row is where such a group's
+// asset class comes from.
+//
+// All three inputs arrive ordered by identifier, so the events are grouped by a
+// scan and the output order follows the queries'. The data provider is not
+// carried: an import records every event and every span against the "import"
+// sentinel, so provenance cannot survive a round trip.
+func corporateEventGroups(splits []db.ExportStockSplit, dividends []db.ExportCashDividend, coverage []db.ExportCoverageRow) []*archivev1.CorporateEventGroup {
+	var order []instKey
+	groups := make(map[instKey]*archivev1.CorporateEventGroup)
+
+	group := func(k instKey, assetClass string) *archivev1.CorporateEventGroup {
+		g, ok := groups[k]
+		if ok {
+			return g
+		}
+		g = &archivev1.CorporateEventGroup{
+			Instrument: &archivev1.InstrumentRef{
+				Type:   identifierTypeFromString(k.typ),
+				Value:  k.value,
+				Domain: k.domain,
+			},
+			AssetClass: db.StrToAssetClass(assetClass),
+		}
+		groups[k] = g
+		order = append(order, k)
+		return g
+	}
+
+	for _, c := range coverage {
+		k := instKey{c.IdentifierType, c.IdentifierValue, c.IdentifierDomain}
+		g := group(k, c.AssetClass)
+		g.Coverage = append(g.Coverage, &archivev1.DateInterval{
+			From:   c.From.Format("2006-01-02"),
+			Before: c.Before.Format("2006-01-02"),
+		})
+	}
+	for _, r := range splits {
+		k := instKey{r.IdentifierType, r.IdentifierValue, r.IdentifierDomain}
+		g := group(k, r.AssetClass)
+		g.Events = append(g.Events, &archivev1.CorporateEvent{
+			Event: &archivev1.CorporateEvent_Split{Split: &archivev1.Split{
+				ExDate:       r.ExDate.Format("2006-01-02"),
+				SplitFrom:    r.SplitFrom,
+				SplitTo:      r.SplitTo,
+				FirstKnownAt: timestamppb.New(r.FirstKnownAt),
+			}},
+		})
+	}
+	for _, r := range dividends {
+		k := instKey{r.IdentifierType, r.IdentifierValue, r.IdentifierDomain}
+		g := group(k, r.AssetClass)
+		g.Events = append(g.Events, &archivev1.CorporateEvent{
+			Event: &archivev1.CorporateEvent_Dividend{Dividend: archiveDividend(r)},
+		})
+	}
+
+	out := make([]*archivev1.CorporateEventGroup, 0, len(order))
+	for _, k := range order {
+		g := groups[k]
+		// The queries order splits and dividends separately, so a group holding
+		// both would read as one block then the other. Order in a file is a
+		// convenience rather than a contract, but a group that reads
+		// chronologically is the one a human can check against a statement.
+		sort.SliceStable(g.Events, func(a, b int) bool {
+			return eventExDate(g.Events[a]) < eventExDate(g.Events[b])
+		})
+		out = append(out, g)
+	}
+	return out
+}
+
+// eventExDate is the valid time of either arm of the event oneof.
+func eventExDate(e *archivev1.CorporateEvent) string {
+	if sp := e.GetSplit(); sp != nil {
+		return sp.GetExDate()
+	}
+	return e.GetDividend().GetExDate()
+}
+
+// archiveDividend converts one cash dividend export row to its archive form.
+func archiveDividend(r db.ExportCashDividend) *archivev1.CashDividend {
+	d := &archivev1.CashDividend{
+		ExDate:          r.ExDate.Format("2006-01-02"),
+		PayDate:         optDate(r.PayDate),
+		RecordDate:      optDate(r.RecordDate),
+		DeclarationDate: optDate(r.DeclarationDate),
+		Amount:          r.Amount,
+		Currency:        r.Currency,
+		Type:            dividendTypeFromString(r.Type),
+		FirstKnownAt:    timestamppb.New(r.FirstKnownAt),
+	}
+	if r.Frequency != "" {
+		d.Frequency = proto.String(r.Frequency)
+	}
+	return d
+}
+
+// dividendTypeFromString maps the stored two-letter vocabulary to the archive
+// enum. An unrecognised value reads as unspecified, which the format defines as
+// a regular cash dividend.
+func dividendTypeFromString(s string) archivev1.DividendType {
+	if v, ok := archivev1.DividendType_value[s]; ok {
+		return archivev1.DividendType(v)
+	}
+	return archivev1.DividendType_DIVIDEND_TYPE_UNSPECIFIED
 }
 
 // ImportCorporateEvents creates an async job to upsert stock splits and cash

--- a/server/service/api/export_corporate_events_test.go
+++ b/server/service/api/export_corporate_events_test.go
@@ -4,11 +4,14 @@ import (
 	"testing"
 	"time"
 
-	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
-	dbpkg "github.com/leedenison/portfoliodb/server/db"
-	"github.com/leedenison/portfoliodb/server/testutil"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/codes"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
+	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
+	dbpkg "github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/testutil"
 )
 
 func TestExportCorporateEvents_NonAdmin_PermissionDenied(t *testing.T) {
@@ -18,6 +21,31 @@ func TestExportCorporateEvents_NonAdmin_PermissionDenied(t *testing.T) {
 	testutil.RequireGRPCCode(t, err, codes.PermissionDenied)
 }
 
+func TestExportCorporateEvents_Empty(t *testing.T) {
+	srv, db := newAPIServerWithMock(t)
+	db.EXPECT().ListCorporateEventCoverageForExport(gomock.Any()).Return(nil, nil)
+	db.EXPECT().ListStockSplitsForExport(gomock.Any()).Return(nil, nil)
+	db.EXPECT().ListCashDividendsForExport(gomock.Any()).Return(nil, nil)
+	stream := &exportCorporateEventStreamMock{ctx: adminCtx("user-1", "sub|1")}
+	if err := srv.ExportCorporateEvents(&apiv1.ExportCorporateEventsRequest{}, stream); err != nil {
+		t.Fatalf("ExportCorporateEvents: %v", err)
+	}
+	// The envelope goes out even when there is nothing to say.
+	if len(stream.sent) != 1 {
+		t.Fatalf("expected exactly the envelope, got %d messages", len(stream.sent))
+	}
+	env := stream.sent[0].GetEnvelope()
+	if env == nil {
+		t.Fatal("first message is not the envelope")
+	}
+	if env.GetFormatVersion() != 1 || env.GetKind() != archivev1.ArchiveKind_ADMIN {
+		t.Fatalf("got format_version=%d kind=%v", env.GetFormatVersion(), env.GetKind())
+	}
+	if !env.GetExportedAt().IsValid() {
+		t.Fatal("envelope carries no exported_at")
+	}
+}
+
 // Knowledge time and dividend type must reach the wire: without them a
 // PortfolioDB-to-PortfolioDB round trip restamps every split with the import
 // time and turns special cash dividends into regular ones.
@@ -25,11 +53,13 @@ func TestExportCorporateEvents_CarriesKnowledgeTimeAndDividendType(t *testing.T)
 	srv, db := newAPIServerWithMock(t)
 	splitKnownAt := time.Date(2015, 3, 4, 9, 30, 0, 0, time.UTC)
 	divKnownAt := time.Date(2024, 2, 2, 8, 0, 0, 0, time.UTC)
+	payDate := time.Date(2024, 2, 15, 0, 0, 0, 0, time.UTC)
 
 	db.EXPECT().ListCorporateEventCoverageForExport(gomock.Any()).Return([]dbpkg.ExportCoverageRow{{
 		IdentifierType:   "MIC_TICKER",
 		IdentifierValue:  "AAPL",
 		IdentifierDomain: "XNAS",
+		AssetClass:       "STOCK",
 		From:             time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
 		Before:           time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
 	}}, nil)
@@ -54,8 +84,10 @@ func TestExportCorporateEvents_CarriesKnowledgeTimeAndDividendType(t *testing.T)
 			AssetClass:       "STOCK",
 			DataProvider:     "massive",
 			ExDate:           time.Date(2024, 2, 9, 0, 0, 0, 0, time.UTC),
+			PayDate:          &payDate,
 			Amount:           "0.24",
 			Currency:         "USD",
+			Frequency:        "quarterly",
 			Type:             "SC",
 			FirstKnownAt:     divKnownAt,
 		},
@@ -65,35 +97,107 @@ func TestExportCorporateEvents_CarriesKnowledgeTimeAndDividendType(t *testing.T)
 	if err := srv.ExportCorporateEvents(&apiv1.ExportCorporateEventsRequest{}, stream); err != nil {
 		t.Fatalf("ExportCorporateEvents: %v", err)
 	}
-	if len(stream.coverage()) != 1 {
-		t.Fatalf("expected 1 coverage span streamed, got %d", len(stream.coverage()))
+	groups := stream.groups()
+	if len(groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(groups))
 	}
-	if cov := stream.coverage()[0]; cov.GetFrom() != "2020-01-01" || cov.GetBefore() != "2025-01-01" {
+	g := groups[0]
+	if g.GetInstrument().GetType() != typev1.IdentifierType_MIC_TICKER ||
+		g.GetInstrument().GetValue() != "AAPL" || g.GetInstrument().GetDomain() != "XNAS" {
+		t.Fatalf("instrument ref = %v", g.GetInstrument())
+	}
+	if g.GetAssetClass() != typev1.AssetClass_STOCK {
+		t.Fatalf("asset_class = %v", g.GetAssetClass())
+	}
+	if len(g.GetCoverage()) != 1 {
+		t.Fatalf("expected 1 coverage span, got %d", len(g.GetCoverage()))
+	}
+	if cov := g.GetCoverage()[0]; cov.GetFrom() != "2020-01-01" || cov.GetBefore() != "2025-01-01" {
 		t.Fatalf("got span [%s, %s)", cov.GetFrom(), cov.GetBefore())
 	}
-	if stream.sent[0].GetCoverage() == nil {
-		t.Fatalf("expected coverage before the rows, got %+v", stream.sent[0])
-	}
-	if len(stream.rows()) != 2 {
-		t.Fatalf("expected 2 rows streamed, got %d", len(stream.rows()))
+	if len(g.GetEvents()) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(g.GetEvents()))
 	}
 
-	split := stream.rows()[0].GetSplit()
+	split := g.GetEvents()[0].GetSplit()
 	if split == nil {
-		t.Fatalf("first row is not a split: %+v", stream.rows()[0])
+		t.Fatalf("first event is not a split: %+v", g.GetEvents()[0])
+	}
+	if split.GetSplitFrom() != "1" || split.GetSplitTo() != "4" || split.GetExDate() != "2020-08-31" {
+		t.Errorf("split = %v", split)
 	}
 	if got := split.GetFirstKnownAt().AsTime(); !got.Equal(splitKnownAt) {
 		t.Errorf("split first_known_at: want %s, got %s", splitKnownAt, got)
 	}
 
-	div := stream.rows()[1].GetDividend()
+	div := g.GetEvents()[1].GetDividend()
 	if div == nil {
-		t.Fatalf("second row is not a dividend: %+v", stream.rows()[1])
+		t.Fatalf("second event is not a dividend: %+v", g.GetEvents()[1])
 	}
-	if div.GetType() != "SC" {
-		t.Errorf("dividend type: want SC, got %q", div.GetType())
+	if div.GetType() != archivev1.DividendType_SC {
+		t.Errorf("dividend type: want SC, got %v", div.GetType())
+	}
+	if div.GetAmount() != "0.24" || div.GetCurrency() != "USD" || div.GetFrequency() != "quarterly" {
+		t.Errorf("dividend = %v", div)
+	}
+	if div.GetPayDate() != "2024-02-15" || div.RecordDate != nil || div.DeclarationDate != nil {
+		t.Errorf("dividend dates: pay=%q record=%v declaration=%v", div.GetPayDate(), div.RecordDate, div.DeclarationDate)
 	}
 	if got := div.GetFirstKnownAt().AsTime(); !got.Equal(divKnownAt) {
 		t.Errorf("dividend first_known_at: want %s, got %s", divKnownAt, got)
+	}
+}
+
+// A group with no events is the only way a file can say a provider was asked
+// about those dates and had nothing, so it has to survive the grouping.
+func TestExportCorporateEvents_CoveredInstrumentWithNoEvents(t *testing.T) {
+	srv, db := newAPIServerWithMock(t)
+	db.EXPECT().ListCorporateEventCoverageForExport(gomock.Any()).Return([]dbpkg.ExportCoverageRow{{
+		IdentifierType:  "ISIN",
+		IdentifierValue: "US0378331005",
+		AssetClass:      "ETF",
+		From:            time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
+		Before:          time.Date(2021, 1, 1, 0, 0, 0, 0, time.UTC),
+	}}, nil)
+	db.EXPECT().ListStockSplitsForExport(gomock.Any()).Return(nil, nil)
+	db.EXPECT().ListCashDividendsForExport(gomock.Any()).Return(nil, nil)
+
+	stream := &exportCorporateEventStreamMock{ctx: adminCtx("user-1", "sub|1")}
+	if err := srv.ExportCorporateEvents(&apiv1.ExportCorporateEventsRequest{}, stream); err != nil {
+		t.Fatalf("ExportCorporateEvents: %v", err)
+	}
+	groups := stream.groups()
+	if len(groups) != 1 || len(groups[0].GetEvents()) != 0 {
+		t.Fatalf("expected one group with no events, got %v", groups)
+	}
+	// The asset class of such a group can only come from the coverage row.
+	if groups[0].GetAssetClass() != typev1.AssetClass_ETF {
+		t.Fatalf("asset_class = %v", groups[0].GetAssetClass())
+	}
+}
+
+// Two venues listing the same ticker are two instruments, so they are two
+// groups: the domain is part of the key, not decoration on it.
+func TestExportCorporateEvents_SplitsGroupsOnDomain(t *testing.T) {
+	srv, db := newAPIServerWithMock(t)
+	db.EXPECT().ListCorporateEventCoverageForExport(gomock.Any()).Return(nil, nil)
+	db.EXPECT().ListStockSplitsForExport(gomock.Any()).Return([]dbpkg.ExportStockSplit{
+		{IdentifierType: "MIC_TICKER", IdentifierValue: "VOD", IdentifierDomain: "XLON", AssetClass: "STOCK",
+			ExDate: time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC), SplitFrom: "1", SplitTo: "2"},
+		{IdentifierType: "MIC_TICKER", IdentifierValue: "VOD", IdentifierDomain: "XNAS", AssetClass: "STOCK",
+			ExDate: time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC), SplitFrom: "1", SplitTo: "3"},
+	}, nil)
+	db.EXPECT().ListCashDividendsForExport(gomock.Any()).Return(nil, nil)
+
+	stream := &exportCorporateEventStreamMock{ctx: adminCtx("user-1", "sub|1")}
+	if err := srv.ExportCorporateEvents(&apiv1.ExportCorporateEventsRequest{}, stream); err != nil {
+		t.Fatalf("ExportCorporateEvents: %v", err)
+	}
+	groups := stream.groups()
+	if len(groups) != 2 {
+		t.Fatalf("expected 2 groups, got %d", len(groups))
+	}
+	if groups[0].GetInstrument().GetDomain() != "XLON" || groups[1].GetInstrument().GetDomain() != "XNAS" {
+		t.Fatalf("domains = %q, %q", groups[0].GetInstrument().GetDomain(), groups[1].GetInstrument().GetDomain())
 	}
 }

--- a/server/service/api/server_test.go
+++ b/server/service/api/server_test.go
@@ -127,23 +127,13 @@ func (e *exportCorporateEventStreamMock) SendMsg(m interface{}) error {
 	return nil
 }
 
-// rows returns the event rows in send order, dropping coverage envelopes.
-func (e *exportCorporateEventStreamMock) rows() []*apiv1.ExportCorporateEventRow {
-	var out []*apiv1.ExportCorporateEventRow
+// groups returns the instrument groups the export streamed, dropping the
+// envelope that precedes them.
+func (e *exportCorporateEventStreamMock) groups() []*archivev1.CorporateEventGroup {
+	var out []*archivev1.CorporateEventGroup
 	for _, m := range e.sent {
-		if r := m.GetRow(); r != nil {
-			out = append(out, r)
-		}
-	}
-	return out
-}
-
-// coverage returns the coverage spans in send order.
-func (e *exportCorporateEventStreamMock) coverage() []*apiv1.ExportCoverage {
-	var out []*apiv1.ExportCoverage
-	for _, m := range e.sent {
-		if c := m.GetCoverage(); c != nil {
-			out = append(out, c)
+		if g := m.GetGroup(); g != nil {
+			out = append(out, g)
 		}
 	}
 	return out


### PR DESCRIPTION
Second of four PRs for 0082. Stacked on #352.

## What changes

`ExportCorporateEventsResponse` becomes a `oneof` of the envelope and one `archive.v1.CorporateEventGroup`. The flat `ExportCorporateEventRow` and `ExportCoverage` messages are deleted, and `splitsToJson` goes with them; `parseSplitsJson` stays until the import follows in the next PR.

**Coverage moves onto the group it applies to.** That is what removes the four precedence rules `client/lib/coverage.ts` implements -- at most one global, a specific overrides rather than adds, several specifics all apply, a partial identifier is an error -- and the reason adr/0035 asks for it. An instrument that was covered and has no events is now simply a group with an empty `events`, which is the only way a file can record that a provider was asked about those dates and had nothing.

**Dividends come with it, which closes 0087.** The export query and the ingestion worker already handled cash dividends end to end; only the client-side `splitsToJson` filter dropped them, so a rebuild lost every dividend it had ever fetched. Excluding them from the archive would have meant *adding* a filter on the way out and a refusal on the way back in. 0087's one open question -- whether dividend coverage is tracked separately from split coverage -- is answered by the schema: `corporate_event_coverage` is keyed `(instrument_id, plugin_id, covered_from)` with no event-kind dimension, so one coverage set is correct. 0087 is closed in the docs PR.

## Two db-layer details

- `ExportCoverageRow` gains `AssetClass`, for the reason `ExportPriceCoverageRow` gained it in #348: it is the only place a covered-but-empty group can get the hint that routes the identifier plugins on the way back in.
- All three export queries gain `COALESCE(best_id.domain, '')` in their `ORDER BY`. Without it two venues listing the same ticker interleave and the single-scan grouping in `corporateEventGroups` breaks.

## UI

The splits tab loses its Provider column. An import records every event and every span against the `import` sentinel, so provenance cannot survive a round trip and the archive does not carry it.

## Verification

`make check`, `make server-test`, `make client-test`, `make db-test` all pass. New coverage: envelope-first on an empty database, knowledge time and dividend type through the grouping, a covered instrument with no events keeping its asset class, and two venues on one ticker splitting into two groups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)