### PR TITLE
Retire the corporate event JSON from the spec, and close 0082 and 0087

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -103,8 +103,8 @@ The informantion architecture of the user interface is described in docs/spec/in
 
 The archive format -- the single import and export format that replaces the
 transaction CSV, the price CSV, the instrument JSON and the corporate event JSON
--- is documented in docs/spec/archive-format.md. The formats it has not yet
-replaced are documented in docs/spec/csv-format.md.
+-- is documented in docs/spec/archive-format.md. The one format it has not yet
+replaced, the standard transaction CSV, is documented in docs/spec/csv-format.md.
 
 Automated transaction import via the browser extension is specified in docs/spec/broker-import-extension.md.
 

--- a/docs/issues/0082-instrument-corporate-event-export-to-archive.md
+++ b/docs/issues/0082-instrument-corporate-event-export-to-archive.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Move instrument and corporate event export to the archive schema
 dependencies: [0078]
 ---

--- a/docs/issues/0083-instrument-archive-carries-lookup-results.md
+++ b/docs/issues/0083-instrument-archive-carries-lookup-results.md
@@ -19,13 +19,12 @@ output of the lookups themselves -- provider-scoped identifiers such as
 (server/plugins/openfigi/identifier/map.go,
 server/plugins/eodhd/identifier/map.go,
 server/plugins/massive/identifier/map.go) and saved at
-server/service/identification/resolve.go. `SerializedInstrument` in
-client/lib/json/instruments.ts does not mention it.
+server/service/identification/resolve.go. `ListInstrumentsForExport` loads it
+onto the row and `archiveInstrument` in server/service/api/instruments.go does
+not write it out.
 
-**`cik`, `sic_code` and the validity interval are dropped** by the same
-serialiser. `cik` and `sic_code` are plugin lookup results;
-`valid_from`/`valid_before` records when the instrument was available to trade
-and is not derivable.
+**`cik`, `sic_code` and the validity interval were dropped** by the
+hand-written serialiser that preceded the archive. 0082 closed that half.
 
 **`ExportInstrumentsRequest` excludes CASH and FX by default.** That default is
 right for browsing and wrong for a rebuild: FX pairs are instruments
@@ -42,3 +41,9 @@ is called.
 
 Independent of 0082 -- this is what the export carries, not how it is encoded --
 but the two are naturally done together.
+
+0082 has since landed the widened export query, so `cik`, `sic_code` and the
+validity interval already reach the file. What remains here is
+`provider_instrument_identifiers` -- carried on export and restored on import
+without calling a plugin -- and the export mode that means everything rather
+than the browsing default that excludes CASH and FX.

--- a/docs/issues/0087-cash-dividends-in-corporate-event-archive.md
+++ b/docs/issues/0087-cash-dividends-in-corporate-event-archive.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Carry cash dividends in the corporate event archive
 dependencies: [0078]
 ---
@@ -26,3 +26,16 @@ backwards-only treatment on import. And coverage is stored per (instrument,
 plugin) for corporate events generally; whether dividend coverage is tracked
 separately from split coverage decides whether the archive needs one coverage
 set or two.
+
+Closed by 0082. Moving corporate events onto the archive schema carried
+dividends as a matter of course: the export query and the ingestion worker
+already handled them end to end, and only the client-side `splitsToJson` filter
+dropped them, so excluding them would have meant adding a filter on the way out
+and a refusal on the way back in.
+
+Both open questions are settled. Dividends carry `first_known_at` with the same
+backwards-only treatment as splits, which the e2e round trip asserts. And there
+is one coverage set rather than two, because `corporate_event_coverage` is keyed
+`(instrument_id, plugin_id, covered_from)` and has no event-kind dimension: a
+span records that a provider was asked about those dates, not which kind of
+event it was asked about.

--- a/docs/spec/bitemporality.md
+++ b/docs/spec/bitemporality.md
@@ -122,8 +122,8 @@ they state when the supplied data was current, and drive OCC split adjustment
 during instrument resolution. See [prices.md](prices.md) and
 [corporate-events.md](corporate-events.md).
 
-Corporate events also carry knowledge time per row: `SplitRow.first_known_at`
-and `CashDividendRow.first_known_at` make an export/import round trip lossless.
+Corporate events also carry knowledge time per event: `Split.first_known_at`
+and `CashDividend.first_known_at` make an export/import round trip lossless.
 An importing row resolves its knowledge time from the row, else the request's
 `exported_at`, else the time it is stored.
 

--- a/docs/spec/corporate-events.md
+++ b/docs/spec/corporate-events.md
@@ -23,14 +23,18 @@ Three sources feed `stock_splits` and `cash_dividends`. All three write through 
 | Source | `data_provider` | Mechanism |
 | --- | --- | --- |
 | External market data plugins | plugin id (e.g. `"massive"`, `"eodhd"`) | Background fetcher worker (`server/corporateevents`) |
-| Admin CSV / JSON import | `"import"` | `ImportCorporateEvents` admin RPC |
+| Admin archive import | `"import"` | `ImportCorporateEvents` admin RPC |
 | Broker statement parsers (planned) | `"import"` | Client-side per-broker parsers; submit through `ImportCorporateEvents` |
 
 ### Export and import
 
-`ExportCorporateEvents` and `ImportCorporateEvents` are a lossless round trip, knowledge time included. `SplitRow` and `CashDividendRow` carry `first_known_at` in both directions, and an importing row resolves its knowledge time from the row, else `ImportCorporateEventsRequest.exported_at`, else the time it is stored. A stored `first_known_at` only ever moves backwards, so re-importing a split learned of years ago restores its original stamp rather than pushing it forward to import time. It is reporting knowledge only: retroactive OCC adjustment of options on the underlying keys off `ex_date`, which does not move, so a restamped split cannot re-adjust symbols that were already correct (see [Option contracts](#option-contracts) and docs/spec/bitemporality.md).
+`ExportCorporateEvents` and `ImportCorporateEvents` carry the corporate event part of an admin archive: one `CorporateEventGroup` per instrument, holding that instrument's coverage and its splits and dividends together. See [archive-format.md](archive-format.md#corporate-events).
+
+The round trip is lossless, knowledge time included. `Split` and `CashDividend` both carry `first_known_at` in both directions, and an importing event resolves its knowledge time from the event, else the envelope's `exported_at`, else the time it is stored. A stored `first_known_at` only ever moves backwards, so re-importing a split learned of years ago restores its original stamp rather than pushing it forward to import time. It is reporting knowledge only: retroactive OCC adjustment of options on the underlying keys off `ex_date`, which does not move, so a restamped split cannot re-adjust symbols that were already correct (see [Option contracts](#option-contracts) and docs/spec/bitemporality.md).
 
 `exported_at` also stamps imported `corporate_event_coverage` spans, so an imported span records when it was actually confirmed rather than when it was imported.
+
+Coverage is stored per (instrument, plugin), but an import records every span against the `import` sentinel, so the file carries spans merged across plugins. The per-plugin distinction cannot survive a round trip and is not written. There is one coverage set per instrument rather than one per event kind, because `corporate_event_coverage` has no event-kind dimension: a span says the provider was asked about those dates, not which kind of event it was asked about.
 
 The broker statement parsers are deferred follow-up work. They live entirely in client converters; broker tx logs that contain SPLIT entries should be parsed by the converter for the broker's specific format and submitted via `ImportCorporateEvents`. The server-side `TX_TYPE=SPLIT` filter in `server/service/ingestion/hints.go` continues to drop SPLIT txs at ingestion; corporate events are admin-only shared data, never derived from user txs (see adr/0005-corporate-events-design.md).
 

--- a/docs/spec/csv-format.md
+++ b/docs/spec/csv-format.md
@@ -1,14 +1,13 @@
 # Import formats
 
-Two file formats feed the import APIs: a transaction CSV and a corporate event JSON.
+One file format still feeds the import APIs: the standard transaction CSV.
 
-> **These formats are being replaced.** One schema, specified in
-> archive-format.md, covers everything below, the price CSV that has already
-> gone, and the instrument JSON that was never documented here. The standard
-> transaction CSV migrates under issue 0084 and the corporate event JSON under
-> 0082; each section goes as its format does, and this file is deleted once it
-> documents nothing. Broker-specific files -- the Fidelity CSV, the IBKR OFX,
-> the Schwab CSV -- are not affected.
+> **This format is being replaced.** One schema, specified in
+> archive-format.md, covers everything below, and has already replaced the
+> price CSV, the corporate event JSON and the instrument JSON that was never
+> documented here. The standard transaction CSV migrates under issue 0084, at
+> which point this file is deleted. Broker-specific files -- the Fidelity CSV,
+> the IBKR OFX, the Schwab CSV -- are not affected.
 
 ## Standard transaction CSV
 
@@ -147,87 +146,3 @@ Lines beginning with `#` are metadata or commentary and are not parsed as rows. 
     # share_count_basis=2026-07-29
 
 It declares the share count the file's quantities and unit prices are denominated in. Omit it for an ordinary export, where each row reflects the splits that happened before its own transaction date and nothing after -- the as-traded convention the server assumes. Set it only when the source has post-adjusted historical rows for splits that happened *after* the transaction, in which case it is the date those quantities are current as of. See [bitemporality.md](bitemporality.md#share-count-basis).
-
-## Corporate event JSON
-
-Stock splits are imported via the `ImportCorporateEvents` API as JSON, and `ExportCorporateEvents` writes the same shape. Cash dividends are part of the API but are not yet carried by this file format.
-
-Coverage is stored per (instrument, plugin) for both prices and corporate events, but an import records every span against the `import` sentinel, so both exports merge spans across plugins rather than preserving a distinction that cannot survive the round trip.
-
-The canonical shape is an object with an `events` array and an optional `coverage` array. A bare array is accepted as events-only.
-
-### Event objects
-
-| Key | Required | Description |
-| --- | -------- | ----------- |
-| `identifier_type` | Yes | Identifier type used to resolve the instrument (`MIC_TICKER`, `OPENFIGI_TICKER`, `ISIN`, etc.). |
-| `identifier_value` | Yes | Identifier value (e.g. `AAPL`, `US0378331005`). |
-| `identifier_domain` | No | Domain for the identifier (MIC for `MIC_TICKER`, exchange code for `OPENFIGI_TICKER`). |
-| `asset_class` | No | `STOCK` or `ETF`. Used as the security type hint when the instrument is unknown and identifier plugins must resolve it. |
-| `ex_date` | Yes | `YYYY-MM-DD`. Effective/execution date. This is valid time -- when the split took effect, not when it was announced or learned of (see [bitemporality.md](bitemporality.md)). |
-| `split_from` | Yes | Decimal numerator of the pre-split ratio (e.g. `1` for a 2:1 split). |
-| `split_to` | Yes | Decimal numerator of the post-split ratio (e.g. `2` for a 2:1 split). The factor is `split_to / split_from`. |
-| `first_known_at` | No | ISO 8601 instant: when the exporting instance first learned of the split. Omit and the server falls back to the request's `exported_at`, then to storage time. A stored value only ever moves backwards. |
-
-When the importer sees an unknown `(identifier_type, identifier_domain, identifier_value)` triple, it routes through the same identifier plugin flow used by price imports: the supplied `asset_class` becomes the security-type hint and the resolved instrument is created with the supplied identifier as canonical.
-
-### Example
-
-```json
-{
-  "events": [
-    { "identifier_type": "MIC_TICKER", "identifier_domain": "XNAS", "identifier_value": "AAPL",
-      "asset_class": "STOCK", "ex_date": "2020-08-31", "split_from": "1", "split_to": "4" },
-    { "identifier_type": "MIC_TICKER", "identifier_domain": "XNAS", "identifier_value": "TSLA",
-      "asset_class": "STOCK", "ex_date": "2022-08-25", "split_from": "1", "split_to": "3" }
-  ],
-  "coverage": [
-    { "from": "2022-01-01", "before": "2026-07-30" }
-  ]
-}
-```
-
-## Coverage declarations
-
-A coverage declaration records that the caller has authoritative coverage of a date interval. The corporate event JSON accepts them, storing a `corporate_event_coverage` row tagged as coming from an import, so the background fetcher does not re-query the same interval from a plugin and cannot overwrite hand-curated data with provider data.
-
-A declared interval containing nothing is meaningful, and is the only way a file can say the caller asked about those dates and there was nothing to report. See adr/0023-price-coverage-is-stored-not-inferred.md.
-
-The archive states coverage inside the group it applies to, so it needs no global declaration and none of the precedence rules below. Prices moved there under 0081; this section goes when corporate events follow.
-
-### Fields
-
-| Field | Required | Description |
-| ----- | -------- | ----------- |
-| `identifier_type` | No | Identifier type. Present together with `identifier_value` to name one instrument; absent to declare a file-wide default. |
-| `identifier_value` | No | Identifier value. See above. |
-| `identifier_domain` | No | Domain for the identifier. Only meaningful alongside the other two. |
-| `from` | Yes | `YYYY-MM-DD`, inclusive. |
-| `before` | Yes | `YYYY-MM-DD`, exclusive; must be after `from`. To cover through 31 December 2024, write `2025-01-01`. |
-
-The interval is half-open `[from, before)`, matching every other date interval on the wire (see [bitemporality.md](bitemporality.md) and adr/0018-half-open-date-intervals.md).
-
-### Global and specific declarations
-
-A declaration carrying no identifier at all is **global**: it applies to every instrument the file names. A declaration carrying one is **specific** to that instrument.
-
-- At most one global declaration per file.
-- A specific declaration **overrides** the global for its instrument rather than adding to it. An instrument with any specific declaration takes none of the global.
-- Several specific declarations for one instrument are all applied, so an instrument can carry more than one interval.
-- A partly-written identifier -- a type with no value, or a domain alone -- is an error rather than a global declaration.
-
-Most files need one global and a handful of exceptions: instruments that started or stopped trading partway through the period the file covers.
-
-Two cases an export always writes out in full, both following from the override rule above. An instrument carrying more than one span writes all of them, since a specific declaration replaces the global rather than adding to it. An instrument that is covered but has no events in the file also writes its own, since the global is expanded against the instruments the file names and would never reach it.
-
-### Syntax
-
-An entry in the top-level `coverage` array. Identifier keys are omitted or empty for a global declaration.
-
-```json
-"coverage": [
-  { "from": "2022-01-01", "before": "2026-07-30" },
-  { "identifier_type": "MIC_TICKER", "identifier_value": "ATVI",
-    "identifier_domain": "XNAS", "from": "2021-12-31", "before": "2023-10-14" }
-]
-```


### PR DESCRIPTION
Last of four PRs for 0082. Stacked on #354. Documentation only.

## What changes

**`docs/spec/csv-format.md`** loses the corporate event JSON section and the whole coverage-declaration section. That second one is the point: the archive states coverage inside the group it applies to, so the global declaration, the override rule, the several-specifics rule and the partial-identifier error case are not merely undocumented but gone -- and with them the two cases an export previously had to write out in full. What is left documents only the standard transaction CSV, which goes under 0084, at which point the file is deleted.

**`docs/spec/corporate-events.md`** described the export in terms of `SplitRow`, `CashDividendRow` and a request-level `exported_at`, none of which exist any more. It now describes the group, and records why there is one coverage set per instrument rather than one per event kind.

**`docs/spec/bitemporality.md`** and **`CLAUDE.md`** get the same names updated.

## Issues

- **0082 closed.**
- **0087 closed**, with a note recording that carrying dividends was what the archive schema did as a matter of course, and that both of its open questions are answered: `first_known_at` behaves for dividends exactly as it does for splits, and `corporate_event_coverage` has no event-kind dimension, so one coverage set is correct.
- **0083 updated.** Its motivation still described a hand-written serialiser that no longer exists. Its remaining scope is `provider_instrument_identifiers` and the export mode that means everything rather than the browsing default excluding CASH and FX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)