### PR TITLE
Add ArchivePart and per-part job results

### DIFF
--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -448,12 +448,39 @@ message GetJobRequest {
   string job_id = 1;
 }
 
+// JobPartResult is one part of a system archive as applied by one job. A row
+// exists for every part the document carried from the moment the job is created,
+// so a page rendering a row per part shows the same rows before, during and
+// after the run, including after a reload.
+//
+// status is FAILED only for a hard failure -- an unreadable payload, or a
+// database error that ended the part. A row the import could not use is a
+// validation error on a part that still succeeded, which is what lets a result
+// read "completed, 12 rows rejected".
+message JobPartResult {
+  portfoliodb.archive.v1.ArchivePart part = 1;
+  JobStatus status = 2;
+  int32 total_count = 3;
+  int32 processed_count = 4;
+  // Row-level problems attributed to this part. row_index is the index of the
+  // group (prices, corporate events) or of the instrument (instruments) the
+  // problem was found in.
+  repeated ValidationError validation_errors = 5;
+  // The hard failure that ended the part. Empty unless status is FAILED.
+  string message = 6;
+}
+
 message GetJobResponse {
   JobStatus status = 1;
+  // Problems with no part of their own: transaction jobs, and a system archive
+  // that failed before any part was reached. Per-part problems are on the part.
   repeated ValidationError validation_errors = 2;
   repeated IdentificationError identification_errors = 3;
   int32 total_count = 4;
   int32 processed_count = 5;
+  // One row per part the archive carried, in restore order. Empty for any job
+  // that is not a system archive import.
+  repeated JobPartResult parts = 6;
 }
 
 // Job is an ingestion job summary for list views.
@@ -465,12 +492,13 @@ message Job {
   google.protobuf.Timestamp created_at = 5;
   int32 validation_error_count = 6;
   int32 identification_error_count = 7;
-  string job_type = 8;  // "tx" or "price"
+  string job_type = 8; // "tx" or "system_archive"
 }
 
 message ListJobsRequest {
   int32 page_size = 1;
   string page_token = 2;
+  string job_type = 3; // optional; empty = every type
 }
 
 message ListJobsResponse {

--- a/proto/archive/v1/common.proto
+++ b/proto/archive/v1/common.proto
@@ -54,6 +54,22 @@ enum ArchiveKind {
   USER = 2;   // one user's own data; no system data
 }
 
+// ArchivePart names one part of an archive document. It is the export's
+// include-menu and the axis an import job reports progress and results along,
+// so the request that asks for a part and the result that reports on it are one
+// vocabulary.
+//
+// Values run in restore order, which is also the field order in SystemArchive:
+// a part is applied after everything it refers to.
+enum ArchivePart {
+  ARCHIVE_PART_UNSPECIFIED = 0;
+  INSTRUMENTS = 1;
+  PRICES = 2;
+  CORPORATE_EVENTS = 3;
+  // 4 onwards are the remaining parts: inflation indices, fetch blocks,
+  // unhandled event resolutions, plugin config.
+}
+
 // Envelope carries only what cannot differ between two rows of a valid file.
 // Anything that can differ between rows belongs on a group or on a row.
 message Envelope {

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
 	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
 	"github.com/shopspring/decimal"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -43,6 +44,7 @@ const (
 	JobTypeTx             = "tx"
 	JobTypePrice          = "price"
 	JobTypeCorporateEvent = "corporate_event"
+	JobTypeSystemArchive  = "system_archive"
 )
 
 // DB is the database abstraction used by the service layer.
@@ -307,29 +309,71 @@ type PendingJob struct {
 // CreateJobParams holds the parameters for creating a new job.
 type CreateJobParams struct {
 	UserID       string
-	JobType      string // "tx" or "price"
+	JobType      string // one of the JobType* constants
 	Broker       string // tx only
 	Source       string // tx only
 	Filename     string
 	PeriodFrom   *timestamppb.Timestamp
 	PeriodBefore *timestamppb.Timestamp
 	Payload      []byte // serialized protobuf request
+	// Parts are the archive parts a system archive job will apply. Their result
+	// rows are written with the job so that a caller polling immediately sees a
+	// row per part rather than an empty list it cannot distinguish from a job
+	// that carried nothing.
+	Parts []archivev1.ArchivePart
+}
+
+// JobPartResult is one archive part as applied by one job.
+type JobPartResult struct {
+	Part             archivev1.ArchivePart
+	Status           apiv1.JobStatus
+	TotalCount       int32
+	ProcessedCount   int32
+	Message          string // the hard failure that ended the part, if any
+	ValidationErrors []*apiv1.ValidationError
+}
+
+// JobDetail is everything GetJob knows about one job. UserID is empty when no
+// such job exists, which is how a caller distinguishes "not found" from an error.
+type JobDetail struct {
+	Status               apiv1.JobStatus
+	UserID               string
+	TotalCount           int32
+	ProcessedCount       int32
+	ValidationErrors     []*apiv1.ValidationError // errors with no part of their own
+	IdentificationErrors []IdentificationError
+	Parts                []JobPartResult // in restore order; empty unless a system archive
 }
 
 // JobDB provides ingestion job operations.
 type JobDB interface {
 	CreateJob(ctx context.Context, params CreateJobParams) (string, error)
-	GetJob(ctx context.Context, jobID string) (apiv1.JobStatus, []*apiv1.ValidationError, []IdentificationError, string, int32, int32, error) // returns (status, validationErrors, idErrors, userID, totalCount, processedCount, error)
+	GetJob(ctx context.Context, jobID string) (*JobDetail, error)
 	SetJobStatus(ctx context.Context, jobID string, status apiv1.JobStatus) error
 	SetJobTotalCount(ctx context.Context, jobID string, total int32) error
 	IncrJobProcessedCount(ctx context.Context, jobID string) error
-	AppendValidationErrors(ctx context.Context, jobID string, errs []*apiv1.ValidationError) error
+	// AppendValidationErrors attributes errors to one archive part, or to the
+	// job itself when part is ARCHIVE_PART_UNSPECIFIED.
+	AppendValidationErrors(ctx context.Context, jobID string, part archivev1.ArchivePart, errs []*apiv1.ValidationError) error
 	AppendIdentificationErrors(ctx context.Context, jobID string, errs []IdentificationError) error
+	SetJobPartStatus(ctx context.Context, jobID string, part archivev1.ArchivePart, status apiv1.JobStatus) error
+	// SetJobPartFailed records the hard failure that ended a part and sets it FAILED.
+	SetJobPartFailed(ctx context.Context, jobID string, part archivev1.ArchivePart, message string) error
+	SetJobPartTotalCount(ctx context.Context, jobID string, part archivev1.ArchivePart, total int32) error
+	// AddJobPartProcessedCount advances a part's progress by n. It takes a delta
+	// rather than incrementing by one so that a caller can batch: a six-figure
+	// price import that reported every row separately would spend more time
+	// updating its own progress than importing.
+	AddJobPartProcessedCount(ctx context.Context, jobID string, part archivev1.ArchivePart, n int32) error
+	// ResetJobPartProgress zeroes a part's processed count, for a part being
+	// re-run after the service restarted mid-job.
+	ResetJobPartProgress(ctx context.Context, jobID string, part archivev1.ArchivePart) error
 	LoadJobPayload(ctx context.Context, jobID string) ([]byte, error)
 	ClearJobPayload(ctx context.Context, jobID string) error
 	ListPendingJobs(ctx context.Context) ([]PendingJob, error)
-	// ListJobs returns jobs for a user, newest first, with error counts. Returns (rows, totalCount, nextPageToken, error).
-	ListJobs(ctx context.Context, userID string, pageSize int32, pageToken string) ([]JobRow, int32, string, error)
+	// ListJobs returns jobs for a user, newest first, with error counts. An empty
+	// jobType matches every type. Returns (rows, totalCount, nextPageToken, error).
+	ListJobs(ctx context.Context, userID, jobType string, pageSize int32, pageToken string) ([]JobRow, int32, string, error)
 }
 
 // IdentifierInput is a single (type, domain, value) for EnsureInstrument.

--- a/server/db/postgres/jobs.go
+++ b/server/db/postgres/jobs.go
@@ -4,9 +4,11 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"sort"
 
 	"github.com/google/uuid"
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
 	"github.com/leedenison/portfoliodb/server/db"
 )
 
@@ -41,69 +43,135 @@ func (p *Postgres) CreateJob(ctx context.Context, params db.CreateJobParams) (st
 	if jobType == "" {
 		jobType = "tx"
 	}
+	// The job and its part rows are written together: a caller that polls the
+	// moment CreateJob returns must see a row per part, not a list that fills in
+	// later and is indistinguishable meanwhile from an archive carrying nothing.
 	var id uuid.UUID
-	err = p.q.QueryRowContext(ctx, `
-		INSERT INTO ingestion_jobs (user_id, job_type, broker, source, filename, period_from, period_before, payload, status)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'PENDING')
-		RETURNING id
-	`, userUUID, jobType, brokerVal, sourceVal, filenameVal, fromT, beforeT, payloadVal).Scan(&id)
+	err = p.runInTx(ctx, func(exec queryable) error {
+		if err := exec.QueryRowContext(ctx, `
+			INSERT INTO ingestion_jobs (user_id, job_type, broker, source, filename, period_from, period_before, payload, status)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'PENDING')
+			RETURNING id
+		`, userUUID, jobType, brokerVal, sourceVal, filenameVal, fromT, beforeT, payloadVal).Scan(&id); err != nil {
+			return fmt.Errorf("create job: %w", err)
+		}
+		for _, part := range params.Parts {
+			if _, err := exec.ExecContext(ctx, `
+				INSERT INTO ingestion_job_parts (job_id, part, status) VALUES ($1, $2, 'PENDING')
+			`, id, archivePartToStr(part)); err != nil {
+				return fmt.Errorf("create job part %s: %w", archivePartToStr(part), err)
+			}
+		}
+		return nil
+	})
 	if err != nil {
-		return "", fmt.Errorf("create job: %w", err)
+		return "", err
 	}
 	return id.String(), nil
 }
 
+// archivePartToStr spells an ArchivePart the way the column holds it, which is
+// the enum name itself.
+func archivePartToStr(p archivev1.ArchivePart) string {
+	return archivev1.ArchivePart_name[int32(p)]
+}
+
+func strToArchivePart(s string) archivev1.ArchivePart {
+	return archivev1.ArchivePart(archivev1.ArchivePart_value[s])
+}
+
 // GetJob implements db.JobDB.
-func (p *Postgres) GetJob(ctx context.Context, jobID string) (apiv1.JobStatus, []*apiv1.ValidationError, []db.IdentificationError, string, int32, int32, error) {
+func (p *Postgres) GetJob(ctx context.Context, jobID string) (*db.JobDetail, error) {
 	jobUUID, err := uuid.Parse(jobID)
 	if err != nil {
-		return apiv1.JobStatus_JOB_STATUS_UNSPECIFIED, nil, nil, "", 0, 0, fmt.Errorf("invalid job id: %w", err)
+		return nil, fmt.Errorf("invalid job id: %w", err)
 	}
+	var d db.JobDetail
 	var statusStr string
 	var jobUserID uuid.UUID
-	var totalCount, processedCount int32
-	err = p.q.QueryRowContext(ctx, `SELECT status, user_id, total_count, processed_count FROM ingestion_jobs WHERE id = $1`, jobUUID).Scan(&statusStr, &jobUserID, &totalCount, &processedCount)
+	err = p.q.QueryRowContext(ctx, `SELECT status, user_id, total_count, processed_count FROM ingestion_jobs WHERE id = $1`, jobUUID).
+		Scan(&statusStr, &jobUserID, &d.TotalCount, &d.ProcessedCount)
 	if err == sql.ErrNoRows {
-		return apiv1.JobStatus_JOB_STATUS_UNSPECIFIED, nil, nil, "", 0, 0, nil
+		// No such job. UserID stays empty, which is how the caller tells this
+		// apart from a failure to read one that exists.
+		return &db.JobDetail{}, nil
 	}
 	if err != nil {
-		return apiv1.JobStatus_JOB_STATUS_UNSPECIFIED, nil, nil, "", 0, 0, fmt.Errorf("get job: %w", err)
+		return nil, fmt.Errorf("get job: %w", err)
 	}
-	rows, err := p.q.QueryContext(ctx, `SELECT row_index, field, message FROM validation_errors WHERE job_id = $1 ORDER BY row_index`, jobUUID)
-	if err != nil {
-		return apiv1.JobStatus_JOB_STATUS_UNSPECIFIED, nil, nil, "", 0, 0, fmt.Errorf("get validation errors: %w", err)
-	}
-	defer rows.Close()
-	var errs []*apiv1.ValidationError
-	for rows.Next() {
-		var rowIndex int32
-		var field, message string
-		if err := rows.Scan(&rowIndex, &field, &message); err != nil {
-			return apiv1.JobStatus_JOB_STATUS_UNSPECIFIED, nil, nil, "", 0, 0, err
-		}
-		errs = append(errs, &apiv1.ValidationError{RowIndex: rowIndex, Field: field, Message: message})
-	}
-	if err := rows.Err(); err != nil {
-		return apiv1.JobStatus_JOB_STATUS_UNSPECIFIED, nil, nil, "", 0, 0, err
-	}
-	// Identification errors
+	d.Status = strToJobStatus(statusStr)
+	d.UserID = jobUserID.String()
+
 	idRows, err := p.q.QueryContext(ctx, `SELECT row_index, instrument_description, message FROM identification_errors WHERE job_id = $1 ORDER BY row_index`, jobUUID)
 	if err != nil {
-		return apiv1.JobStatus_JOB_STATUS_UNSPECIFIED, nil, nil, "", 0, 0, fmt.Errorf("get identification errors: %w", err)
+		return nil, fmt.Errorf("get identification errors: %w", err)
 	}
 	defer idRows.Close()
-	var idErrs []db.IdentificationError
 	for idRows.Next() {
 		var e db.IdentificationError
 		if err := idRows.Scan(&e.RowIndex, &e.InstrumentDescription, &e.Message); err != nil {
-			return apiv1.JobStatus_JOB_STATUS_UNSPECIFIED, nil, nil, "", 0, 0, err
+			return nil, err
 		}
-		idErrs = append(idErrs, e)
+		d.IdentificationErrors = append(d.IdentificationErrors, e)
 	}
 	if err := idRows.Err(); err != nil {
-		return apiv1.JobStatus_JOB_STATUS_UNSPECIFIED, nil, nil, "", 0, 0, err
+		return nil, err
 	}
-	return strToJobStatus(statusStr), errs, idErrs, jobUserID.String(), totalCount, processedCount, nil
+
+	// Parts are read before the validation errors, because which parts exist is
+	// what decides where an error can be attributed.
+	partRows, err := p.q.QueryContext(ctx, `SELECT part, status, total_count, processed_count, COALESCE(message, '') FROM ingestion_job_parts WHERE job_id = $1`, jobUUID)
+	if err != nil {
+		return nil, fmt.Errorf("get job parts: %w", err)
+	}
+	defer partRows.Close()
+	partIndex := map[archivev1.ArchivePart]int{}
+	for partRows.Next() {
+		var r db.JobPartResult
+		var partStr, partStatus string
+		if err := partRows.Scan(&partStr, &partStatus, &r.TotalCount, &r.ProcessedCount, &r.Message); err != nil {
+			return nil, err
+		}
+		r.Part = strToArchivePart(partStr)
+		r.Status = strToJobStatus(partStatus)
+		partIndex[r.Part] = len(d.Parts)
+		d.Parts = append(d.Parts, r)
+	}
+	if err := partRows.Err(); err != nil {
+		return nil, err
+	}
+	// Restore order is the enum's order. The column holds the enum name, so
+	// sorting has to be by number and not by the string.
+	sort.Slice(d.Parts, func(i, j int) bool { return d.Parts[i].Part < d.Parts[j].Part })
+	for i, r := range d.Parts {
+		partIndex[r.Part] = i
+	}
+
+	// Validation errors go to the part they name. A NULL part, or one naming a
+	// part this job has no row for, belongs to the job: an error that cannot be
+	// attributed is still an error, and dropping it would report a clean run.
+	rows, err := p.q.QueryContext(ctx, `SELECT COALESCE(part, ''), row_index, field, message FROM validation_errors WHERE job_id = $1 ORDER BY row_index`, jobUUID)
+	if err != nil {
+		return nil, fmt.Errorf("get validation errors: %w", err)
+	}
+	defer rows.Close()
+	for rows.Next() {
+		var partStr string
+		var e apiv1.ValidationError
+		if err := rows.Scan(&partStr, &e.RowIndex, &e.Field, &e.Message); err != nil {
+			return nil, err
+		}
+		i, ok := partIndex[strToArchivePart(partStr)]
+		if !ok {
+			d.ValidationErrors = append(d.ValidationErrors, &e)
+			continue
+		}
+		d.Parts[i].ValidationErrors = append(d.Parts[i].ValidationErrors, &e)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return &d, nil
 }
 
 // SetJobStatus implements db.JobDB.
@@ -146,17 +214,65 @@ func (p *Postgres) IncrJobProcessedCount(ctx context.Context, jobID string) erro
 }
 
 // AppendValidationErrors implements db.JobDB.
-func (p *Postgres) AppendValidationErrors(ctx context.Context, jobID string, errs []*apiv1.ValidationError) error {
+func (p *Postgres) AppendValidationErrors(ctx context.Context, jobID string, part archivev1.ArchivePart, errs []*apiv1.ValidationError) error {
 	jobUUID, err := uuid.Parse(jobID)
 	if err != nil {
 		return fmt.Errorf("invalid job id: %w", err)
 	}
+	var partVal interface{}
+	if part != archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED {
+		partVal = archivePartToStr(part)
+	}
 	for _, e := range errs {
-		_, err = p.q.ExecContext(ctx, `INSERT INTO validation_errors (job_id, row_index, field, message) VALUES ($1, $2, $3, $4)`,
-			jobUUID, e.RowIndex, e.Field, e.Message)
+		_, err = p.q.ExecContext(ctx, `INSERT INTO validation_errors (job_id, part, row_index, field, message) VALUES ($1, $2, $3, $4, $5)`,
+			jobUUID, partVal, e.RowIndex, e.Field, e.Message)
 		if err != nil {
 			return fmt.Errorf("append validation error: %w", err)
 		}
+	}
+	return nil
+}
+
+// SetJobPartStatus implements db.JobDB.
+func (p *Postgres) SetJobPartStatus(ctx context.Context, jobID string, part archivev1.ArchivePart, status apiv1.JobStatus) error {
+	return p.execJobPart(ctx, jobID, part, `UPDATE ingestion_job_parts SET status = $3 WHERE job_id = $1 AND part = $2`,
+		"set job part status", jobStatusToStr(status))
+}
+
+// SetJobPartFailed implements db.JobDB.
+func (p *Postgres) SetJobPartFailed(ctx context.Context, jobID string, part archivev1.ArchivePart, message string) error {
+	return p.execJobPart(ctx, jobID, part, `UPDATE ingestion_job_parts SET status = 'FAILED', message = $3 WHERE job_id = $1 AND part = $2`,
+		"set job part failed", message)
+}
+
+// SetJobPartTotalCount implements db.JobDB.
+func (p *Postgres) SetJobPartTotalCount(ctx context.Context, jobID string, part archivev1.ArchivePart, total int32) error {
+	return p.execJobPart(ctx, jobID, part, `UPDATE ingestion_job_parts SET total_count = $3 WHERE job_id = $1 AND part = $2`,
+		"set job part total count", total)
+}
+
+// AddJobPartProcessedCount implements db.JobDB.
+func (p *Postgres) AddJobPartProcessedCount(ctx context.Context, jobID string, part archivev1.ArchivePart, n int32) error {
+	return p.execJobPart(ctx, jobID, part, `UPDATE ingestion_job_parts SET processed_count = processed_count + $3 WHERE job_id = $1 AND part = $2`,
+		"add job part processed count", n)
+}
+
+// ResetJobPartProgress implements db.JobDB.
+func (p *Postgres) ResetJobPartProgress(ctx context.Context, jobID string, part archivev1.ArchivePart) error {
+	return p.execJobPart(ctx, jobID, part, `UPDATE ingestion_job_parts SET processed_count = 0, message = NULL WHERE job_id = $1 AND part = $2`,
+		"reset job part progress")
+}
+
+// execJobPart runs one UPDATE against a part row. Every part mutation is the
+// same shape -- parse the id, name the part, set one column -- so they share it.
+func (p *Postgres) execJobPart(ctx context.Context, jobID string, part archivev1.ArchivePart, query, what string, args ...interface{}) error {
+	jobUUID, err := uuid.Parse(jobID)
+	if err != nil {
+		return fmt.Errorf("invalid job id: %w", err)
+	}
+	args = append([]interface{}{jobUUID, archivePartToStr(part)}, args...)
+	if _, err := p.q.ExecContext(ctx, query, args...); err != nil {
+		return fmt.Errorf("%s: %w", what, err)
 	}
 	return nil
 }
@@ -227,7 +343,7 @@ func (p *Postgres) ListPendingJobs(ctx context.Context) ([]db.PendingJob, error)
 }
 
 // ListJobs implements db.JobDB.
-func (p *Postgres) ListJobs(ctx context.Context, userID string, pageSize int32, pageToken string) ([]db.JobRow, int32, string, error) {
+func (p *Postgres) ListJobs(ctx context.Context, userID, jobType string, pageSize int32, pageToken string) ([]db.JobRow, int32, string, error) {
 	userUUID, err := uuid.Parse(userID)
 	if err != nil {
 		return nil, 0, "", fmt.Errorf("invalid user id: %w", err)
@@ -235,8 +351,15 @@ func (p *Postgres) ListJobs(ctx context.Context, userID string, pageSize int32, 
 
 	offset := decodePageToken(pageToken)
 
+	// An empty jobType matches every type, so the filter is written once as a
+	// predicate that is trivially true rather than as two spellings of the query.
+	var typeVal interface{}
+	if jobType != "" {
+		typeVal = jobType
+	}
+
 	var total int32
-	if err := p.q.QueryRowContext(ctx, `SELECT COUNT(*) FROM ingestion_jobs WHERE user_id = $1`, userUUID).Scan(&total); err != nil {
+	if err := p.q.QueryRowContext(ctx, `SELECT COUNT(*) FROM ingestion_jobs WHERE user_id = $1 AND ($2::text IS NULL OR job_type = $2)`, userUUID, typeVal).Scan(&total); err != nil {
 		return nil, 0, "", fmt.Errorf("count jobs: %w", err)
 	}
 	if total == 0 {
@@ -248,10 +371,10 @@ func (p *Postgres) ListJobs(ctx context.Context, userID string, pageSize int32, 
 			(SELECT COUNT(*) FROM validation_errors WHERE job_id = j.id),
 			(SELECT COUNT(*) FROM identification_errors WHERE job_id = j.id)
 		FROM ingestion_jobs j
-		WHERE j.user_id = $1
+		WHERE j.user_id = $1 AND ($2::text IS NULL OR j.job_type = $2)
 		ORDER BY j.created_at DESC
-		LIMIT $2 OFFSET $3
-	`, userUUID, pageSize+1, offset)
+		LIMIT $3 OFFSET $4
+	`, userUUID, typeVal, pageSize+1, offset)
 	if err != nil {
 		return nil, 0, "", fmt.Errorf("list jobs: %w", err)
 	}

--- a/server/db/postgres/jobs_test.go
+++ b/server/db/postgres/jobs_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
 	"github.com/leedenison/portfoliodb/server/db"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
@@ -31,15 +32,18 @@ func TestCreateJob_GetJob(t *testing.T) {
 	if jobID == "" {
 		t.Fatal("expected job id")
 	}
-	status, errs, idErrs, jobUserID, totalCount, processedCount, err := p.GetJob(ctx, jobID)
+	d, err := p.GetJob(ctx, jobID)
 	if err != nil {
 		t.Fatalf("get job: %v", err)
 	}
-	if status != apiv1.JobStatus_PENDING || len(errs) != 0 || len(idErrs) != 0 || jobUserID != userID {
-		t.Fatalf("get job: %v %v %v %s", status, errs, idErrs, jobUserID)
+	if d.Status != apiv1.JobStatus_PENDING || len(d.ValidationErrors) != 0 || len(d.IdentificationErrors) != 0 || d.UserID != userID {
+		t.Fatalf("get job: %v %v %v %s", d.Status, d.ValidationErrors, d.IdentificationErrors, d.UserID)
 	}
-	if totalCount != 0 || processedCount != 0 {
-		t.Fatalf("initial counts: total=%d processed=%d", totalCount, processedCount)
+	if d.TotalCount != 0 || d.ProcessedCount != 0 {
+		t.Fatalf("initial counts: total=%d processed=%d", d.TotalCount, d.ProcessedCount)
+	}
+	if len(d.Parts) != 0 {
+		t.Fatalf("a tx job has no parts, got %d", len(d.Parts))
 	}
 
 	// Test LoadJobPayload.
@@ -67,13 +71,13 @@ func TestCreateJob_GetJob(t *testing.T) {
 	_ = p.SetJobTotalCount(ctx, jobID, 5)
 	_ = p.IncrJobProcessedCount(ctx, jobID)
 	_ = p.IncrJobProcessedCount(ctx, jobID)
-	_ = p.AppendValidationErrors(ctx, jobID, []*apiv1.ValidationError{{RowIndex: 0, Field: "x", Message: "y"}})
-	status2, errs2, idErrs2, _, totalCount2, processedCount2, _ := p.GetJob(ctx, jobID)
-	if status2 != apiv1.JobStatus_SUCCESS || len(errs2) != 1 || len(idErrs2) != 0 {
-		t.Fatalf("after update: %v %v %v", status2, errs2, idErrs2)
+	_ = p.AppendValidationErrors(ctx, jobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, []*apiv1.ValidationError{{RowIndex: 0, Field: "x", Message: "y"}})
+	d2, _ := p.GetJob(ctx, jobID)
+	if d2.Status != apiv1.JobStatus_SUCCESS || len(d2.ValidationErrors) != 1 || len(d2.IdentificationErrors) != 0 {
+		t.Fatalf("after update: %v %v %v", d2.Status, d2.ValidationErrors, d2.IdentificationErrors)
 	}
-	if totalCount2 != 5 || processedCount2 != 2 {
-		t.Fatalf("after update counts: total=%d processed=%d", totalCount2, processedCount2)
+	if d2.TotalCount != 5 || d2.ProcessedCount != 2 {
+		t.Fatalf("after update counts: total=%d processed=%d", d2.TotalCount, d2.ProcessedCount)
 	}
 }
 
@@ -92,12 +96,12 @@ func TestCreateJob_PriceImport(t *testing.T) {
 	if jobID == "" {
 		t.Fatal("expected job id")
 	}
-	status, _, _, jobUserID, _, _, err := p.GetJob(ctx, jobID)
+	d, err := p.GetJob(ctx, jobID)
 	if err != nil {
 		t.Fatalf("get job: %v", err)
 	}
-	if status != apiv1.JobStatus_PENDING || jobUserID != userID {
-		t.Fatalf("get job: status=%v user=%s", status, jobUserID)
+	if d.Status != apiv1.JobStatus_PENDING || d.UserID != userID {
+		t.Fatalf("get job: status=%v user=%s", d.Status, d.UserID)
 	}
 }
 
@@ -166,11 +170,11 @@ func TestListJobs(t *testing.T) {
 	})
 
 	// Add errors to j1.
-	_ = p.AppendValidationErrors(ctx, j1, []*apiv1.ValidationError{{RowIndex: 0, Field: "x", Message: "y"}})
+	_ = p.AppendValidationErrors(ctx, j1, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, []*apiv1.ValidationError{{RowIndex: 0, Field: "x", Message: "y"}})
 	_ = p.AppendIdentificationErrors(ctx, j1, []db.IdentificationError{{RowIndex: 1, InstrumentDescription: "AAPL", Message: "timeout"}})
 
 	// List all (newest first).
-	rows, total, nextToken, err := p.ListJobs(ctx, userID, 30, "")
+	rows, total, nextToken, err := p.ListJobs(ctx, userID, "", 30, "")
 	if err != nil {
 		t.Fatalf("list jobs: %v", err)
 	}
@@ -201,12 +205,129 @@ func TestListJobs(t *testing.T) {
 	}
 
 	// Pagination: page size 1.
-	page1, _, tok1, _ := p.ListJobs(ctx, userID, 1, "")
+	page1, _, tok1, _ := p.ListJobs(ctx, userID, "", 1, "")
 	if len(page1) != 1 || tok1 == "" {
 		t.Fatalf("page1: got %d rows, token %q", len(page1), tok1)
 	}
-	page2, _, tok2, _ := p.ListJobs(ctx, userID, 1, tok1)
+	page2, _, tok2, _ := p.ListJobs(ctx, userID, "", 1, tok1)
 	if len(page2) != 1 || tok2 != "" {
 		t.Fatalf("page2: got %d rows, token %q", len(page2), tok2)
+	}
+}
+
+// A system archive job's part rows exist from creation, so a caller polling
+// before the worker starts sees the parts it will apply rather than an empty
+// list it cannot tell apart from an archive that carried nothing.
+func TestCreateJob_SystemArchiveParts(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|sa", "U", "u@sa.com")
+	jobID, err := p.CreateJob(ctx, db.CreateJobParams{
+		UserID:  userID,
+		JobType: db.JobTypeSystemArchive,
+		Payload: []byte("archive"),
+		// Deliberately out of restore order: GetJob sorts by the enum, not by
+		// the order the caller happened to list them in.
+		Parts: []archivev1.ArchivePart{archivev1.ArchivePart_CORPORATE_EVENTS, archivev1.ArchivePart_INSTRUMENTS},
+	})
+	if err != nil {
+		t.Fatalf("create job: %v", err)
+	}
+	d, err := p.GetJob(ctx, jobID)
+	if err != nil {
+		t.Fatalf("get job: %v", err)
+	}
+	if len(d.Parts) != 2 {
+		t.Fatalf("got %d parts, want 2", len(d.Parts))
+	}
+	if d.Parts[0].Part != archivev1.ArchivePart_INSTRUMENTS || d.Parts[1].Part != archivev1.ArchivePart_CORPORATE_EVENTS {
+		t.Fatalf("parts out of restore order: %v, %v", d.Parts[0].Part, d.Parts[1].Part)
+	}
+	for _, r := range d.Parts {
+		if r.Status != apiv1.JobStatus_PENDING || r.TotalCount != 0 || r.ProcessedCount != 0 {
+			t.Fatalf("part %v starts as %v %d/%d", r.Part, r.Status, r.ProcessedCount, r.TotalCount)
+		}
+	}
+}
+
+func TestJobParts_ProgressStatusAndErrors(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|sap", "U", "u@sap.com")
+	jobID, _ := p.CreateJob(ctx, db.CreateJobParams{
+		UserID:  userID,
+		JobType: db.JobTypeSystemArchive,
+		Parts:   []archivev1.ArchivePart{archivev1.ArchivePart_INSTRUMENTS, archivev1.ArchivePart_PRICES},
+	})
+
+	if err := p.SetJobPartStatus(ctx, jobID, archivev1.ArchivePart_INSTRUMENTS, apiv1.JobStatus_SUCCESS); err != nil {
+		t.Fatalf("set part status: %v", err)
+	}
+	if err := p.SetJobPartTotalCount(ctx, jobID, archivev1.ArchivePart_PRICES, 10); err != nil {
+		t.Fatalf("set part total: %v", err)
+	}
+	// Batched progress: the delta is the point, so two calls must add up.
+	_ = p.AddJobPartProcessedCount(ctx, jobID, archivev1.ArchivePart_PRICES, 4)
+	_ = p.AddJobPartProcessedCount(ctx, jobID, archivev1.ArchivePart_PRICES, 3)
+	if err := p.SetJobPartFailed(ctx, jobID, archivev1.ArchivePart_PRICES, "upsert failed"); err != nil {
+		t.Fatalf("set part failed: %v", err)
+	}
+	_ = p.AppendValidationErrors(ctx, jobID, archivev1.ArchivePart_PRICES,
+		[]*apiv1.ValidationError{{RowIndex: 2, Field: "close", Message: "unparseable"}})
+	// An error with no part belongs to the job rather than to any one part.
+	_ = p.AppendValidationErrors(ctx, jobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED,
+		[]*apiv1.ValidationError{{RowIndex: -1, Field: "payload", Message: "unreadable"}})
+
+	d, err := p.GetJob(ctx, jobID)
+	if err != nil {
+		t.Fatalf("get job: %v", err)
+	}
+	if len(d.ValidationErrors) != 1 || d.ValidationErrors[0].GetField() != "payload" {
+		t.Fatalf("job-level errors = %v", d.ValidationErrors)
+	}
+	instruments, prices := d.Parts[0], d.Parts[1]
+	if instruments.Status != apiv1.JobStatus_SUCCESS || len(instruments.ValidationErrors) != 0 {
+		t.Fatalf("instruments = %v with %d errors", instruments.Status, len(instruments.ValidationErrors))
+	}
+	if prices.Status != apiv1.JobStatus_FAILED || prices.Message != "upsert failed" {
+		t.Fatalf("prices = %v %q", prices.Status, prices.Message)
+	}
+	if prices.TotalCount != 10 || prices.ProcessedCount != 7 {
+		t.Fatalf("prices progress = %d/%d", prices.ProcessedCount, prices.TotalCount)
+	}
+	if len(prices.ValidationErrors) != 1 || prices.ValidationErrors[0].GetField() != "close" {
+		t.Fatalf("prices errors = %v", prices.ValidationErrors)
+	}
+
+	// A re-run after a restart starts the part's progress over.
+	if err := p.ResetJobPartProgress(ctx, jobID, archivev1.ArchivePart_PRICES); err != nil {
+		t.Fatalf("reset part progress: %v", err)
+	}
+	d2, _ := p.GetJob(ctx, jobID)
+	if d2.Parts[1].ProcessedCount != 0 || d2.Parts[1].Message != "" {
+		t.Fatalf("after reset: %d processed, message %q", d2.Parts[1].ProcessedCount, d2.Parts[1].Message)
+	}
+}
+
+func TestListJobs_FiltersByJobType(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|jt", "U", "u@jt.com")
+	_, _ = p.CreateJob(ctx, db.CreateJobParams{UserID: userID, JobType: db.JobTypeTx})
+	archiveJob, _ := p.CreateJob(ctx, db.CreateJobParams{UserID: userID, JobType: db.JobTypeSystemArchive})
+
+	all, allTotal, _, err := p.ListJobs(ctx, userID, "", 30, "")
+	if err != nil {
+		t.Fatalf("list jobs: %v", err)
+	}
+	if len(all) != 2 || allTotal != 2 {
+		t.Fatalf("unfiltered = %d rows, total %d", len(all), allTotal)
+	}
+	filtered, total, _, err := p.ListJobs(ctx, userID, db.JobTypeSystemArchive, 30, "")
+	if err != nil {
+		t.Fatalf("list jobs filtered: %v", err)
+	}
+	if len(filtered) != 1 || total != 1 || filtered[0].ID != archiveJob {
+		t.Fatalf("filtered = %d rows, total %d", len(filtered), total)
 	}
 }

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -182,12 +182,13 @@ CREATE INDEX idx_txs_user_broker_time ON txs (user_id, broker, timestamp);
 CREATE INDEX idx_txs_group_id ON txs (group_id);
 
 -- Async ingestion jobs. status and validation_errors surfaced via front-end API.
--- job_type distinguishes tx uploads from price imports; broker/source are tx-specific.
+-- job_type distinguishes tx uploads from system archive imports; broker/source
+-- are tx-specific.
 -- payload stores the serialized protobuf request and is cleared after processing.
 CREATE TABLE ingestion_jobs (
   id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id      UUID NOT NULL REFERENCES users (id) ON DELETE CASCADE,
-  job_type     TEXT NOT NULL DEFAULT 'tx' CHECK (job_type IN ('tx', 'price', 'corporate_event')),
+  job_type     TEXT NOT NULL DEFAULT 'tx' CHECK (job_type IN ('tx', 'price', 'corporate_event', 'system_archive')),
   broker       TEXT,
   source       TEXT,
   filename     TEXT,
@@ -203,10 +204,30 @@ CREATE TABLE ingestion_jobs (
 CREATE INDEX idx_ingestion_jobs_user ON ingestion_jobs (user_id);
 CREATE INDEX idx_ingestion_jobs_status ON ingestion_jobs (status);
 
+-- Per-part results for a system archive import. One row per part the document
+-- carried, created with the job so a page can render a row per part before the
+-- worker has started and after a reload. part spells the ArchivePart enum name,
+-- so the proto value, the column and the archive section are one string.
+--
+-- Restore order is a property of the archive format rather than of a row, so
+-- there is no ordinal column: readers order by the enum.
+CREATE TABLE ingestion_job_parts (
+  job_id          UUID NOT NULL REFERENCES ingestion_jobs (id) ON DELETE CASCADE,
+  part            TEXT NOT NULL CHECK (part IN ('INSTRUMENTS', 'PRICES', 'CORPORATE_EVENTS')),
+  status          TEXT NOT NULL CHECK (status IN ('PENDING', 'RUNNING', 'SUCCESS', 'FAILED')),
+  total_count     INT NOT NULL DEFAULT 0,
+  processed_count INT NOT NULL DEFAULT 0,
+  message         TEXT,
+  PRIMARY KEY (job_id, part)
+);
+
 -- Validation errors for async ingestion. row_index, field, message per API.
+-- part attributes an error to one part of a system archive; NULL for a tx job
+-- and for a failure that happened before any part was reached.
 CREATE TABLE validation_errors (
   id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   job_id     UUID NOT NULL REFERENCES ingestion_jobs (id) ON DELETE CASCADE,
+  part       TEXT,
   row_index  INT NOT NULL,
   field      TEXT NOT NULL,
   message    TEXT NOT NULL

--- a/server/service/api/jobs.go
+++ b/server/service/api/jobs.go
@@ -26,28 +26,46 @@ func (s *Server) GetJob(ctx context.Context, req *apiv1.GetJobRequest) (*apiv1.G
 	if req.GetJobId() == "" {
 		return nil, status.Error(codes.InvalidArgument, "job_id required")
 	}
-	statusVal, errs, idErrs, jobUserID, totalCount, processedCount, err := s.db.GetJob(ctx, req.GetJobId())
+	d, err := s.db.GetJob(ctx, req.GetJobId())
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
-	if jobUserID == "" {
+	// A job that does not exist and one belonging to someone else are the same
+	// answer: revealing the difference would confirm the id.
+	if d.UserID == "" || d.UserID != u.ID {
 		return nil, status.Error(codes.NotFound, "job not found")
 	}
-	if jobUserID != u.ID {
-		return nil, status.Error(codes.NotFound, "job not found")
-	}
-	idErrProtos := make([]*apiv1.IdentificationError, 0, len(idErrs))
-	for _, e := range idErrs {
+	idErrProtos := make([]*apiv1.IdentificationError, 0, len(d.IdentificationErrors))
+	for _, e := range d.IdentificationErrors {
 		idErrProtos = append(idErrProtos, &apiv1.IdentificationError{
 			RowIndex:              e.RowIndex,
 			InstrumentDescription: e.InstrumentDescription,
 			Message:               e.Message,
 		})
 	}
-	return &apiv1.GetJobResponse{Status: statusVal, ValidationErrors: errs, IdentificationErrors: idErrProtos, TotalCount: totalCount, ProcessedCount: processedCount}, nil
+	parts := make([]*apiv1.JobPartResult, 0, len(d.Parts))
+	for _, r := range d.Parts {
+		parts = append(parts, &apiv1.JobPartResult{
+			Part:             r.Part,
+			Status:           r.Status,
+			TotalCount:       r.TotalCount,
+			ProcessedCount:   r.ProcessedCount,
+			ValidationErrors: r.ValidationErrors,
+			Message:          r.Message,
+		})
+	}
+	return &apiv1.GetJobResponse{
+		Status:               d.Status,
+		ValidationErrors:     d.ValidationErrors,
+		IdentificationErrors: idErrProtos,
+		TotalCount:           d.TotalCount,
+		ProcessedCount:       d.ProcessedCount,
+		Parts:                parts,
+	}, nil
 }
 
-// ListJobs returns paginated ingestion jobs for the authenticated user, newest first.
+// ListJobs returns paginated ingestion jobs for the authenticated user, newest
+// first. An empty job_type matches every type.
 func (s *Server) ListJobs(ctx context.Context, req *apiv1.ListJobsRequest) (*apiv1.ListJobsResponse, error) {
 	u, authErr := auth.RequireUser(ctx)
 	if authErr != nil {
@@ -60,7 +78,7 @@ func (s *Server) ListJobs(ctx context.Context, req *apiv1.ListJobsRequest) (*api
 	if pageSize > 100 {
 		pageSize = 100
 	}
-	rows, totalCount, nextToken, err := s.db.ListJobs(ctx, u.ID, pageSize, req.GetPageToken())
+	rows, totalCount, nextToken, err := s.db.ListJobs(ctx, u.ID, req.GetJobType(), pageSize, req.GetPageToken())
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/server/service/api/jobs_test.go
+++ b/server/service/api/jobs_test.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
 	"github.com/leedenison/portfoliodb/server/db"
 	"github.com/leedenison/portfoliodb/server/testutil"
 	"go.uber.org/mock/gomock"
@@ -12,20 +13,20 @@ import (
 )
 
 func TestGetJob_NotFound(t *testing.T) {
-	srv, db := newAPIServerWithMock(t)
-	db.EXPECT().
+	srv, mockDB := newAPIServerWithMock(t)
+	mockDB.EXPECT().
 		GetJob(gomock.Any(), "job-1").
-		Return(apiv1.JobStatus_JOB_STATUS_UNSPECIFIED, nil, nil, "", int32(0), int32(0), nil)
+		Return(&db.JobDetail{}, nil)
 	ctx := authCtx("user-1", "sub|1")
 	_, err := srv.GetJob(ctx, &apiv1.GetJobRequest{JobId: "job-1"})
 	testutil.RequireGRPCCode(t, err, codes.NotFound)
 }
 
 func TestGetJob_Success(t *testing.T) {
-	srv, db := newAPIServerWithMock(t)
-	db.EXPECT().
+	srv, mockDB := newAPIServerWithMock(t)
+	mockDB.EXPECT().
 		GetJob(gomock.Any(), "job-1").
-		Return(apiv1.JobStatus_PENDING, nil, nil, "user-1", int32(0), int32(0), nil)
+		Return(&db.JobDetail{Status: apiv1.JobStatus_PENDING, UserID: "user-1"}, nil)
 	ctx := authCtx("user-1", "sub|1")
 	resp, err := srv.GetJob(ctx, &apiv1.GetJobRequest{JobId: "job-1"})
 	if err != nil {
@@ -44,7 +45,7 @@ func TestListJobs_Success(t *testing.T) {
 		{ID: "j2", Filename: "", Broker: "FIDELITY", Status: "FAILED", CreatedAt: now.Add(-time.Hour), ValidationErrorCount: 3, IdentificationErrorCount: 0},
 	}
 	mockDB.EXPECT().
-		ListJobs(gomock.Any(), "user-1", int32(30), "").
+		ListJobs(gomock.Any(), "user-1", "", int32(30), "").
 		Return(rows, int32(2), "", nil)
 	ctx := authCtx("user-1", "sub|1")
 	resp, err := srv.ListJobs(ctx, &apiv1.ListJobsRequest{})
@@ -71,11 +72,54 @@ func TestListJobs_Success(t *testing.T) {
 func TestListJobs_PageSizeClamping(t *testing.T) {
 	srv, mockDB := newAPIServerWithMock(t)
 	mockDB.EXPECT().
-		ListJobs(gomock.Any(), "user-1", int32(100), "").
+		ListJobs(gomock.Any(), "user-1", "", int32(100), "").
 		Return(nil, int32(0), "", nil)
 	ctx := authCtx("user-1", "sub|1")
 	_, err := srv.ListJobs(ctx, &apiv1.ListJobsRequest{PageSize: 999})
 	if err != nil {
+		t.Fatalf("ListJobs: %v", err)
+	}
+}
+
+// A system archive job reports a row per part, so the page can render the parts
+// it will apply before the worker has touched any of them.
+func TestGetJob_ReturnsPerPartResults(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	mockDB.EXPECT().
+		GetJob(gomock.Any(), "job-1").
+		Return(&db.JobDetail{
+			Status: apiv1.JobStatus_RUNNING,
+			UserID: "user-1",
+			Parts: []db.JobPartResult{
+				{Part: archivev1.ArchivePart_INSTRUMENTS, Status: apiv1.JobStatus_SUCCESS, TotalCount: 3, ProcessedCount: 3},
+				{Part: archivev1.ArchivePart_PRICES, Status: apiv1.JobStatus_RUNNING, TotalCount: 9, ProcessedCount: 4,
+					ValidationErrors: []*apiv1.ValidationError{{RowIndex: 1, Field: "close", Message: "bad"}}},
+			},
+		}, nil)
+	ctx := authCtx("user-1", "sub|1")
+	resp, err := srv.GetJob(ctx, &apiv1.GetJobRequest{JobId: "job-1"})
+	if err != nil {
+		t.Fatalf("GetJob: %v", err)
+	}
+	parts := resp.GetParts()
+	if len(parts) != 2 {
+		t.Fatalf("got %d parts, want 2", len(parts))
+	}
+	if parts[0].GetPart() != archivev1.ArchivePart_INSTRUMENTS || parts[0].GetStatus() != apiv1.JobStatus_SUCCESS {
+		t.Fatalf("part 0 = %v %v", parts[0].GetPart(), parts[0].GetStatus())
+	}
+	if parts[1].GetProcessedCount() != 4 || len(parts[1].GetValidationErrors()) != 1 {
+		t.Fatalf("part 1 = %d processed, %d errors", parts[1].GetProcessedCount(), len(parts[1].GetValidationErrors()))
+	}
+}
+
+func TestListJobs_ForwardsJobTypeFilter(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	mockDB.EXPECT().
+		ListJobs(gomock.Any(), "user-1", db.JobTypeSystemArchive, int32(30), "").
+		Return(nil, int32(0), "", nil)
+	ctx := authCtx("user-1", "sub|1")
+	if _, err := srv.ListJobs(ctx, &apiv1.ListJobsRequest{JobType: db.JobTypeSystemArchive}); err != nil {
 		t.Fatalf("ListJobs: %v", err)
 	}
 }

--- a/server/service/ingestion/corporate_event_worker.go
+++ b/server/service/ingestion/corporate_event_worker.go
@@ -114,7 +114,7 @@ func processCorporateEventImport(ctx context.Context, database db.DB, pluginRegi
 	if len(splits) > 0 {
 		if err := database.UpsertStockSplits(ctx, splits); err != nil {
 			if len(valErrs) > 0 {
-				_ = database.AppendValidationErrors(ctx, j.JobID, valErrs)
+				_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, valErrs)
 			}
 			failJob(ctx, database, j.JobID, "splits", err)
 			return false
@@ -124,7 +124,7 @@ func processCorporateEventImport(ctx context.Context, database db.DB, pluginRegi
 	if len(dividends) > 0 {
 		if err := database.UpsertCashDividends(ctx, dividends); err != nil {
 			if len(valErrs) > 0 {
-				_ = database.AppendValidationErrors(ctx, j.JobID, valErrs)
+				_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, valErrs)
 			}
 			failJob(ctx, database, j.JobID, "dividends", err)
 			return false
@@ -141,7 +141,7 @@ func processCorporateEventImport(ctx context.Context, database db.DB, pluginRegi
 	covCount, covErrs, err := writeImportCoverage(ctx, database, groups, resolveCache, pluginRegistry, eventsAsOf)
 	if err != nil {
 		if len(valErrs) > 0 || len(covErrs) > 0 {
-			_ = database.AppendValidationErrors(ctx, j.JobID, append(valErrs, covErrs...))
+			_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, append(valErrs, covErrs...))
 		}
 		failJob(ctx, database, j.JobID, "coverage", err)
 		return false
@@ -152,7 +152,7 @@ func processCorporateEventImport(ctx context.Context, database db.DB, pluginRegi
 	valErrs = append(valErrs, covErrs...)
 
 	if len(valErrs) > 0 {
-		_ = database.AppendValidationErrors(ctx, j.JobID, valErrs)
+		_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, valErrs)
 	}
 
 	for instID := range splitInstruments {
@@ -372,7 +372,7 @@ func writeImportCoverage(ctx context.Context, database db.DB, groups []*archivev
 
 func failJob(ctx context.Context, database db.DB, jobID, field string, err error) {
 	log.Printf("corporate event import job %s: %s: %v", jobID, field, err)
-	_ = database.AppendValidationErrors(ctx, jobID, []*apiv1.ValidationError{
+	_ = database.AppendValidationErrors(ctx, jobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, []*apiv1.ValidationError{
 		{RowIndex: -1, Field: field, Message: err.Error()},
 	})
 	_ = database.SetJobStatus(ctx, jobID, apiv1.JobStatus_FAILED)

--- a/server/service/ingestion/corporate_event_worker_test.go
+++ b/server/service/ingestion/corporate_event_worker_test.go
@@ -212,8 +212,8 @@ func TestProcessCorporateEventImport_RejectsBadSplitRatio(t *testing.T) {
 	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-ce-2").Return(nil)
 
 	var capturedErrs []*apiv1.ValidationError
-	database.EXPECT().AppendValidationErrors(gomock.Any(), "job-ce-2", gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ string, errs []*apiv1.ValidationError) error {
+	database.EXPECT().AppendValidationErrors(gomock.Any(), "job-ce-2", gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, _ archivev1.ArchivePart, errs []*apiv1.ValidationError) error {
 			capturedErrs = errs
 			return nil
 		})
@@ -287,8 +287,8 @@ func TestProcessCorporateEventImport_RejectsBadCoverageDate(t *testing.T) {
 		Return("inst-aapl", "STOCK", "XNAS", "USD", nil)
 
 	var capturedErrs []*apiv1.ValidationError
-	database.EXPECT().AppendValidationErrors(gomock.Any(), "job-ce-cov", gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ string, errs []*apiv1.ValidationError) error {
+	database.EXPECT().AppendValidationErrors(gomock.Any(), "job-ce-cov", gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, _ archivev1.ArchivePart, errs []*apiv1.ValidationError) error {
 			capturedErrs = errs
 			return nil
 		})
@@ -328,8 +328,8 @@ func TestProcessCorporateEventImport_EmptyCoverageInterval(t *testing.T) {
 		Return("inst-aapl", "STOCK", "XNAS", "USD", nil)
 
 	var capturedErrs []*apiv1.ValidationError
-	database.EXPECT().AppendValidationErrors(gomock.Any(), "job-ce-empty", gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ string, errs []*apiv1.ValidationError) error {
+	database.EXPECT().AppendValidationErrors(gomock.Any(), "job-ce-empty", gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, _ archivev1.ArchivePart, errs []*apiv1.ValidationError) error {
 			capturedErrs = errs
 			return nil
 		})
@@ -404,8 +404,8 @@ func TestProcessCorporateEventImport_RejectsInvalidDecimal(t *testing.T) {
 	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-ce-bad").Return(nil)
 
 	var capturedErrs []*apiv1.ValidationError
-	database.EXPECT().AppendValidationErrors(gomock.Any(), "job-ce-bad", gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ string, errs []*apiv1.ValidationError) error {
+	database.EXPECT().AppendValidationErrors(gomock.Any(), "job-ce-bad", gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, _ archivev1.ArchivePart, errs []*apiv1.ValidationError) error {
 			capturedErrs = errs
 			return nil
 		})
@@ -446,8 +446,8 @@ func TestProcessCorporateEventImport_RejectsHintDiff(t *testing.T) {
 	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-ce-diff").Return(nil)
 
 	var capturedErrs []*apiv1.ValidationError
-	database.EXPECT().AppendValidationErrors(gomock.Any(), "job-ce-diff", gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ string, errs []*apiv1.ValidationError) error {
+	database.EXPECT().AppendValidationErrors(gomock.Any(), "job-ce-diff", gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, _ archivev1.ArchivePart, errs []*apiv1.ValidationError) error {
 			capturedErrs = errs
 			return nil
 		})

--- a/server/service/ingestion/price_worker.go
+++ b/server/service/ingestion/price_worker.go
@@ -93,14 +93,14 @@ func processPriceImport(ctx context.Context, database db.DB, pluginRegistry *ide
 	}
 
 	if len(valErrs) > 0 {
-		_ = database.AppendValidationErrors(ctx, j.JobID, valErrs)
+		_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, valErrs)
 	}
 
 	persisted := false
 	if len(resolved) > 0 {
 		if err := upsertGroups(ctx, database, resolved); err != nil {
 			log.Printf("price import job %s: upsert: %v", j.JobID, err)
-			_ = database.AppendValidationErrors(ctx, j.JobID, []*apiv1.ValidationError{
+			_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, []*apiv1.ValidationError{
 				{RowIndex: -1, Field: "prices", Message: err.Error()},
 			})
 			_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_FAILED)

--- a/server/service/ingestion/price_worker_test.go
+++ b/server/service/ingestion/price_worker_test.go
@@ -58,8 +58,8 @@ func TestProcessPriceImport_RejectsUnknownIdentifierType(t *testing.T) {
 
 	var capturedErrs []*apiv1.ValidationError
 	database.EXPECT().
-		AppendValidationErrors(gomock.Any(), "job-price-1", gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ string, errs []*apiv1.ValidationError) error {
+		AppendValidationErrors(gomock.Any(), "job-price-1", gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, _ archivev1.ArchivePart, errs []*apiv1.ValidationError) error {
 			capturedErrs = errs
 			return nil
 		})
@@ -318,8 +318,8 @@ func TestProcessPriceImport_RejectsHintDiff(t *testing.T) {
 
 	var capturedErrs []*apiv1.ValidationError
 	database.EXPECT().
-		AppendValidationErrors(gomock.Any(), "job-price-diff", gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ string, errs []*apiv1.ValidationError) error {
+		AppendValidationErrors(gomock.Any(), "job-price-diff", gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, _ archivev1.ArchivePart, errs []*apiv1.ValidationError) error {
 			capturedErrs = errs
 			return nil
 		})
@@ -373,8 +373,8 @@ func TestProcessPriceImport_RejectsCurrencyHintDiff(t *testing.T) {
 
 	var capturedErrs []*apiv1.ValidationError
 	database.EXPECT().
-		AppendValidationErrors(gomock.Any(), "job-price-curdiff", gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ string, errs []*apiv1.ValidationError) error {
+		AppendValidationErrors(gomock.Any(), "job-price-curdiff", gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, _ archivev1.ArchivePart, errs []*apiv1.ValidationError) error {
 			capturedErrs = errs
 			return nil
 		})

--- a/server/service/ingestion/worker.go
+++ b/server/service/ingestion/worker.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
 	ingestionv1 "github.com/leedenison/portfoliodb/proto/ingestion/v1"
 	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
 	"github.com/leedenison/portfoliodb/server/db"
@@ -141,7 +142,10 @@ func loadAndClearPayload(ctx context.Context, database db.DB, jobID string) ([]b
 
 func processTx(ctx context.Context, database db.DB, registry *identifier.Registry, descRegistry *description.Registry, counter telemetry.CounterIncrementer, j *JobRequest) (bool, string) {
 	// Look up userID from the job row.
-	_, _, _, userID, _, _, _ := database.GetJob(ctx, j.JobID)
+	var userID string
+	if d, err := database.GetJob(ctx, j.JobID); err == nil {
+		userID = d.UserID
+	}
 
 	payload, err := loadAndClearPayload(ctx, database, j.JobID)
 	if err != nil {
@@ -170,7 +174,7 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 	if b := req.GetShareCountBasis(); b != "" {
 		parsed, err := time.Parse("2006-01-02", b)
 		if err != nil {
-			_ = database.AppendValidationErrors(ctx, j.JobID, []*apiv1.ValidationError{
+			_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, []*apiv1.ValidationError{
 				{RowIndex: -1, Field: "share_count_basis", Message: fmt.Sprintf("invalid date %q: want YYYY-MM-DD", b)},
 			})
 			_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_FAILED)
@@ -182,7 +186,7 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 	// Validate.
 	errs := ValidateTxs(txs)
 	if len(errs) > 0 {
-		_ = database.AppendValidationErrors(ctx, j.JobID, errs)
+		_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, errs)
 		_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_FAILED)
 		return false, ""
 	}
@@ -203,7 +207,7 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 	cache, extractedHintsCache, err := extractDescHints(ctx, database, descRegistry, counter, source, broker, txsToProcess)
 	if err != nil {
 		log.Printf("ingestion job %s: extract description hints: %v", j.JobID, err)
-		_ = database.AppendValidationErrors(ctx, j.JobID, []*apiv1.ValidationError{
+		_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, []*apiv1.ValidationError{
 			{RowIndex: -1, Field: "txs", Message: err.Error()},
 		})
 		_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_FAILED)
@@ -213,7 +217,7 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 	instrumentIDs, idErrs, err := resolveInstruments(ctx, database, registry, broker, source, j.JobID, counter, txsToProcess, originalIndices, cache, extractedHintsCache)
 	if err != nil {
 		log.Printf("ingestion job %s: resolve instrument: %v", j.JobID, err)
-		_ = database.AppendValidationErrors(ctx, j.JobID, []*apiv1.ValidationError{
+		_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, []*apiv1.ValidationError{
 			{RowIndex: -1, Field: "instrument_description", Message: err.Error()},
 		})
 		_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_FAILED)
@@ -226,7 +230,7 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 	instByID, err := instrumentsByID(ctx, database, instrumentIDs)
 	if err != nil {
 		log.Printf("ingestion job %s: load instruments: %v", j.JobID, err)
-		_ = database.AppendValidationErrors(ctx, j.JobID, []*apiv1.ValidationError{
+		_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, []*apiv1.ValidationError{
 			{RowIndex: -1, Field: "txs", Message: err.Error()},
 		})
 		_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_FAILED)
@@ -238,7 +242,7 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 	// different asset classes (e.g. BUYSTOCK + INCOME), as well as any other
 	// path where resolution lands on an instrument of the wrong class.
 	if classErrs := validateAssetClasses(txsToProcess, originalIndices, instrumentIDs, instByID); len(classErrs) > 0 {
-		_ = database.AppendValidationErrors(ctx, j.JobID, classErrs)
+		_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, classErrs)
 		_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_FAILED)
 		return false, ""
 	}
@@ -264,7 +268,7 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 				Message:  fmt.Sprintf("no instrument for residual commodity %q; the group it balances cannot be stored", cur),
 			}
 		}
-		_ = database.AppendValidationErrors(ctx, j.JobID, errs)
+		_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, errs)
 		_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_FAILED)
 		return false, ""
 	}
@@ -285,7 +289,7 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 	}
 	if storeErr != nil {
 		log.Printf("ingestion job %s: %v", j.JobID, storeErr)
-		_ = database.AppendValidationErrors(ctx, j.JobID, []*apiv1.ValidationError{
+		_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, []*apiv1.ValidationError{
 			{RowIndex: -1, Field: "txs", Message: storeErr.Error()},
 		})
 		_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_FAILED)

--- a/server/service/ingestion/worker_test.go
+++ b/server/service/ingestion/worker_test.go
@@ -3,6 +3,7 @@ package ingestion
 import (
 	"context"
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
 	ingestionv1 "github.com/leedenison/portfoliodb/proto/ingestion/v1"
 	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
 	"github.com/leedenison/portfoliodb/server/db"
@@ -30,7 +31,7 @@ func expectLoadPayload(database *mock.MockDB, jobID, userID string, payload []by
 	database.EXPECT().LoadJobPayload(gomock.Any(), jobID).Return(payload, nil)
 	database.EXPECT().ClearJobPayload(gomock.Any(), jobID).Return(nil)
 	database.EXPECT().GetJob(gomock.Any(), jobID).Return(
-		apiv1.JobStatus_RUNNING, nil, nil, userID, int32(0), int32(0), nil,
+		&db.JobDetail{Status: apiv1.JobStatus_RUNNING, UserID: userID}, nil,
 	)
 	database.EXPECT().ListIgnoredAssetClasses(gomock.Any(), userID).Return(nil, nil)
 }
@@ -319,8 +320,8 @@ func TestProcessBulk_BuystockIncomeSameDescriptionFails(t *testing.T) {
 		ListInstrumentsByIDs(gomock.Any(), []string{"msft-stock-id"}).
 		Return([]*db.InstrumentRow{{ID: "msft-stock-id", AssetClass: strPtr(db.AssetClassStock)}}, nil)
 	database.EXPECT().
-		AppendValidationErrors(gomock.Any(), "job-contradict", gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ string, errs []*apiv1.ValidationError) error {
+		AppendValidationErrors(gomock.Any(), "job-contradict", gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, _ archivev1.ArchivePart, errs []*apiv1.ValidationError) error {
 			if len(errs) != 1 {
 				t.Errorf("expected 1 validation error, got %d", len(errs))
 				return nil
@@ -446,8 +447,8 @@ func TestProcessBulk_StockMutualFundNotEquivalent(t *testing.T) {
 		ListInstrumentsByIDs(gomock.Any(), []string{"vfiax-id"}).
 		Return([]*db.InstrumentRow{{ID: "vfiax-id", AssetClass: strPtr(db.AssetClassMutualFund)}}, nil)
 	database.EXPECT().
-		AppendValidationErrors(gomock.Any(), "job-mf", gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ string, errs []*apiv1.ValidationError) error {
+		AppendValidationErrors(gomock.Any(), "job-mf", gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, _ archivev1.ArchivePart, errs []*apiv1.ValidationError) error {
 			if len(errs) != 1 {
 				t.Errorf("expected 1 validation error, got %d", len(errs))
 			}
@@ -505,7 +506,7 @@ func TestProcessBulk_TransferToCashRejected(t *testing.T) {
 		ListInstrumentsByIDs(gomock.Any(), []string{"cash-id"}).
 		Return([]*db.InstrumentRow{{ID: "cash-id", AssetClass: strPtr(db.AssetClassCash)}}, nil)
 	database.EXPECT().
-		AppendValidationErrors(gomock.Any(), "job-transfer-cash", gomock.Any()).
+		AppendValidationErrors(gomock.Any(), "job-transfer-cash", gomock.Any(), gomock.Any()).
 		Return(nil)
 	database.EXPECT().
 		SetJobStatus(gomock.Any(), "job-transfer-cash", apiv1.JobStatus_FAILED).


### PR DESCRIPTION
Second of the stack for 0079. **Depends on #356** -- based on
`archive-system-terminology`, so review that first.

The consolidated system archive import will apply several parts under one job,
so a job needs to report along an axis it does not have today: one status, one
pair of counters and one error list cannot describe three parts.

- **`ArchivePart`** (`archive/v1/common.proto`) names the parts. It is both the
  export's include-menu and the axis a job reports along, so the request that
  asks for a part and the result that reports on it are one vocabulary. Values
  run in restore order.
- **`ingestion_job_parts`** carries a row per part, written in the same
  transaction as the job so a caller polling the moment `CreateJob` returns sees
  the parts it will apply, not a list that fills in later and is meanwhile
  indistinguishable from an archive that carried nothing.
- **`validation_errors.part`** attributes an error to a part. An error naming no
  part, or one naming a part the job has no row for, stays on the job rather
  than being silently dropped -- an error that cannot be attributed is still an
  error, and dropping it would report a clean run.
- **`AddJobPartProcessedCount` takes a delta**, not an increment: a six-figure
  price import that reported every row separately would spend more time updating
  its own progress than importing.
- **`GetJob`'s seven-value return becomes a `JobDetail`**, and **`ListJobs` gains
  a `job_type` filter** so a page can find its own job without paging through
  transaction uploads.

No new RPC and no behaviour change: the existing price and corporate-event
imports pass `ARCHIVE_PART_UNSPECIFIED` and keep reporting exactly as before.
The `job_type` check keeps `price` and `corporate_event` until those RPCs are
retired at the end of the stack.

Verified: `make test`, `make db-test`, `make lint-go`, `make lint-proto`,
`make fmt-check`, `make client-typecheck`, `make lint-ts` all clean. New DB
coverage for part creation ordering, batched progress, per-part failure and
error attribution, and the job_type filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)