### PR TITLE
Extract the price and corporate event import parts

### DIFF
--- a/server/service/ingestion/corporate_event_worker.go
+++ b/server/service/ingestion/corporate_event_worker.go
@@ -33,25 +33,18 @@ import (
 // the corporate event fetcher worker -- mirrors the processTx success
 // signal so a job that rejected every row does not produce churn.
 func processCorporateEventImport(ctx context.Context, database db.DB, pluginRegistry *identifier.Registry, j *JobRequest) bool {
-	payload, err := loadAndClearPayload(ctx, database, j.JobID)
+	payload, err := database.LoadJobPayload(ctx, j.JobID)
 	if err != nil {
 		log.Printf("corporate event import job %s: load payload: %v", j.JobID, err)
-		_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_FAILED)
+		finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
 		return false
 	}
 	var req apiv1.ImportCorporateEventsRequest
 	if err := proto.Unmarshal(payload, &req); err != nil {
 		log.Printf("corporate event import job %s: unmarshal payload: %v", j.JobID, err)
-		_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_FAILED)
+		finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
 		return false
 	}
-
-	groups := req.GetCorporateEvents().GetGroups()
-	total := 0
-	for _, g := range groups {
-		total += len(g.GetEvents())
-	}
-	_ = database.SetJobTotalCount(ctx, j.JobID, int32(total))
 
 	// Knowledge time declared for the whole file: OCC symbols are
 	// split-adjusted to this point during resolution, events that carry no
@@ -63,8 +56,31 @@ func processCorporateEventImport(ctx context.Context, database db.DB, pluginRegi
 		eventsAsOf = &t
 	}
 
-	resolveCache := make(map[string]*resolveEntry)
-	var valErrs []*apiv1.ValidationError
+	rep := newPartReporter(database, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED)
+	persisted, err := importCorporateEventPart(ctx, database, pluginRegistry, req.GetCorporateEvents(), eventsAsOf, newResolveCache(), rep)
+	rep.Flush(ctx)
+	if err != nil {
+		log.Printf("corporate event import job %s: %v", j.JobID, err)
+		finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
+		return false
+	}
+	finishJob(ctx, database, j.JobID, apiv1.JobStatus_SUCCESS)
+	return persisted
+}
+
+// importCorporateEventPart applies one archive corporate event part, reporting
+// through rep. Like the price part it returns whether anything was persisted,
+// and an error only for a hard failure: an event the import could not read is a
+// validation error on a part that still succeeded.
+func importCorporateEventPart(ctx context.Context, database db.DB, pluginRegistry *identifier.Registry,
+	part *archivev1.CorporateEventPart, eventsAsOf *time.Time, resolveCache map[string]*resolveEntry, rep *partReporter) (bool, error) {
+	groups := part.GetGroups()
+	total := 0
+	for _, g := range groups {
+		total += len(g.GetEvents())
+	}
+	rep.Total(ctx, total)
+
 	var splits []db.StockSplit
 	var dividends []db.CashDividend
 	splitInstruments := make(map[string]bool)
@@ -74,11 +90,9 @@ func processCorporateEventImport(ctx context.Context, database db.DB, pluginRegi
 		if gErr != nil {
 			// One unresolvable instrument fails its whole group: every event
 			// under it names the same instrument, so none of them can land.
-			valErrs = append(valErrs, gErr)
 			gErr.RowIndex = int32(gi)
-			for range g.GetEvents() {
-				_ = database.IncrJobProcessedCount(ctx, j.JobID)
-			}
+			rep.Err(gErr)
+			rep.Advance(ctx, len(g.GetEvents()))
 			continue
 		}
 		for ei, ev := range g.GetEvents() {
@@ -86,7 +100,7 @@ func processCorporateEventImport(ctx context.Context, database db.DB, pluginRegi
 			case *archivev1.CorporateEvent_Split:
 				sp, vErr := buildSplit(instID, e.Split, gi, ei, eventsAsOf)
 				if vErr != nil {
-					valErrs = append(valErrs, vErr)
+					rep.Err(vErr)
 					break
 				}
 				splits = append(splits, sp)
@@ -94,70 +108,50 @@ func processCorporateEventImport(ctx context.Context, database db.DB, pluginRegi
 			case *archivev1.CorporateEvent_Dividend:
 				d, vErr := buildDividend(instID, e.Dividend, gi, ei, eventsAsOf)
 				if vErr != nil {
-					valErrs = append(valErrs, vErr)
+					rep.Err(vErr)
 					break
 				}
 				dividends = append(dividends, d)
 			default:
-				valErrs = append(valErrs, &apiv1.ValidationError{
-					RowIndex: int32(gi),
-					Field:    fmt.Sprintf("events[%d]", ei),
-					Message:  "event is neither a split nor a dividend",
-				})
+				rep.Errf(gi, fmt.Sprintf("events[%d]", ei), "event is neither a split nor a dividend")
 			}
-			_ = database.IncrJobProcessedCount(ctx, j.JobID)
+			rep.Advance(ctx, 1)
 		}
 	}
 
 	persisted := false
-
 	if len(splits) > 0 {
 		if err := database.UpsertStockSplits(ctx, splits); err != nil {
-			if len(valErrs) > 0 {
-				_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, valErrs)
-			}
-			failJob(ctx, database, j.JobID, "splits", err)
-			return false
+			rep.Errf(-1, "splits", err.Error())
+			return false, fmt.Errorf("upsert splits: %w", err)
 		}
 		persisted = true
 	}
 	if len(dividends) > 0 {
 		if err := database.UpsertCashDividends(ctx, dividends); err != nil {
-			if len(valErrs) > 0 {
-				_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, valErrs)
-			}
-			failJob(ctx, database, j.JobID, "dividends", err)
-			return false
+			rep.Errf(-1, "dividends", err.Error())
+			return false, fmt.Errorf("upsert dividends: %w", err)
 		}
 		persisted = true
 	}
 
 	// Coverage rows are recorded after the events are upserted so a partial
 	// failure above does not advertise data we did not persist. Per-span
-	// validation errors (a bad date, an empty interval) are accumulated
-	// alongside the per-event errors so the caller sees everything via
-	// AppendValidationErrors. A hard DB error from the coverage upsert still
-	// fails the job.
+	// validation errors (a bad date, an empty interval) join the per-event ones.
+	// A hard DB error from the coverage upsert still fails the part.
 	covCount, covErrs, err := writeImportCoverage(ctx, database, groups, resolveCache, pluginRegistry, eventsAsOf)
+	rep.Errs(covErrs)
 	if err != nil {
-		if len(valErrs) > 0 || len(covErrs) > 0 {
-			_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, append(valErrs, covErrs...))
-		}
-		failJob(ctx, database, j.JobID, "coverage", err)
-		return false
+		rep.Errf(-1, "coverage", err.Error())
+		return false, fmt.Errorf("upsert coverage: %w", err)
 	}
 	if covCount > 0 {
 		persisted = true
 	}
-	valErrs = append(valErrs, covErrs...)
-
-	if len(valErrs) > 0 {
-		_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, valErrs)
-	}
 
 	for instID := range splitInstruments {
 		if err := database.RecomputeSplitAdjustments(ctx, instID); err != nil {
-			log.Printf("corporate event import job %s: recompute %s: %v", j.JobID, instID, err)
+			log.Printf("corporate event import: recompute %s: %v", instID, err)
 		}
 	}
 	// Adjust options whose identity predates an effective split, once for the
@@ -168,9 +162,7 @@ func processCorporateEventImport(ctx context.Context, database db.DB, pluginRegi
 	if len(splitInstruments) > 0 {
 		corporateevents.ProcessPendingOptionSplits(ctx, database, "", ingestionLog)
 	}
-
-	_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_SUCCESS)
-	return persisted
+	return persisted, nil
 }
 
 // resolveEventGroupInstrument resolves the instrument one archive group names,
@@ -368,14 +360,6 @@ func writeImportCoverage(ctx context.Context, database db.DB, groups []*archivev
 		}
 	}
 	return written, errs, nil
-}
-
-func failJob(ctx context.Context, database db.DB, jobID, field string, err error) {
-	log.Printf("corporate event import job %s: %s: %v", jobID, field, err)
-	_ = database.AppendValidationErrors(ctx, jobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, []*apiv1.ValidationError{
-		{RowIndex: -1, Field: field, Message: err.Error()},
-	})
-	_ = database.SetJobStatus(ctx, jobID, apiv1.JobStatus_FAILED)
 }
 
 // parseDecimal parses an arbitrary-precision decimal string. The CSV import

--- a/server/service/ingestion/part_reporter.go
+++ b/server/service/ingestion/part_reporter.go
@@ -1,0 +1,110 @@
+package ingestion
+
+import (
+	"context"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+)
+
+// progressFlushEvery is how many rows a part advances before its counter is
+// written. A six-figure price import that wrote its progress a row at a time
+// would spend more time reporting than importing, and nobody watching a
+// progress bar can tell a hundred rows apart.
+const progressFlushEvery = 100
+
+// partReporter records one archive part's progress and problems. It batches the
+// progress counter and accumulates validation errors so that a part costs a
+// handful of writes rather than one per row.
+//
+// A reporter whose part is ARCHIVE_PART_UNSPECIFIED reports against the job
+// itself. That is the shape the per-entity price and corporate event imports
+// still have -- one job, one part, no part rows -- and it goes when those RPCs do.
+type partReporter struct {
+	db      db.DB
+	jobID   string
+	part    archivev1.ArchivePart
+	errs    []*apiv1.ValidationError
+	pending int32
+}
+
+func newPartReporter(database db.DB, jobID string, part archivev1.ArchivePart) *partReporter {
+	return &partReporter{db: database, jobID: jobID, part: part}
+}
+
+// scoped reports whether this reporter writes to a part row rather than to the
+// job.
+func (r *partReporter) scoped() bool {
+	return r.part != archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED
+}
+
+// Total records how much work the part has, which is what turns a spinner into
+// a proportion.
+func (r *partReporter) Total(ctx context.Context, n int) {
+	if r.scoped() {
+		_ = r.db.SetJobPartTotalCount(ctx, r.jobID, r.part, int32(n))
+		return
+	}
+	_ = r.db.SetJobTotalCount(ctx, r.jobID, int32(n))
+}
+
+// Advance moves the part's progress on by n rows, writing through once enough
+// have accumulated.
+func (r *partReporter) Advance(ctx context.Context, n int) {
+	if !r.scoped() {
+		for i := 0; i < n; i++ {
+			_ = r.db.IncrJobProcessedCount(ctx, r.jobID)
+		}
+		return
+	}
+	r.pending += int32(n)
+	if r.pending >= progressFlushEvery {
+		r.flushProgress(ctx)
+	}
+}
+
+func (r *partReporter) flushProgress(ctx context.Context) {
+	if r.pending == 0 {
+		return
+	}
+	_ = r.db.AddJobPartProcessedCount(ctx, r.jobID, r.part, r.pending)
+	r.pending = 0
+}
+
+// Err records one row-level problem. A part with errors has still succeeded --
+// what failed is a row, and the count is what lets a result read "completed, 12
+// rows rejected".
+func (r *partReporter) Err(e *apiv1.ValidationError) {
+	if e != nil {
+		r.errs = append(r.errs, e)
+	}
+}
+
+// Errf records a problem against a row and a field.
+func (r *partReporter) Errf(rowIndex int, field, message string) {
+	r.Err(&apiv1.ValidationError{RowIndex: int32(rowIndex), Field: field, Message: message})
+}
+
+// Errs records several problems at once.
+func (r *partReporter) Errs(errs []*apiv1.ValidationError) {
+	r.errs = append(r.errs, errs...)
+}
+
+// ErrCount is how many row-level problems have been recorded.
+func (r *partReporter) ErrCount() int {
+	return len(r.errs)
+}
+
+// Flush writes the outstanding progress and validation errors. It is safe to
+// call more than once and must be called before the part is marked terminal,
+// including on the failure path: errors gathered before a hard failure explain
+// it and are dropped if they are never written.
+func (r *partReporter) Flush(ctx context.Context) {
+	r.flushProgress(ctx)
+	if len(r.errs) == 0 {
+		return
+	}
+	_ = r.db.AppendValidationErrors(ctx, r.jobID, r.part, r.errs)
+	r.errs = nil
+}

--- a/server/service/ingestion/price_worker.go
+++ b/server/service/ingestion/price_worker.go
@@ -32,16 +32,16 @@ type resolveEntry struct {
 // mirrors the processTx and processCorporateEventImport success signal so a
 // job that rejected every row does not produce churn.
 func processPriceImport(ctx context.Context, database db.DB, pluginRegistry *identifier.Registry, j *JobRequest) bool {
-	payload, err := loadAndClearPayload(ctx, database, j.JobID)
+	payload, err := database.LoadJobPayload(ctx, j.JobID)
 	if err != nil {
 		log.Printf("price import job %s: load payload: %v", j.JobID, err)
-		_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_FAILED)
+		finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
 		return false
 	}
 	var req apiv1.ImportPricesRequest
 	if err := proto.Unmarshal(payload, &req); err != nil {
 		log.Printf("price import job %s: unmarshal payload: %v", j.JobID, err)
-		_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_FAILED)
+		finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
 		return false
 	}
 
@@ -55,67 +55,81 @@ func processPriceImport(ctx context.Context, database db.DB, pluginRegistry *ide
 		slog.Warn("price import missing exported_at; OCC symbols will not be split-adjusted", "job_id", j.JobID)
 	}
 
-	groups := req.GetPrices().GetGroups()
+	rep := newPartReporter(database, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED)
+	persisted, err := importPricePart(ctx, database, pluginRegistry, req.GetPrices(), pricesAsOf, newResolveCache(), rep)
+	rep.Flush(ctx)
+	if err != nil {
+		log.Printf("price import job %s: %v", j.JobID, err)
+		finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
+		return false
+	}
+	finishJob(ctx, database, j.JobID, apiv1.JobStatus_SUCCESS)
+	return persisted
+}
+
+// importPricePart applies one archive price part, reporting through rep.
+//
+// It reports whether anything was persisted, which is what decides whether the
+// price fetcher is nudged: a part that rejected every row must not produce churn.
+// The error return is a hard failure -- a database write that did not land --
+// as against a row the import could not use, which is a validation error on a
+// part that still succeeded.
+//
+// The resolve cache is passed in rather than made here so that a single archive
+// carrying both prices and corporate events for one instrument identifies it
+// once rather than once per part.
+func importPricePart(ctx context.Context, database db.DB, pluginRegistry *identifier.Registry,
+	part *archivev1.PricePart, pricesAsOf *time.Time, resolveCache map[string]*resolveEntry, rep *partReporter) (bool, error) {
+	groups := part.GetGroups()
 	total := 0
 	for _, g := range groups {
 		total += len(g.GetRows())
 	}
-	_ = database.SetJobTotalCount(ctx, j.JobID, int32(total))
+	rep.Total(ctx, total)
 
 	var resolved []resolvedGroup
-	var valErrs []*apiv1.ValidationError
-
-	// Dedup cache: avoid calling plugins twice for one identifier, and make two
-	// groups naming one instrument land on the same id.
-	resolveCache := make(map[string]*resolveEntry)
-
 	for i, g := range groups {
 		instID, err := resolveGroupInstrument(ctx, database, pluginRegistry, resolveCache, g, pricesAsOf)
 		if err != nil {
-			valErrs = append(valErrs, &apiv1.ValidationError{
-				RowIndex: int32(i),
-				Field:    "instrument",
-				Message:  err.Error(),
-			})
-			for range g.GetRows() {
-				_ = database.IncrJobProcessedCount(ctx, j.JobID)
-			}
+			rep.Errf(i, "instrument", err.Error())
+			rep.Advance(ctx, len(g.GetRows()))
 			continue
 		}
 
-		bars, rowErrs := groupBars(ctx, database, j.JobID, g, i, instID, pricesAsOf)
-		valErrs = append(valErrs, rowErrs...)
+		bars, rowErrs := groupBars(g, i, instID, pricesAsOf)
+		rep.Errs(rowErrs)
+		rep.Advance(ctx, len(g.GetRows()))
+		var covErrs []*apiv1.ValidationError
 		resolved = append(resolved, resolvedGroup{
 			instrumentID: instID,
-			coverage:     groupCoverage(g, i, &valErrs),
+			coverage:     groupCoverage(g, i, &covErrs),
 			bars:         bars,
 		})
+		rep.Errs(covErrs)
 	}
 
-	if len(valErrs) > 0 {
-		_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, valErrs)
+	if len(resolved) == 0 {
+		return false, nil
 	}
-
-	persisted := false
-	if len(resolved) > 0 {
-		if err := upsertGroups(ctx, database, resolved); err != nil {
-			log.Printf("price import job %s: upsert: %v", j.JobID, err)
-			_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, []*apiv1.ValidationError{
-				{RowIndex: -1, Field: "prices", Message: err.Error()},
-			})
-			_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_FAILED)
-			return false
-		}
-		for _, r := range resolved {
-			if len(r.bars) > 0 {
-				persisted = true
-				break
-			}
+	if err := upsertGroups(ctx, database, resolved); err != nil {
+		rep.Errf(-1, "prices", err.Error())
+		return false, fmt.Errorf("upsert prices: %w", err)
+	}
+	for _, r := range resolved {
+		if len(r.bars) > 0 {
+			return true, nil
 		}
 	}
+	return false, nil
+}
 
-	_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_SUCCESS)
-	return persisted
+// newResolveCache makes the per-import identifier cache. Resolving an
+// instrument can mean a paid plugin call, so two groups naming the same one
+// must resolve it once -- and one archive's parts share a cache, because a
+// price group and a corporate event group naming the same instrument is the
+// ordinary case rather than the exception.
+func newResolveCache() map[string]*resolveEntry {
+	return make(map[string]*resolveEntry)
 }
 
 // dateRange is a half-open [from, before) span of dates.
@@ -160,9 +174,10 @@ func resolveGroupInstrument(ctx context.Context, database db.DB, pluginRegistry 
 }
 
 // groupBars converts one group's rows into storable bars, reporting a bad row
-// against the group it came from and carrying on with the rest.
-func groupBars(ctx context.Context, database db.DB, jobID string, g *archivev1.PriceGroup,
-	groupIndex int, instrumentID string, fetchedAt *time.Time) ([]db.EODPrice, []*apiv1.ValidationError) {
+// against the group it came from and carrying on with the rest. Every row is
+// accounted for either as a bar or as an error, so the caller advances the
+// progress counter by the whole group and does not count rows itself.
+func groupBars(g *archivev1.PriceGroup, groupIndex int, instrumentID string, fetchedAt *time.Time) ([]db.EODPrice, []*apiv1.ValidationError) {
 	rows := g.GetRows()
 	bars := make([]db.EODPrice, 0, len(rows))
 	var errs []*apiv1.ValidationError
@@ -173,7 +188,6 @@ func groupBars(ctx context.Context, database db.DB, jobID string, g *archivev1.P
 			Field:    fmt.Sprintf("rows[%d].%s", i, field),
 			Message:  msg,
 		})
-		_ = database.IncrJobProcessedCount(ctx, jobID)
 	}
 
 	for i, row := range rows {
@@ -213,7 +227,6 @@ func groupBars(ctx context.Context, database db.DB, jobID string, g *archivev1.P
 			p.Volume = row.Volume
 		}
 		bars = append(bars, p)
-		_ = database.IncrJobProcessedCount(ctx, jobID)
 	}
 	return bars, errs
 }

--- a/server/service/ingestion/price_worker_test.go
+++ b/server/service/ingestion/price_worker_test.go
@@ -577,3 +577,56 @@ func TestProcessPriceImport_OptionFallbackStampsExportedAt(t *testing.T) {
 		t.Error("expected persisted=true after a successful upsert")
 	}
 }
+
+// The payload is what a job is. Clearing it before the work is done means a
+// service restarted mid-job re-enqueues a row whose payload is NULL, which
+// unmarshals cleanly as an empty request, imports nothing and reports SUCCESS.
+// So it must survive until the job reaches a terminal status.
+func TestProcessPriceImport_ClearsPayloadOnlyAfterTerminalStatus(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
+	database.EXPECT().SaveProviderIdentifiers(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	registry := identifier.NewRegistry()
+	ctx := context.Background()
+
+	payload := pricePayload(t, nil, &archivev1.PriceGroup{
+		Instrument: &archivev1.InstrumentRef{Type: typev1.IdentifierType_OPENFIGI_GLOBAL, Value: "BBG000B9XRY4"},
+		Rows:       []*archivev1.PriceRow{{PriceDate: "2024-01-15", Close: "185.90"}},
+	})
+	j := &JobRequest{JobID: "job-price-order", JobType: "price"}
+
+	database.EXPECT().LoadJobPayload(gomock.Any(), "job-price-order").Return(payload, nil)
+	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-price-order", int32(1)).Return(nil)
+	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-price-order").Return(nil)
+	database.EXPECT().AppendValidationErrors(gomock.Any(), "job-price-order", gomock.Any(), gomock.Any()).Return(nil)
+
+	gomock.InOrder(
+		database.EXPECT().SetJobStatus(gomock.Any(), "job-price-order", apiv1.JobStatus_SUCCESS).Return(nil),
+		database.EXPECT().ClearJobPayload(gomock.Any(), "job-price-order").Return(nil),
+	)
+
+	processPriceImport(ctx, database, registry, j)
+}
+
+// A payload that cannot be read fails the job, and that is terminal too, so the
+// payload goes with it rather than being left to be retried forever.
+func TestProcessPriceImport_ClearsPayloadAfterFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	database := mock.NewMockDB(ctrl)
+	registry := identifier.NewRegistry()
+	ctx := context.Background()
+	j := &JobRequest{JobID: "job-price-badpayload", JobType: "price"}
+
+	database.EXPECT().LoadJobPayload(gomock.Any(), "job-price-badpayload").Return([]byte("not a proto"), nil)
+	gomock.InOrder(
+		database.EXPECT().SetJobStatus(gomock.Any(), "job-price-badpayload", apiv1.JobStatus_FAILED).Return(nil),
+		database.EXPECT().ClearJobPayload(gomock.Any(), "job-price-badpayload").Return(nil),
+	)
+
+	if processPriceImport(ctx, database, registry, j) {
+		t.Error("expected persisted=false for an unreadable payload")
+	}
+}

--- a/server/service/ingestion/worker.go
+++ b/server/service/ingestion/worker.go
@@ -130,14 +130,17 @@ func processJob(ctx context.Context, opts WorkerOptions, j *JobRequest) {
 	}
 }
 
-// loadAndClearPayload loads the serialized payload from the DB and clears it.
-func loadAndClearPayload(ctx context.Context, database db.DB, jobID string) ([]byte, error) {
-	payload, err := database.LoadJobPayload(ctx, jobID)
-	if err != nil {
-		return nil, err
-	}
+// finishJob sets a job's terminal status and only then discards its payload.
+//
+// The order matters. The payload is what a job is; clearing it before the work
+// is done means a service restarted mid-job re-enqueues a row whose payload is
+// NULL, which unmarshals cleanly as an empty request, imports nothing and
+// reports SUCCESS. Clearing it at the end instead makes the recovery path at
+// startup able to actually redo the work, and the imports are built from
+// idempotent upserts so redoing it is safe.
+func finishJob(ctx context.Context, database db.DB, jobID string, status apiv1.JobStatus) {
+	_ = database.SetJobStatus(ctx, jobID, status)
 	_ = database.ClearJobPayload(ctx, jobID)
-	return payload, nil
 }
 
 func processTx(ctx context.Context, database db.DB, registry *identifier.Registry, descRegistry *description.Registry, counter telemetry.CounterIncrementer, j *JobRequest) (bool, string) {
@@ -147,16 +150,16 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 		userID = d.UserID
 	}
 
-	payload, err := loadAndClearPayload(ctx, database, j.JobID)
+	payload, err := database.LoadJobPayload(ctx, j.JobID)
 	if err != nil {
 		log.Printf("ingestion job %s: load payload: %v", j.JobID, err)
-		_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_FAILED)
+		finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
 		return false, ""
 	}
 	var req ingestionv1.UpsertTxsRequest
 	if err := proto.Unmarshal(payload, &req); err != nil {
 		log.Printf("ingestion job %s: unmarshal payload: %v", j.JobID, err)
-		_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_FAILED)
+		finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
 		return false, ""
 	}
 
@@ -177,7 +180,7 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 			_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, []*apiv1.ValidationError{
 				{RowIndex: -1, Field: "share_count_basis", Message: fmt.Sprintf("invalid date %q: want YYYY-MM-DD", b)},
 			})
-			_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_FAILED)
+			finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
 			return false, ""
 		}
 		shareCountBasis = &parsed
@@ -187,7 +190,7 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 	errs := ValidateTxs(txs)
 	if len(errs) > 0 {
 		_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, errs)
-		_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_FAILED)
+		finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
 		return false, ""
 	}
 	// Load ignored asset classes for this user.
@@ -199,7 +202,7 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 	// Filter non-stored tx types (e.g. SPLIT) and ignored asset classes.
 	txsToProcess, originalIndices := filterStoredTxs(txs, broker, ignoredClasses)
 	if len(txsToProcess) == 0 {
-		_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_SUCCESS)
+		finishJob(ctx, database, j.JobID, apiv1.JobStatus_SUCCESS)
 		return true, userID
 	}
 	_ = database.SetJobTotalCount(ctx, j.JobID, int32(len(txsToProcess)))
@@ -210,7 +213,7 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 		_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, []*apiv1.ValidationError{
 			{RowIndex: -1, Field: "txs", Message: err.Error()},
 		})
-		_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_FAILED)
+		finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
 		return false, ""
 	}
 	// Resolve instruments.
@@ -220,7 +223,7 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 		_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, []*apiv1.ValidationError{
 			{RowIndex: -1, Field: "instrument_description", Message: err.Error()},
 		})
-		_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_FAILED)
+		finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
 		return false, ""
 	}
 	if len(idErrs) > 0 {
@@ -233,7 +236,7 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 		_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, []*apiv1.ValidationError{
 			{RowIndex: -1, Field: "txs", Message: err.Error()},
 		})
-		_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_FAILED)
+		finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
 		return false, ""
 	}
 	// Validate that each resolved instrument's asset class is compatible with
@@ -243,7 +246,7 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 	// path where resolution lands on an instrument of the wrong class.
 	if classErrs := validateAssetClasses(txsToProcess, originalIndices, instrumentIDs, instByID); len(classErrs) > 0 {
 		_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, classErrs)
-		_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_FAILED)
+		finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
 		return false, ""
 	}
 	// Balance every group by routing whatever its postings leave over to an
@@ -269,7 +272,7 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 			}
 		}
 		_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, errs)
-		_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_FAILED)
+		finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
 		return false, ""
 	}
 	// Weighed after routing, which is what assigns a synthetic group_ref to a posting
@@ -292,7 +295,7 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 		_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, []*apiv1.ValidationError{
 			{RowIndex: -1, Field: "txs", Message: storeErr.Error()},
 		})
-		_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_FAILED)
+		finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
 		return false, ""
 	}
 
@@ -300,7 +303,7 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 	// The INSERT trigger on txs copies raw values; this pass corrects them.
 	recomputeSplitAdjustedTxs(ctx, database, instrumentIDs)
 
-	_ = database.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_SUCCESS)
+	finishJob(ctx, database, j.JobID, apiv1.JobStatus_SUCCESS)
 	return true, userID
 }
 


### PR DESCRIPTION
Third of the stack for 0079. **Depends on #357.**

Mostly a refactor, plus one real bug fix.

### Refactor

The consolidated import will run several parts under one job, so applying a part
has to be separable from the job carrying it. Each worker splits in two: a
payload half that stays with the per-entity RPC, and `importPricePart` /
`importCorporateEventPart`, which apply an archive part and report through a
`partReporter`.

`partReporter` batches the progress counter and accumulates validation errors, so
a part costs a handful of writes rather than one per row. A reporter constructed
with no part reports against the job itself -- the shape the per-entity imports
still have -- and that branch goes when they do.

The resolve cache is now passed in rather than made per part: one archive naming
an instrument in both its price and corporate event parts is the ordinary case,
and identifying it twice means paying a plugin twice.

`groupBars` no longer counts rows; every row is accounted for either as a bar or
as an error, so the caller advances by the whole group.

### Bug fix: the payload was cleared before the work was done

`loadAndClearPayload` nulled `payload` up front. The recovery path in `main.go`
re-enqueues `PENDING` and `RUNNING` jobs at startup, but by then the payload is
`NULL` -- and `proto.Unmarshal(nil, &req)` **succeeds** as an empty message, so
the job imports nothing and is marked `SUCCESS`. A service restarted mid-import
silently claimed to have done it.

`finishJob` sets the terminal status and only then discards the payload, so the
recovery path can actually redo the work. Redoing it is safe: every import is
built from idempotent upserts.

Two tests cover the ordering with `gomock.InOrder`, on both the success and the
unreadable-payload path. I checked they fail against the old ordering
("doesn't have a prerequisite call satisfied") and pass against the fix.

Verified: `make test`, `make lint-go`, `make fmt-check` clean. Every existing
worker test passes unchanged, which is the evidence the extraction preserved
behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)