### PR TITLE
Import a whole system archive under one job

### DIFF
--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 package portfoliodb.api.v1;
 
+import "archive/v1/archive.proto";
 import "archive/v1/common.proto";
 import "archive/v1/corporate_events.proto";
 import "archive/v1/instruments.proto";
@@ -174,6 +175,11 @@ service ApiService {
 
   // Instruments: browse and search (any authenticated user).
   rpc ListInstruments(ListInstrumentsRequest) returns (ListInstrumentsResponse);
+
+  // System archive import (admin-only). Applies a whole system archive
+  // asynchronously, sequencing its parts server-side. See
+  // ImportSystemArchiveRequest.
+  rpc ImportSystemArchive(ImportSystemArchiveRequest) returns (ImportSystemArchiveResponse);
 
   // Instrument export/import (admin-only). Export streams the instrument part of a system archive; optional exchange filter.
   rpc ExportInstruments(ExportInstrumentsRequest) returns (stream ExportInstrumentsResponse);
@@ -520,6 +526,30 @@ message ListInstrumentsResponse {
   repeated Instrument instruments = 1;
   string next_page_token = 2;
   int32 total_count = 3;  // total matching instruments (for UI pagination display)
+}
+
+// ImportSystemArchiveRequest carries one whole system archive. The parts are
+// applied server-side in restore order -- instruments, prices, corporate events
+// -- so a client that navigates away mid-import does not stop it, and the caller
+// polls one job rather than sequencing the parts itself.
+//
+// A part absent from the document is not applied. A part present and empty is
+// applied and produces a result with a total of zero: "the export included it
+// and there was nothing" is a statement the import honours rather than an error.
+// To import one kind of data, supply a document carrying only that part.
+//
+// The archive is the file's own document, forwarded rather than rebuilt, so the
+// server sees the format_version and the kind the file declared rather than what
+// the uploading client assumed.
+message ImportSystemArchiveRequest {
+  portfoliodb.archive.v1.SystemArchive archive = 1 [(buf.validate.field).required = true];
+  string filename = 2; // optional; shown in the job list
+}
+
+// ImportSystemArchiveResponse returns immediately with the job to poll. Per-part
+// progress and results are on GetJobResponse.parts.
+message ImportSystemArchiveResponse {
+  string job_id = 1;
 }
 
 // ExportInstruments streams the instrument part of a system archive: every

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -352,6 +352,9 @@ type JobDB interface {
 	SetJobStatus(ctx context.Context, jobID string, status apiv1.JobStatus) error
 	SetJobTotalCount(ctx context.Context, jobID string, total int32) error
 	IncrJobProcessedCount(ctx context.Context, jobID string) error
+	// SetJobProcessedCount sets a job's progress outright, for a job whose
+	// progress is the sum over its parts rather than its own running count.
+	SetJobProcessedCount(ctx context.Context, jobID string, processed int32) error
 	// AppendValidationErrors attributes errors to one archive part, or to the
 	// job itself when part is ARCHIVE_PART_UNSPECIFIED.
 	AppendValidationErrors(ctx context.Context, jobID string, part archivev1.ArchivePart, errs []*apiv1.ValidationError) error

--- a/server/db/postgres/jobs.go
+++ b/server/db/postgres/jobs.go
@@ -200,6 +200,19 @@ func (p *Postgres) SetJobTotalCount(ctx context.Context, jobID string, total int
 	return nil
 }
 
+// SetJobProcessedCount implements db.JobDB.
+func (p *Postgres) SetJobProcessedCount(ctx context.Context, jobID string, processed int32) error {
+	jobUUID, err := uuid.Parse(jobID)
+	if err != nil {
+		return fmt.Errorf("invalid job id: %w", err)
+	}
+	_, err = p.q.ExecContext(ctx, `UPDATE ingestion_jobs SET processed_count = $2 WHERE id = $1`, jobUUID, processed)
+	if err != nil {
+		return fmt.Errorf("set job processed count: %w", err)
+	}
+	return nil
+}
+
 // IncrJobProcessedCount implements db.JobDB.
 func (p *Postgres) IncrJobProcessedCount(ctx context.Context, jobID string) error {
 	jobUUID, err := uuid.Parse(jobID)

--- a/server/service/api/archive.go
+++ b/server/service/api/archive.go
@@ -1,0 +1,84 @@
+package api
+
+import (
+	"context"
+	"errors"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
+	"github.com/leedenison/portfoliodb/server/archive"
+	"github.com/leedenison/portfoliodb/server/auth"
+	"github.com/leedenison/portfoliodb/server/db"
+)
+
+// ImportSystemArchive queues one whole system archive and returns the job to
+// poll. Admin only.
+//
+// The parts are applied in the worker rather than in this request, which is what
+// makes an import survive the admin closing the tab: the only thing the client
+// has to hold on to is the job id, and the per-part results are readable from
+// GetJob for as long as the job row lives.
+func (s *Server) ImportSystemArchive(ctx context.Context, req *apiv1.ImportSystemArchiveRequest) (*apiv1.ImportSystemArchiveResponse, error) {
+	u, authErr := auth.RequireAdmin(ctx)
+	if authErr != nil {
+		return nil, authErr
+	}
+	a := req.GetArchive()
+	if err := archive.CheckEnvelope(a.GetEnvelope(), archivev1.ArchiveKind_SYSTEM); err != nil {
+		var ve *archive.VersionError
+		if errors.As(err, &ve) {
+			// The request is well formed and this server is the thing that is out
+			// of date, which is a precondition rather than a bad argument.
+			return nil, status.Error(codes.FailedPrecondition, err.Error())
+		}
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	parts := presentParts(a)
+	if len(parts) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "archive carries no parts")
+	}
+
+	// The document alone is stored: the filename is a label for the job row and
+	// the worker has no use for it.
+	payload, err := proto.Marshal(a)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	jobID, err := s.db.CreateJob(ctx, db.CreateJobParams{
+		UserID:   u.ID,
+		JobType:  db.JobTypeSystemArchive,
+		Filename: req.GetFilename(),
+		Payload:  payload,
+		Parts:    parts,
+	})
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	if err := s.enqueueJob(jobID, db.JobTypeSystemArchive); err != nil {
+		return nil, status.Error(codes.Unavailable, err.Error())
+	}
+	return &apiv1.ImportSystemArchiveResponse{JobId: jobID}, nil
+}
+
+// presentParts names the parts a document carries, in restore order.
+//
+// Presence, not emptiness: a section present but empty says the export included
+// it and there was nothing, which is a different statement from a section that
+// was never included, and the import honours the difference.
+func presentParts(a *archivev1.SystemArchive) []archivev1.ArchivePart {
+	var parts []archivev1.ArchivePart
+	if a.GetInstruments() != nil {
+		parts = append(parts, archivev1.ArchivePart_INSTRUMENTS)
+	}
+	if a.GetPrices() != nil {
+		parts = append(parts, archivev1.ArchivePart_PRICES)
+	}
+	if a.GetCorporateEvents() != nil {
+		parts = append(parts, archivev1.ArchivePart_CORPORATE_EVENTS)
+	}
+	return parts
+}

--- a/server/service/api/archive_test.go
+++ b/server/service/api/archive_test.go
@@ -1,0 +1,130 @@
+package api
+
+import (
+	"context"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
+	"github.com/leedenison/portfoliodb/server/archive"
+	dbpkg "github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/testutil"
+)
+
+func systemArchive(mutate func(*archivev1.SystemArchive)) *apiv1.ImportSystemArchiveRequest {
+	a := &archivev1.SystemArchive{
+		Envelope: archive.NewEnvelope("portfoliodb.example.com", archivev1.ArchiveKind_SYSTEM),
+	}
+	if mutate != nil {
+		mutate(a)
+	}
+	return &apiv1.ImportSystemArchiveRequest{Archive: a, Filename: "system-archive.json"}
+}
+
+func TestImportSystemArchive_NonAdmin_PermissionDenied(t *testing.T) {
+	srv, _ := newAPIServerWithMock(t)
+	req := systemArchive(func(a *archivev1.SystemArchive) {
+		a.Instruments = &archivev1.InstrumentPart{}
+	})
+	_, err := srv.ImportSystemArchive(authCtx("user-1", "sub|1"), req)
+	testutil.RequireGRPCCode(t, err, codes.PermissionDenied)
+}
+
+func TestImportSystemArchive_NoParts_ReturnsError(t *testing.T) {
+	srv, _ := newAPIServerWithMock(t)
+	_, err := srv.ImportSystemArchive(adminCtx("user-1", "sub|1"), systemArchive(nil))
+	testutil.RequireGRPCCode(t, err, codes.InvalidArgument)
+}
+
+func TestImportSystemArchive_NewerFormatVersion_Refused(t *testing.T) {
+	srv, _ := newAPIServerWithMock(t)
+	req := systemArchive(func(a *archivev1.SystemArchive) {
+		a.Instruments = &archivev1.InstrumentPart{}
+		a.Envelope.FormatVersion = archive.FormatVersion + 1
+	})
+	// The request is well formed and this server is the thing that is out of
+	// date, so this is a precondition rather than a bad argument.
+	_, err := srv.ImportSystemArchive(adminCtx("user-1", "sub|1"), req)
+	testutil.RequireGRPCCode(t, err, codes.FailedPrecondition)
+}
+
+func TestImportSystemArchive_UserArchive_Refused(t *testing.T) {
+	srv, _ := newAPIServerWithMock(t)
+	req := systemArchive(func(a *archivev1.SystemArchive) {
+		a.Instruments = &archivev1.InstrumentPart{}
+		a.Envelope.Kind = archivev1.ArchiveKind_USER
+	})
+	_, err := srv.ImportSystemArchive(adminCtx("user-1", "sub|1"), req)
+	testutil.RequireGRPCCode(t, err, codes.InvalidArgument)
+}
+
+// The job records the parts the document carried, in restore order, so a caller
+// polling immediately sees what the import will apply.
+func TestImportSystemArchive_QueuesJobWithPresentParts(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	req := systemArchive(func(a *archivev1.SystemArchive) {
+		a.CorporateEvents = &archivev1.CorporateEventPart{}
+		a.Instruments = &archivev1.InstrumentPart{}
+	})
+	var enqueuedType string
+	srv.enqueueJob = func(_, jobType string) error {
+		enqueuedType = jobType
+		return nil
+	}
+	var got dbpkg.CreateJobParams
+	mockDB.EXPECT().CreateJob(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, params dbpkg.CreateJobParams) (string, error) {
+			got = params
+			return "job-1", nil
+		})
+	resp, err := srv.ImportSystemArchive(adminCtx("user-1", "sub|1"), req)
+	if err != nil {
+		t.Fatalf("ImportSystemArchive: %v", err)
+	}
+	if resp.GetJobId() != "job-1" {
+		t.Fatalf("job_id = %q", resp.GetJobId())
+	}
+	if got.JobType != dbpkg.JobTypeSystemArchive || got.Filename != "system-archive.json" {
+		t.Fatalf("job = %q %q", got.JobType, got.Filename)
+	}
+	if enqueuedType != dbpkg.JobTypeSystemArchive {
+		t.Fatalf("enqueued as %q", enqueuedType)
+	}
+	want := []archivev1.ArchivePart{archivev1.ArchivePart_INSTRUMENTS, archivev1.ArchivePart_CORPORATE_EVENTS}
+	if len(got.Parts) != len(want) {
+		t.Fatalf("parts = %v, want %v", got.Parts, want)
+	}
+	for i := range want {
+		if got.Parts[i] != want[i] {
+			t.Fatalf("parts = %v, want %v", got.Parts, want)
+		}
+	}
+	if len(got.Payload) == 0 {
+		t.Fatal("job carries no payload")
+	}
+}
+
+// A part present but empty says the export included it and there was nothing.
+// That is a different statement from a part never included, so it is applied.
+func TestImportSystemArchive_EmptyPartIsStillApplied(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	req := systemArchive(func(a *archivev1.SystemArchive) {
+		a.Prices = &archivev1.PricePart{}
+	})
+	srv.enqueueJob = func(_, _ string) error { return nil }
+	var got dbpkg.CreateJobParams
+	mockDB.EXPECT().CreateJob(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, params dbpkg.CreateJobParams) (string, error) {
+			got = params
+			return "job-2", nil
+		})
+	if _, err := srv.ImportSystemArchive(adminCtx("user-1", "sub|1"), req); err != nil {
+		t.Fatalf("ImportSystemArchive: %v", err)
+	}
+	if len(got.Parts) != 1 || got.Parts[0] != archivev1.ArchivePart_PRICES {
+		t.Fatalf("parts = %v, want [PRICES]", got.Parts)
+	}
+}

--- a/server/service/ingestion/system_import.go
+++ b/server/service/ingestion/system_import.go
@@ -1,0 +1,143 @@
+package ingestion
+
+import (
+	"context"
+	"errors"
+	"log"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
+	"github.com/leedenison/portfoliodb/server/archiveimport"
+	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/identifier"
+)
+
+// errUnknownPart is a part row naming something this build cannot apply, which
+// means a job written by a later build. It fails that part and leaves the rest
+// alone rather than failing the whole import.
+var errUnknownPart = errors.New("this build cannot apply that archive part")
+
+// systemImportResult says which fetchers the import earned a nudge for. An
+// instrument part triggers nothing: imported instruments have no holdings yet,
+// so there are no price gaps to fill.
+type systemImportResult struct {
+	pricesPersisted bool
+	eventsPersisted bool
+}
+
+// processSystemImport applies the parts of a system archive in restore order,
+// recording a result per part.
+//
+// A failed part does not stop the sequence. The parts are not hard-dependent:
+// the price and corporate event parts resolve any instrument they cannot find,
+// so they work against an instance whose instrument part failed. Running
+// instruments first is what stops them paying a plugin for instruments the file
+// already describes -- an optimisation, not a prerequisite -- and abandoning
+// the rest would throw away work that would otherwise land. Which parts did not
+// apply is what the per-part results are for.
+func processSystemImport(ctx context.Context, database db.DB, registry *identifier.Registry, j *JobRequest) systemImportResult {
+	var out systemImportResult
+
+	payload, err := database.LoadJobPayload(ctx, j.JobID)
+	if err != nil {
+		log.Printf("system archive job %s: load payload: %v", j.JobID, err)
+		failWholeJob(ctx, database, j.JobID, "payload", err.Error())
+		return out
+	}
+	var a archivev1.SystemArchive
+	if err := proto.Unmarshal(payload, &a); err != nil {
+		log.Printf("system archive job %s: unmarshal payload: %v", j.JobID, err)
+		failWholeJob(ctx, database, j.JobID, "payload", err.Error())
+		return out
+	}
+
+	// Knowledge time declared once for the whole document: every part reads it
+	// the same way, which is the point of the envelope carrying it.
+	var asOf *time.Time
+	if ts := a.GetEnvelope().GetExportedAt(); ts != nil {
+		t := ts.AsTime()
+		asOf = &t
+	}
+
+	// One cache for the whole archive. An instrument named in both the price and
+	// the corporate event part is the ordinary case, and resolving it twice means
+	// paying a plugin twice.
+	resolveCache := newResolveCache()
+
+	// Which parts to run comes from the job's own rows rather than from the
+	// document, so a job resumed after a restart skips what already finished.
+	detail, err := database.GetJob(ctx, j.JobID)
+	if err != nil {
+		log.Printf("system archive job %s: read parts: %v", j.JobID, err)
+		failWholeJob(ctx, database, j.JobID, "job", err.Error())
+		return out
+	}
+
+	anyFailed := false
+	for _, pr := range detail.Parts {
+		if pr.Status == apiv1.JobStatus_SUCCESS {
+			// Already applied by a run this one is resuming.
+			continue
+		}
+		// A part being re-run starts its progress over rather than counting on
+		// from where the interrupted run left off.
+		if pr.ProcessedCount > 0 || pr.Message != "" {
+			_ = database.ResetJobPartProgress(ctx, j.JobID, pr.Part)
+		}
+		_ = database.SetJobPartStatus(ctx, j.JobID, pr.Part, apiv1.JobStatus_RUNNING)
+
+		rep := archiveimport.NewPartReporter(database, j.JobID, pr.Part)
+		var partErr error
+		switch pr.Part {
+		case archivev1.ArchivePart_INSTRUMENTS:
+			_, partErr = archiveimport.InstrumentPart(ctx, database, a.GetInstruments(), rep)
+		case archivev1.ArchivePart_PRICES:
+			out.pricesPersisted, partErr = importPricePart(ctx, database, registry, a.GetPrices(), asOf, resolveCache, rep)
+		case archivev1.ArchivePart_CORPORATE_EVENTS:
+			out.eventsPersisted, partErr = importCorporateEventPart(ctx, database, registry, a.GetCorporateEvents(), asOf, resolveCache, rep)
+		default:
+			partErr = errUnknownPart
+		}
+		// Flushed before the part is marked terminal on both paths: the errors
+		// gathered before a hard failure are what explain it.
+		rep.Flush(ctx)
+
+		if partErr != nil {
+			log.Printf("system archive job %s: part %s: %v", j.JobID, pr.Part, partErr)
+			_ = database.SetJobPartFailed(ctx, j.JobID, pr.Part, partErr.Error())
+			anyFailed = true
+			continue
+		}
+		_ = database.SetJobPartStatus(ctx, j.JobID, pr.Part, apiv1.JobStatus_SUCCESS)
+	}
+
+	// The job's own counters are the sum over its parts, so a caller that only
+	// knows about jobs still sees sensible progress.
+	if final, err := database.GetJob(ctx, j.JobID); err == nil {
+		var total, processed int32
+		for _, pr := range final.Parts {
+			total += pr.TotalCount
+			processed += pr.ProcessedCount
+		}
+		_ = database.SetJobTotalCount(ctx, j.JobID, total)
+		_ = database.SetJobProcessedCount(ctx, j.JobID, processed)
+	}
+
+	status := apiv1.JobStatus_SUCCESS
+	if anyFailed {
+		status = apiv1.JobStatus_FAILED
+	}
+	finishJob(ctx, database, j.JobID, status)
+	return out
+}
+
+// failWholeJob records a failure that happened before any part could be reached,
+// which belongs to the job rather than to a part.
+func failWholeJob(ctx context.Context, database db.DB, jobID, field, message string) {
+	_ = database.AppendValidationErrors(ctx, jobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED,
+		[]*apiv1.ValidationError{{RowIndex: -1, Field: field, Message: message}})
+	finishJob(ctx, database, jobID, apiv1.JobStatus_FAILED)
+}

--- a/server/service/ingestion/system_import_test.go
+++ b/server/service/ingestion/system_import_test.go
@@ -1,0 +1,245 @@
+package ingestion
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
+	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/db/mock"
+	"github.com/leedenison/portfoliodb/server/identifier"
+)
+
+// systemArchivePayload is a document carrying one instrument, one price group
+// and one corporate event group, which is enough to watch all three parts run.
+func systemArchivePayload(t *testing.T) []byte {
+	t.Helper()
+	ref := &archivev1.InstrumentRef{Type: typev1.IdentifierType_MIC_TICKER, Value: "AAPL", Domain: "XNAS"}
+	b, err := proto.Marshal(&archivev1.SystemArchive{
+		Envelope: &archivev1.Envelope{
+			FormatVersion: 1,
+			ExportedAt:    timestamppb.Now(),
+			Kind:          archivev1.ArchiveKind_SYSTEM,
+		},
+		Instruments: &archivev1.InstrumentPart{Instruments: []*archivev1.Instrument{{
+			AssetClass:  typev1.AssetClass_STOCK,
+			Identifiers: []*archivev1.Identifier{{Type: typev1.IdentifierType_MIC_TICKER, Value: "AAPL", Domain: "XNAS", Canonical: true}},
+		}}},
+		Prices: &archivev1.PricePart{Groups: []*archivev1.PriceGroup{{
+			Instrument: ref,
+			Rows:       []*archivev1.PriceRow{{PriceDate: "2024-01-15", Close: "185.90"}},
+		}}},
+		CorporateEvents: &archivev1.CorporateEventPart{Groups: []*archivev1.CorporateEventGroup{{
+			Instrument: ref,
+		}}},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+// partRows is the job's own record of which parts it will apply, which is what
+// the worker reads to decide what to run.
+func partRows(parts ...archivev1.ArchivePart) []db.JobPartResult {
+	rows := make([]db.JobPartResult, 0, len(parts))
+	for _, p := range parts {
+		rows = append(rows, db.JobPartResult{Part: p, Status: apiv1.JobStatus_PENDING})
+	}
+	return rows
+}
+
+// The parts run in restore order, each marked RUNNING then SUCCESS, and the job
+// is SUCCESS once they are all done.
+func TestProcessSystemImport_RunsPartsInRestoreOrder(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
+	database.EXPECT().SaveProviderIdentifiers(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().FindInstrumentByIdentifier(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("inst-1", nil).AnyTimes()
+	database.EXPECT().FindInstrumentWithMetaByIdentifier(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return("inst-1", "STOCK", "XNAS", "USD", nil).AnyTimes()
+	database.EXPECT().EnsureInstrument(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("inst-1", nil).AnyTimes()
+	database.EXPECT().UpsertPrices(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().UpsertPricesForRange(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().SetJobPartTotalCount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().AddJobPartProcessedCount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().AppendValidationErrors(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().SetJobTotalCount(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().SetJobProcessedCount(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	j := &JobRequest{JobID: "job-sa-1", JobType: db.JobTypeSystemArchive}
+	database.EXPECT().LoadJobPayload(gomock.Any(), j.JobID).Return(systemArchivePayload(t), nil)
+	database.EXPECT().GetJob(gomock.Any(), j.JobID).Return(&db.JobDetail{
+		UserID: "user-1",
+		Parts:  partRows(archivev1.ArchivePart_INSTRUMENTS, archivev1.ArchivePart_PRICES, archivev1.ArchivePart_CORPORATE_EVENTS),
+	}, nil).AnyTimes()
+
+	var order []string
+	database.EXPECT().SetJobPartStatus(gomock.Any(), j.JobID, gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, part archivev1.ArchivePart, st apiv1.JobStatus) error {
+			order = append(order, part.String()+":"+st.String())
+			return nil
+		}).AnyTimes()
+	gomock.InOrder(
+		database.EXPECT().SetJobStatus(gomock.Any(), j.JobID, apiv1.JobStatus_SUCCESS).Return(nil),
+		database.EXPECT().ClearJobPayload(gomock.Any(), j.JobID).Return(nil),
+	)
+
+	processSystemImport(context.Background(), database, identifier.NewRegistry(), j)
+
+	want := []string{
+		"INSTRUMENTS:RUNNING", "INSTRUMENTS:SUCCESS",
+		"PRICES:RUNNING", "PRICES:SUCCESS",
+		"CORPORATE_EVENTS:RUNNING", "CORPORATE_EVENTS:SUCCESS",
+	}
+	if len(order) != len(want) {
+		t.Fatalf("part transitions = %v, want %v", order, want)
+	}
+	for i := range want {
+		if order[i] != want[i] {
+			t.Fatalf("part transitions = %v, want %v", order, want)
+		}
+	}
+}
+
+// A part that fails does not stop the ones after it: the parts are not
+// hard-dependent, and abandoning the rest would throw away work that would
+// otherwise land. The job is FAILED, and the per-part results say which part.
+func TestProcessSystemImport_FailedPartDoesNotStopTheRest(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
+	database.EXPECT().SaveProviderIdentifiers(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().FindInstrumentByIdentifier(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("inst-1", nil).AnyTimes()
+	database.EXPECT().FindInstrumentWithMetaByIdentifier(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return("inst-1", "STOCK", "XNAS", "USD", nil).AnyTimes()
+	database.EXPECT().EnsureInstrument(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("inst-1", nil).AnyTimes()
+	database.EXPECT().SetJobPartTotalCount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().AddJobPartProcessedCount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().AppendValidationErrors(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().SetJobTotalCount(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().SetJobProcessedCount(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	var transitions []string
+	database.EXPECT().SetJobPartStatus(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, part archivev1.ArchivePart, st apiv1.JobStatus) error {
+			transitions = append(transitions, part.String()+":"+st.String())
+			return nil
+		}).AnyTimes()
+
+	// The price part cannot write, which is a hard failure for that part.
+	database.EXPECT().UpsertPrices(gomock.Any(), gomock.Any()).Return(errors.New("disk on fire")).AnyTimes()
+	database.EXPECT().UpsertPricesForRange(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(errors.New("disk on fire")).AnyTimes()
+
+	j := &JobRequest{JobID: "job-sa-2", JobType: db.JobTypeSystemArchive}
+	database.EXPECT().LoadJobPayload(gomock.Any(), j.JobID).Return(systemArchivePayload(t), nil)
+	database.EXPECT().GetJob(gomock.Any(), j.JobID).Return(&db.JobDetail{
+		UserID: "user-1",
+		Parts:  partRows(archivev1.ArchivePart_INSTRUMENTS, archivev1.ArchivePart_PRICES, archivev1.ArchivePart_CORPORATE_EVENTS),
+	}, nil).AnyTimes()
+
+	var failedPart archivev1.ArchivePart
+	database.EXPECT().SetJobPartFailed(gomock.Any(), j.JobID, gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, part archivev1.ArchivePart, _ string) error {
+			failedPart = part
+			return nil
+		})
+	// The corporate event part still runs, which is what proves the sequence
+	// carried on past the failure.
+	database.EXPECT().UpsertCorporateEventCoverage(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().SetJobStatus(gomock.Any(), j.JobID, apiv1.JobStatus_FAILED).Return(nil)
+	database.EXPECT().ClearJobPayload(gomock.Any(), j.JobID).Return(nil)
+
+	processSystemImport(context.Background(), database, identifier.NewRegistry(), j)
+
+	if failedPart != archivev1.ArchivePart_PRICES {
+		t.Fatalf("failed part = %v, want PRICES", failedPart)
+	}
+	// The part after the failure still ran and still succeeded, which is the
+	// whole point: a failed part costs its own work and nothing else's.
+	if !contains(transitions, "CORPORATE_EVENTS:RUNNING") || !contains(transitions, "CORPORATE_EVENTS:SUCCESS") {
+		t.Fatalf("corporate events did not run after the price part failed: %v", transitions)
+	}
+	// And the failed part was never marked SUCCESS.
+	if contains(transitions, "PRICES:SUCCESS") {
+		t.Fatalf("a failed part was marked SUCCESS: %v", transitions)
+	}
+}
+
+// A job resumed after a restart skips the parts that already finished rather
+// than redoing them.
+func TestProcessSystemImport_ResumeSkipsFinishedParts(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
+	database.EXPECT().SaveProviderIdentifiers(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().FindInstrumentByIdentifier(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("inst-1", nil).AnyTimes()
+	database.EXPECT().FindInstrumentWithMetaByIdentifier(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return("inst-1", "STOCK", "XNAS", "USD", nil).AnyTimes()
+	database.EXPECT().UpsertPrices(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().UpsertPricesForRange(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().SetJobPartTotalCount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().AddJobPartProcessedCount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().AppendValidationErrors(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().SetJobTotalCount(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().SetJobProcessedCount(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().SetJobPartStatus(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().SetJobStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().ClearJobPayload(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	j := &JobRequest{JobID: "job-sa-3", JobType: db.JobTypeSystemArchive}
+	database.EXPECT().LoadJobPayload(gomock.Any(), j.JobID).Return(systemArchivePayload(t), nil)
+	database.EXPECT().GetJob(gomock.Any(), j.JobID).Return(&db.JobDetail{
+		UserID: "user-1",
+		Parts: []db.JobPartResult{
+			{Part: archivev1.ArchivePart_INSTRUMENTS, Status: apiv1.JobStatus_SUCCESS, TotalCount: 1, ProcessedCount: 1},
+			// Interrupted halfway, so its progress is reset before it re-runs.
+			{Part: archivev1.ArchivePart_PRICES, Status: apiv1.JobStatus_RUNNING, TotalCount: 1, ProcessedCount: 1},
+		},
+	}, nil).AnyTimes()
+
+	// The finished instrument part is not re-ensured.
+	database.EXPECT().EnsureInstrument(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+	database.EXPECT().ResetJobPartProgress(gomock.Any(), j.JobID, archivev1.ArchivePart_PRICES).Return(nil)
+
+	processSystemImport(context.Background(), database, identifier.NewRegistry(), j)
+}
+
+// A payload that cannot be read is the job's failure rather than any part's,
+// because no part was reached.
+func TestProcessSystemImport_UnreadablePayloadFailsTheJob(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	database := mock.NewMockDB(ctrl)
+	j := &JobRequest{JobID: "job-sa-4", JobType: db.JobTypeSystemArchive}
+
+	database.EXPECT().LoadJobPayload(gomock.Any(), j.JobID).Return([]byte("not a proto"), nil)
+	database.EXPECT().
+		AppendValidationErrors(gomock.Any(), j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, gomock.Any()).
+		Return(nil)
+	gomock.InOrder(
+		database.EXPECT().SetJobStatus(gomock.Any(), j.JobID, apiv1.JobStatus_FAILED).Return(nil),
+		database.EXPECT().ClearJobPayload(gomock.Any(), j.JobID).Return(nil),
+	)
+
+	processSystemImport(context.Background(), database, identifier.NewRegistry(), j)
+}
+
+func contains(ss []string, want string) bool {
+	for _, s := range ss {
+		if s == want {
+			return true
+		}
+	}
+	return false
+}

--- a/server/service/ingestion/worker.go
+++ b/server/service/ingestion/worker.go
@@ -124,6 +124,17 @@ func processJob(ctx context.Context, opts WorkerOptions, j *JobRequest) {
 			// gaps that would require price data.
 			pluginutil.Trigger(opts.CorporateEventTrigger)
 		}
+	case db.JobTypeSystemArchive:
+		res := processSystemImport(ctx, opts.DB, opts.IdentifierRegistry, j)
+		// Nudged once for the whole import rather than per part. Instruments
+		// trigger nothing: an imported instrument has no holdings yet, so it
+		// opens no price gap.
+		if res.pricesPersisted {
+			pluginutil.Trigger(opts.PriceTrigger)
+		}
+		if res.eventsPersisted {
+			pluginutil.Trigger(opts.CorporateEventTrigger)
+		}
 	default:
 		log.Printf("ingestion job %s: unknown job type %q", j.JobID, j.JobType)
 		_ = opts.DB.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_FAILED)


### PR DESCRIPTION
Fifth of the stack for 0079. **Depends on #359.**

`ImportSystemArchive` takes the whole document, returns a job id, and applies the
parts in the worker. The client uploads once and holds a job id; closing the tab
does not stop the import, and the per-part results stay readable from `GetJob`
for as long as the job row lives.

### Semantics

- **Presence, not emptiness.** A part absent from the document is not applied. A
  part present and empty is applied and reports a total of zero -- "the export
  included it and there was nothing" is a statement the format makes and the
  import honours. To import one kind of data you supply a document carrying only
  that part.
- **A failed part does not stop the sequence.** The parts are not hard-dependent:
  the price and corporate event parts resolve any instrument they cannot find, so
  they work against an instance whose instrument part failed. Instruments run
  first because that is what stops the later parts paying a plugin for
  instruments the file already describes -- an optimisation, not a prerequisite.
  Abandoning the rest would throw away work that would otherwise land. The job is
  `FAILED`, and the per-part results say which part.
- **`FAILED` means a hard failure** -- an unreadable payload, or a database write
  that did not land. A row the import could not use stays a validation error on a
  part that still succeeded.
- **Resume.** Which parts to run comes from the job's own part rows rather than
  from the document, so a job re-enqueued after a restart skips what already
  finished and resets the progress of what did not. Safe because every part is
  built from idempotent upserts.
- **One resolve cache spans the archive.** An instrument named in both the price
  and the corporate event part is the ordinary case; resolving it twice means
  paying a plugin twice.

Also adds `SetJobProcessedCount` so the job's aggregate progress is one UPDATE
rather than one per row.

Tests: restore-order sequencing, a failed part leaving later parts running and
never marking itself SUCCESS, resume skipping finished parts, an unreadable
payload failing the job rather than a part, and the RPC's guards and part
detection.

Verified: `make test`, `make db-test`, `make lint-go`, `make lint-proto`,
`make fmt-check`, `make client-typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)