### PR TITLE
Export a whole system archive from one endpoint

### DIFF
--- a/client/lib/archive/codec.test.ts
+++ b/client/lib/archive/codec.test.ts
@@ -119,6 +119,19 @@ describe("archive codec", () => {
     expect(got.prices?.groups[0].coverage[0].before).toBe("2024-01-17");
   });
 
+  // A part present but empty means the export included it and there was
+  // nothing; a part absent means it was not included at all. The export menu
+  // rests on those being distinguishable, and the client is what assembles the
+  // document, so its codec has to keep them apart too.
+  it("keeps a present but empty part distinct from an absent one", () => {
+    const json = marshalSystem({ prices: {} });
+    expect(json).toContain('"prices":{}');
+    expect(json).not.toContain('"instruments"');
+    const got = unmarshalSystem(json);
+    expect(got.prices).toBeDefined();
+    expect(got.instruments).toBeUndefined();
+  });
+
   it("round trips a user archive", () => {
     const got = unmarshalUser(marshalUser(userFixture()));
     expect(got.envelope?.kind).toBe(ArchiveKind.USER);

--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -176,9 +176,10 @@ service ApiService {
   // Instruments: browse and search (any authenticated user).
   rpc ListInstruments(ListInstrumentsRequest) returns (ListInstrumentsResponse);
 
-  // System archive import (admin-only). Applies a whole system archive
-  // asynchronously, sequencing its parts server-side. See
-  // ImportSystemArchiveRequest.
+  // System archive export/import (admin-only). Export streams one whole
+  // document; import applies one asynchronously, sequencing its parts
+  // server-side. See ExportSystemArchiveRequest and ImportSystemArchiveRequest.
+  rpc ExportSystemArchive(ExportSystemArchiveRequest) returns (stream ExportSystemArchiveResponse);
   rpc ImportSystemArchive(ImportSystemArchiveRequest) returns (ImportSystemArchiveResponse);
 
   // Instrument export/import (admin-only). Export streams the instrument part of a system archive; optional exchange filter.
@@ -526,6 +527,55 @@ message ListInstrumentsResponse {
   repeated Instrument instruments = 1;
   string next_page_token = 2;
   int32 total_count = 3;  // total matching instruments (for UI pagination display)
+}
+
+// ExportSystemArchiveRequest asks for one system archive document. Admin only.
+message ExportSystemArchiveRequest {
+  // Which parts to include: the export menu. A part not named here is absent
+  // from the document, which says it was not included at all. A part named here
+  // is present even when it holds nothing, which says the export included it and
+  // there was nothing. The two are different statements and a reader relies on
+  // the difference.
+  repeated portfoliodb.archive.v1.ArchivePart parts = 1 [(buf.validate.field).repeated = {
+    min_items: 1
+    items: {
+      enum: {
+        defined_only: true
+        not_in: [0]
+      }
+    }
+  }];
+  // Filters for the instrument part, ignored when INSTRUMENTS is not selected.
+  string exchange = 2; // optional; empty = all exchanges
+  repeated portfoliodb.type.v1.AssetClass asset_classes = 3; // optional; empty = server default (excludes CASH/FX)
+}
+
+// ExportSystemArchiveResponse is one element of the export stream: the envelope
+// first and exactly once, then for each selected part a part_begin followed by
+// that part's items.
+//
+// part_begin is what carries a part that is present and empty. Without it a
+// selected part holding nothing would be indistinguishable on the wire from one
+// that was never selected, and those mean different things.
+//
+// The stream is a document taken apart, because a part is too large to buffer
+// server-side and too large to send as one message. The envelope travels on it
+// rather than being built by the caller because exported_at is knowledge time
+// and has to be the server's clock, and source_instance is a server property the
+// browser does not know.
+message ExportSystemArchiveResponse {
+  oneof item {
+    portfoliodb.archive.v1.Envelope envelope = 1;
+    ArchivePartBegin part_begin = 2;
+    portfoliodb.archive.v1.Instrument instrument = 3;
+    portfoliodb.archive.v1.PriceGroup price_group = 4;
+    portfoliodb.archive.v1.CorporateEventGroup corporate_event_group = 5;
+  }
+}
+
+// ArchivePartBegin marks the start of one part's items in an export stream.
+message ArchivePartBegin {
+  portfoliodb.archive.v1.ArchivePart part = 1;
 }
 
 // ImportSystemArchiveRequest carries one whole system archive. The parts are

--- a/server/archive/codec_test.go
+++ b/server/archive/codec_test.go
@@ -367,3 +367,32 @@ func TestGoldenFiles(t *testing.T) {
 		}
 	}
 }
+
+// A part present but empty means the export included it and there was nothing;
+// a part absent means it was not included at all. The whole export menu rests on
+// those being distinguishable, so the codec has to keep them apart.
+func TestRoundTrip_PresentButEmptyPartIsNotAbsent(t *testing.T) {
+	b, err := archive.MarshalSystem(&archivev1.SystemArchive{
+		Envelope: archive.NewEnvelope("portfoliodb.example.com", archivev1.ArchiveKind_SYSTEM),
+		Prices:   &archivev1.PricePart{},
+	})
+	if err != nil {
+		t.Fatalf("MarshalSystem: %v", err)
+	}
+	if !strings.Contains(string(b), `"prices":{}`) {
+		t.Fatalf("an empty part must still be written: %s", b)
+	}
+	if strings.Contains(string(b), `"instruments"`) {
+		t.Fatalf("an unselected part must not be written: %s", b)
+	}
+	got, err := archive.UnmarshalSystem(b)
+	if err != nil {
+		t.Fatalf("UnmarshalSystem: %v", err)
+	}
+	if got.GetPrices() == nil {
+		t.Error("a present but empty price part came back absent")
+	}
+	if got.GetInstruments() != nil {
+		t.Error("an absent instrument part came back present")
+	}
+}

--- a/server/service/api/archive.go
+++ b/server/service/api/archive.go
@@ -82,3 +82,144 @@ func presentParts(a *archivev1.SystemArchive) []archivev1.ArchivePart {
 	}
 	return parts
 }
+
+// ExportSystemArchive streams one system archive: the envelope, then the
+// selected parts in restore order. Admin only.
+//
+// The envelope is sent once and first, so exported_at is one reading of the
+// clock for the whole document. Knowledge time that differs between a file's own
+// parts is not knowledge time.
+func (s *Server) ExportSystemArchive(req *apiv1.ExportSystemArchiveRequest, stream apiv1.ApiService_ExportSystemArchiveServer) error {
+	ctx := stream.Context()
+	if _, authErr := auth.RequireAdmin(ctx); authErr != nil {
+		return authErr
+	}
+	// source_instance is left empty: nothing keys off it, and this build has no
+	// configured identity to put there.
+	if err := stream.Send(&apiv1.ExportSystemArchiveResponse{
+		Item: &apiv1.ExportSystemArchiveResponse_Envelope{
+			Envelope: archive.NewEnvelope("", archivev1.ArchiveKind_SYSTEM),
+		},
+	}); err != nil {
+		return err
+	}
+	for _, part := range requestedParts(req.GetParts()) {
+		if err := stream.Send(&apiv1.ExportSystemArchiveResponse{
+			Item: &apiv1.ExportSystemArchiveResponse_PartBegin{
+				PartBegin: &apiv1.ArchivePartBegin{Part: part},
+			},
+		}); err != nil {
+			return err
+		}
+		var err error
+		switch part {
+		case archivev1.ArchivePart_INSTRUMENTS:
+			err = s.sendInstrumentPart(ctx, req, stream)
+		case archivev1.ArchivePart_PRICES:
+			err = s.sendPricePart(ctx, stream)
+		case archivev1.ArchivePart_CORPORATE_EVENTS:
+			err = s.sendCorporateEventPart(ctx, stream)
+		}
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// requestedParts dedupes the menu and puts it in restore order. Order in the
+// document is the order it is applied, so it is the server's to decide and not
+// the caller's to state.
+func requestedParts(req []archivev1.ArchivePart) []archivev1.ArchivePart {
+	seen := make(map[archivev1.ArchivePart]bool, len(req))
+	for _, p := range req {
+		seen[p] = true
+	}
+	var out []archivev1.ArchivePart
+	for _, p := range []archivev1.ArchivePart{
+		archivev1.ArchivePart_INSTRUMENTS,
+		archivev1.ArchivePart_PRICES,
+		archivev1.ArchivePart_CORPORATE_EVENTS,
+	} {
+		if seen[p] {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// sendInstrumentPart streams the security master.
+//
+// A derivative names its underlying by identifier rather than nesting it, so a
+// shared underlying appears once and the order the list is written in carries no
+// meaning. The query guarantees every named underlying is itself in the stream,
+// including one the caller's asset-class filter would have excluded.
+func (s *Server) sendInstrumentPart(ctx context.Context, req *apiv1.ExportSystemArchiveRequest, stream apiv1.ApiService_ExportSystemArchiveServer) error {
+	var acStrs []string
+	for _, ac := range req.GetAssetClasses() {
+		acStrs = append(acStrs, db.AssetClassToStr(ac))
+	}
+	rows, err := s.db.ListInstrumentsForExport(ctx, req.GetExchange(), acStrs)
+	if err != nil {
+		return status.Error(codes.Internal, err.Error())
+	}
+	for _, row := range rows {
+		if err := stream.Send(&apiv1.ExportSystemArchiveResponse{
+			Item: &apiv1.ExportSystemArchiveResponse_Instrument{Instrument: archiveInstrument(row)},
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// sendPricePart streams one group per instrument.
+//
+// The coverage nested in each group is not derivable from its rows: a span
+// covering dates with no rows records that a provider was asked and had nothing.
+func (s *Server) sendPricePart(ctx context.Context, stream apiv1.ApiService_ExportSystemArchiveServer) error {
+	coverage, err := s.db.ListPriceCoverageForExport(ctx)
+	if err != nil {
+		return status.Error(codes.Internal, err.Error())
+	}
+	rows, err := s.db.ListPricesForExport(ctx)
+	if err != nil {
+		return status.Error(codes.Internal, err.Error())
+	}
+	for _, g := range priceGroups(rows, coverage) {
+		if err := stream.Send(&apiv1.ExportSystemArchiveResponse{
+			Item: &apiv1.ExportSystemArchiveResponse_PriceGroup{PriceGroup: g},
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// sendCorporateEventPart streams one group per instrument.
+//
+// The coverage nested in each group is not derivable from its events: events are
+// sparse, so a span holding none of them records that a provider was asked and
+// had nothing, which is a different statement from never having asked.
+func (s *Server) sendCorporateEventPart(ctx context.Context, stream apiv1.ApiService_ExportSystemArchiveServer) error {
+	coverage, err := s.db.ListCorporateEventCoverageForExport(ctx)
+	if err != nil {
+		return status.Error(codes.Internal, err.Error())
+	}
+	splits, err := s.db.ListStockSplitsForExport(ctx)
+	if err != nil {
+		return status.Error(codes.Internal, err.Error())
+	}
+	dividends, err := s.db.ListCashDividendsForExport(ctx)
+	if err != nil {
+		return status.Error(codes.Internal, err.Error())
+	}
+	for _, g := range corporateEventGroups(splits, dividends, coverage) {
+		if err := stream.Send(&apiv1.ExportSystemArchiveResponse{
+			Item: &apiv1.ExportSystemArchiveResponse_CorporateEventGroup{CorporateEventGroup: g},
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/server/service/api/archive_test.go
+++ b/server/service/api/archive_test.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/shopspring/decimal"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
 	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
@@ -127,4 +129,162 @@ func TestImportSystemArchive_EmptyPartIsStillApplied(t *testing.T) {
 	if len(got.Parts) != 1 || got.Parts[0] != archivev1.ArchivePart_PRICES {
 		t.Fatalf("parts = %v, want [PRICES]", got.Parts)
 	}
+}
+
+// exportArchiveStreamMock captures a whole system archive export.
+type exportArchiveStreamMock struct {
+	ctx  context.Context
+	sent []*apiv1.ExportSystemArchiveResponse
+}
+
+func (e *exportArchiveStreamMock) Context() context.Context    { return e.ctx }
+func (e *exportArchiveStreamMock) RecvMsg(m interface{}) error { return nil }
+func (e *exportArchiveStreamMock) Send(m *apiv1.ExportSystemArchiveResponse) error {
+	e.sent = append(e.sent, m)
+	return nil
+}
+func (e *exportArchiveStreamMock) SendHeader(m metadata.MD) error { return nil }
+func (e *exportArchiveStreamMock) SetHeader(m metadata.MD) error  { return nil }
+func (e *exportArchiveStreamMock) SetTrailer(m metadata.MD)       {}
+func (e *exportArchiveStreamMock) SendMsg(m interface{}) error {
+	if r, ok := m.(*apiv1.ExportSystemArchiveResponse); ok {
+		e.sent = append(e.sent, r)
+	}
+	return nil
+}
+
+// shape describes the stream as a sequence of item kinds, which is what the
+// client's reassembly reads.
+func (e *exportArchiveStreamMock) shape() []string {
+	var out []string
+	for _, m := range e.sent {
+		switch {
+		case m.GetEnvelope() != nil:
+			out = append(out, "envelope")
+		case m.GetPartBegin() != nil:
+			out = append(out, "begin:"+m.GetPartBegin().GetPart().String())
+		case m.GetInstrument() != nil:
+			out = append(out, "instrument")
+		case m.GetPriceGroup() != nil:
+			out = append(out, "price_group")
+		case m.GetCorporateEventGroup() != nil:
+			out = append(out, "corporate_event_group")
+		}
+	}
+	return out
+}
+
+func TestExportSystemArchive_NonAdmin_PermissionDenied(t *testing.T) {
+	srv, _ := newAPIServerWithMock(t)
+	stream := &exportArchiveStreamMock{ctx: authCtx("user-1", "sub|1")}
+	err := srv.ExportSystemArchive(&apiv1.ExportSystemArchiveRequest{
+		Parts: []archivev1.ArchivePart{archivev1.ArchivePart_INSTRUMENTS},
+	}, stream)
+	testutil.RequireGRPCCode(t, err, codes.PermissionDenied)
+}
+
+// A selected part that holds nothing still announces itself, because a part
+// present and empty is a different statement from a part never selected.
+func TestExportSystemArchive_EmptyPartStillAnnouncesItself(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	mockDB.EXPECT().ListInstrumentsForExport(gomock.Any(), "", []string(nil)).Return(nil, nil)
+	stream := &exportArchiveStreamMock{ctx: adminCtx("user-1", "sub|1")}
+	if err := srv.ExportSystemArchive(&apiv1.ExportSystemArchiveRequest{
+		Parts: []archivev1.ArchivePart{archivev1.ArchivePart_INSTRUMENTS},
+	}, stream); err != nil {
+		t.Fatalf("ExportSystemArchive: %v", err)
+	}
+	want := []string{"envelope", "begin:INSTRUMENTS"}
+	if got := stream.shape(); !equalStrings(got, want) {
+		t.Fatalf("stream = %v, want %v", got, want)
+	}
+}
+
+// The parts come out in restore order whatever order they were asked for in,
+// and each part's items follow its own marker.
+func TestExportSystemArchive_PartsInRestoreOrder(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	mockDB.EXPECT().ListInstrumentsForExport(gomock.Any(), "", []string(nil)).
+		Return([]*dbpkg.InstrumentRow{{ID: "id-1", ContractMultiplier: decimal.NewFromInt(1)}}, nil)
+	mockDB.EXPECT().ListCorporateEventCoverageForExport(gomock.Any()).Return(nil, nil)
+	mockDB.EXPECT().ListStockSplitsForExport(gomock.Any()).Return(nil, nil)
+	mockDB.EXPECT().ListCashDividendsForExport(gomock.Any()).Return(nil, nil)
+
+	stream := &exportArchiveStreamMock{ctx: adminCtx("user-1", "sub|1")}
+	// Asked for out of order, and with a duplicate.
+	if err := srv.ExportSystemArchive(&apiv1.ExportSystemArchiveRequest{
+		Parts: []archivev1.ArchivePart{
+			archivev1.ArchivePart_CORPORATE_EVENTS,
+			archivev1.ArchivePart_INSTRUMENTS,
+			archivev1.ArchivePart_CORPORATE_EVENTS,
+		},
+	}, stream); err != nil {
+		t.Fatalf("ExportSystemArchive: %v", err)
+	}
+	want := []string{"envelope", "begin:INSTRUMENTS", "instrument", "begin:CORPORATE_EVENTS"}
+	if got := stream.shape(); !equalStrings(got, want) {
+		t.Fatalf("stream = %v, want %v", got, want)
+	}
+}
+
+// A part that was not asked for is absent from the stream entirely -- no marker,
+// no items -- which is what makes it absent from the document.
+func TestExportSystemArchive_UnselectedPartIsAbsent(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	mockDB.EXPECT().ListPriceCoverageForExport(gomock.Any()).Return(nil, nil)
+	mockDB.EXPECT().ListPricesForExport(gomock.Any()).Return(nil, nil)
+	// Neither instruments nor corporate events are read at all.
+	stream := &exportArchiveStreamMock{ctx: adminCtx("user-1", "sub|1")}
+	if err := srv.ExportSystemArchive(&apiv1.ExportSystemArchiveRequest{
+		Parts: []archivev1.ArchivePart{archivev1.ArchivePart_PRICES},
+	}, stream); err != nil {
+		t.Fatalf("ExportSystemArchive: %v", err)
+	}
+	want := []string{"envelope", "begin:PRICES"}
+	if got := stream.shape(); !equalStrings(got, want) {
+		t.Fatalf("stream = %v, want %v", got, want)
+	}
+}
+
+// One clock reading for the whole document: knowledge time that differs between
+// a file's own parts is not knowledge time.
+func TestExportSystemArchive_SendsExactlyOneEnvelopeFirst(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	mockDB.EXPECT().ListInstrumentsForExport(gomock.Any(), "", []string(nil)).Return(nil, nil)
+	mockDB.EXPECT().ListPriceCoverageForExport(gomock.Any()).Return(nil, nil)
+	mockDB.EXPECT().ListPricesForExport(gomock.Any()).Return(nil, nil)
+	stream := &exportArchiveStreamMock{ctx: adminCtx("user-1", "sub|1")}
+	if err := srv.ExportSystemArchive(&apiv1.ExportSystemArchiveRequest{
+		Parts: []archivev1.ArchivePart{archivev1.ArchivePart_INSTRUMENTS, archivev1.ArchivePart_PRICES},
+	}, stream); err != nil {
+		t.Fatalf("ExportSystemArchive: %v", err)
+	}
+	envelopes := 0
+	for _, m := range stream.sent {
+		if m.GetEnvelope() != nil {
+			envelopes++
+		}
+	}
+	if envelopes != 1 {
+		t.Fatalf("got %d envelopes, want exactly 1", envelopes)
+	}
+	env := stream.sent[0].GetEnvelope()
+	if env == nil {
+		t.Fatal("the envelope is not the first message")
+	}
+	if env.GetKind() != archivev1.ArchiveKind_SYSTEM || env.GetFormatVersion() != archive.FormatVersion {
+		t.Fatalf("envelope = %v v%d", env.GetKind(), env.GetFormatVersion())
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }


### PR DESCRIPTION
Sixth of the stack for 0079. **Depends on #360.**

One streaming RPC takes the include-menu and streams the document: the envelope,
then the selected parts in restore order. It replaces stitching three per-entity
exports together on the client, which left the client owning a contract the
server should.

- **One envelope, sent first.** Three separate exports produced three different
  `exported_at` values that the client merged arbitrarily. `exported_at` is
  knowledge time, and knowledge time that differs between a file's own parts is
  not knowledge time.
- **`part_begin` carries the empty part.** Without it, a selected part holding
  nothing is indistinguishable on the wire from one never selected -- and those
  mean different things. It also delimits the stream and gives the client a free
  progress signal.
- **Restore order is the server's.** The menu is deduped and sorted rather than
  taken as given: order in the document is the order it is applied.

### The assumption this rests on

The menu only works if protojson writes a present-but-empty message field as `{}`
rather than omitting it. I checked rather than assumed, and it holds -- an empty
price part marshals to `"prices":{}` and comes back present, while an unselected
part is absent entirely. There is now a test for it in **both** runtimes
(`server/archive/codec_test.go`, `client/lib/archive/codec.test.ts`), since the
server writes the parts and the client assembles the document.

Other tests: part ordering under an out-of-order request with a duplicate, an
empty part still announcing itself, an unselected part being absent with its
queries never run, and exactly one envelope arriving first.

Verified: `make test`, `make client-test`, `make lint-go`, `make lint-proto`,
`make lint-ts`, `make client-typecheck`, `make fmt-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)