### PR TITLE
Retire the per-entity archive endpoints

### DIFF
--- a/cli/google/sheets.go
+++ b/cli/google/sheets.go
@@ -389,12 +389,17 @@ func importPrices(ctx context.Context, client apiv1.ApiServiceClient, groups []*
 			rows += len(groups[end].GetRows())
 			end++
 		}
-		resp, err := client.ImportPrices(ctx, &apiv1.ImportPricesRequest{
-			Envelope: archive.NewEnvelope("google-finance-cli", archivev1.ArchiveKind_SYSTEM),
-			Prices:   &archivev1.PricePart{Groups: groups[i:end]},
+		// A document carrying only a price part: there is one import endpoint,
+		// and asking it for one kind of data means sending one kind of part.
+		resp, err := client.ImportSystemArchive(ctx, &apiv1.ImportSystemArchiveRequest{
+			Archive: &archivev1.SystemArchive{
+				Envelope: archive.NewEnvelope("google-finance-cli", archivev1.ArchiveKind_SYSTEM),
+				Prices:   &archivev1.PricePart{Groups: groups[i:end]},
+			},
+			Filename: "google-finance-cli",
 		})
 		if err != nil {
-			return fmt.Errorf("ImportPrices groups %d-%d: %w", i, end-1, err)
+			return fmt.Errorf("ImportSystemArchive groups %d-%d: %w", i, end-1, err)
 		}
 		fmt.Fprintf(os.Stderr, "  Submitted %d group(s), %d prices (job %s)\n", end-i, rows, resp.GetJobId())
 		i = end

--- a/client/lib/portfolio-api.ts
+++ b/client/lib/portfolio-api.ts
@@ -6,15 +6,11 @@ import { create, fromBinary, toBinary } from "@bufbuild/protobuf";
 import { timestampDate, timestampFromDate } from "@bufbuild/protobuf/wkt";
 import { DateSchema } from "@/gen/google/type/date_pb";
 import type { Date as ProtoDate } from "@/gen/google/type/date_pb";
-import { ExportCorporateEventsResponseSchema, ExportCorporateEventsRequestSchema, ExportInstrumentsRequestSchema, ExportInstrumentsResponseSchema, ExportPricesResponseSchema, ExportPricesRequestSchema, GetPortfolioValuationRequestSchema, GetPortfolioValuationResponseSchema, ImportCorporateEventsRequestSchema, ImportCorporateEventsResponseSchema, ImportInstrumentsRequestSchema, ImportInstrumentsResponseSchema, ImportPricesRequestSchema, ImportPricesResponseSchema, CreatePortfolioRequestSchema, CreatePortfolioResponseSchema, DeletePortfolioRequestSchema, GetHoldingsRequestSchema, GetHoldingsResponseSchema, GetJobRequestSchema, GetJobResponseSchema, GetPortfolioRequestSchema, GetPortfolioResponseSchema, GetPortfolioFiltersRequestSchema, GetPortfolioFiltersResponseSchema, ListBrokersAndAccountsRequestSchema, ListBrokersAndAccountsResponseSchema, ListDescriptionPluginsRequestSchema, ListDescriptionPluginsResponseSchema, ListIdentifierPluginsRequestSchema, ListIdentifierPluginsResponseSchema, ListPriceFetchBlocksRequestSchema, ListPriceFetchBlocksResponseSchema, DeletePriceFetchBlockRequestSchema, ListPricesRequestSchema, ListPricesResponseSchema, ExportSystemArchiveRequestSchema, ExportSystemArchiveResponseSchema, ImportSystemArchiveRequestSchema, ImportSystemArchiveResponseSchema, ListPricePluginsRequestSchema, ListPricePluginsResponseSchema, ListInstrumentsRequestSchema, ListInstrumentsResponseSchema, ListJobsRequestSchema, ListJobsResponseSchema, ListPortfoliosRequestSchema, ListPortfoliosResponseSchema, ListTelemetryCountersRequestSchema, ListTelemetryCountersResponseSchema, ListTxsRequestSchema, ListTxsResponseSchema, SetPortfolioFiltersRequestSchema, UpdateDescriptionPluginRequestSchema, UpdateDescriptionPluginResponseSchema, UpdateIdentifierPluginRequestSchema, UpdateIdentifierPluginResponseSchema, UpdatePricePluginRequestSchema, UpdatePricePluginResponseSchema, UpdatePortfolioRequestSchema, UpdatePortfolioResponseSchema, ReorderPluginsRequestSchema, CreateHoldingDeclarationRequestSchema, CreateHoldingDeclarationResponseSchema, UpdateHoldingDeclarationRequestSchema, UpdateHoldingDeclarationResponseSchema, DeleteHoldingDeclarationRequestSchema, ListHoldingDeclarationsRequestSchema, ListHoldingDeclarationsResponseSchema, ListWorkersRequestSchema, ListWorkersResponseSchema, GetDisplayCurrencyRequestSchema, GetDisplayCurrencyResponseSchema, SetDisplayCurrencyRequestSchema, SetDisplayCurrencyResponseSchema, GetIgnoredAssetClassesRequestSchema, GetIgnoredAssetClassesResponseSchema, SetIgnoredAssetClassesRequestSchema, CountIgnoredTxsRequestSchema, CountIgnoredTxsResponseSchema, IgnoredAssetClassRuleSchema, ListInflationIndicesRequestSchema, ListInflationIndicesResponseSchema, ListInflationPluginsRequestSchema, ListInflationPluginsResponseSchema, UpdateInflationPluginRequestSchema, UpdateInflationPluginResponseSchema, TriggerInflationFetchRequestSchema, TriggerPriceFetchRequestSchema, CountUnhandledCorporateEventsRequestSchema, CountUnhandledCorporateEventsResponseSchema, ListUnhandledCorporateEventsRequestSchema, ListUnhandledCorporateEventsResponseSchema, ResolveUnhandledCorporateEventRequestSchema, ListResidualBalancesRequestSchema, ListResidualBalancesResponseSchema, CountResidualBalancesRequestSchema, CountResidualBalancesResponseSchema, JobStatus, WorkerState } from "@/gen/api/v1/api_pb";
+import { GetPortfolioValuationRequestSchema, GetPortfolioValuationResponseSchema, CreatePortfolioRequestSchema, CreatePortfolioResponseSchema, DeletePortfolioRequestSchema, GetHoldingsRequestSchema, GetHoldingsResponseSchema, GetJobRequestSchema, GetJobResponseSchema, GetPortfolioRequestSchema, GetPortfolioResponseSchema, GetPortfolioFiltersRequestSchema, GetPortfolioFiltersResponseSchema, ListBrokersAndAccountsRequestSchema, ListBrokersAndAccountsResponseSchema, ListDescriptionPluginsRequestSchema, ListDescriptionPluginsResponseSchema, ListIdentifierPluginsRequestSchema, ListIdentifierPluginsResponseSchema, ListPriceFetchBlocksRequestSchema, ListPriceFetchBlocksResponseSchema, DeletePriceFetchBlockRequestSchema, ListPricesRequestSchema, ListPricesResponseSchema, ExportSystemArchiveRequestSchema, ExportSystemArchiveResponseSchema, ImportSystemArchiveRequestSchema, ImportSystemArchiveResponseSchema, ListPricePluginsRequestSchema, ListPricePluginsResponseSchema, ListInstrumentsRequestSchema, ListInstrumentsResponseSchema, ListJobsRequestSchema, ListJobsResponseSchema, ListPortfoliosRequestSchema, ListPortfoliosResponseSchema, ListTelemetryCountersRequestSchema, ListTelemetryCountersResponseSchema, ListTxsRequestSchema, ListTxsResponseSchema, SetPortfolioFiltersRequestSchema, UpdateDescriptionPluginRequestSchema, UpdateDescriptionPluginResponseSchema, UpdateIdentifierPluginRequestSchema, UpdateIdentifierPluginResponseSchema, UpdatePricePluginRequestSchema, UpdatePricePluginResponseSchema, UpdatePortfolioRequestSchema, UpdatePortfolioResponseSchema, ReorderPluginsRequestSchema, CreateHoldingDeclarationRequestSchema, CreateHoldingDeclarationResponseSchema, UpdateHoldingDeclarationRequestSchema, UpdateHoldingDeclarationResponseSchema, DeleteHoldingDeclarationRequestSchema, ListHoldingDeclarationsRequestSchema, ListHoldingDeclarationsResponseSchema, ListWorkersRequestSchema, ListWorkersResponseSchema, GetDisplayCurrencyRequestSchema, GetDisplayCurrencyResponseSchema, SetDisplayCurrencyRequestSchema, SetDisplayCurrencyResponseSchema, GetIgnoredAssetClassesRequestSchema, GetIgnoredAssetClassesResponseSchema, SetIgnoredAssetClassesRequestSchema, CountIgnoredTxsRequestSchema, CountIgnoredTxsResponseSchema, IgnoredAssetClassRuleSchema, ListInflationIndicesRequestSchema, ListInflationIndicesResponseSchema, ListInflationPluginsRequestSchema, ListInflationPluginsResponseSchema, UpdateInflationPluginRequestSchema, UpdateInflationPluginResponseSchema, TriggerInflationFetchRequestSchema, TriggerPriceFetchRequestSchema, CountUnhandledCorporateEventsRequestSchema, CountUnhandledCorporateEventsResponseSchema, ListUnhandledCorporateEventsRequestSchema, ListUnhandledCorporateEventsResponseSchema, ResolveUnhandledCorporateEventRequestSchema, ListResidualBalancesRequestSchema, ListResidualBalancesResponseSchema, CountResidualBalancesRequestSchema, CountResidualBalancesResponseSchema, JobStatus, WorkerState } from "@/gen/api/v1/api_pb";
 import { AccountType, AssetClass } from "@/gen/type/v1/type_pb";
 import { ArchivePart } from "@/gen/archive/v1/common_pb";
-import type { Envelope } from "@/gen/archive/v1/common_pb";
 import type { SystemArchive } from "@/gen/archive/v1/archive_pb";
-import type { CorporateEventPart } from "@/gen/archive/v1/corporate_events_pb";
-import type { InstrumentPart } from "@/gen/archive/v1/instruments_pb";
-import type { PricePart } from "@/gen/archive/v1/prices_pb";
-import type { DescriptionPluginConfig, EODPriceProto, ExportCorporateEventsResponse, ExportSystemArchiveResponse, ExportInstrumentsResponse, InflationIndexProto, InflationPluginConfig, ExportPricesResponse, Holding, HoldingDeclaration, IdentificationError, IdentifierPluginConfig, Instrument, PriceFetchBlock, PricePluginConfig, Portfolio as GenPortfolio, PortfolioFilterProto, PortfolioTx, ResidualBalance as ResidualBalanceProto, ValidationError, Worker as WorkerProto } from "@/gen/api/v1/api_pb";
+import type { DescriptionPluginConfig, EODPriceProto, ExportSystemArchiveResponse, InflationIndexProto, InflationPluginConfig, Holding, HoldingDeclaration, IdentificationError, IdentifierPluginConfig, Instrument, PriceFetchBlock, PricePluginConfig, Portfolio as GenPortfolio, PortfolioFilterProto, PortfolioTx, ResidualBalance as ResidualBalanceProto, ValidationError, Worker as WorkerProto } from "@/gen/api/v1/api_pb";
 import type { Broker } from "@/gen/type/v1/type_pb";
 import { streamingFetch, unaryFetch } from "./grpc-web";
 
@@ -523,20 +519,6 @@ export async function listJobs(pageToken?: string | null, jobType?: string): Pro
   };
 }
 
-/**
- * Stream the instrument part of an admin archive (admin only): the envelope
- * first, exactly once, then one instrument per message.
- */
-export async function* exportInstruments(params?: { exchange?: string; assetClasses?: AssetClass[] }): AsyncGenerator<ExportInstrumentsResponse> {
-  const base = getBaseUrl();
-  const req = create(ExportInstrumentsRequestSchema, {
-    exchange: params?.exchange ?? "",
-    assetClasses: params?.assetClasses ?? [],
-  });
-  for await (const bytes of streamingFetch(base, ApiServicePrefix + "ExportInstruments", toBinary(ExportInstrumentsRequestSchema, req), { credentials: "include" })) {
-    yield fromBinary(ExportInstrumentsResponseSchema, bytes);
-  }
-}
 
 /**
  * Stream one whole system archive (admin only): the envelope, then for each
@@ -567,81 +549,6 @@ export async function importSystemArchive(archive: SystemArchive, filename: stri
     credentials: "include",
   });
   return fromBinary(ImportSystemArchiveResponseSchema, resBytes).jobId;
-}
-
-export interface ImportInstrumentsResult {
-  ensuredCount: number;
-  errors: Array<{ index: number; message: string }>;
-}
-
-/**
- * Import (upsert) one archive's instrument part (admin only).
- *
- * The envelope is the file's own, forwarded rather than rebuilt, so the server
- * sees the format version and the kind the file declared.
- */
-export async function importInstruments(envelope: Envelope, instruments: InstrumentPart): Promise<ImportInstrumentsResult> {
-  const base = getBaseUrl();
-  const req = create(ImportInstrumentsRequestSchema, { envelope, instruments });
-  const resBytes = await unaryFetch(base, ApiServicePrefix + "ImportInstruments", toBinary(ImportInstrumentsRequestSchema, req), { credentials: "include" });
-  const res = fromBinary(ImportInstrumentsResponseSchema, resBytes);
-  return {
-    ensuredCount: res.ensuredCount,
-    errors: res.errors.map((e) => ({ index: e.index, message: e.message })),
-  };
-}
-
-/** Stream all exported prices (admin only). */
-export async function* exportPrices(): AsyncGenerator<ExportPricesResponse> {
-  const base = getBaseUrl();
-  const req = create(ExportPricesRequestSchema, {});
-  for await (const bytes of streamingFetch(base, ApiServicePrefix + "ExportPrices", toBinary(ExportPricesRequestSchema, req), { credentials: "include" })) {
-    yield fromBinary(ExportPricesResponseSchema, bytes);
-  }
-}
-
-/**
- * Import one archive's price part (admin only). Returns a job ID for async
- * processing.
- *
- * The envelope is the file's own, forwarded rather than rebuilt, so the server
- * sees the format version and the kind the file declared.
- */
-export async function importPrices(envelope: Envelope, prices: PricePart): Promise<string> {
-  const base = getBaseUrl();
-  const req = create(ImportPricesRequestSchema, { envelope, prices });
-  const resBytes = await unaryFetch(base, ApiServicePrefix + "ImportPrices", toBinary(ImportPricesRequestSchema, req), { credentials: "include" });
-  const res = fromBinary(ImportPricesResponseSchema, resBytes);
-  return res.jobId;
-}
-
-/**
- * Import one archive's corporate event part (admin only). Returns a job ID for
- * async processing.
- *
- * The envelope is the file's own, forwarded rather than rebuilt, so the server
- * sees the format version and the kind the file declared.
- */
-export async function importCorporateEvents(envelope: Envelope, corporateEvents: CorporateEventPart): Promise<string> {
-  const base = getBaseUrl();
-  const req = create(ImportCorporateEventsRequestSchema, { envelope, corporateEvents });
-  const resBytes = await unaryFetch(
-    base,
-    ApiServicePrefix + "ImportCorporateEvents",
-    toBinary(ImportCorporateEventsRequestSchema, req),
-    { credentials: "include" },
-  );
-  const res = fromBinary(ImportCorporateEventsResponseSchema, resBytes);
-  return res.jobId;
-}
-
-/** Stream all exported corporate events (admin only). */
-export async function* exportCorporateEvents(): AsyncGenerator<ExportCorporateEventsResponse> {
-  const base = getBaseUrl();
-  const req = create(ExportCorporateEventsRequestSchema, {});
-  for await (const bytes of streamingFetch(base, ApiServicePrefix + "ExportCorporateEvents", toBinary(ExportCorporateEventsRequestSchema, req), { credentials: "include" })) {
-    yield fromBinary(ExportCorporateEventsResponseSchema, bytes);
-  }
 }
 
 /** A single day's portfolio value point. */

--- a/docs/issues/0079-consolidated-system-export-import-page.md
+++ b/docs/issues/0079-consolidated-system-export-import-page.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Consolidated system export and import page
 dependencies: [0078]
 ---
@@ -36,3 +36,15 @@ to do it. Update docs/spec/information-architecture.md.
 
 The user archive has its own page under 0080. The two never mix: no user data is
 reachable from this page.
+
+Closed. `/admin/archive` exports and imports the system archive, and the three
+per-entity affordances are gone.
+
+Two things landed differently from the description. The three parts the archive
+format does not carry yet -- inflation indices, fetch blocks, unhandled event
+resolutions, plugin config -- ship as disabled menu rows rather than as working
+entries; 0086 enables them, and the note about plugin config carrying live API
+keys lives on the row until it does. And the per-entity export and import
+endpoints were replaced rather than merely hidden: there is now one export RPC
+taking a menu of parts and one import RPC taking a whole document and sequencing
+it server-side, so an import survives the admin closing the tab.

--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -5,7 +5,7 @@
 import { createClient } from "@connectrpc/connect";
 import { createGrpcWebTransport } from "@connectrpc/connect-node";
 import { ApiService, JobStatus, type GetJobResponse } from "../gen/api/v1/api_pb";
-import { ArchiveKind } from "../gen/archive/v1/common_pb";
+import { ArchiveKind, ArchivePart } from "../gen/archive/v1/common_pb";
 import { CorporateEventGroupSchema, type CorporateEventGroup } from "../gen/archive/v1/corporate_events_pb";
 import { PriceGroupSchema } from "../gen/archive/v1/prices_pb";
 import type { MessageInitShape } from "@bufbuild/protobuf";
@@ -30,8 +30,11 @@ export async function setDisplayCurrency(
 }
 
 /**
- * Import one archive's worth of price groups and wait for the async job to
+ * Import one archive carrying only a price part and wait for the job to
  * complete. Returns the final job status.
+ *
+ * Importing one kind of data means supplying a document carrying only that
+ * part; there is no per-entity endpoint.
  *
  * The envelope is built here: exported_at is knowledge time, and a test that had
  * to supply it would be stating something it does not care about.
@@ -42,15 +45,17 @@ export async function importPricesAndWait(
   timeoutMs = 30_000,
 ): Promise<GetJobResponse> {
   const headers = { Cookie: `${COOKIE_NAME}=${sessionId}` };
-  const resp = await client.importPrices(
+  const resp = await client.importSystemArchive(
     {
-      envelope: {
-        formatVersion: 1,
-        exportedAt: timestampNow(),
-        sourceInstance: "e2e",
-        kind: ArchiveKind.SYSTEM,
+      archive: {
+        envelope: {
+          formatVersion: 1,
+          exportedAt: timestampNow(),
+          sourceInstance: "e2e",
+          kind: ArchiveKind.SYSTEM,
+        },
+        prices: { groups },
       },
-      prices: { groups },
     },
     { headers },
   );
@@ -67,8 +72,8 @@ export async function importPricesAndWait(
 }
 
 /**
- * Import one archive's worth of corporate event groups and wait for the async
- * job to complete. Returns the final job status.
+ * Import one archive carrying only a corporate event part and wait for the job
+ * to complete. Returns the final job status.
  *
  * The envelope is built here for the same reason importPricesAndWait builds
  * one: exported_at is knowledge time, and a test that had to supply it would be
@@ -80,15 +85,17 @@ export async function importCorporateEventsAndWait(
   timeoutMs = 30_000,
 ): Promise<GetJobResponse> {
   const headers = { Cookie: `${COOKIE_NAME}=${sessionId}` };
-  const resp = await client.importCorporateEvents(
+  const resp = await client.importSystemArchive(
     {
-      envelope: {
-        formatVersion: 1,
-        exportedAt: timestampNow(),
-        sourceInstance: "e2e",
-        kind: ArchiveKind.SYSTEM,
+      archive: {
+        envelope: {
+          formatVersion: 1,
+          exportedAt: timestampNow(),
+          sourceInstance: "e2e",
+          kind: ArchiveKind.SYSTEM,
+        },
+        corporateEvents: { groups },
       },
-      corporateEvents: { groups },
     },
     { headers },
   );
@@ -106,14 +113,20 @@ export async function importCorporateEventsAndWait(
   );
 }
 
-/** Drain the ExportCorporateEvents stream into its instrument groups. */
+/**
+ * Drain a corporate-event-only export into its instrument groups.
+ *
+ * Only that part is asked for, so the stream carries the envelope, the part
+ * marker and the groups.
+ */
 export async function exportCorporateEvents(
   sessionId: string,
 ): Promise<CorporateEventGroup[]> {
   const headers = { Cookie: `${COOKIE_NAME}=${sessionId}` };
   const groups: CorporateEventGroup[] = [];
-  for await (const resp of client.exportCorporateEvents({}, { headers })) {
-    if (resp.item.case === "group") {
+  const req = { parts: [ArchivePart.CORPORATE_EVENTS] };
+  for await (const resp of client.exportSystemArchive(req, { headers })) {
+    if (resp.item.case === "corporateEventGroup") {
       groups.push(resp.item.value);
     }
   }

--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -48,7 +48,7 @@ message Instrument {
   // eight digits of thousandths, so it is an exact decimal string rather than a
   // double: comparing identity components as floats is a latent bug. Optional
   // rather than sentinel-zero, because a non-option has no strike and
-  // ImportInstruments would otherwise have to send one.
+  // an instrument import would otherwise have to send one.
   optional string strike = 14 [(buf.validate.field).string.pattern = "^-?[0-9]+(\\.[0-9]+)?$"];
   string expiry = 15;             // YYYY-MM-DD expiry date; empty for non-options.
   string put_call = 16;           // "C" or "P"; empty for non-options.
@@ -182,10 +182,6 @@ service ApiService {
   rpc ExportSystemArchive(ExportSystemArchiveRequest) returns (stream ExportSystemArchiveResponse);
   rpc ImportSystemArchive(ImportSystemArchiveRequest) returns (ImportSystemArchiveResponse);
 
-  // Instrument export/import (admin-only). Export streams the instrument part of a system archive; optional exchange filter.
-  rpc ExportInstruments(ExportInstrumentsRequest) returns (stream ExportInstrumentsResponse);
-  rpc ImportInstruments(ImportInstrumentsRequest) returns (ImportInstrumentsResponse);
-
   // Identifier plugin config (admin-only). List all plugins; update enabled, precedence, and config JSON (including API keys).
   rpc ListIdentifierPlugins(ListIdentifierPluginsRequest) returns (ListIdentifierPluginsResponse);
   rpc UpdateIdentifierPlugin(UpdateIdentifierPluginRequest) returns (UpdateIdentifierPluginResponse);
@@ -219,9 +215,6 @@ service ApiService {
   rpc ListPrices(ListPricesRequest) returns (ListPricesResponse);
 
   // Price export/import (admin-only). Export streams the price part of an admin
-  // archive; import upserts it with data_provider = "import".
-  rpc ExportPrices(ExportPricesRequest) returns (stream ExportPricesResponse);
-  rpc ImportPrices(ImportPricesRequest) returns (ImportPricesResponse);
 
   // Telemetry counters (admin-only). Returns counters discovered from Redis (portfoliodb:counters:*).
   rpc ListTelemetryCounters(ListTelemetryCountersRequest) returns (ListTelemetryCountersResponse);
@@ -272,8 +265,6 @@ service ApiService {
   // Corporate event import / export. Mirrors the price import/export RPCs:
   // import is async via the job queue, export streams every event with the
   // best identifier per instrument.
-  rpc ExportCorporateEvents(ExportCorporateEventsRequest) returns (stream ExportCorporateEventsResponse);
-  rpc ImportCorporateEvents(ImportCorporateEventsRequest) returns (ImportCorporateEventsResponse);
 
   // Unhandled corporate events (reverse splits, non-whole splits, mergers, etc.)
   // that require admin review.
@@ -602,48 +593,6 @@ message ImportSystemArchiveResponse {
   string job_id = 1;
 }
 
-// ExportInstruments streams the instrument part of a system archive: every
-// instrument with at least one canonical identifier, plus the underlying of any
-// derivative it carries. Optional exchange filter.
-message ExportInstrumentsRequest {
-  string exchange = 1;              // optional; empty = all exchanges
-  repeated portfoliodb.type.v1.AssetClass asset_classes = 2;  // optional; empty = server default (excludes CASH/FX)
-}
-
-// ExportInstrumentsResponse is one element of the export stream: the envelope
-// first, exactly once, then one message per instrument.
-//
-// The envelope travels on the stream rather than being built by the caller
-// because exported_at is knowledge time and has to be the server's clock, and
-// source_instance is a server property the browser does not know.
-message ExportInstrumentsResponse {
-  oneof item {
-    portfoliodb.archive.v1.Envelope envelope = 1;
-    portfoliodb.archive.v1.Instrument instrument = 2;
-  }
-}
-
-// ImportInstrumentsRequest carries one archive's instrument part, ensuring each
-// instrument exists: find-or-create by identifiers, merging on conflict, with no
-// overwrite of an existing instrument's canonical fields. The envelope is the
-// file's own, forwarded rather than rebuilt, so the server sees the
-// format_version and the kind the file declared rather than what the uploading
-// client assumed.
-message ImportInstrumentsRequest {
-  portfoliodb.archive.v1.Envelope envelope = 1 [(buf.validate.field).required = true];
-  portfoliodb.archive.v1.InstrumentPart instruments = 2 [(buf.validate.field).required = true];
-}
-
-message ImportInstrumentsResponse {
-  int32 ensured_count = 1;
-  repeated ImportInstrumentError errors = 2;
-}
-
-message ImportInstrumentError {
-  int32 index = 1;    // index into request.instruments.instruments
-  string message = 2;
-}
-
 // IdentifierPluginConfig is one row from identifier_plugin_config (admin-only).
 message IdentifierPluginConfig {
   string plugin_id = 1;
@@ -816,36 +765,6 @@ message ListPricesResponse {
   repeated EODPriceProto prices = 1;
   string next_page_token = 2;
   int32 total_count = 3;
-}
-
-// ExportPrices streams the price part of a system archive: one group per
-// instrument, carrying the best identifier for it.
-message ExportPricesRequest {}
-
-// ExportPricesResponse is one element of the export stream: the envelope first,
-// exactly once, then one message per instrument group.
-//
-// The envelope travels on the stream rather than being built by the caller
-// because exported_at is knowledge time and has to be the server's clock, and
-// source_instance is a server property the browser does not know.
-message ExportPricesResponse {
-  oneof item {
-    portfoliodb.archive.v1.Envelope envelope = 1;
-    portfoliodb.archive.v1.PriceGroup group = 2;
-  }
-}
-
-// ImportPricesRequest carries one archive's price part. The envelope is the
-// file's own, forwarded rather than rebuilt, so the server sees the
-// format_version and the kind the file declared rather than what the uploading
-// client assumed.
-message ImportPricesRequest {
-  portfoliodb.archive.v1.Envelope envelope = 1 [(buf.validate.field).required = true];
-  portfoliodb.archive.v1.PricePart prices = 2 [(buf.validate.field).required = true];
-}
-
-message ImportPricesResponse {
-  string job_id = 1;
 }
 
 // GetPortfolioValuation computes one value per day over the half-open
@@ -1143,39 +1062,6 @@ message TriggerCorporateEventFetchResponse {}
 message TriggerTransferMatchRequest {}
 
 message TriggerTransferMatchResponse {}
-
-// ExportCorporateEvents streams the corporate event part of a system archive:
-// one group per instrument, carrying the best identifier for it.
-message ExportCorporateEventsRequest {}
-
-// ExportCorporateEventsResponse is one element of the export stream: the
-// envelope first, exactly once, then one message per instrument group.
-//
-// The envelope travels on the stream rather than being built by the caller
-// because exported_at is knowledge time and has to be the server's clock, and
-// source_instance is a server property the browser does not know.
-message ExportCorporateEventsResponse {
-  oneof item {
-    portfoliodb.archive.v1.Envelope envelope = 1;
-    portfoliodb.archive.v1.CorporateEventGroup group = 2;
-  }
-}
-
-// ImportCorporateEventsRequest carries one archive's corporate event part. The
-// envelope is the file's own, forwarded rather than rebuilt, so the server sees
-// the format_version and the kind the file declared rather than what the
-// uploading client assumed. Knowledge time comes from the envelope's
-// exported_at: OCC symbols are split-adjusted to it during instrument
-// resolution, imported coverage records it as last_fetched_at, and events that
-// carry no first_known_at of their own fall back to it.
-message ImportCorporateEventsRequest {
-  portfoliodb.archive.v1.Envelope envelope = 1 [(buf.validate.field).required = true];
-  portfoliodb.archive.v1.CorporateEventPart corporate_events = 2 [(buf.validate.field).required = true];
-}
-
-message ImportCorporateEventsResponse {
-  string job_id = 1;
-}
 
 // Unhandled corporate events.
 

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -41,10 +41,8 @@ const PriceProviderImport = "import"
 
 // Job type constants for the ingestion_jobs table.
 const (
-	JobTypeTx             = "tx"
-	JobTypePrice          = "price"
-	JobTypeCorporateEvent = "corporate_event"
-	JobTypeSystemArchive  = "system_archive"
+	JobTypeTx            = "tx"
+	JobTypeSystemArchive = "system_archive"
 )
 
 // DB is the database abstraction used by the service layer.

--- a/server/db/postgres/jobs_test.go
+++ b/server/db/postgres/jobs_test.go
@@ -81,30 +81,6 @@ func TestCreateJob_GetJob(t *testing.T) {
 	}
 }
 
-func TestCreateJob_PriceImport(t *testing.T) {
-	p := testDBTx(t)
-	ctx := context.Background()
-	userID, _ := p.GetOrCreateUser(ctx, "sub|pi", "U", "u@pi.com")
-	jobID, err := p.CreateJob(ctx, db.CreateJobParams{
-		UserID:  userID,
-		JobType: "price",
-		Payload: []byte("price-data"),
-	})
-	if err != nil {
-		t.Fatalf("create price import job: %v", err)
-	}
-	if jobID == "" {
-		t.Fatal("expected job id")
-	}
-	d, err := p.GetJob(ctx, jobID)
-	if err != nil {
-		t.Fatalf("get job: %v", err)
-	}
-	if d.Status != apiv1.JobStatus_PENDING || d.UserID != userID {
-		t.Fatalf("get job: status=%v user=%s", d.Status, d.UserID)
-	}
-}
-
 func TestListPendingJobs(t *testing.T) {
 	p := testDBTx(t)
 	ctx := context.Background()
@@ -117,7 +93,7 @@ func TestListPendingJobs(t *testing.T) {
 	})
 	j2, _ := p.CreateJob(ctx, db.CreateJobParams{
 		UserID:  userID,
-		JobType: "price",
+		JobType: db.JobTypeSystemArchive,
 	})
 	// Mark j1 as RUNNING (should still be returned).
 	_ = p.SetJobStatus(ctx, j1, apiv1.JobStatus_RUNNING)
@@ -137,7 +113,7 @@ func TestListPendingJobs(t *testing.T) {
 	if got, ok := byID[j1]; !ok || got.JobType != "tx" {
 		t.Fatalf("j1 not found or wrong type: %+v", byID)
 	}
-	if got, ok := byID[j2]; !ok || got.JobType != "price" {
+	if got, ok := byID[j2]; !ok || got.JobType != db.JobTypeSystemArchive {
 		t.Fatalf("j2 not found or wrong type: %+v", byID)
 	}
 }

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -188,7 +188,7 @@ CREATE INDEX idx_txs_group_id ON txs (group_id);
 CREATE TABLE ingestion_jobs (
   id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id      UUID NOT NULL REFERENCES users (id) ON DELETE CASCADE,
-  job_type     TEXT NOT NULL DEFAULT 'tx' CHECK (job_type IN ('tx', 'price', 'corporate_event', 'system_archive')),
+  job_type     TEXT NOT NULL DEFAULT 'tx' CHECK (job_type IN ('tx', 'system_archive')),
   broker       TEXT,
   source       TEXT,
   filename     TEXT,

--- a/server/service/api/archive_test.go
+++ b/server/service/api/archive_test.go
@@ -153,6 +153,39 @@ func (e *exportArchiveStreamMock) SendMsg(m interface{}) error {
 	return nil
 }
 
+// instruments returns the instruments the export streamed.
+func (e *exportArchiveStreamMock) instruments() []*archivev1.Instrument {
+	var out []*archivev1.Instrument
+	for _, m := range e.sent {
+		if v := m.GetInstrument(); v != nil {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// groups returns the price groups the export streamed.
+func (e *exportArchiveStreamMock) groups() []*archivev1.PriceGroup {
+	var out []*archivev1.PriceGroup
+	for _, m := range e.sent {
+		if v := m.GetPriceGroup(); v != nil {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// eventGroups returns the corporate event groups the export streamed.
+func (e *exportArchiveStreamMock) eventGroups() []*archivev1.CorporateEventGroup {
+	var out []*archivev1.CorporateEventGroup
+	for _, m := range e.sent {
+		if v := m.GetCorporateEventGroup(); v != nil {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
 // shape describes the stream as a sequence of item kinds, which is what the
 // client's reassembly reads.
 func (e *exportArchiveStreamMock) shape() []string {

--- a/server/service/api/corporate_events.go
+++ b/server/service/api/corporate_events.go
@@ -2,13 +2,10 @@ package api
 
 import (
 	"context"
-	"errors"
-	"fmt"
 	"sort"
 
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
 	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
-	"github.com/leedenison/portfoliodb/server/archive"
 	"github.com/leedenison/portfoliodb/server/auth"
 	"github.com/leedenison/portfoliodb/server/db"
 	"google.golang.org/grpc/codes"
@@ -16,48 +13,6 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
-
-// ExportCorporateEvents streams the corporate event part of a system archive:
-// the envelope first, then one group per instrument. Admin only.
-//
-// The coverage nested in each group is not derivable from its events: events are
-// sparse, so a span holding none of them records that a provider was asked and
-// had nothing, which is a different statement from never having asked.
-func (s *Server) ExportCorporateEvents(req *apiv1.ExportCorporateEventsRequest, stream apiv1.ApiService_ExportCorporateEventsServer) error {
-	ctx := stream.Context()
-	if _, authErr := auth.RequireAdmin(ctx); authErr != nil {
-		return authErr
-	}
-	coverage, err := s.db.ListCorporateEventCoverageForExport(ctx)
-	if err != nil {
-		return status.Error(codes.Internal, err.Error())
-	}
-	splits, err := s.db.ListStockSplitsForExport(ctx)
-	if err != nil {
-		return status.Error(codes.Internal, err.Error())
-	}
-	dividends, err := s.db.ListCashDividendsForExport(ctx)
-	if err != nil {
-		return status.Error(codes.Internal, err.Error())
-	}
-	// source_instance is left empty: nothing keys off it, and this build has no
-	// configured identity to put there.
-	if err := stream.Send(&apiv1.ExportCorporateEventsResponse{
-		Item: &apiv1.ExportCorporateEventsResponse_Envelope{
-			Envelope: archive.NewEnvelope("", archivev1.ArchiveKind_SYSTEM),
-		},
-	}); err != nil {
-		return err
-	}
-	for _, g := range corporateEventGroups(splits, dividends, coverage) {
-		if err := stream.Send(&apiv1.ExportCorporateEventsResponse{
-			Item: &apiv1.ExportCorporateEventsResponse_Group{Group: g},
-		}); err != nil {
-			return err
-		}
-	}
-	return nil
-}
 
 // corporateEventGroups turns the three flat export queries into archive groups,
 // one per instrument.
@@ -170,44 +125,6 @@ func dividendTypeFromString(s string) archivev1.DividendType {
 		return archivev1.DividendType(v)
 	}
 	return archivev1.DividendType_DIVIDEND_TYPE_UNSPECIFIED
-}
-
-// ImportCorporateEvents creates an async job to upsert the corporate event part
-// of a system archive. The serialized request is persisted to the DB and
-// processed by the ingestion worker. Admin only.
-func (s *Server) ImportCorporateEvents(ctx context.Context, req *apiv1.ImportCorporateEventsRequest) (*apiv1.ImportCorporateEventsResponse, error) {
-	u, authErr := auth.RequireAdmin(ctx)
-	if authErr != nil {
-		return nil, authErr
-	}
-	if err := archive.CheckEnvelope(req.GetEnvelope(), archivev1.ArchiveKind_SYSTEM); err != nil {
-		var ve *archive.VersionError
-		if errors.As(err, &ve) {
-			// The request is well formed and this server is the thing that is
-			// out of date, which is a precondition rather than a bad argument.
-			return nil, status.Error(codes.FailedPrecondition, err.Error())
-		}
-		return nil, status.Error(codes.InvalidArgument, err.Error())
-	}
-	if len(req.GetCorporateEvents().GetGroups()) == 0 {
-		return nil, status.Error(codes.InvalidArgument, "no corporate event groups provided")
-	}
-	payload, err := proto.Marshal(req)
-	if err != nil {
-		return nil, status.Error(codes.Internal, fmt.Sprintf("serialize request: %v", err))
-	}
-	jobID, err := s.db.CreateJob(ctx, db.CreateJobParams{
-		UserID:  u.ID,
-		JobType: db.JobTypeCorporateEvent,
-		Payload: payload,
-	})
-	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-	if err := s.enqueueJob(jobID, db.JobTypeCorporateEvent); err != nil {
-		return nil, status.Error(codes.Unavailable, err.Error())
-	}
-	return &apiv1.ImportCorporateEventsResponse{JobId: jobID}, nil
 }
 
 // ListUnhandledCorporateEvents returns corporate events that could not be

--- a/server/service/api/export_corporate_events_test.go
+++ b/server/service/api/export_corporate_events_test.go
@@ -14,25 +14,31 @@ import (
 	"github.com/leedenison/portfoliodb/server/testutil"
 )
 
-func TestExportCorporateEvents_NonAdmin_PermissionDenied(t *testing.T) {
+func TestExportSystemArchive_CorporateEvents_NonAdmin_PermissionDenied(t *testing.T) {
 	srv, _ := newAPIServerWithMock(t)
-	stream := &exportCorporateEventStreamMock{ctx: authCtx("user-1", "sub|1")}
-	err := srv.ExportCorporateEvents(&apiv1.ExportCorporateEventsRequest{}, stream)
+	stream := &exportArchiveStreamMock{ctx: authCtx("user-1", "sub|1")}
+	err := srv.ExportSystemArchive(&apiv1.ExportSystemArchiveRequest{Parts: []archivev1.ArchivePart{archivev1.ArchivePart_CORPORATE_EVENTS}}, stream)
 	testutil.RequireGRPCCode(t, err, codes.PermissionDenied)
 }
 
-func TestExportCorporateEvents_Empty(t *testing.T) {
+func TestExportSystemArchive_CorporateEvents_Empty(t *testing.T) {
 	srv, db := newAPIServerWithMock(t)
 	db.EXPECT().ListCorporateEventCoverageForExport(gomock.Any()).Return(nil, nil)
 	db.EXPECT().ListStockSplitsForExport(gomock.Any()).Return(nil, nil)
 	db.EXPECT().ListCashDividendsForExport(gomock.Any()).Return(nil, nil)
-	stream := &exportCorporateEventStreamMock{ctx: adminCtx("user-1", "sub|1")}
-	if err := srv.ExportCorporateEvents(&apiv1.ExportCorporateEventsRequest{}, stream); err != nil {
-		t.Fatalf("ExportCorporateEvents: %v", err)
+	stream := &exportArchiveStreamMock{ctx: adminCtx("user-1", "sub|1")}
+	if err := srv.ExportSystemArchive(&apiv1.ExportSystemArchiveRequest{Parts: []archivev1.ArchivePart{archivev1.ArchivePart_CORPORATE_EVENTS}}, stream); err != nil {
+		t.Fatalf("ExportSystemArchive: %v", err)
 	}
 	// The envelope goes out even when there is nothing to say.
-	if len(stream.sent) != 1 {
-		t.Fatalf("expected exactly the envelope, got %d messages", len(stream.sent))
+	// The envelope and the part marker go out even when there is nothing to
+	// say: a part present and empty means the export included it and there
+	// was nothing, which a reader has to tell apart from a part left out.
+	if len(stream.sent) != 2 {
+		t.Fatalf("expected the envelope and the part marker, got %d messages", len(stream.sent))
+	}
+	if stream.sent[1].GetPartBegin().GetPart() != archivev1.ArchivePart_CORPORATE_EVENTS {
+		t.Fatalf("expected the part marker second, got %+v", stream.sent[1])
 	}
 	env := stream.sent[0].GetEnvelope()
 	if env == nil {
@@ -49,7 +55,7 @@ func TestExportCorporateEvents_Empty(t *testing.T) {
 // Knowledge time and dividend type must reach the wire: without them a
 // PortfolioDB-to-PortfolioDB round trip restamps every split with the import
 // time and turns special cash dividends into regular ones.
-func TestExportCorporateEvents_CarriesKnowledgeTimeAndDividendType(t *testing.T) {
+func TestExportSystemArchive_CorporateEvents_CarriesKnowledgeTimeAndDividendType(t *testing.T) {
 	srv, db := newAPIServerWithMock(t)
 	splitKnownAt := time.Date(2015, 3, 4, 9, 30, 0, 0, time.UTC)
 	divKnownAt := time.Date(2024, 2, 2, 8, 0, 0, 0, time.UTC)
@@ -93,11 +99,11 @@ func TestExportCorporateEvents_CarriesKnowledgeTimeAndDividendType(t *testing.T)
 		},
 	}, nil)
 
-	stream := &exportCorporateEventStreamMock{ctx: adminCtx("user-1", "sub|1")}
-	if err := srv.ExportCorporateEvents(&apiv1.ExportCorporateEventsRequest{}, stream); err != nil {
-		t.Fatalf("ExportCorporateEvents: %v", err)
+	stream := &exportArchiveStreamMock{ctx: adminCtx("user-1", "sub|1")}
+	if err := srv.ExportSystemArchive(&apiv1.ExportSystemArchiveRequest{Parts: []archivev1.ArchivePart{archivev1.ArchivePart_CORPORATE_EVENTS}}, stream); err != nil {
+		t.Fatalf("ExportSystemArchive: %v", err)
 	}
-	groups := stream.groups()
+	groups := stream.eventGroups()
 	if len(groups) != 1 {
 		t.Fatalf("expected 1 group, got %d", len(groups))
 	}
@@ -150,7 +156,7 @@ func TestExportCorporateEvents_CarriesKnowledgeTimeAndDividendType(t *testing.T)
 
 // A group with no events is the only way a file can say a provider was asked
 // about those dates and had nothing, so it has to survive the grouping.
-func TestExportCorporateEvents_CoveredInstrumentWithNoEvents(t *testing.T) {
+func TestExportSystemArchive_CorporateEvents_CoveredInstrumentWithNoEvents(t *testing.T) {
 	srv, db := newAPIServerWithMock(t)
 	db.EXPECT().ListCorporateEventCoverageForExport(gomock.Any()).Return([]dbpkg.ExportCoverageRow{{
 		IdentifierType:  "ISIN",
@@ -162,11 +168,11 @@ func TestExportCorporateEvents_CoveredInstrumentWithNoEvents(t *testing.T) {
 	db.EXPECT().ListStockSplitsForExport(gomock.Any()).Return(nil, nil)
 	db.EXPECT().ListCashDividendsForExport(gomock.Any()).Return(nil, nil)
 
-	stream := &exportCorporateEventStreamMock{ctx: adminCtx("user-1", "sub|1")}
-	if err := srv.ExportCorporateEvents(&apiv1.ExportCorporateEventsRequest{}, stream); err != nil {
-		t.Fatalf("ExportCorporateEvents: %v", err)
+	stream := &exportArchiveStreamMock{ctx: adminCtx("user-1", "sub|1")}
+	if err := srv.ExportSystemArchive(&apiv1.ExportSystemArchiveRequest{Parts: []archivev1.ArchivePart{archivev1.ArchivePart_CORPORATE_EVENTS}}, stream); err != nil {
+		t.Fatalf("ExportSystemArchive: %v", err)
 	}
-	groups := stream.groups()
+	groups := stream.eventGroups()
 	if len(groups) != 1 || len(groups[0].GetEvents()) != 0 {
 		t.Fatalf("expected one group with no events, got %v", groups)
 	}
@@ -178,7 +184,7 @@ func TestExportCorporateEvents_CoveredInstrumentWithNoEvents(t *testing.T) {
 
 // Two venues listing the same ticker are two instruments, so they are two
 // groups: the domain is part of the key, not decoration on it.
-func TestExportCorporateEvents_SplitsGroupsOnDomain(t *testing.T) {
+func TestExportSystemArchive_CorporateEvents_SplitsGroupsOnDomain(t *testing.T) {
 	srv, db := newAPIServerWithMock(t)
 	db.EXPECT().ListCorporateEventCoverageForExport(gomock.Any()).Return(nil, nil)
 	db.EXPECT().ListStockSplitsForExport(gomock.Any()).Return([]dbpkg.ExportStockSplit{
@@ -189,11 +195,11 @@ func TestExportCorporateEvents_SplitsGroupsOnDomain(t *testing.T) {
 	}, nil)
 	db.EXPECT().ListCashDividendsForExport(gomock.Any()).Return(nil, nil)
 
-	stream := &exportCorporateEventStreamMock{ctx: adminCtx("user-1", "sub|1")}
-	if err := srv.ExportCorporateEvents(&apiv1.ExportCorporateEventsRequest{}, stream); err != nil {
-		t.Fatalf("ExportCorporateEvents: %v", err)
+	stream := &exportArchiveStreamMock{ctx: adminCtx("user-1", "sub|1")}
+	if err := srv.ExportSystemArchive(&apiv1.ExportSystemArchiveRequest{Parts: []archivev1.ArchivePart{archivev1.ArchivePart_CORPORATE_EVENTS}}, stream); err != nil {
+		t.Fatalf("ExportSystemArchive: %v", err)
 	}
-	groups := stream.groups()
+	groups := stream.eventGroups()
 	if len(groups) != 2 {
 		t.Fatalf("expected 2 groups, got %d", len(groups))
 	}

--- a/server/service/api/export_import_prices_test.go
+++ b/server/service/api/export_import_prices_test.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"context"
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
 	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
 	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
@@ -15,14 +14,14 @@ import (
 	"time"
 )
 
-func TestExportPrices_NonAdmin_PermissionDenied(t *testing.T) {
+func TestExportSystemArchive_Prices_NonAdmin_PermissionDenied(t *testing.T) {
 	srv, _ := newAPIServerWithMock(t)
-	stream := &exportPriceStreamMock{ctx: authCtx("user-1", "sub|1")}
-	err := srv.ExportPrices(&apiv1.ExportPricesRequest{}, stream)
+	stream := &exportArchiveStreamMock{ctx: authCtx("user-1", "sub|1")}
+	err := srv.ExportSystemArchive(&apiv1.ExportSystemArchiveRequest{Parts: []archivev1.ArchivePart{archivev1.ArchivePart_PRICES}}, stream)
 	testutil.RequireGRPCCode(t, err, codes.PermissionDenied)
 }
 
-func TestExportPrices_Success(t *testing.T) {
+func TestExportSystemArchive_Prices_Success(t *testing.T) {
 	srv, db := newAPIServerWithMock(t)
 	open := decimal.RequireFromString("185.5")
 	vol := int64(50000000)
@@ -64,10 +63,10 @@ func TestExportPrices_Success(t *testing.T) {
 	db.EXPECT().
 		ListPricesForExport(gomock.Any()).
 		Return(rows, nil)
-	stream := &exportPriceStreamMock{ctx: adminCtx("user-1", "sub|1")}
-	err := srv.ExportPrices(&apiv1.ExportPricesRequest{}, stream)
+	stream := &exportArchiveStreamMock{ctx: adminCtx("user-1", "sub|1")}
+	err := srv.ExportSystemArchive(&apiv1.ExportSystemArchiveRequest{Parts: []archivev1.ArchivePart{archivev1.ArchivePart_PRICES}}, stream)
 	if err != nil {
-		t.Fatalf("ExportPrices: %v", err)
+		t.Fatalf("ExportSystemArchive: %v", err)
 	}
 	if len(stream.groups()) != 1 {
 		t.Fatalf("expected 1 group streamed, got %d", len(stream.groups()))
@@ -118,7 +117,7 @@ func TestExportPrices_Success(t *testing.T) {
 
 // The envelope carries the knowledge time the whole file is stamped with, so it
 // has to arrive before anything a reader would attribute to it.
-func TestExportPrices_SendsEnvelopeFirst(t *testing.T) {
+func TestExportSystemArchive_Prices_SendsEnvelopeFirst(t *testing.T) {
 	srv, db := newAPIServerWithMock(t)
 	db.EXPECT().
 		ListPriceCoverageForExport(gomock.Any()).
@@ -131,12 +130,13 @@ func TestExportPrices_SendsEnvelopeFirst(t *testing.T) {
 			PriceDate:       time.Date(2024, 1, 15, 0, 0, 0, 0, time.UTC),
 			Close:           decimal.RequireFromString("185.90"),
 		}}, nil)
-	stream := &exportPriceStreamMock{ctx: adminCtx("user-1", "sub|1")}
-	if err := srv.ExportPrices(&apiv1.ExportPricesRequest{}, stream); err != nil {
-		t.Fatalf("ExportPrices: %v", err)
+	stream := &exportArchiveStreamMock{ctx: adminCtx("user-1", "sub|1")}
+	if err := srv.ExportSystemArchive(&apiv1.ExportSystemArchiveRequest{Parts: []archivev1.ArchivePart{archivev1.ArchivePart_PRICES}}, stream); err != nil {
+		t.Fatalf("ExportSystemArchive: %v", err)
 	}
-	if len(stream.sent) != 2 {
-		t.Fatalf("expected 2 stream items, got %d", len(stream.sent))
+	// Envelope, then the part marker, then the group.
+	if len(stream.sent) != 3 {
+		t.Fatalf("expected 3 stream items, got %d", len(stream.sent))
 	}
 	env := stream.sent[0].GetEnvelope()
 	if env == nil {
@@ -146,19 +146,22 @@ func TestExportPrices_SendsEnvelopeFirst(t *testing.T) {
 		t.Fatalf("expected format_version=%d, got %d", archive.FormatVersion, env.GetFormatVersion())
 	}
 	if env.GetKind() != archivev1.ArchiveKind_SYSTEM {
-		t.Fatalf("expected kind=ADMIN, got %s", env.GetKind())
+		t.Fatalf("expected kind=SYSTEM, got %s", env.GetKind())
 	}
 	if env.GetExportedAt() == nil {
 		t.Fatal("expected exported_at to be stamped")
 	}
-	if stream.sent[1].GetGroup() == nil {
-		t.Fatalf("expected a group second, got %+v", stream.sent[1])
+	if stream.sent[1].GetPartBegin().GetPart() != archivev1.ArchivePart_PRICES {
+		t.Fatalf("expected the price part marker second, got %+v", stream.sent[1])
+	}
+	if stream.sent[2].GetPriceGroup() == nil {
+		t.Fatalf("expected a group third, got %+v", stream.sent[2])
 	}
 }
 
 // A provider asked about a range and reporting nothing is the one fact rows
 // cannot carry, so a covered instrument with no bars is still a group.
-func TestExportPrices_CoveredInstrumentWithNoRows(t *testing.T) {
+func TestExportSystemArchive_Prices_CoveredInstrumentWithNoRows(t *testing.T) {
 	srv, db := newAPIServerWithMock(t)
 	db.EXPECT().
 		ListPriceCoverageForExport(gomock.Any()).
@@ -173,9 +176,9 @@ func TestExportPrices_CoveredInstrumentWithNoRows(t *testing.T) {
 	db.EXPECT().
 		ListPricesForExport(gomock.Any()).
 		Return(nil, nil)
-	stream := &exportPriceStreamMock{ctx: adminCtx("user-1", "sub|1")}
-	if err := srv.ExportPrices(&apiv1.ExportPricesRequest{}, stream); err != nil {
-		t.Fatalf("ExportPrices: %v", err)
+	stream := &exportArchiveStreamMock{ctx: adminCtx("user-1", "sub|1")}
+	if err := srv.ExportSystemArchive(&apiv1.ExportSystemArchiveRequest{Parts: []archivev1.ArchivePart{archivev1.ArchivePart_PRICES}}, stream); err != nil {
+		t.Fatalf("ExportSystemArchive: %v", err)
 	}
 	groups := stream.groups()
 	if len(groups) != 1 {
@@ -194,7 +197,7 @@ func TestExportPrices_CoveredInstrumentWithNoRows(t *testing.T) {
 }
 
 // Two venues can list one ticker, and they are two instruments with two groups.
-func TestExportPrices_SplitsGroupsOnDomain(t *testing.T) {
+func TestExportSystemArchive_Prices_SplitsGroupsOnDomain(t *testing.T) {
 	srv, db := newAPIServerWithMock(t)
 	db.EXPECT().
 		ListPriceCoverageForExport(gomock.Any()).
@@ -213,9 +216,9 @@ func TestExportPrices_SplitsGroupsOnDomain(t *testing.T) {
 				Close:     decimal.RequireFromString("9"),
 			},
 		}, nil)
-	stream := &exportPriceStreamMock{ctx: adminCtx("user-1", "sub|1")}
-	if err := srv.ExportPrices(&apiv1.ExportPricesRequest{}, stream); err != nil {
-		t.Fatalf("ExportPrices: %v", err)
+	stream := &exportArchiveStreamMock{ctx: adminCtx("user-1", "sub|1")}
+	if err := srv.ExportSystemArchive(&apiv1.ExportSystemArchiveRequest{Parts: []archivev1.ArchivePart{archivev1.ArchivePart_PRICES}}, stream); err != nil {
+		t.Fatalf("ExportSystemArchive: %v", err)
 	}
 	groups := stream.groups()
 	if len(groups) != 2 {
@@ -227,7 +230,7 @@ func TestExportPrices_SplitsGroupsOnDomain(t *testing.T) {
 	}
 }
 
-func TestExportPrices_Empty(t *testing.T) {
+func TestExportSystemArchive_Prices_Empty(t *testing.T) {
 	srv, db := newAPIServerWithMock(t)
 	db.EXPECT().
 		ListPriceCoverageForExport(gomock.Any()).
@@ -235,110 +238,18 @@ func TestExportPrices_Empty(t *testing.T) {
 	db.EXPECT().
 		ListPricesForExport(gomock.Any()).
 		Return(nil, nil)
-	stream := &exportPriceStreamMock{ctx: adminCtx("user-1", "sub|1")}
-	err := srv.ExportPrices(&apiv1.ExportPricesRequest{}, stream)
+	stream := &exportArchiveStreamMock{ctx: adminCtx("user-1", "sub|1")}
+	err := srv.ExportSystemArchive(&apiv1.ExportSystemArchiveRequest{Parts: []archivev1.ArchivePart{archivev1.ArchivePart_PRICES}}, stream)
 	if err != nil {
-		t.Fatalf("ExportPrices: %v", err)
+		t.Fatalf("ExportSystemArchive: %v", err)
 	}
-	// The envelope goes out even when there is nothing to say: an empty archive
-	// is a statement, and a reader still has to see the version and the kind.
-	if len(stream.sent) != 1 || stream.sent[0].GetEnvelope() == nil {
-		t.Fatalf("expected the envelope alone, got %+v", stream.sent)
+	// The envelope and the part marker go out even when there is nothing to
+	// say: a part present and empty is a statement, and a reader still has to
+	// see the version and the kind.
+	if len(stream.sent) != 2 || stream.sent[0].GetEnvelope() == nil {
+		t.Fatalf("expected the envelope and the part marker, got %+v", stream.sent)
 	}
-}
-
-// systemEnvelope is the envelope a system archive file carries in.
-func systemEnvelope() *archivev1.Envelope {
-	return archive.NewEnvelope("portfoliodb.example.com", archivev1.ArchiveKind_SYSTEM)
-}
-
-func priceGroupFixture() *archivev1.PricePart {
-	return &archivev1.PricePart{Groups: []*archivev1.PriceGroup{{
-		Instrument: &archivev1.InstrumentRef{Type: typev1.IdentifierType_ISIN, Value: "US0378331005"},
-		Rows:       []*archivev1.PriceRow{{PriceDate: "2024-01-15", Close: "185.90"}},
-	}}}
-}
-
-func TestImportPrices_NonAdmin_PermissionDenied(t *testing.T) {
-	srv, _ := newAPIServerWithMock(t)
-	ctx := authCtx("user-1", "sub|1")
-	_, err := srv.ImportPrices(ctx, &apiv1.ImportPricesRequest{
-		Envelope: systemEnvelope(),
-		Prices:   priceGroupFixture(),
-	})
-	testutil.RequireGRPCCode(t, err, codes.PermissionDenied)
-}
-
-func TestImportPrices_Empty_ReturnsError(t *testing.T) {
-	srv, _ := newAPIServerWithMock(t)
-	ctx := adminCtx("user-1", "sub|1")
-	_, err := srv.ImportPrices(ctx, &apiv1.ImportPricesRequest{Envelope: systemEnvelope()})
-	testutil.RequireGRPCCode(t, err, codes.InvalidArgument)
-}
-
-// A file from a later PortfolioDB is refused before anything is stored, and it
-// is refused as a precondition rather than a bad argument: the request is well
-// formed and this server is the thing that is out of date.
-func TestImportPrices_NewerFormatVersion_Refused(t *testing.T) {
-	srv, _ := newAPIServerWithMock(t)
-	env := systemEnvelope()
-	env.FormatVersion = archive.FormatVersion + 1
-	_, err := srv.ImportPrices(adminCtx("user-1", "sub|1"), &apiv1.ImportPricesRequest{
-		Envelope: env,
-		Prices:   priceGroupFixture(),
-	})
-	testutil.RequireGRPCCode(t, err, codes.FailedPrecondition)
-}
-
-// The document's message type says which archive this is, but protojson records
-// no type name, so the envelope has to carry it -- and the price importer has
-// to check it, or a user archive lands in the system path.
-func TestImportPrices_UserArchive_Refused(t *testing.T) {
-	srv, _ := newAPIServerWithMock(t)
-	env := archive.NewEnvelope("portfoliodb.example.com", archivev1.ArchiveKind_USER)
-	_, err := srv.ImportPrices(adminCtx("user-1", "sub|1"), &apiv1.ImportPricesRequest{
-		Envelope: env,
-		Prices:   priceGroupFixture(),
-	})
-	testutil.RequireGRPCCode(t, err, codes.InvalidArgument)
-}
-
-func TestImportPrices_Success_CreatesJob(t *testing.T) {
-	srv, db := newAPIServerWithMock(t)
-	var enqueued bool
-	srv.enqueueJob = func(jobID, jobType string) error {
-		enqueued = true
-		if jobType != "price" {
-			t.Errorf("expected job type price, got %s", jobType)
-		}
-		return nil
-	}
-	db.EXPECT().
-		CreateJob(gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, p dbpkg.CreateJobParams) (string, error) {
-			if p.JobType != "price" {
-				t.Errorf("expected job_type=price, got %s", p.JobType)
-			}
-			if p.UserID != "user-1" {
-				t.Errorf("expected user_id=user-1, got %s", p.UserID)
-			}
-			if len(p.Payload) == 0 {
-				t.Error("expected non-empty payload")
-			}
-			return "job-456", nil
-		})
-	ctx := adminCtx("user-1", "sub|1")
-	resp, err := srv.ImportPrices(ctx, &apiv1.ImportPricesRequest{
-		Envelope: systemEnvelope(),
-		Prices:   priceGroupFixture(),
-	})
-	if err != nil {
-		t.Fatalf("ImportPrices: %v", err)
-	}
-	if resp.GetJobId() != "job-456" {
-		t.Fatalf("expected job_id=job-456, got %s", resp.GetJobId())
-	}
-	if !enqueued {
-		t.Fatal("expected job to be enqueued")
+	if stream.sent[1].GetPartBegin().GetPart() != archivev1.ArchivePart_PRICES {
+		t.Fatalf("expected the price part marker, got %+v", stream.sent[1])
 	}
 }

--- a/server/service/api/instruments.go
+++ b/server/service/api/instruments.go
@@ -2,7 +2,6 @@ package api
 
 import (
 	"context"
-	"errors"
 	"time"
 
 	"github.com/shopspring/decimal"
@@ -13,8 +12,6 @@ import (
 
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
 	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
-	"github.com/leedenison/portfoliodb/server/archive"
-	"github.com/leedenison/portfoliodb/server/archiveimport"
 	"github.com/leedenison/portfoliodb/server/auth"
 	"github.com/leedenison/portfoliodb/server/db"
 )
@@ -48,45 +45,6 @@ func (s *Server) ListInstruments(ctx context.Context, req *apiv1.ListInstruments
 		NextPageToken: nextToken,
 		TotalCount:    totalCount,
 	}, nil
-}
-
-// ExportInstruments streams the instrument part of a system archive: the
-// envelope first, then one instrument per row. Admin only.
-//
-// A derivative names its underlying by identifier rather than nesting it, so a
-// shared underlying appears once and the order the list is written in carries no
-// meaning. The query guarantees every named underlying is itself in the stream,
-// including one the caller's asset-class filter would have excluded.
-func (s *Server) ExportInstruments(req *apiv1.ExportInstrumentsRequest, stream apiv1.ApiService_ExportInstrumentsServer) error {
-	ctx := stream.Context()
-	if _, authErr := auth.RequireAdmin(ctx); authErr != nil {
-		return authErr
-	}
-	var acStrs []string
-	for _, ac := range req.GetAssetClasses() {
-		acStrs = append(acStrs, db.AssetClassToStr(ac))
-	}
-	rows, err := s.db.ListInstrumentsForExport(ctx, req.GetExchange(), acStrs)
-	if err != nil {
-		return status.Error(codes.Internal, err.Error())
-	}
-	// source_instance is left empty: nothing keys off it, and this build has no
-	// configured identity to put there.
-	if err := stream.Send(&apiv1.ExportInstrumentsResponse{
-		Item: &apiv1.ExportInstrumentsResponse_Envelope{
-			Envelope: archive.NewEnvelope("", archivev1.ArchiveKind_SYSTEM),
-		},
-	}); err != nil {
-		return err
-	}
-	for _, row := range rows {
-		if err := stream.Send(&apiv1.ExportInstrumentsResponse{
-			Item: &apiv1.ExportInstrumentsResponse_Instrument{Instrument: archiveInstrument(row)},
-		}); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // archiveInstrument converts one export row to its archive form.
@@ -156,40 +114,4 @@ func optDate(t *time.Time) *string {
 		return nil
 	}
 	return proto.String(t.Format("2006-01-02"))
-}
-
-// ImportInstruments ensures the instruments of an archive's instrument part
-// exist, finding or creating each by its identifiers. Admin only.
-//
-// It applies the part synchronously and reports per-instrument problems in its
-// own response, so it reports through a detached reporter: there is no job to
-// record them against.
-func (s *Server) ImportInstruments(ctx context.Context, req *apiv1.ImportInstrumentsRequest) (*apiv1.ImportInstrumentsResponse, error) {
-	if _, authErr := auth.RequireAdmin(ctx); authErr != nil {
-		return nil, authErr
-	}
-	if err := archive.CheckEnvelope(req.GetEnvelope(), archivev1.ArchiveKind_SYSTEM); err != nil {
-		var ve *archive.VersionError
-		if errors.As(err, &ve) {
-			// The request is well formed and this server is the thing that is out
-			// of date, which is a precondition rather than a bad argument.
-			return nil, status.Error(codes.FailedPrecondition, err.Error())
-		}
-		return nil, status.Error(codes.InvalidArgument, err.Error())
-	}
-	part := req.GetInstruments()
-	if len(part.GetInstruments()) == 0 {
-		return nil, status.Error(codes.InvalidArgument, "no instruments provided")
-	}
-
-	rep := archiveimport.NewDetachedReporter()
-	ensured, err := archiveimport.InstrumentPart(ctx, s.db, part, rep)
-	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-	errs := make([]*apiv1.ImportInstrumentError, 0, len(rep.Errors()))
-	for _, e := range rep.Errors() {
-		errs = append(errs, &apiv1.ImportInstrumentError{Index: e.GetRowIndex(), Message: e.GetMessage()})
-	}
-	return &apiv1.ImportInstrumentsResponse{EnsuredCount: ensured, Errors: errs}, nil
 }

--- a/server/service/api/instruments_test.go
+++ b/server/service/api/instruments_test.go
@@ -12,7 +12,6 @@ import (
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
 	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
 	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
-	"github.com/leedenison/portfoliodb/server/archive"
 	dbpkg "github.com/leedenison/portfoliodb/server/db"
 	"github.com/leedenison/portfoliodb/server/testutil"
 )
@@ -115,17 +114,23 @@ func TestListInstruments_DBError(t *testing.T) {
 	testutil.RequireGRPCCode(t, err, codes.Internal)
 }
 
-func TestExportInstruments_SendsEnvelopeFirst(t *testing.T) {
+func TestExportSystemArchive_Instruments_SendsEnvelopeFirst(t *testing.T) {
 	srv, db := newAPIServerWithMock(t)
 	db.EXPECT().ListInstrumentsForExport(gomock.Any(), "", []string(nil)).Return(nil, nil)
-	stream := &exportStreamMock{ctx: adminCtx("user-1", "sub|1")}
-	if err := srv.ExportInstruments(&apiv1.ExportInstrumentsRequest{}, stream); err != nil {
+	stream := &exportArchiveStreamMock{ctx: adminCtx("user-1", "sub|1")}
+	if err := srv.ExportSystemArchive(instrumentExportReq(), stream); err != nil {
 		t.Fatalf("ExportInstruments: %v", err)
 	}
 	// The envelope goes out even when there is nothing to say: a file with an
 	// empty instrument part means the export included it and there was nothing.
-	if len(stream.sent) != 1 {
-		t.Fatalf("expected exactly the envelope, got %d messages", len(stream.sent))
+	// The envelope and the part marker go out even when there is nothing to
+	// say: a part present and empty means the export included it and there
+	// was nothing, which a reader has to tell apart from a part left out.
+	if len(stream.sent) != 2 {
+		t.Fatalf("expected the envelope and the part marker, got %d messages", len(stream.sent))
+	}
+	if stream.sent[1].GetPartBegin().GetPart() != archivev1.ArchivePart_INSTRUMENTS {
+		t.Fatalf("expected the part marker second, got %+v", stream.sent[1])
 	}
 	env := stream.sent[0].GetEnvelope()
 	if env == nil {
@@ -139,7 +144,7 @@ func TestExportInstruments_SendsEnvelopeFirst(t *testing.T) {
 	}
 }
 
-func TestExportInstruments_Success(t *testing.T) {
+func TestExportSystemArchive_Instruments_Success(t *testing.T) {
 	srv, db := newAPIServerWithMock(t)
 	rows := []*dbpkg.InstrumentRow{
 		{ID: "id-1", Name: strPtr("Apple"), AssetClass: strPtr("STOCK"), ExchangeMIC: strPtr("XNAS"), Currency: strPtr("USD"),
@@ -150,8 +155,8 @@ func TestExportInstruments_Success(t *testing.T) {
 			}},
 	}
 	db.EXPECT().ListInstrumentsForExport(gomock.Any(), "", []string(nil)).Return(rows, nil)
-	stream := &exportStreamMock{ctx: adminCtx("user-1", "sub|1")}
-	if err := srv.ExportInstruments(&apiv1.ExportInstrumentsRequest{}, stream); err != nil {
+	stream := &exportArchiveStreamMock{ctx: adminCtx("user-1", "sub|1")}
+	if err := srv.ExportSystemArchive(instrumentExportReq(), stream); err != nil {
 		t.Fatalf("ExportInstruments: %v", err)
 	}
 	got := stream.instruments()
@@ -178,7 +183,7 @@ func TestExportInstruments_Success(t *testing.T) {
 	}
 }
 
-func TestExportInstruments_CarriesWhatNothingRecomputes(t *testing.T) {
+func TestExportSystemArchive_Instruments_CarriesWhatNothingRecomputes(t *testing.T) {
 	srv, db := newAPIServerWithMock(t)
 	expiry := time.Date(2026, 1, 16, 0, 0, 0, 0, time.UTC)
 	validFrom := time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC)
@@ -197,8 +202,8 @@ func TestExportInstruments_CarriesWhatNothingRecomputes(t *testing.T) {
 		},
 	}
 	db.EXPECT().ListInstrumentsForExport(gomock.Any(), "", []string(nil)).Return(rows, nil)
-	stream := &exportStreamMock{ctx: adminCtx("user-1", "sub|1")}
-	if err := srv.ExportInstruments(&apiv1.ExportInstrumentsRequest{}, stream); err != nil {
+	stream := &exportArchiveStreamMock{ctx: adminCtx("user-1", "sub|1")}
+	if err := srv.ExportSystemArchive(instrumentExportReq(), stream); err != nil {
 		t.Fatalf("ExportInstruments: %v", err)
 	}
 	inst := stream.instruments()[0]
@@ -224,11 +229,11 @@ func TestExportInstruments_CarriesWhatNothingRecomputes(t *testing.T) {
 	}
 }
 
-func TestExportInstruments_WithExchangeFilter(t *testing.T) {
+func TestExportSystemArchive_Instruments_WithExchangeFilter(t *testing.T) {
 	srv, db := newAPIServerWithMock(t)
 	db.EXPECT().ListInstrumentsForExport(gomock.Any(), "XNAS", []string(nil)).Return(nil, nil)
-	stream := &exportStreamMock{ctx: adminCtx("user-1", "sub|1")}
-	if err := srv.ExportInstruments(&apiv1.ExportInstrumentsRequest{Exchange: "XNAS"}, stream); err != nil {
+	stream := &exportArchiveStreamMock{ctx: adminCtx("user-1", "sub|1")}
+	if err := srv.ExportSystemArchive(&apiv1.ExportSystemArchiveRequest{Parts: []archivev1.ArchivePart{archivev1.ArchivePart_INSTRUMENTS}, Exchange: "XNAS"}, stream); err != nil {
 		t.Fatalf("ExportInstruments: %v", err)
 	}
 	if got := stream.instruments(); len(got) != 0 {
@@ -236,55 +241,15 @@ func TestExportInstruments_WithExchangeFilter(t *testing.T) {
 	}
 }
 
-func TestExportInstruments_NonAdmin_PermissionDenied(t *testing.T) {
+func TestExportSystemArchive_Instruments_NonAdmin_PermissionDenied(t *testing.T) {
 	srv, _ := newAPIServerWithMock(t)
-	stream := &exportStreamMock{ctx: authCtx("user-1", "sub|1")}
-	err := srv.ExportInstruments(&apiv1.ExportInstrumentsRequest{}, stream)
+	stream := &exportArchiveStreamMock{ctx: authCtx("user-1", "sub|1")}
+	err := srv.ExportSystemArchive(instrumentExportReq(), stream)
 	testutil.RequireGRPCCode(t, err, codes.PermissionDenied)
 }
 
-// systemInstrumentPart wraps instruments as a system archive's instrument part,
-// with the envelope a file carries in.
-func systemInstrumentPart(insts ...*archivev1.Instrument) *apiv1.ImportInstrumentsRequest {
-	return &apiv1.ImportInstrumentsRequest{
-		Envelope:    archive.NewEnvelope("portfoliodb.example.com", archivev1.ArchiveKind_SYSTEM),
-		Instruments: &archivev1.InstrumentPart{Instruments: insts},
-	}
-}
-
-func TestImportInstruments_NonAdmin_PermissionDenied(t *testing.T) {
-	srv, _ := newAPIServerWithMock(t)
-	req := systemInstrumentPart(&archivev1.Instrument{
-		Identifiers: []*archivev1.Identifier{{Type: typev1.IdentifierType_ISIN, Value: "x", Canonical: true}},
-	})
-	_, err := srv.ImportInstruments(authCtx("user-1", "sub|1"), req)
-	testutil.RequireGRPCCode(t, err, codes.PermissionDenied)
-}
-
-func TestImportInstruments_Empty_ReturnsError(t *testing.T) {
-	srv, _ := newAPIServerWithMock(t)
-	_, err := srv.ImportInstruments(adminCtx("user-1", "sub|1"), systemInstrumentPart())
-	testutil.RequireGRPCCode(t, err, codes.InvalidArgument)
-}
-
-func TestImportInstruments_NewerFormatVersion_Refused(t *testing.T) {
-	srv, _ := newAPIServerWithMock(t)
-	req := systemInstrumentPart(&archivev1.Instrument{
-		Identifiers: []*archivev1.Identifier{{Type: typev1.IdentifierType_ISIN, Value: "x", Canonical: true}},
-	})
-	req.Envelope.FormatVersion = archive.FormatVersion + 1
-	// The request is well formed and this server is the thing that is out of
-	// date, so this is a precondition rather than a bad argument.
-	_, err := srv.ImportInstruments(adminCtx("user-1", "sub|1"), req)
-	testutil.RequireGRPCCode(t, err, codes.FailedPrecondition)
-}
-
-func TestImportInstruments_UserArchive_Refused(t *testing.T) {
-	srv, _ := newAPIServerWithMock(t)
-	req := systemInstrumentPart(&archivev1.Instrument{
-		Identifiers: []*archivev1.Identifier{{Type: typev1.IdentifierType_ISIN, Value: "x", Canonical: true}},
-	})
-	req.Envelope.Kind = archivev1.ArchiveKind_USER
-	_, err := srv.ImportInstruments(adminCtx("user-1", "sub|1"), req)
-	testutil.RequireGRPCCode(t, err, codes.InvalidArgument)
+// instrumentExportReq asks for the instrument part only, which is what these
+// tests are about.
+func instrumentExportReq() *apiv1.ExportSystemArchiveRequest {
+	return &apiv1.ExportSystemArchiveRequest{Parts: []archivev1.ArchivePart{archivev1.ArchivePart_INSTRUMENTS}}
 }

--- a/server/service/api/prices.go
+++ b/server/service/api/prices.go
@@ -2,12 +2,9 @@ package api
 
 import (
 	"context"
-	"errors"
-	"fmt"
 
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
 	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
-	"github.com/leedenison/portfoliodb/server/archive"
 	"github.com/leedenison/portfoliodb/server/auth"
 	"github.com/leedenison/portfoliodb/server/db"
 	"google.golang.org/grpc/codes"
@@ -64,44 +61,6 @@ func (s *Server) ListPrices(ctx context.Context, req *apiv1.ListPricesRequest) (
 		NextPageToken: nextToken,
 		TotalCount:    totalCount,
 	}, nil
-}
-
-// ExportPrices streams the price part of a system archive: the envelope first,
-// then one group per instrument. Admin only.
-//
-// The coverage nested in each group is not derivable from its rows: a span
-// covering dates with no rows records that a provider was asked and had
-// nothing.
-func (s *Server) ExportPrices(req *apiv1.ExportPricesRequest, stream apiv1.ApiService_ExportPricesServer) error {
-	ctx := stream.Context()
-	if _, authErr := auth.RequireAdmin(ctx); authErr != nil {
-		return authErr
-	}
-	coverage, err := s.db.ListPriceCoverageForExport(ctx)
-	if err != nil {
-		return status.Error(codes.Internal, err.Error())
-	}
-	rows, err := s.db.ListPricesForExport(ctx)
-	if err != nil {
-		return status.Error(codes.Internal, err.Error())
-	}
-	// source_instance is left empty: nothing keys off it, and this build has no
-	// configured identity to put there.
-	if err := stream.Send(&apiv1.ExportPricesResponse{
-		Item: &apiv1.ExportPricesResponse_Envelope{
-			Envelope: archive.NewEnvelope("", archivev1.ArchiveKind_SYSTEM),
-		},
-	}); err != nil {
-		return err
-	}
-	for _, g := range priceGroups(rows, coverage) {
-		if err := stream.Send(&apiv1.ExportPricesResponse{
-			Item: &apiv1.ExportPricesResponse_Group{Group: g},
-		}); err != nil {
-			return err
-		}
-	}
-	return nil
 }
 
 // instKey is an instrument named the way a file names it: the identifier triple
@@ -192,40 +151,4 @@ func priceRow(r db.ExportPriceRow) *archivev1.PriceRow {
 		row.Volume = r.Volume
 	}
 	return row
-}
-
-// ImportPrices creates an async job to upsert the price part of a system
-// archive. Admin only. The serialized request is persisted to the DB and
-// processed by the worker.
-func (s *Server) ImportPrices(ctx context.Context, req *apiv1.ImportPricesRequest) (*apiv1.ImportPricesResponse, error) {
-	u, authErr := auth.RequireAdmin(ctx)
-	if authErr != nil {
-		return nil, authErr
-	}
-	if err := archive.CheckEnvelope(req.GetEnvelope(), archivev1.ArchiveKind_SYSTEM); err != nil {
-		var ve *archive.VersionError
-		if errors.As(err, &ve) {
-			return nil, status.Error(codes.FailedPrecondition, err.Error())
-		}
-		return nil, status.Error(codes.InvalidArgument, err.Error())
-	}
-	if len(req.GetPrices().GetGroups()) == 0 {
-		return nil, status.Error(codes.InvalidArgument, "no price groups provided")
-	}
-	payload, err := proto.Marshal(req)
-	if err != nil {
-		return nil, status.Error(codes.Internal, fmt.Sprintf("serialize request: %v", err))
-	}
-	jobID, err := s.db.CreateJob(ctx, db.CreateJobParams{
-		UserID:  u.ID,
-		JobType: "price",
-		Payload: payload,
-	})
-	if err != nil {
-		return nil, status.Error(codes.Internal, err.Error())
-	}
-	if err := s.enqueueJob(jobID, "price"); err != nil {
-		return nil, status.Error(codes.Unavailable, err.Error())
-	}
-	return &apiv1.ImportPricesResponse{JobId: jobID}, nil
 }

--- a/server/service/api/server_test.go
+++ b/server/service/api/server_test.go
@@ -5,14 +5,12 @@ import (
 	"testing"
 
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
-	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
 	"github.com/leedenison/portfoliodb/server/auth"
 	"github.com/leedenison/portfoliodb/server/db/mock"
 	"github.com/leedenison/portfoliodb/server/testutil"
 	"go.uber.org/mock/gomock"
 	"google.golang.org/genproto/googleapis/type/date"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/metadata"
 )
 
 func ctxNoAuth() context.Context {
@@ -35,108 +33,6 @@ func newAPIServerWithMock(t *testing.T) (*Server, *mock.MockDB) {
 	t.Cleanup(func() { ctrl.Finish() })
 	db := mock.NewMockDB(ctrl)
 	return NewServer(ServerConfig{DB: db}), db
-}
-
-// exportStreamMock provides a stream with configurable context for ExportInstruments tests.
-type exportStreamMock struct {
-	ctx  context.Context
-	sent []*apiv1.ExportInstrumentsResponse
-}
-
-func (e *exportStreamMock) Context() context.Context    { return e.ctx }
-func (e *exportStreamMock) RecvMsg(m interface{}) error { return nil }
-func (e *exportStreamMock) Send(m *apiv1.ExportInstrumentsResponse) error {
-	e.sent = append(e.sent, m)
-	return nil
-}
-func (e *exportStreamMock) SendHeader(m metadata.MD) error { return nil }
-func (e *exportStreamMock) SetHeader(m metadata.MD) error  { return nil }
-func (e *exportStreamMock) SetTrailer(m metadata.MD)       {}
-func (e *exportStreamMock) SendMsg(m interface{}) error {
-	if r, ok := m.(*apiv1.ExportInstrumentsResponse); ok {
-		e.sent = append(e.sent, r)
-	}
-	return nil
-}
-
-// instruments returns the instruments the export streamed, dropping the
-// envelope that precedes them.
-func (e *exportStreamMock) instruments() []*archivev1.Instrument {
-	var out []*archivev1.Instrument
-	for _, m := range e.sent {
-		if inst := m.GetInstrument(); inst != nil {
-			out = append(out, inst)
-		}
-	}
-	return out
-}
-
-// exportPriceStreamMock provides a stream with configurable context for ExportPrices tests.
-type exportPriceStreamMock struct {
-	ctx  context.Context
-	sent []*apiv1.ExportPricesResponse
-}
-
-func (e *exportPriceStreamMock) Context() context.Context    { return e.ctx }
-func (e *exportPriceStreamMock) RecvMsg(m interface{}) error { return nil }
-func (e *exportPriceStreamMock) Send(m *apiv1.ExportPricesResponse) error {
-	e.sent = append(e.sent, m)
-	return nil
-}
-func (e *exportPriceStreamMock) SendHeader(m metadata.MD) error { return nil }
-func (e *exportPriceStreamMock) SetHeader(m metadata.MD) error  { return nil }
-func (e *exportPriceStreamMock) SetTrailer(m metadata.MD)       {}
-func (e *exportPriceStreamMock) SendMsg(m interface{}) error {
-	if row, ok := m.(*apiv1.ExportPricesResponse); ok {
-		e.sent = append(e.sent, row)
-	}
-	return nil
-}
-
-// groups returns the price groups in send order, dropping the envelope.
-func (e *exportPriceStreamMock) groups() []*archivev1.PriceGroup {
-	var out []*archivev1.PriceGroup
-	for _, m := range e.sent {
-		if g := m.GetGroup(); g != nil {
-			out = append(out, g)
-		}
-	}
-	return out
-}
-
-// exportCorporateEventStreamMock provides a stream with configurable context
-// for ExportCorporateEvents tests.
-type exportCorporateEventStreamMock struct {
-	ctx  context.Context
-	sent []*apiv1.ExportCorporateEventsResponse
-}
-
-func (e *exportCorporateEventStreamMock) Context() context.Context    { return e.ctx }
-func (e *exportCorporateEventStreamMock) RecvMsg(m interface{}) error { return nil }
-func (e *exportCorporateEventStreamMock) Send(m *apiv1.ExportCorporateEventsResponse) error {
-	e.sent = append(e.sent, m)
-	return nil
-}
-func (e *exportCorporateEventStreamMock) SendHeader(m metadata.MD) error { return nil }
-func (e *exportCorporateEventStreamMock) SetHeader(m metadata.MD) error  { return nil }
-func (e *exportCorporateEventStreamMock) SetTrailer(m metadata.MD)       {}
-func (e *exportCorporateEventStreamMock) SendMsg(m interface{}) error {
-	if row, ok := m.(*apiv1.ExportCorporateEventsResponse); ok {
-		e.sent = append(e.sent, row)
-	}
-	return nil
-}
-
-// groups returns the instrument groups the export streamed, dropping the
-// envelope that precedes them.
-func (e *exportCorporateEventStreamMock) groups() []*archivev1.CorporateEventGroup {
-	var out []*archivev1.CorporateEventGroup
-	for _, m := range e.sent {
-		if g := m.GetGroup(); g != nil {
-			out = append(out, g)
-		}
-	}
-	return out
 }
 
 func TestAPI_Unauthenticated(t *testing.T) {
@@ -171,19 +67,17 @@ func TestAPI_Unauthenticated(t *testing.T) {
 			return err
 		}},
 		{"GetJob", func() error { _, err := srv.GetJob(ctx, &apiv1.GetJobRequest{JobId: "job-1"}); return err }},
-		{"ExportInstruments", func() error {
-			stream := &exportStreamMock{ctx: context.Background()}
-			return srv.ExportInstruments(&apiv1.ExportInstrumentsRequest{}, stream)
+		{"ExportSystemArchive", func() error {
+			stream := &exportArchiveStreamMock{ctx: context.Background()}
+			return srv.ExportSystemArchive(&apiv1.ExportSystemArchiveRequest{}, stream)
 		}},
-		{"ImportInstruments", func() error { _, err := srv.ImportInstruments(ctx, &apiv1.ImportInstrumentsRequest{}); return err }},
+		{"ImportSystemArchive", func() error {
+			_, err := srv.ImportSystemArchive(ctx, &apiv1.ImportSystemArchiveRequest{})
+			return err
+		}},
 		{"ListInstruments", func() error { _, err := srv.ListInstruments(ctx, &apiv1.ListInstrumentsRequest{}); return err }},
 		{"ListJobs", func() error { _, err := srv.ListJobs(ctx, &apiv1.ListJobsRequest{}); return err }},
 		{"ListPrices", func() error { _, err := srv.ListPrices(ctx, &apiv1.ListPricesRequest{}); return err }},
-		{"ExportPrices", func() error {
-			stream := &exportPriceStreamMock{ctx: context.Background()}
-			return srv.ExportPrices(&apiv1.ExportPricesRequest{}, stream)
-		}},
-		{"ImportPrices", func() error { _, err := srv.ImportPrices(ctx, &apiv1.ImportPricesRequest{}); return err }},
 		{"GetPortfolioValuation", func() error {
 			_, err := srv.GetPortfolioValuation(ctx, &apiv1.GetPortfolioValuationRequest{PortfolioId: "p", DateFrom: &date.Date{Year: 2025, Month: 1, Day: 1}, DateBefore: &date.Date{Year: 2025, Month: 1, Day: 3}})
 			return err

--- a/server/service/ingestion/corporate_event_worker.go
+++ b/server/service/ingestion/corporate_event_worker.go
@@ -14,60 +14,8 @@ import (
 	"github.com/leedenison/portfoliodb/server/corporateevents"
 	"github.com/leedenison/portfoliodb/server/db"
 	"github.com/leedenison/portfoliodb/server/identifier"
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
-
-// processCorporateEventImport loads a persisted ImportCorporateEventsRequest,
-// resolves each group's instrument via the existing identifier flow (so unknown
-// MIC_TICKER / OPENFIGI_TICKER / ISIN values are passed through identifier
-// plugins), upserts the splits and cash dividends nested under it, records
-// coverage rows tagged "import", and runs the split adjustment recompute for
-// every instrument that received at least one new split.
-//
-// The archive nests by instrument, so an instrument is resolved once per group
-// rather than once per event, and a validation error names the group it came
-// from with the event's position inside it.
-//
-// Returns true when at least one split, dividend, or coverage row was
-// successfully persisted. The caller uses this to decide whether to nudge
-// the corporate event fetcher worker -- mirrors the processTx success
-// signal so a job that rejected every row does not produce churn.
-func processCorporateEventImport(ctx context.Context, database db.DB, pluginRegistry *identifier.Registry, j *JobRequest) bool {
-	payload, err := database.LoadJobPayload(ctx, j.JobID)
-	if err != nil {
-		log.Printf("corporate event import job %s: load payload: %v", j.JobID, err)
-		finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
-		return false
-	}
-	var req apiv1.ImportCorporateEventsRequest
-	if err := proto.Unmarshal(payload, &req); err != nil {
-		log.Printf("corporate event import job %s: unmarshal payload: %v", j.JobID, err)
-		finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
-		return false
-	}
-
-	// Knowledge time declared for the whole file: OCC symbols are
-	// split-adjusted to this point during resolution, events that carry no
-	// first_known_at of their own fall back to it, and imported coverage
-	// records it as last_fetched_at. Mirrors the price import path.
-	var eventsAsOf *time.Time
-	if ts := req.GetEnvelope().GetExportedAt(); ts != nil {
-		t := ts.AsTime()
-		eventsAsOf = &t
-	}
-
-	rep := archiveimport.NewPartReporter(database, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED)
-	persisted, err := importCorporateEventPart(ctx, database, pluginRegistry, req.GetCorporateEvents(), eventsAsOf, newResolveCache(), rep)
-	rep.Flush(ctx)
-	if err != nil {
-		log.Printf("corporate event import job %s: %v", j.JobID, err)
-		finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
-		return false
-	}
-	finishJob(ctx, database, j.JobID, apiv1.JobStatus_SUCCESS)
-	return persisted
-}
 
 // importCorporateEventPart applies one archive corporate event part, reporting
 // through rep. Like the price part it returns whether anything was persisted,

--- a/server/service/ingestion/corporate_event_worker_test.go
+++ b/server/service/ingestion/corporate_event_worker_test.go
@@ -13,6 +13,7 @@ import (
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
 	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
 	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
+	"github.com/leedenison/portfoliodb/server/archiveimport"
 	"github.com/leedenison/portfoliodb/server/db"
 	"github.com/leedenison/portfoliodb/server/db/mock"
 	"github.com/leedenison/portfoliodb/server/identifier"
@@ -21,20 +22,18 @@ import (
 // eventPayload builds the persisted job payload for a corporate event import.
 // exportedAt is nil only to exercise the worker's guard for a payload written
 // before the envelope was required.
-func eventPayload(t *testing.T, exportedAt *time.Time, groups ...*archivev1.CorporateEventGroup) []byte {
+func eventPart(groups ...*archivev1.CorporateEventGroup) *archivev1.CorporateEventPart {
+	return &archivev1.CorporateEventPart{Groups: groups}
+}
+
+// runEventPart applies a corporate event part with a detached reporter and
+// returns what it persisted along with the problems it recorded.
+func runEventPart(t *testing.T, database db.DB, registry *identifier.Registry,
+	part *archivev1.CorporateEventPart, asOf *time.Time) (bool, []*apiv1.ValidationError, error) {
 	t.Helper()
-	env := &archivev1.Envelope{FormatVersion: 1, Kind: archivev1.ArchiveKind_SYSTEM}
-	if exportedAt != nil {
-		env.ExportedAt = timestamppb.New(*exportedAt)
-	}
-	payload, err := proto.Marshal(&apiv1.ImportCorporateEventsRequest{
-		Envelope:        env,
-		CorporateEvents: &archivev1.CorporateEventPart{Groups: groups},
-	})
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
-	}
-	return payload
+	rep := archiveimport.NewDetachedReporter()
+	persisted, err := importCorporateEventPart(context.Background(), database, registry, part, asOf, newResolveCache(), rep)
+	return persisted, rep.Errors(), err
 }
 
 // tickerGroup is one group naming an instrument by MIC ticker.
@@ -86,20 +85,13 @@ func TestProcessCorporateEventImport_HappyPath(t *testing.T) {
 			Type:      archivev1.DividendType_SC,
 		}),
 	}
-	payload := eventPayload(t, &exportedAt, g)
-	j := &JobRequest{JobID: "job-ce-1", JobType: db.JobTypeCorporateEvent}
-
-	database.EXPECT().LoadJobPayload(gomock.Any(), "job-ce-1").Return(payload, nil)
-	database.EXPECT().ClearJobPayload(gomock.Any(), "job-ce-1").Return(nil)
-	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-ce-1", int32(2)).Return(nil)
+	part := eventPart(g)
 
 	// Resolution: one cache miss for the group, and the coverage pass reuses
 	// it rather than resolving the same instrument a second time.
 	database.EXPECT().
 		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").
 		Return("inst-aapl", "STOCK", "XNAS", "USD", nil)
-
-	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-ce-1").Return(nil).Times(2)
 
 	database.EXPECT().UpsertStockSplits(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, splits []db.StockSplit) error {
@@ -150,9 +142,12 @@ func TestProcessCorporateEventImport_HappyPath(t *testing.T) {
 	// The option pass runs once for the import, across all underlyings, and
 	// derives its own work rather than being handed this instrument's splits.
 	database.EXPECT().ListPendingOptionSplits(gomock.Any(), "").Return(nil, nil)
-	database.EXPECT().SetJobStatus(gomock.Any(), "job-ce-1", apiv1.JobStatus_SUCCESS).Return(nil)
 
-	if !processCorporateEventImport(context.Background(), database, registry, j) {
+	persisted, _, err := runEventPart(t, database, registry, part, &exportedAt)
+	if err != nil {
+		t.Fatalf("importCorporateEventPart: %v", err)
+	}
+	if !persisted {
 		t.Error("expected persisted=true after a successful upsert")
 	}
 }
@@ -171,20 +166,19 @@ func TestProcessCorporateEventImport_CoverageWithNoEvents(t *testing.T) {
 	exportedAt := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
 	g := tickerGroup("AAPL", typev1.AssetClass_STOCK)
 	g.Coverage = []*archivev1.DateInterval{{From: "2014-01-01", Before: "2025-01-01"}}
-	payload := eventPayload(t, &exportedAt, g)
-	j := &JobRequest{JobID: "job-ce-cov0", JobType: db.JobTypeCorporateEvent}
+	part := eventPart(g)
 
-	database.EXPECT().LoadJobPayload(gomock.Any(), "job-ce-cov0").Return(payload, nil)
-	database.EXPECT().ClearJobPayload(gomock.Any(), "job-ce-cov0").Return(nil)
-	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-ce-cov0", int32(0)).Return(nil)
 	database.EXPECT().FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").
 		Return("inst-aapl", "STOCK", "XNAS", "USD", nil)
 	database.EXPECT().UpsertCorporateEventCoverage(gomock.Any(), "inst-aapl", db.CorporateEventProviderImport,
 		time.Date(2014, 1, 1, 0, 0, 0, 0, time.UTC),
 		time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC), &exportedAt).Return(nil)
-	database.EXPECT().SetJobStatus(gomock.Any(), "job-ce-cov0", apiv1.JobStatus_SUCCESS).Return(nil)
 
-	if !processCorporateEventImport(context.Background(), database, registry, j) {
+	persisted, _, err := runEventPart(t, database, registry, part, &exportedAt)
+	if err != nil {
+		t.Fatalf("importCorporateEventPart: %v", err)
+	}
+	if !persisted {
 		t.Error("expected persisted=true after a coverage-only import")
 	}
 }
@@ -202,25 +196,17 @@ func TestProcessCorporateEventImport_RejectsBadSplitRatio(t *testing.T) {
 
 	g := tickerGroup("AAPL", typev1.AssetClass_STOCK)
 	g.Events = []*archivev1.CorporateEvent{splitEvent(&archivev1.Split{ExDate: "2020-08-31", SplitFrom: "1", SplitTo: "0"})}
-	payload := eventPayload(t, nil, g)
-	j := &JobRequest{JobID: "job-ce-2", JobType: db.JobTypeCorporateEvent}
+	part := eventPart(g)
 
-	database.EXPECT().LoadJobPayload(gomock.Any(), "job-ce-2").Return(payload, nil)
-	database.EXPECT().ClearJobPayload(gomock.Any(), "job-ce-2").Return(nil)
-	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-ce-2", int32(1)).Return(nil)
 	database.EXPECT().FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").Return("inst-aapl", "STOCK", "XNAS", "USD", nil)
-	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-ce-2").Return(nil)
 
-	var capturedErrs []*apiv1.ValidationError
-	database.EXPECT().AppendValidationErrors(gomock.Any(), "job-ce-2", gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ string, _ archivev1.ArchivePart, errs []*apiv1.ValidationError) error {
-			capturedErrs = errs
-			return nil
-		})
 	// No upserts and no recompute (no valid splits landed).
-	database.EXPECT().SetJobStatus(gomock.Any(), "job-ce-2", apiv1.JobStatus_SUCCESS).Return(nil)
 
-	if processCorporateEventImport(context.Background(), database, registry, j) {
+	persisted, capturedErrs, err := runEventPart(t, database, registry, part, nil)
+	if err != nil {
+		t.Fatalf("importCorporateEventPart: %v", err)
+	}
+	if persisted {
 		t.Error("expected persisted=false when every event was rejected")
 	}
 
@@ -247,19 +233,17 @@ func TestProcessCorporateEventImport_DividendOnlyDoesNotRecompute(t *testing.T) 
 
 	g := tickerGroup("MSFT", typev1.AssetClass_STOCK)
 	g.Events = []*archivev1.CorporateEvent{dividendEvent(&archivev1.CashDividend{ExDate: "2024-02-15", Amount: "0.75", Currency: "USD"})}
-	payload := eventPayload(t, nil, g)
-	j := &JobRequest{JobID: "job-ce-3", JobType: db.JobTypeCorporateEvent}
+	part := eventPart(g)
 
-	database.EXPECT().LoadJobPayload(gomock.Any(), "job-ce-3").Return(payload, nil)
-	database.EXPECT().ClearJobPayload(gomock.Any(), "job-ce-3").Return(nil)
-	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-ce-3", int32(1)).Return(nil)
 	database.EXPECT().FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "MSFT").Return("inst-msft", "STOCK", "XNAS", "USD", nil)
-	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-ce-3").Return(nil)
 	database.EXPECT().UpsertCashDividends(gomock.Any(), gomock.Any()).Return(nil)
 	// Critically: NO RecomputeSplitAdjustments call.
-	database.EXPECT().SetJobStatus(gomock.Any(), "job-ce-3", apiv1.JobStatus_SUCCESS).Return(nil)
 
-	if !processCorporateEventImport(context.Background(), database, registry, j) {
+	persisted, _, err := runEventPart(t, database, registry, part, nil)
+	if err != nil {
+		t.Fatalf("importCorporateEventPart: %v", err)
+	}
+	if !persisted {
 		t.Error("expected persisted=true after a successful dividend upsert")
 	}
 }
@@ -277,24 +261,16 @@ func TestProcessCorporateEventImport_RejectsBadCoverageDate(t *testing.T) {
 
 	g := tickerGroup("AAPL", typev1.AssetClass_STOCK)
 	g.Coverage = []*archivev1.DateInterval{{From: "2024-13-01", Before: "2025-01-01"}} // invalid month
-	payload := eventPayload(t, nil, g)
-	j := &JobRequest{JobID: "job-ce-cov", JobType: db.JobTypeCorporateEvent}
+	part := eventPart(g)
 
-	database.EXPECT().LoadJobPayload(gomock.Any(), "job-ce-cov").Return(payload, nil)
-	database.EXPECT().ClearJobPayload(gomock.Any(), "job-ce-cov").Return(nil)
-	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-ce-cov", int32(0)).Return(nil)
 	database.EXPECT().FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").
 		Return("inst-aapl", "STOCK", "XNAS", "USD", nil)
 
-	var capturedErrs []*apiv1.ValidationError
-	database.EXPECT().AppendValidationErrors(gomock.Any(), "job-ce-cov", gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ string, _ archivev1.ArchivePart, errs []*apiv1.ValidationError) error {
-			capturedErrs = errs
-			return nil
-		})
-	database.EXPECT().SetJobStatus(gomock.Any(), "job-ce-cov", apiv1.JobStatus_SUCCESS).Return(nil)
-
-	if processCorporateEventImport(context.Background(), database, registry, j) {
+	persisted, capturedErrs, err := runEventPart(t, database, registry, part, nil)
+	if err != nil {
+		t.Fatalf("importCorporateEventPart: %v", err)
+	}
+	if persisted {
 		t.Error("expected persisted=false when no events or coverage spans succeeded")
 	}
 
@@ -318,24 +294,16 @@ func TestProcessCorporateEventImport_EmptyCoverageInterval(t *testing.T) {
 
 	g := tickerGroup("AAPL", typev1.AssetClass_STOCK)
 	g.Coverage = []*archivev1.DateInterval{{From: "2024-01-01", Before: "2024-01-01"}}
-	payload := eventPayload(t, nil, g)
-	j := &JobRequest{JobID: "job-ce-empty", JobType: db.JobTypeCorporateEvent}
+	part := eventPart(g)
 
-	database.EXPECT().LoadJobPayload(gomock.Any(), "job-ce-empty").Return(payload, nil)
-	database.EXPECT().ClearJobPayload(gomock.Any(), "job-ce-empty").Return(nil)
-	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-ce-empty", int32(0)).Return(nil)
 	database.EXPECT().FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").
 		Return("inst-aapl", "STOCK", "XNAS", "USD", nil)
 
-	var capturedErrs []*apiv1.ValidationError
-	database.EXPECT().AppendValidationErrors(gomock.Any(), "job-ce-empty", gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ string, _ archivev1.ArchivePart, errs []*apiv1.ValidationError) error {
-			capturedErrs = errs
-			return nil
-		})
-	database.EXPECT().SetJobStatus(gomock.Any(), "job-ce-empty", apiv1.JobStatus_SUCCESS).Return(nil)
-
-	if processCorporateEventImport(context.Background(), database, registry, j) {
+	persisted, capturedErrs, err := runEventPart(t, database, registry, part, nil)
+	if err != nil {
+		t.Fatalf("importCorporateEventPart: %v", err)
+	}
+	if persisted {
 		t.Error("expected persisted=false when the only coverage span was rejected")
 	}
 	if len(capturedErrs) != 1 {
@@ -360,14 +328,9 @@ func TestProcessCorporateEventImport_AcceptsHighPrecisionDecimal(t *testing.T) {
 
 	g := tickerGroup("MSFT", typev1.AssetClass_STOCK)
 	g.Events = []*archivev1.CorporateEvent{dividendEvent(&archivev1.CashDividend{ExDate: "2024-02-15", Amount: "0.1", Currency: "USD"})}
-	payload := eventPayload(t, nil, g)
-	j := &JobRequest{JobID: "job-ce-prec", JobType: db.JobTypeCorporateEvent}
+	part := eventPart(g)
 
-	database.EXPECT().LoadJobPayload(gomock.Any(), "job-ce-prec").Return(payload, nil)
-	database.EXPECT().ClearJobPayload(gomock.Any(), "job-ce-prec").Return(nil)
-	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-ce-prec", int32(1)).Return(nil)
 	database.EXPECT().FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "MSFT").Return("inst-msft", "STOCK", "XNAS", "USD", nil)
-	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-ce-prec").Return(nil)
 	database.EXPECT().UpsertCashDividends(gomock.Any(), gomock.Any()).DoAndReturn(
 		func(_ context.Context, divs []db.CashDividend) error {
 			if divs[0].Amount != "0.1" {
@@ -375,9 +338,12 @@ func TestProcessCorporateEventImport_AcceptsHighPrecisionDecimal(t *testing.T) {
 			}
 			return nil
 		})
-	database.EXPECT().SetJobStatus(gomock.Any(), "job-ce-prec", apiv1.JobStatus_SUCCESS).Return(nil)
 
-	if !processCorporateEventImport(context.Background(), database, registry, j) {
+	persisted, _, err := runEventPart(t, database, registry, part, nil)
+	if err != nil {
+		t.Fatalf("importCorporateEventPart: %v", err)
+	}
+	if !persisted {
 		t.Error("expected persisted=true")
 	}
 }
@@ -394,24 +360,15 @@ func TestProcessCorporateEventImport_RejectsInvalidDecimal(t *testing.T) {
 
 	g := tickerGroup("MSFT", typev1.AssetClass_STOCK)
 	g.Events = []*archivev1.CorporateEvent{dividendEvent(&archivev1.CashDividend{ExDate: "2024-02-15", Amount: "abc", Currency: "USD"})}
-	payload := eventPayload(t, nil, g)
-	j := &JobRequest{JobID: "job-ce-bad", JobType: db.JobTypeCorporateEvent}
+	part := eventPart(g)
 
-	database.EXPECT().LoadJobPayload(gomock.Any(), "job-ce-bad").Return(payload, nil)
-	database.EXPECT().ClearJobPayload(gomock.Any(), "job-ce-bad").Return(nil)
-	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-ce-bad", int32(1)).Return(nil)
 	database.EXPECT().FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "MSFT").Return("inst-msft", "STOCK", "XNAS", "USD", nil)
-	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-ce-bad").Return(nil)
 
-	var capturedErrs []*apiv1.ValidationError
-	database.EXPECT().AppendValidationErrors(gomock.Any(), "job-ce-bad", gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ string, _ archivev1.ArchivePart, errs []*apiv1.ValidationError) error {
-			capturedErrs = errs
-			return nil
-		})
-	database.EXPECT().SetJobStatus(gomock.Any(), "job-ce-bad", apiv1.JobStatus_SUCCESS).Return(nil)
-
-	if processCorporateEventImport(context.Background(), database, registry, j) {
+	persisted, capturedErrs, err := runEventPart(t, database, registry, part, nil)
+	if err != nil {
+		t.Fatalf("importCorporateEventPart: %v", err)
+	}
+	if persisted {
 		t.Error("expected persisted=false")
 	}
 	if len(capturedErrs) != 1 || capturedErrs[0].Field != "events[0].amount" {
@@ -433,27 +390,17 @@ func TestProcessCorporateEventImport_RejectsHintDiff(t *testing.T) {
 
 	g := tickerGroup("AAPL", typev1.AssetClass_STOCK)
 	g.Events = []*archivev1.CorporateEvent{splitEvent(&archivev1.Split{ExDate: "2020-08-31", SplitFrom: "1", SplitTo: "4"})}
-	payload := eventPayload(t, nil, g)
-	j := &JobRequest{JobID: "job-ce-diff", JobType: db.JobTypeCorporateEvent}
-
-	database.EXPECT().LoadJobPayload(gomock.Any(), "job-ce-diff").Return(payload, nil)
-	database.EXPECT().ClearJobPayload(gomock.Any(), "job-ce-diff").Return(nil)
-	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-ce-diff", int32(1)).Return(nil)
+	part := eventPart(g)
 
 	// Instrument found but has asset class ETF, not STOCK.
 	database.EXPECT().FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").
 		Return("inst-aapl", "ETF", "XNAS", "USD", nil)
-	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-ce-diff").Return(nil)
 
-	var capturedErrs []*apiv1.ValidationError
-	database.EXPECT().AppendValidationErrors(gomock.Any(), "job-ce-diff", gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ string, _ archivev1.ArchivePart, errs []*apiv1.ValidationError) error {
-			capturedErrs = errs
-			return nil
-		})
-	database.EXPECT().SetJobStatus(gomock.Any(), "job-ce-diff", apiv1.JobStatus_SUCCESS).Return(nil)
-
-	if processCorporateEventImport(context.Background(), database, registry, j) {
+	persisted, capturedErrs, err := runEventPart(t, database, registry, part, nil)
+	if err != nil {
+		t.Fatalf("importCorporateEventPart: %v", err)
+	}
+	if persisted {
 		t.Error("expected persisted=false when the group was rejected for a hint diff")
 	}
 	if len(capturedErrs) != 1 {

--- a/server/service/ingestion/price_worker.go
+++ b/server/service/ingestion/price_worker.go
@@ -3,7 +3,6 @@ package ingestion
 import (
 	"context"
 	"fmt"
-	"log"
 	"log/slog"
 	"time"
 
@@ -15,57 +14,12 @@ import (
 	"github.com/leedenison/portfoliodb/server/identifier"
 	"github.com/leedenison/portfoliodb/server/service/identification"
 	"github.com/shopspring/decimal"
-	"google.golang.org/protobuf/proto"
 )
 
 // resolveEntry caches the result of instrument resolution for a given identifier.
 type resolveEntry struct {
 	result identification.ResolveResult
 	err    error
-}
-
-// processPriceImport loads a persisted ImportPricesRequest, resolves each
-// group's instrument, and upserts its bars. Progress is tracked via
-// SetJobTotalCount / IncrJobProcessedCount.
-//
-// Returns true when at least one price row was successfully persisted. The
-// caller uses this to decide whether to nudge the price fetcher worker --
-// mirrors the processTx and processCorporateEventImport success signal so a
-// job that rejected every row does not produce churn.
-func processPriceImport(ctx context.Context, database db.DB, pluginRegistry *identifier.Registry, j *JobRequest) bool {
-	payload, err := database.LoadJobPayload(ctx, j.JobID)
-	if err != nil {
-		log.Printf("price import job %s: load payload: %v", j.JobID, err)
-		finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
-		return false
-	}
-	var req apiv1.ImportPricesRequest
-	if err := proto.Unmarshal(payload, &req); err != nil {
-		log.Printf("price import job %s: unmarshal payload: %v", j.JobID, err)
-		finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
-		return false
-	}
-
-	// The envelope is required at the API, so this only fires for a payload
-	// written by an older build.
-	var pricesAsOf *time.Time
-	if ts := req.GetEnvelope().GetExportedAt(); ts != nil {
-		t := ts.AsTime()
-		pricesAsOf = &t
-	} else {
-		slog.Warn("price import missing exported_at; OCC symbols will not be split-adjusted", "job_id", j.JobID)
-	}
-
-	rep := archiveimport.NewPartReporter(database, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED)
-	persisted, err := importPricePart(ctx, database, pluginRegistry, req.GetPrices(), pricesAsOf, newResolveCache(), rep)
-	rep.Flush(ctx)
-	if err != nil {
-		log.Printf("price import job %s: %v", j.JobID, err)
-		finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
-		return false
-	}
-	finishJob(ctx, database, j.JobID, apiv1.JobStatus_SUCCESS)
-	return persisted
 }
 
 // importPricePart applies one archive price part, reporting through rep.

--- a/server/service/ingestion/price_worker_test.go
+++ b/server/service/ingestion/price_worker_test.go
@@ -5,7 +5,7 @@ import (
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
 	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
 	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
-	"github.com/leedenison/portfoliodb/server/archive"
+	"github.com/leedenison/portfoliodb/server/archiveimport"
 	"github.com/leedenison/portfoliodb/server/db"
 	"github.com/leedenison/portfoliodb/server/db/mock"
 	"github.com/leedenison/portfoliodb/server/identifier"
@@ -17,21 +17,25 @@ import (
 	"time"
 )
 
-// pricePayload marshals the request a price import job carries. exportedAt is
-// nil only to exercise the worker's guard for a payload written before the
-// envelope was required.
-func pricePayload(t *testing.T, exportedAt *timestamppb.Timestamp, groups ...*archivev1.PriceGroup) []byte {
+// pricePart wraps groups as the price part of an archive. asOf is knowledge
+// time, and nil exercises the path for a document that declares none.
+func pricePart(groups ...*archivev1.PriceGroup) *archivev1.PricePart {
+	return &archivev1.PricePart{Groups: groups}
+}
+
+// runPricePart applies a price part with a detached reporter and returns what
+// it persisted along with the problems it recorded.
+func runPricePart(t *testing.T, database db.DB, registry *identifier.Registry,
+	part *archivev1.PricePart, asOf *timestamppb.Timestamp) (bool, []*apiv1.ValidationError, error) {
 	t.Helper()
-	env := archive.NewEnvelope("test", archivev1.ArchiveKind_SYSTEM)
-	env.ExportedAt = exportedAt
-	payload, err := proto.Marshal(&apiv1.ImportPricesRequest{
-		Envelope: env,
-		Prices:   &archivev1.PricePart{Groups: groups},
-	})
-	if err != nil {
-		t.Fatalf("marshal: %v", err)
+	var at *time.Time
+	if asOf != nil {
+		v := asOf.AsTime()
+		at = &v
 	}
-	return payload
+	rep := archiveimport.NewDetachedReporter()
+	persisted, err := importPricePart(context.Background(), database, registry, part, at, newResolveCache(), rep)
+	return persisted, rep.Errors(), err
 }
 
 func TestProcessPriceImport_RejectsUnknownIdentifierType(t *testing.T) {
@@ -42,32 +46,17 @@ func TestProcessPriceImport_RejectsUnknownIdentifierType(t *testing.T) {
 	database.EXPECT().SaveProviderIdentifiers(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	registry := identifier.NewRegistry()
 
-	ctx := context.Background()
 	// A valid enum value the resolver has no plugin vocabulary for.
-	payload := pricePayload(t, nil, &archivev1.PriceGroup{
+	part := pricePart(&archivev1.PriceGroup{
 		Instrument: &archivev1.InstrumentRef{Type: typev1.IdentifierType_OPENFIGI_GLOBAL, Value: "BBG000B9XRY4"},
 		Rows:       []*archivev1.PriceRow{{PriceDate: "2024-01-15", Close: "185.90"}},
 	})
 
-	j := &JobRequest{JobID: "job-price-1", JobType: "price"}
-
-	database.EXPECT().LoadJobPayload(gomock.Any(), "job-price-1").Return(payload, nil)
-	database.EXPECT().ClearJobPayload(gomock.Any(), "job-price-1").Return(nil)
-	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-price-1", int32(1)).Return(nil)
-	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-price-1").Return(nil)
-
-	var capturedErrs []*apiv1.ValidationError
-	database.EXPECT().
-		AppendValidationErrors(gomock.Any(), "job-price-1", gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ string, _ archivev1.ArchivePart, errs []*apiv1.ValidationError) error {
-			capturedErrs = errs
-			return nil
-		})
-	database.EXPECT().
-		SetJobStatus(gomock.Any(), "job-price-1", apiv1.JobStatus_SUCCESS).
-		Return(nil)
-
-	if processPriceImport(ctx, database, registry, j) {
+	persisted, capturedErrs, err := runPricePart(t, database, registry, part, nil)
+	if err != nil {
+		t.Fatalf("importPricePart: %v", err)
+	}
+	if persisted {
 		t.Error("expected persisted=false when every row was rejected")
 	}
 
@@ -90,32 +79,25 @@ func TestProcessPriceImport_AcceptsValidIdentifierType(t *testing.T) {
 	database.EXPECT().SaveProviderIdentifiers(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	registry := identifier.NewRegistry()
 
-	ctx := context.Background()
-	payload := pricePayload(t, nil, &archivev1.PriceGroup{
+	part := pricePart(&archivev1.PriceGroup{
 		Instrument: &archivev1.InstrumentRef{Type: typev1.IdentifierType_MIC_TICKER, Value: "AAPL", Domain: "XNAS"},
 		Rows:       []*archivev1.PriceRow{{PriceDate: "2024-01-15", Close: "185.90"}},
 	})
-
-	j := &JobRequest{JobID: "job-price-2", JobType: "price"}
-
-	database.EXPECT().LoadJobPayload(gomock.Any(), "job-price-2").Return(payload, nil)
-	database.EXPECT().ClearJobPayload(gomock.Any(), "job-price-2").Return(nil)
-	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-price-2", int32(1)).Return(nil)
 
 	// Valid type passes validation, so resolveOrIdentifyInstrument is called.
 	// With no asset_class and no plugins, it does DB-only lookup.
 	database.EXPECT().
 		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").
 		Return("inst-aapl", "", "XNAS", "", nil)
-	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-price-2").Return(nil)
 	database.EXPECT().
 		UpsertPrices(gomock.Any(), gomock.Any()).
 		Return(nil)
-	database.EXPECT().
-		SetJobStatus(gomock.Any(), "job-price-2", apiv1.JobStatus_SUCCESS).
-		Return(nil)
 
-	if !processPriceImport(ctx, database, registry, j) {
+	persisted, _, err := runPricePart(t, database, registry, part, nil)
+	if err != nil {
+		t.Fatalf("importPricePart: %v", err)
+	}
+	if !persisted {
 		t.Error("expected persisted=true after a successful upsert")
 	}
 }
@@ -131,8 +113,7 @@ func TestProcessPriceImport_CarriesShareCountBasis(t *testing.T) {
 	database.EXPECT().SaveProviderIdentifiers(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	registry := identifier.NewRegistry()
 
-	ctx := context.Background()
-	payload := pricePayload(t, nil, &archivev1.PriceGroup{
+	part := pricePart(&archivev1.PriceGroup{
 		Instrument: &archivev1.InstrumentRef{Type: typev1.IdentifierType_MIC_TICKER, Value: "NVDA", Domain: "XNAS"},
 		Rows: []*archivev1.PriceRow{
 			{PriceDate: "2024-01-15", Close: "48.0"},
@@ -140,15 +121,9 @@ func TestProcessPriceImport_CarriesShareCountBasis(t *testing.T) {
 		},
 	})
 
-	j := &JobRequest{JobID: "job-price-basis", JobType: "price"}
-
-	database.EXPECT().LoadJobPayload(gomock.Any(), "job-price-basis").Return(payload, nil)
-	database.EXPECT().ClearJobPayload(gomock.Any(), "job-price-basis").Return(nil)
-	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-price-basis", int32(2)).Return(nil)
 	database.EXPECT().
 		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "NVDA").
 		Return("inst-nvda", "", "XNAS", "", nil)
-	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-price-basis").Return(nil).Times(2)
 
 	var captured []db.EODPrice
 	database.EXPECT().
@@ -157,9 +132,12 @@ func TestProcessPriceImport_CarriesShareCountBasis(t *testing.T) {
 			captured = prices
 			return nil
 		})
-	database.EXPECT().SetJobStatus(gomock.Any(), "job-price-basis", apiv1.JobStatus_SUCCESS).Return(nil)
 
-	if !processPriceImport(ctx, database, registry, j) {
+	persisted, _, err := runPricePart(t, database, registry, part, nil)
+	if err != nil {
+		t.Fatalf("importPricePart: %v", err)
+	}
+	if !persisted {
 		t.Fatal("expected persisted=true after a successful upsert")
 	}
 	if len(captured) != 2 {
@@ -185,17 +163,11 @@ func TestProcessPriceImport_CoverageWithNoRows(t *testing.T) {
 	database.EXPECT().SaveProviderIdentifiers(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	registry := identifier.NewRegistry()
 
-	ctx := context.Background()
-	payload := pricePayload(t, nil, &archivev1.PriceGroup{
+	part := pricePart(&archivev1.PriceGroup{
 		Instrument: &archivev1.InstrumentRef{Type: typev1.IdentifierType_MIC_TICKER, Value: "DELISTED", Domain: "XNAS"},
 		Coverage:   []*archivev1.DateInterval{{From: "2024-01-01", Before: "2024-04-01"}},
 	})
 
-	j := &JobRequest{JobID: "job-price-empty", JobType: "price"}
-
-	database.EXPECT().LoadJobPayload(gomock.Any(), "job-price-empty").Return(payload, nil)
-	database.EXPECT().ClearJobPayload(gomock.Any(), "job-price-empty").Return(nil)
-	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-price-empty", int32(0)).Return(nil)
 	database.EXPECT().
 		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "DELISTED").
 		Return("inst-delisted", "", "XNAS", "", nil)
@@ -204,10 +176,13 @@ func TestProcessPriceImport_CoverageWithNoRows(t *testing.T) {
 			time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
 			time.Date(2024, 4, 1, 0, 0, 0, 0, time.UTC), gomock.Any()).
 		Return(nil)
-	database.EXPECT().SetJobStatus(gomock.Any(), "job-price-empty", apiv1.JobStatus_SUCCESS).Return(nil)
 
 	// No bars were stored, so there is nothing for the price fetcher to react to.
-	if processPriceImport(ctx, database, registry, j) {
+	persisted, _, err := runPricePart(t, database, registry, part, nil)
+	if err != nil {
+		t.Fatalf("importPricePart: %v", err)
+	}
+	if persisted {
 		t.Error("expected persisted=false when the group carried no bars")
 	}
 }
@@ -220,31 +195,25 @@ func TestProcessPriceImport_WithCoverage_UsesUpsertWithFill(t *testing.T) {
 	database.EXPECT().SaveProviderIdentifiers(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	registry := identifier.NewRegistry()
 
-	ctx := context.Background()
-	payload := pricePayload(t, nil, &archivev1.PriceGroup{
+	part := pricePart(&archivev1.PriceGroup{
 		Instrument: &archivev1.InstrumentRef{Type: typev1.IdentifierType_MIC_TICKER, Value: "AAPL", Domain: "XNAS"},
 		Coverage:   []*archivev1.DateInterval{{From: "2024-01-01", Before: "2024-04-01"}},
 		Rows:       []*archivev1.PriceRow{{PriceDate: "2024-01-15", Close: "185.90"}},
 	})
 
-	j := &JobRequest{JobID: "job-price-cov", JobType: "price"}
-
-	database.EXPECT().LoadJobPayload(gomock.Any(), "job-price-cov").Return(payload, nil)
-	database.EXPECT().ClearJobPayload(gomock.Any(), "job-price-cov").Return(nil)
-	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-price-cov", int32(1)).Return(nil)
 	database.EXPECT().
 		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").
 		Return("inst-aapl", "", "XNAS", "", nil)
-	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-price-cov").Return(nil)
 	// Expect UpsertPricesForRange (not UpsertPrices) because coverage was provided.
 	database.EXPECT().
 		UpsertPricesForRange(gomock.Any(), "inst-aapl", "import", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil)
-	database.EXPECT().
-		SetJobStatus(gomock.Any(), "job-price-cov", apiv1.JobStatus_SUCCESS).
-		Return(nil)
 
-	if !processPriceImport(ctx, database, registry, j) {
+	persisted, _, err := runPricePart(t, database, registry, part, nil)
+	if err != nil {
+		t.Fatalf("importPricePart: %v", err)
+	}
+	if !persisted {
 		t.Error("expected persisted=true after a successful upsert")
 	}
 }
@@ -257,32 +226,26 @@ func TestProcessPriceImport_WithCoverage_NoCoverageForInstrument_UsesPlanUpsert(
 	database.EXPECT().SaveProviderIdentifiers(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	registry := identifier.NewRegistry()
 
-	ctx := context.Background()
 	// Coverage now sits inside the group it applies to, so a group that
 	// declares none has bars covering only their own dates.
-	payload := pricePayload(t, nil, &archivev1.PriceGroup{
+	part := pricePart(&archivev1.PriceGroup{
 		Instrument: &archivev1.InstrumentRef{Type: typev1.IdentifierType_MIC_TICKER, Value: "AAPL", Domain: "XNAS"},
 		Rows:       []*archivev1.PriceRow{{PriceDate: "2024-01-15", Close: "185.90"}},
 	})
 
-	j := &JobRequest{JobID: "job-price-nocov", JobType: "price"}
-
-	database.EXPECT().LoadJobPayload(gomock.Any(), "job-price-nocov").Return(payload, nil)
-	database.EXPECT().ClearJobPayload(gomock.Any(), "job-price-nocov").Return(nil)
-	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-price-nocov", int32(1)).Return(nil)
 	database.EXPECT().
 		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").
 		Return("inst-aapl", "", "XNAS", "", nil)
-	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-price-nocov").Return(nil)
 	// No coverage match for AAPL, so expect plain UpsertPrices.
 	database.EXPECT().
 		UpsertPrices(gomock.Any(), gomock.Any()).
 		Return(nil)
-	database.EXPECT().
-		SetJobStatus(gomock.Any(), "job-price-nocov", apiv1.JobStatus_SUCCESS).
-		Return(nil)
 
-	if !processPriceImport(ctx, database, registry, j) {
+	persisted, _, err := runPricePart(t, database, registry, part, nil)
+	if err != nil {
+		t.Fatalf("importPricePart: %v", err)
+	}
+	if !persisted {
 		t.Error("expected persisted=true after a successful upsert")
 	}
 }
@@ -298,36 +261,21 @@ func TestProcessPriceImport_RejectsHintDiff(t *testing.T) {
 	database.EXPECT().SaveProviderIdentifiers(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	registry := identifier.NewRegistry()
 
-	ctx := context.Background()
-	payload := pricePayload(t, nil, &archivev1.PriceGroup{
+	part := pricePart(&archivev1.PriceGroup{
 		Instrument: &archivev1.InstrumentRef{Type: typev1.IdentifierType_MIC_TICKER, Value: "AAPL", Domain: "XNAS"},
 		Rows:       []*archivev1.PriceRow{{PriceDate: "2024-01-15", Close: "185.90"}},
 	})
-
-	j := &JobRequest{JobID: "job-price-diff", JobType: "price"}
-
-	database.EXPECT().LoadJobPayload(gomock.Any(), "job-price-diff").Return(payload, nil)
-	database.EXPECT().ClearJobPayload(gomock.Any(), "job-price-diff").Return(nil)
-	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-price-diff", int32(1)).Return(nil)
 
 	// DB-only lookup succeeds, but the instrument has a different exchange.
 	database.EXPECT().
 		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").
 		Return("inst-aapl", "", "XNYS", "", nil) // exchange mismatch: XNYS != XNAS
-	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-price-diff").Return(nil)
 
-	var capturedErrs []*apiv1.ValidationError
-	database.EXPECT().
-		AppendValidationErrors(gomock.Any(), "job-price-diff", gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ string, _ archivev1.ArchivePart, errs []*apiv1.ValidationError) error {
-			capturedErrs = errs
-			return nil
-		})
-	database.EXPECT().
-		SetJobStatus(gomock.Any(), "job-price-diff", apiv1.JobStatus_SUCCESS).
-		Return(nil)
-
-	if processPriceImport(ctx, database, registry, j) {
+	persisted, capturedErrs, err := runPricePart(t, database, registry, part, nil)
+	if err != nil {
+		t.Fatalf("importPricePart: %v", err)
+	}
+	if persisted {
 		t.Error("expected persisted=false when row was rejected for hint diff")
 	}
 
@@ -353,36 +301,21 @@ func TestProcessPriceImport_RejectsCurrencyHintDiff(t *testing.T) {
 	database.EXPECT().SaveProviderIdentifiers(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	registry := identifier.NewRegistry()
 
-	ctx := context.Background()
-	payload := pricePayload(t, nil, &archivev1.PriceGroup{
+	part := pricePart(&archivev1.PriceGroup{
 		Instrument: &archivev1.InstrumentRef{Type: typev1.IdentifierType_MIC_TICKER, Value: "AAPL", Domain: "XNAS"},
 		Currency:   "GBP",
 		Rows:       []*archivev1.PriceRow{{PriceDate: "2024-01-15", Close: "185.90"}},
 	})
 
-	j := &JobRequest{JobID: "job-price-curdiff", JobType: "price"}
-
-	database.EXPECT().LoadJobPayload(gomock.Any(), "job-price-curdiff").Return(payload, nil)
-	database.EXPECT().ClearJobPayload(gomock.Any(), "job-price-curdiff").Return(nil)
-	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-price-curdiff", int32(1)).Return(nil)
-
 	database.EXPECT().
 		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").
 		Return("inst-aapl", "", "XNAS", "USD", nil) // currency mismatch: USD != GBP
-	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-price-curdiff").Return(nil)
 
-	var capturedErrs []*apiv1.ValidationError
-	database.EXPECT().
-		AppendValidationErrors(gomock.Any(), "job-price-curdiff", gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, _ string, _ archivev1.ArchivePart, errs []*apiv1.ValidationError) error {
-			capturedErrs = errs
-			return nil
-		})
-	database.EXPECT().
-		SetJobStatus(gomock.Any(), "job-price-curdiff", apiv1.JobStatus_SUCCESS).
-		Return(nil)
-
-	if processPriceImport(ctx, database, registry, j) {
+	persisted, capturedErrs, err := runPricePart(t, database, registry, part, nil)
+	if err != nil {
+		t.Fatalf("importPricePart: %v", err)
+	}
+	if persisted {
 		t.Error("expected persisted=false when row was rejected for currency hint diff")
 	}
 
@@ -406,19 +339,12 @@ func TestProcessPriceImport_FallbackPassesAssetClassAndCurrency(t *testing.T) {
 	database.EXPECT().SaveProviderIdentifiers(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	registry := identifier.NewRegistry()
 
-	ctx := context.Background()
-	payload := pricePayload(t, nil, &archivev1.PriceGroup{
+	part := pricePart(&archivev1.PriceGroup{
 		Instrument: &archivev1.InstrumentRef{Type: typev1.IdentifierType_FX_PAIR, Value: "EURGBP"},
 		AssetClass: typev1.AssetClass_FX,
 		Currency:   "EUR",
 		Rows:       []*archivev1.PriceRow{{PriceDate: "2021-12-31", Close: "0.84"}},
 	})
-
-	j := &JobRequest{JobID: "job-price-fx", JobType: "price"}
-
-	database.EXPECT().LoadJobPayload(gomock.Any(), "job-price-fx").Return(payload, nil)
-	database.EXPECT().ClearJobPayload(gomock.Any(), "job-price-fx").Return(nil)
-	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-price-fx", int32(1)).Return(nil)
 
 	// asset_class is non-empty so the plugin path is taken. With no plugins
 	// registered, ListEnabledPluginConfigs returns empty and the DB-only
@@ -441,15 +367,15 @@ func TestProcessPriceImport_FallbackPassesAssetClassAndCurrency(t *testing.T) {
 		Return("inst-eurgbp", nil)
 	// No exported_at, so the vintage is now.
 	database.EXPECT().UpdateIdentityAsOf(gomock.Any(), "inst-eurgbp").Return(nil)
-	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-price-fx").Return(nil)
 	database.EXPECT().
 		UpsertPrices(gomock.Any(), gomock.Any()).
 		Return(nil)
-	database.EXPECT().
-		SetJobStatus(gomock.Any(), "job-price-fx", apiv1.JobStatus_SUCCESS).
-		Return(nil)
 
-	if !processPriceImport(ctx, database, registry, j) {
+	persisted, _, err := runPricePart(t, database, registry, part, nil)
+	if err != nil {
+		t.Fatalf("importPricePart: %v", err)
+	}
+	if !persisted {
 		t.Error("expected persisted=true after a successful upsert")
 	}
 }
@@ -465,19 +391,12 @@ func TestProcessPriceImport_OptionFallbackResolvesUnderlying(t *testing.T) {
 	database.EXPECT().SaveProviderIdentifiers(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	registry := identifier.NewRegistry()
 
-	ctx := context.Background()
-	payload := pricePayload(t, nil, &archivev1.PriceGroup{
+	part := pricePart(&archivev1.PriceGroup{
 		Instrument: &archivev1.InstrumentRef{Type: typev1.IdentifierType_OCC, Value: "NVDA240315P00510000"},
 		AssetClass: typev1.AssetClass_OPTION,
 		Currency:   "USD",
 		Rows:       []*archivev1.PriceRow{{PriceDate: "2024-03-01", Close: "12.50"}},
 	})
-
-	j := &JobRequest{JobID: "job-price-opt", JobType: "price"}
-
-	database.EXPECT().LoadJobPayload(gomock.Any(), "job-price-opt").Return(payload, nil)
-	database.EXPECT().ClearJobPayload(gomock.Any(), "job-price-opt").Return(nil)
-	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-price-opt", int32(1)).Return(nil)
 
 	// No plugins registered: plugin path triggers fallback.
 	database.EXPECT().
@@ -505,15 +424,15 @@ func TestProcessPriceImport_OptionFallbackResolvesUnderlying(t *testing.T) {
 	// No exported_at on the request, so the supplied OCC is taken at face value
 	// as current and the vintage is now.
 	database.EXPECT().UpdateIdentityAsOf(gomock.Any(), "inst-opt").Return(nil)
-	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-price-opt").Return(nil)
 	database.EXPECT().
 		UpsertPrices(gomock.Any(), gomock.Any()).
 		Return(nil)
-	database.EXPECT().
-		SetJobStatus(gomock.Any(), "job-price-opt", apiv1.JobStatus_SUCCESS).
-		Return(nil)
 
-	if !processPriceImport(ctx, database, registry, j) {
+	persisted, _, err := runPricePart(t, database, registry, part, nil)
+	if err != nil {
+		t.Fatalf("importPricePart: %v", err)
+	}
+	if !persisted {
 		t.Error("expected persisted=true after a successful upsert")
 	}
 }
@@ -536,19 +455,13 @@ func TestProcessPriceImport_OptionFallbackStampsExportedAt(t *testing.T) {
 	registry := identifier.NewRegistry()
 
 	exportedAt := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
-	ctx := context.Background()
-	payload := pricePayload(t, timestamppb.New(exportedAt), &archivev1.PriceGroup{
+	part := pricePart(&archivev1.PriceGroup{
 		Instrument: &archivev1.InstrumentRef{Type: typev1.IdentifierType_OCC, Value: "NVDA240315P00510000"},
 		AssetClass: typev1.AssetClass_OPTION,
 		Currency:   "USD",
 		Rows:       []*archivev1.PriceRow{{PriceDate: "2024-03-01", Close: "12.50"}},
 	})
 
-	j := &JobRequest{JobID: "job-price-vintage", JobType: "price"}
-
-	database.EXPECT().LoadJobPayload(gomock.Any(), "job-price-vintage").Return(payload, nil)
-	database.EXPECT().ClearJobPayload(gomock.Any(), "job-price-vintage").Return(nil)
-	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-price-vintage", int32(1)).Return(nil)
 	database.EXPECT().ListEnabledPluginConfigs(gomock.Any(), "identifier").Return(nil, nil)
 	database.EXPECT().SplitsByUnderlyingTicker(gomock.Any(), "NVDA").Return(nil, nil).AnyTimes()
 	database.EXPECT().
@@ -569,64 +482,13 @@ func TestProcessPriceImport_OptionFallbackStampsExportedAt(t *testing.T) {
 	// The assertion: the file's declared vintage, not now() and not NULL.
 	database.EXPECT().SetIdentityAsOf(gomock.Any(), "inst-opt", exportedAt).Return(nil)
 
-	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-price-vintage").Return(nil)
 	database.EXPECT().UpsertPrices(gomock.Any(), gomock.Any()).Return(nil)
-	database.EXPECT().SetJobStatus(gomock.Any(), "job-price-vintage", apiv1.JobStatus_SUCCESS).Return(nil)
 
-	if !processPriceImport(ctx, database, registry, j) {
-		t.Error("expected persisted=true after a successful upsert")
+	persisted, _, err := runPricePart(t, database, registry, part, timestamppb.New(exportedAt))
+	if err != nil {
+		t.Fatalf("importPricePart: %v", err)
 	}
-}
-
-// The payload is what a job is. Clearing it before the work is done means a
-// service restarted mid-job re-enqueues a row whose payload is NULL, which
-// unmarshals cleanly as an empty request, imports nothing and reports SUCCESS.
-// So it must survive until the job reaches a terminal status.
-func TestProcessPriceImport_ClearsPayloadOnlyAfterTerminalStatus(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	database := mock.NewMockDB(ctrl)
-	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
-	database.EXPECT().SaveProviderIdentifiers(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-	registry := identifier.NewRegistry()
-	ctx := context.Background()
-
-	payload := pricePayload(t, nil, &archivev1.PriceGroup{
-		Instrument: &archivev1.InstrumentRef{Type: typev1.IdentifierType_OPENFIGI_GLOBAL, Value: "BBG000B9XRY4"},
-		Rows:       []*archivev1.PriceRow{{PriceDate: "2024-01-15", Close: "185.90"}},
-	})
-	j := &JobRequest{JobID: "job-price-order", JobType: "price"}
-
-	database.EXPECT().LoadJobPayload(gomock.Any(), "job-price-order").Return(payload, nil)
-	database.EXPECT().SetJobTotalCount(gomock.Any(), "job-price-order", int32(1)).Return(nil)
-	database.EXPECT().IncrJobProcessedCount(gomock.Any(), "job-price-order").Return(nil)
-	database.EXPECT().AppendValidationErrors(gomock.Any(), "job-price-order", gomock.Any(), gomock.Any()).Return(nil)
-
-	gomock.InOrder(
-		database.EXPECT().SetJobStatus(gomock.Any(), "job-price-order", apiv1.JobStatus_SUCCESS).Return(nil),
-		database.EXPECT().ClearJobPayload(gomock.Any(), "job-price-order").Return(nil),
-	)
-
-	processPriceImport(ctx, database, registry, j)
-}
-
-// A payload that cannot be read fails the job, and that is terminal too, so the
-// payload goes with it rather than being left to be retried forever.
-func TestProcessPriceImport_ClearsPayloadAfterFailure(t *testing.T) {
-	ctrl := gomock.NewController(t)
-	defer ctrl.Finish()
-	database := mock.NewMockDB(ctrl)
-	registry := identifier.NewRegistry()
-	ctx := context.Background()
-	j := &JobRequest{JobID: "job-price-badpayload", JobType: "price"}
-
-	database.EXPECT().LoadJobPayload(gomock.Any(), "job-price-badpayload").Return([]byte("not a proto"), nil)
-	gomock.InOrder(
-		database.EXPECT().SetJobStatus(gomock.Any(), "job-price-badpayload", apiv1.JobStatus_FAILED).Return(nil),
-		database.EXPECT().ClearJobPayload(gomock.Any(), "job-price-badpayload").Return(nil),
-	)
-
-	if processPriceImport(ctx, database, registry, j) {
-		t.Error("expected persisted=false for an unreadable payload")
+	if !persisted {
+		t.Error("expected persisted=true after a successful upsert")
 	}
 }

--- a/server/service/ingestion/worker.go
+++ b/server/service/ingestion/worker.go
@@ -112,18 +112,6 @@ func processJob(ctx context.Context, opts WorkerOptions, j *JobRequest) {
 			// whose first side arrived months ago.
 			pluginutil.Trigger(opts.TransferMatchTrigger)
 		}
-	case db.JobTypePrice:
-		if processPriceImport(ctx, opts.DB, opts.IdentifierRegistry, j) {
-			pluginutil.Trigger(opts.PriceTrigger)
-		}
-	case db.JobTypeCorporateEvent:
-		if processCorporateEventImport(ctx, opts.DB, opts.IdentifierRegistry, j) {
-			// Only the corporate event fetcher is triggered here. The price
-			// fetcher is not nudged because instruments resolved during
-			// corporate event import cannot by definition create new holding
-			// gaps that would require price data.
-			pluginutil.Trigger(opts.CorporateEventTrigger)
-		}
 	case db.JobTypeSystemArchive:
 		res := processSystemImport(ctx, opts.DB, opts.IdentifierRegistry, j)
 		// Nudged once for the whole import rather than per part. Instruments


### PR DESCRIPTION
Last of the stack for 0079. **Depends on #362.** Closes 0079.

The six per-entity export and import RPCs have no callers left -- the page, the
CLI and the e2e helpers all go through the consolidated pair. Keeping them would
leave two ways to produce and consume the same file, which is what 0079 set out
to remove.

- `Export/ImportInstruments`, `Export/ImportPrices`, `Export/ImportCorporateEvents`
  and their messages are gone, along with the `price` and `corporate_event` job
  types and the two legacy job processors.
- **Callers migrated**: `cli/google` and the e2e helpers now send a document
  carrying only the part they mean. That is what "import one kind of data" is
  now: one endpoint, one document, one part populated.
- **Tests repointed, not deleted.** The price and corporate event part functions
  still exist and are reached through a system archive job, so the ~20 tests that
  covered them now drive `importPricePart` / `importCorporateEventPart` directly
  with a detached reporter. The export tests drive `ExportSystemArchive` and
  assert the new stream shape (envelope, part marker, items). Only the guard
  tests went, and only because the consolidated endpoints already cover the same
  guards.

### Verified

`make test`, `make db-test`, `make lint-go`, `make lint-proto`, `make lint-ts`,
`make client-typecheck`, `make client-test`, `make fmt-check` all clean.

**The full e2e suite passes against the real stack: 37/37.** That is the evidence
that matters here -- the corporate event round trip, the price import merge and
the stock split suites all exercise the migrated helpers end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)