### PR TITLE
Cover what the archive round trip actually preserves

### DIFF
--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -8,6 +8,7 @@ import { ApiService, JobStatus, type GetJobResponse } from "../gen/api/v1/api_pb
 import { ArchiveKind, ArchivePart } from "../gen/archive/v1/common_pb";
 import { CorporateEventGroupSchema, type CorporateEventGroup } from "../gen/archive/v1/corporate_events_pb";
 import { PriceGroupSchema } from "../gen/archive/v1/prices_pb";
+import { SystemArchiveSchema } from "../gen/archive/v1/archive_pb";
 import type { MessageInitShape } from "@bufbuild/protobuf";
 import { timestampNow } from "@bufbuild/protobuf/wkt";
 
@@ -27,6 +28,46 @@ export async function setDisplayCurrency(
     { displayCurrency: currency },
     { headers: { Cookie: `${COOKIE_NAME}=${sessionId}` } },
   );
+}
+
+/**
+ * Import a whole system archive document and wait for the job to complete.
+ *
+ * The document is passed as it would be read from a file, so a test can hand it
+ * a generated or hand-written archive rather than only the parts these helpers
+ * know how to build.
+ */
+export async function importSystemArchiveAndWait(
+  sessionId: string,
+  archive: MessageInitShape<typeof SystemArchiveSchema>,
+  timeoutMs = 60_000,
+): Promise<GetJobResponse> {
+  const headers = { Cookie: `${COOKIE_NAME}=${sessionId}` };
+  const resp = await client.importSystemArchive({ archive }, { headers });
+  return waitForJob(resp.jobId, headers, timeoutMs);
+}
+
+/** Read one job's status without waiting for it to finish. */
+export async function getJobStatus(sessionId: string, jobId: string): Promise<GetJobResponse> {
+  const headers = { Cookie: `${COOKIE_NAME}=${sessionId}` };
+  return client.getJob({ jobId }, { headers });
+}
+
+/** Poll one job until it reaches a terminal status. */
+async function waitForJob(
+  jobId: string,
+  headers: Record<string, string>,
+  timeoutMs: number,
+): Promise<GetJobResponse> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const job = await client.getJob({ jobId }, { headers });
+    if (job.status === JobStatus.SUCCESS || job.status === JobStatus.FAILED) {
+      return job;
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  throw new Error(`job ${jobId} did not complete within ${timeoutMs}ms`);
 }
 
 /**

--- a/e2e/helpers/archive.ts
+++ b/e2e/helpers/archive.ts
@@ -1,0 +1,120 @@
+// Generates system archive files for tests that need more data than a fixture
+// should carry.
+//
+// The document is written as protojson by hand rather than through the codec,
+// which is worth doing on its own account: docs/spec/archive-format.md says a
+// hand-written archive is a supported way to produce one, and nothing else
+// checks that claim.
+
+import { readFileSync, writeFileSync } from "fs";
+import path from "path";
+import { tmpdir } from "os";
+import { fromJsonString } from "@bufbuild/protobuf";
+import { SystemArchiveSchema, type SystemArchive } from "../gen/archive/v1/archive_pb";
+
+export interface GeneratedArchive {
+  /** Where the file was written. */
+  path: string;
+  /** How many instruments the instrument part carries. */
+  instruments: number;
+  /** How many price rows the price part carries in total. */
+  priceRows: number;
+  /** The identifier values used, in order. */
+  tickers: string[];
+}
+
+/** Formats a day offset from 2024-01-01 as YYYY-MM-DD. */
+function day(offset: number): string {
+  const d = new Date(Date.UTC(2024, 0, 1));
+  d.setUTCDate(d.getUTCDate() + offset);
+  return d.toISOString().slice(0, 10);
+}
+
+/**
+ * Write an archive carrying `instruments` instruments and `rowsEach` price rows
+ * for each of them.
+ *
+ * The price groups deliberately declare no asset_class. A group that declares
+ * one is routed through the identifier plugins, which in a test means a cassette
+ * -- and a generated instrument has nothing to record against. Naming the
+ * instruments in their own part instead gives them an asset class through
+ * EnsureInstrument, which calls no plugin.
+ */
+export function writeGeneratedArchive(opts: {
+  instruments: number;
+  rowsEach: number;
+  filename?: string;
+  /**
+   * Rows given a well-formed but impossible date, as [instrument, row] pairs.
+   * The date still matches the field's pattern, so protovalidate passes it and
+   * it becomes a row-level problem rather than a rejection of the whole file.
+   */
+  badDates?: [number, number][];
+  /**
+   * Rows given a close that is not a decimal at all. The field is
+   * pattern-constrained, so this is refused for the whole document before any
+   * of it is applied.
+   */
+  badDecimals?: [number, number][];
+}): GeneratedArchive {
+  const { instruments, rowsEach } = opts;
+  const badDate = new Set((opts.badDates ?? []).map(([i, r]) => `${i}:${r}`));
+  const badDecimal = new Set((opts.badDecimals ?? []).map(([i, r]) => `${i}:${r}`));
+  const tickers: string[] = [];
+
+  const instrumentPart: unknown[] = [];
+  const priceGroups: unknown[] = [];
+
+  for (let i = 0; i < instruments; i++) {
+    const ticker = `E2E${String(i).padStart(4, "0")}`;
+    tickers.push(ticker);
+    instrumentPart.push({
+      asset_class: "STOCK",
+      currency: "USD",
+      exchange_mic: "XNAS",
+      name: `E2E Test Instrument ${i}`,
+      identifiers: [{ type: "MIC_TICKER", value: ticker, domain: "XNAS", canonical: true }],
+    });
+
+    const rows: unknown[] = [];
+    for (let r = 0; r < rowsEach; r++) {
+      const key = `${i}:${r}`;
+      rows.push({
+        // 31 February matches the pattern and is not a date, which is exactly
+        // the shape of problem that reaches the importer rather than being
+        // caught at the edge.
+        price_date: badDate.has(key) ? "2024-02-31" : day(r),
+        close: badDecimal.has(key) ? "not-a-number" : (100 + (r % 50) + i / 1000).toFixed(4),
+      });
+    }
+    priceGroups.push({
+      instrument: { type: "MIC_TICKER", value: ticker, domain: "XNAS" },
+      currency: "USD",
+      coverage: [{ from: day(0), before: day(rowsEach) }],
+      rows,
+    });
+  }
+
+  const doc = {
+    envelope: {
+      format_version: 1,
+      exported_at: "2026-07-30T00:00:00Z",
+      source_instance: "e2e-generated",
+      kind: "SYSTEM",
+    },
+    instruments: { instruments: instrumentPart },
+    prices: { groups: priceGroups },
+  };
+
+  const file = path.join(tmpdir(), opts.filename ?? "generated-archive.json");
+  writeFileSync(file, JSON.stringify(doc));
+  return { path: file, instruments, priceRows: instruments * rowsEach, tickers };
+}
+
+/**
+ * Read an archive file the way a client does: protojson in, message out. A test
+ * that generated the file still goes through the decode rather than around it.
+ */
+export function readArchive(file: string): SystemArchive {
+  return fromJsonString(SystemArchiveSchema, readFileSync(file, "utf8"));
+}

--- a/e2e/tests/system-archive-bad-rows.spec.ts
+++ b/e2e/tests/system-archive-bad-rows.spec.ts
@@ -1,0 +1,113 @@
+// E2E test: what an import does with data it cannot use.
+//
+// Two different failures, and the difference between them is the point. A row
+// the importer cannot read is rejected on its own and the part still succeeds,
+// so a mostly-good archive still lands. A field that does not match its declared
+// shape is refused for the whole document before any of it is applied, because
+// whether a file is a valid archive is an all-or-nothing question.
+
+import { test, expect } from "@playwright/test";
+import { TIMEOUT_SLOW } from "../helpers/timeouts";
+import { seedSession, injectSession, closeRedis } from "../helpers/auth";
+import { resetAndSeedBase, closeDB, rawQuery } from "../helpers/db";
+import { writeGeneratedArchive } from "../helpers/archive";
+
+const INSTRUMENTS = 2;
+const ROWS_EACH = 5;
+
+test.beforeAll(async () => {
+  await resetAndSeedBase();
+});
+
+test.afterAll(async () => {
+  await closeRedis();
+  await closeDB();
+});
+
+test.describe("system archive import with unusable data", () => {
+  let adminSessionId: string;
+
+  test.beforeAll(async () => {
+    adminSessionId = await seedSession("admin");
+  });
+
+  test("rejects the bad row, applies the rest, and says how many it dropped", async ({
+    context,
+    page,
+  }) => {
+    // One impossible date in the first instrument's second row. It matches the
+    // field's pattern, so it reaches the importer rather than being refused at
+    // the edge.
+    const gen = writeGeneratedArchive({
+      instruments: INSTRUMENTS,
+      rowsEach: ROWS_EACH,
+      badDates: [[0, 1]],
+      filename: "bad-row-archive.json",
+    });
+
+    await injectSession(context, adminSessionId);
+    await page.goto("/admin/archive");
+    await page.locator("[data-testid='choose-archive-file']").click();
+    await page.locator("input[aria-label='Choose archive file']").setInputFiles(gen.path);
+    await page.locator("[data-testid='start-archive-import']").click();
+
+    const parts = page.locator("[data-testid='job-parts']");
+    await expect(parts).toBeVisible({ timeout: TIMEOUT_SLOW });
+    // Both parts finish. A rejected row is not a failed part -- what failed is a
+    // row, and the result reads "done, one rejected" rather than "failed".
+    await expect(parts.getByText("Done")).toHaveCount(2, { timeout: TIMEOUT_SLOW });
+    await expect(parts.getByText("Failed")).toHaveCount(0);
+
+    // The count is on the Prices row, and the problem is named underneath it.
+    const priceRow = parts.locator("tr", { hasText: "Prices" });
+    await expect(priceRow).toContainText("1");
+    await expect(page.locator("[data-testid='archive-job']")).toContainText("price_date");
+
+    // Everything except the bad row landed, which is what makes rejecting a row
+    // rather than the file worth doing.
+    const rows = (await rawQuery("SELECT count(*)::int AS n FROM eod_prices")) as { n: number }[];
+    expect(rows[0].n).toBe(INSTRUMENTS * ROWS_EACH - 1);
+  });
+
+  test("refuses the whole file when a field does not match its declared shape", async ({
+    context,
+    page,
+  }) => {
+    await rawQuery("DELETE FROM eod_prices");
+    const before = (await rawQuery(
+      "SELECT count(*)::int AS n FROM ingestion_jobs WHERE job_type = 'system_archive'",
+    )) as { n: number }[];
+    const gen = writeGeneratedArchive({
+      instruments: INSTRUMENTS,
+      rowsEach: ROWS_EACH,
+      badDecimals: [[1, 2]],
+      filename: "bad-decimal-archive.json",
+    });
+
+    await injectSession(context, adminSessionId);
+    await page.goto("/admin/archive");
+    await page.locator("[data-testid='choose-archive-file']").click();
+    await page.locator("input[aria-label='Choose archive file']").setInputFiles(gen.path);
+    await page.locator("[data-testid='start-archive-import']").click();
+
+    // The upload is refused rather than queued, so the page reports it where the
+    // upload happened. The offending field is named, which is the difference
+    // between "this file is wrong" and "this file is wrong here".
+    await expect(page.locator("[data-testid='archive-import']")).toContainText(/close/i, {
+      timeout: TIMEOUT_SLOW,
+    });
+
+    // No job was created. The results panel still shows the previous run, which
+    // is right -- a refused upload does not erase the last import -- so counting
+    // jobs is what says nothing was queued.
+    const after = (await rawQuery(
+      "SELECT count(*)::int AS n FROM ingestion_jobs WHERE job_type = 'system_archive'",
+    )) as { n: number }[];
+    expect(after[0].n).toBe(before[0].n);
+
+    // Nothing from a refused document is applied, including the rows that were
+    // perfectly good.
+    const rows = (await rawQuery("SELECT count(*)::int AS n FROM eod_prices")) as { n: number }[];
+    expect(rows[0].n).toBe(0);
+  });
+});

--- a/e2e/tests/system-archive-roundtrip.spec.ts
+++ b/e2e/tests/system-archive-roundtrip.spec.ts
@@ -1,9 +1,15 @@
 // E2E test: the consolidated archive page.
 //
-// Exports a system archive through the UI, then imports the same file back and
-// reads the per-part results. The round trip is the point: a file this instance
+// Exports a system archive through the UI, imports the same file back, and then
+// checks the database. The round trip is the point: a file this instance
 // produced has to be one it can consume, and the per-part results are what tell
 // an admin what an import actually applied.
+//
+// The seed is loaded as an archive carrying an instrument part rather than
+// prices alone, so the exported file has instruments in it. An instrument whose
+// asset_class is still NULL -- one created by a price import before
+// identification has run -- is dropped from the export today; that is issue
+// 0083 and is deliberately not covered here.
 
 import { test, expect } from "@playwright/test";
 import path from "path";
@@ -11,9 +17,14 @@ import { readFile, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import { TIMEOUT_SLOW } from "../helpers/timeouts";
 import { seedSession, injectSession, closeRedis } from "../helpers/auth";
-import { resetAndSeedBase, closeDB } from "../helpers/db";
-import { importPricesAndWait } from "../helpers/api";
-import { IdentifierType } from "../gen/type/v1/type_pb";
+import { resetAndSeedBase, closeDB, rawQuery } from "../helpers/db";
+import { importSystemArchiveAndWait } from "../helpers/api";
+import { writeGeneratedArchive, readArchive } from "../helpers/archive";
+import { JobStatus } from "../gen/api/v1/api_pb";
+
+// Two instruments with three price rows each: small enough to assert on every
+// value, large enough to have a second group.
+const SEED = { instruments: 2, rowsEach: 3 };
 
 test.beforeAll(async () => {
   await resetAndSeedBase();
@@ -26,36 +37,24 @@ test.afterAll(async () => {
 
 test.describe("system archive page", () => {
   let adminSessionId: string;
+  let tickers: string[];
 
   test.beforeAll(async () => {
     adminSessionId = await seedSession("admin");
-    // Something to export. Prices create the instrument they name, so this
-    // seeds the instrument and price parts at once.
-    await importPricesAndWait(adminSessionId, [
-      {
-        instrument: { type: IdentifierType.MIC_TICKER, value: "AAPL", domain: "XNAS" },
-        currency: "USD",
-        coverage: [{ from: "2024-01-02", before: "2024-01-04" }],
-        rows: [
-          { priceDate: "2024-01-02", close: "185.64" },
-          { priceDate: "2024-01-03", close: "184.25" },
-        ],
-      },
-    ]);
+    const seed = writeGeneratedArchive({ ...SEED, filename: "roundtrip-seed.json" });
+    tickers = seed.tickers;
+    const job = await importSystemArchiveAndWait(adminSessionId, readArchive(seed.path));
+    expect(job.status).toBe(JobStatus.SUCCESS);
   });
 
-  test("exports a file and imports it back, reporting a result per part", async ({
-    context,
-    page,
-  }) => {
+  test("exports a file and imports it back, preserving the data", async ({ context, page }) => {
     await injectSession(context, adminSessionId);
     await page.goto("/admin/archive");
     await expect(page.getByRole("heading", { name: "Archive" })).toBeVisible();
 
     // Parts the format does not carry yet are visible but not selectable, so the
     // menu says what the archive will hold rather than only what it holds today.
-    const pluginConfig = page.getByLabel(/Plugin config/);
-    await expect(pluginConfig).toBeDisabled();
+    await expect(page.getByLabel(/Plugin config/)).toBeDisabled();
 
     const downloadPromise = page.waitForEvent("download");
     await page.locator("[data-testid='export-archive']").click();
@@ -66,39 +65,57 @@ test.describe("system archive page", () => {
     await download.saveAs(exported);
     const doc = JSON.parse(await readFile(exported, "utf8"));
 
-    // The envelope says what the file is, and the parts asked for are present.
+    // The envelope says what the file is, and every part asked for is carried
+    // with its contents -- not merely present and empty, which is what an
+    // export that silently dropped its rows would also look like.
     expect(doc.envelope.kind).toBe("SYSTEM");
-    expect(doc.instruments).toBeDefined();
-    expect(doc.prices).toBeDefined();
-    expect(doc.prices.groups[0].rows).toHaveLength(2);
+    expect(doc.envelope.format_version).toBe(1);
+    const exportedTickers = doc.instruments.instruments
+      .flatMap((i: { identifiers: { value: string }[] }) => i.identifiers.map((id) => id.value))
+      .filter((v: string) => v.startsWith("E2E"));
+    expect(exportedTickers.sort()).toEqual([...tickers].sort());
+    expect(doc.prices.groups).toHaveLength(SEED.instruments);
+    expect(doc.prices.groups[0].rows).toHaveLength(SEED.rowsEach);
+    // Coverage is not derivable from the rows, so losing it would be silent.
+    expect(doc.prices.groups[0].coverage).toHaveLength(1);
 
-    // Import the same file back.
+    // Wipe the price rows and re-import the file, so what lands afterwards came
+    // from the archive rather than from what was already there.
+    await rawQuery("DELETE FROM eod_prices");
+    await rawQuery("DELETE FROM price_coverage");
+
     await page.locator("[data-testid='choose-archive-file']").click();
     await page.locator("input[aria-label='Choose archive file']").setInputFiles(exported);
     await expect(page.locator("[data-testid='archive-import']")).toContainText("Carries");
     await page.locator("[data-testid='start-archive-import']").click();
 
-    // A row per part, each finishing. The import runs on the server, so this is
-    // watching a job rather than driving it.
     const parts = page.locator("[data-testid='job-parts']");
     await expect(parts).toBeVisible({ timeout: TIMEOUT_SLOW });
-    await expect(parts).toContainText("Instruments");
-    await expect(parts).toContainText("Prices");
     await expect(parts.getByText("Done")).toHaveCount(3, { timeout: TIMEOUT_SLOW });
-  });
 
-  test("shows a running import after the page is left and returned to", async ({
-    context,
-    page,
-  }) => {
-    await injectSession(context, adminSessionId);
-    // The job is found rather than remembered, so a fresh visit shows the last
-    // import even though this page never started one.
-    await page.goto("/admin/archive");
-    await expect(page.locator("[data-testid='archive-job']")).toBeVisible({
-      timeout: TIMEOUT_SLOW,
-    });
-    await expect(page.locator("[data-testid='job-parts']")).toContainText("Prices");
+    // What the page said happened, checked against what is stored.
+    const priceRows = (await rawQuery(
+      `SELECT count(*)::int AS n FROM eod_prices p
+         JOIN instrument_identifiers ii ON ii.instrument_id = p.instrument_id
+        WHERE ii.value = $1`,
+      [tickers[0]],
+    )) as { n: number }[];
+    expect(priceRows[0].n).toBe(SEED.rowsEach);
+
+    const coverage = (await rawQuery(
+      `SELECT count(*)::int AS n FROM price_coverage c
+         JOIN instrument_identifiers ii ON ii.instrument_id = c.instrument_id
+        WHERE ii.value = $1`,
+      [tickers[0]],
+    )) as { n: number }[];
+    expect(coverage[0].n).toBeGreaterThan(0);
+
+    // The instrument was matched rather than duplicated: an archive re-imported
+    // into the instance that produced it must not fork its own security master.
+    const instruments = (await rawQuery(
+      `SELECT count(*)::int AS n FROM instrument_identifiers WHERE value LIKE 'E2E%'`,
+    )) as { n: number }[];
+    expect(instruments[0].n).toBe(SEED.instruments);
   });
 
   test("refuses a file that is not a system archive", async ({ context, page }) => {
@@ -108,7 +125,9 @@ test.describe("system archive page", () => {
     const notAnArchive = path.join(tmpdir(), "not-an-archive.json");
     await writeFile(
       notAnArchive,
-      JSON.stringify({ envelope: { format_version: 1, exported_at: "2026-07-30T00:00:00Z", kind: "USER" } }),
+      JSON.stringify({
+        envelope: { format_version: 1, exported_at: "2026-07-30T00:00:00Z", kind: "USER" },
+      }),
     );
     await page.locator("[data-testid='choose-archive-file']").click();
     await page.locator("input[aria-label='Choose archive file']").setInputFiles(notAnArchive);

--- a/e2e/tests/system-archive-scale.spec.ts
+++ b/e2e/tests/system-archive-scale.spec.ts
@@ -1,0 +1,158 @@
+// E2E test: a system archive at a size worth calling a rebuild, and what
+// happens when the admin walks away from one.
+//
+// The size is the test. A two-row archive proves the wiring; it does not
+// exercise streaming the export, batching the progress counter, or leave a
+// window in which the browser can be closed while the import is still running.
+//
+// The archive is generated rather than committed: a file this size does not
+// belong in the repository, and generating it means the shape is stated in code
+// rather than buried in a fixture.
+
+import { test, expect } from "@playwright/test";
+import { readFile } from "fs/promises";
+import type { Page } from "@playwright/test";
+import { TIMEOUT_SLOW } from "../helpers/timeouts";
+import { seedSession, injectSession, closeRedis } from "../helpers/auth";
+import { resetAndSeedBase, closeDB, rawQuery } from "../helpers/db";
+import { getJobStatus } from "../helpers/api";
+import { writeGeneratedArchive } from "../helpers/archive";
+import { JobStatus } from "../gen/api/v1/api_pb";
+
+// 200 instruments x 250 rows. Enough that the import runs for seconds rather
+// than milliseconds, which is what makes closing the browser mid-import mean
+// anything, and enough that the export has to stream.
+const INSTRUMENTS = 200;
+const ROWS_EACH = 250;
+const TOTAL_ROWS = INSTRUMENTS * ROWS_EACH;
+
+test.beforeAll(async () => {
+  await resetAndSeedBase();
+});
+
+test.afterAll(async () => {
+  await closeRedis();
+  await closeDB();
+});
+
+/** Reads the id of the newest system archive job straight from the database. */
+async function newestArchiveJobId(): Promise<string> {
+  const rows = (await rawQuery(
+    `SELECT id::text AS id FROM ingestion_jobs
+      WHERE job_type = 'system_archive'
+      ORDER BY created_at DESC LIMIT 1`,
+  )) as { id: string }[];
+  expect(rows).toHaveLength(1);
+  return rows[0].id;
+}
+
+async function startImport(page: Page, file: string): Promise<void> {
+  await page.goto("/admin/archive");
+  await page.locator("[data-testid='choose-archive-file']").click();
+  await page.locator("input[aria-label='Choose archive file']").setInputFiles(file);
+  await expect(page.locator("[data-testid='archive-import']")).toContainText("Carries", {
+    timeout: TIMEOUT_SLOW,
+  });
+  await page.locator("[data-testid='start-archive-import']").click();
+}
+
+test.describe("system archive at scale", () => {
+  let adminSessionId: string;
+  let generated: ReturnType<typeof writeGeneratedArchive>;
+
+  test.beforeAll(async () => {
+    adminSessionId = await seedSession("admin");
+    generated = writeGeneratedArchive({
+      instruments: INSTRUMENTS,
+      rowsEach: ROWS_EACH,
+      filename: "scale-archive.json",
+    });
+  });
+
+  test("an import outlives the browser that started it", async ({ context }) => {
+    test.setTimeout(TIMEOUT_SLOW);
+    await injectSession(context, adminSessionId);
+    const page = await context.newPage();
+    await startImport(page, generated.path);
+
+    // Wait until the job exists, then close the browser page outright. Not a
+    // navigation -- the client is gone.
+    await expect(page.locator("[data-testid='archive-job']")).toBeVisible({
+      timeout: TIMEOUT_SLOW,
+    });
+    const jobId = await newestArchiveJobId();
+    await page.close();
+
+    // It was genuinely unfinished when the client left, so completing it is
+    // something the server did on its own.
+    const atClose = await getJobStatus(adminSessionId, jobId);
+    expect(atClose.status).not.toBe(JobStatus.SUCCESS);
+
+    // Poll the API with no browser open at all.
+    const deadline = Date.now() + 120_000;
+    let final = atClose;
+    while (Date.now() < deadline && final.status !== JobStatus.SUCCESS && final.status !== JobStatus.FAILED) {
+      await new Promise((r) => setTimeout(r, 500));
+      final = await getJobStatus(adminSessionId, jobId);
+    }
+    expect(final.status).toBe(JobStatus.SUCCESS);
+
+    // Every row landed, so what finished was the whole import and not a
+    // truncated one.
+    const rows = (await rawQuery("SELECT count(*)::int AS n FROM eod_prices")) as { n: number }[];
+    expect(rows[0].n).toBe(TOTAL_ROWS);
+    const instruments = (await rawQuery(
+      "SELECT count(*)::int AS n FROM instrument_identifiers WHERE value LIKE 'E2E%'",
+    )) as { n: number }[];
+    expect(instruments[0].n).toBe(INSTRUMENTS);
+
+    // A returning admin is shown the run they walked away from, because the page
+    // looks the job up rather than remembering it.
+    const returning = await context.newPage();
+    await returning.goto("/admin/archive");
+    const parts = returning.locator("[data-testid='job-parts']");
+    await expect(parts).toBeVisible({ timeout: TIMEOUT_SLOW });
+    await expect(parts).toContainText(String(TOTAL_ROWS.toLocaleString()));
+    // Two rows, because the uploaded document carries two parts. A part absent
+    // from the file is not applied and gets no row -- which is the difference
+    // between a part left out and one included but empty.
+    await expect(parts.getByText("Done")).toHaveCount(2, { timeout: TIMEOUT_SLOW });
+  });
+
+  test("exports the whole instance and the file round trips", async ({ context }) => {
+    test.setTimeout(TIMEOUT_SLOW);
+    await injectSession(context, adminSessionId);
+    const page = await context.newPage();
+    await page.goto("/admin/archive");
+
+    const downloadPromise = page.waitForEvent("download");
+    await page.locator("[data-testid='export-archive']").click();
+    const exported = await downloadPromise;
+    const file = "/tmp/scale-export.json";
+    await exported.saveAs(file);
+
+    // The streamed export reassembled into a document with everything in it.
+    // Asserted on the file rather than only on what a re-import produces, so
+    // that an export which dropped rows is not mistaken for an import which did.
+    const doc = JSON.parse(await readFile(file, "utf8"));
+    expect(doc.prices.groups).toHaveLength(INSTRUMENTS);
+    const exportedRows = doc.prices.groups.reduce(
+      (n: number, g: { rows: unknown[] }) => n + g.rows.length,
+      0,
+    );
+    expect(exportedRows).toBe(TOTAL_ROWS);
+
+    // Re-importing what was just exported is the rebuild the archive exists for,
+    // and at this size it is the streaming export and the batched progress
+    // counter being exercised rather than described.
+    await rawQuery("DELETE FROM eod_prices");
+    await startImport(page, file);
+    const parts = page.locator("[data-testid='job-parts']");
+    // Three rows this time: an export writes every part that was asked for,
+    // including the corporate event part that has nothing in it.
+    await expect(parts.getByText("Done")).toHaveCount(3, { timeout: TIMEOUT_SLOW });
+
+    const rows = (await rawQuery("SELECT count(*)::int AS n FROM eod_prices")) as { n: number }[];
+    expect(rows[0].n).toBe(TOTAL_ROWS);
+  });
+});


### PR DESCRIPTION
Follow-on to the 0079 stack. **Depends on #363.**

Closes the e2e gaps we discussed. Four things, one of which is a correction to a
test I wrote earlier in the stack.

### The round trip now checks the data, not just the pipe

The old test asserted `doc.instruments` was *defined* — which a present-but-empty
part satisfies — and that the parts reported "Done", which Done over zero rows
also satisfies. It passed while the export was dropping every instrument.

It now seeds through an instrument part so the exported file genuinely has
instruments, asserts the exported tickers match what was seeded, and checks
Postgres after the re-import: the price rows, the coverage that is not derivable
from them, and that re-importing an archive into the instance that produced it
**matches** its instruments rather than forking the security master.

### Scale (`system-archive-scale.spec.ts`)

200 instruments × 250 rows = **50,000 price rows**, generated at runtime rather
than committed. First time the streaming export, the batched progress counter and
a ~2.4 MB upload are exercised rather than described. Imports in ~5s.

The export is asserted on the *file* as well as on the re-import, so an export
that dropped rows can't be mistaken for an import that did.

### An import outliving the browser

The size is what makes this testable. The page is **closed outright** — not
navigated — while the job is still unfinished (asserted), the job is then polled
through the API with no browser open at all, and every row is checked to have
landed. A returning admin then sees the finished run on a fresh page.

Ran it with `--repeat-each=3`: stable, 5.9s each time.

### Data an import cannot use (`system-archive-bad-rows.spec.ts`)

The distinction is the point, and it turned out to be sharper than I expected:

- A **row with an impossible date** (`2024-02-31` — matches the field's pattern,
  so it reaches the importer) is rejected on its own. Its part still says Done,
  the Rejected count shows 1, the field is named, and the other 9 rows land.
- A **malformed decimal** never reaches the importer at all: `close` is
  pattern-constrained, so protovalidate refuses the whole document and *nothing*
  is applied, not even the good rows. The panel names the offending field and no
  job is created.

I originally wrote the first case with a malformed decimal and found it was
covering the second behaviour by accident.

### Notes

- Generated archives are hand-written protojson, which also exercises the claim
  in `docs/spec/archive-format.md` that an archive can be authored by hand.
- Price groups deliberately declare no `asset_class`: a group that declares one
  is routed through the identifier plugins, which in a test means a cassette a
  generated instrument has nothing to record against. Instruments get their asset
  class from their own part instead, via `EnsureInstrument`, which calls no
  plugin. No new cassettes.
- The NULL-`asset_class` export gap is still deliberately uncovered and noted in
  the spec's header comment, since it belongs to 0083.

**Full suite: 40/40 in 2.0 minutes** (was 37).

🤖 Generated with [Claude Code](https://claude.com/claude-code)