### PR TITLE
Cover an import interrupted by the service restarting

### DIFF
--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -47,6 +47,19 @@ export async function importSystemArchiveAndWait(
   return waitForJob(resp.jobId, headers, timeoutMs);
 }
 
+/**
+ * Queue a system archive import and return the job id without waiting, for a
+ * test that wants to do something while the import is still running.
+ */
+export async function importSystemArchive(
+  sessionId: string,
+  archive: MessageInitShape<typeof SystemArchiveSchema>,
+): Promise<string> {
+  const headers = { Cookie: `${COOKIE_NAME}=${sessionId}` };
+  const resp = await client.importSystemArchive({ archive }, { headers });
+  return resp.jobId;
+}
+
 /** Read one job's status without waiting for it to finish. */
 export async function getJobStatus(sessionId: string, jobId: string): Promise<GetJobResponse> {
   const headers = { Cookie: `${COOKIE_NAME}=${sessionId}` };

--- a/e2e/helpers/cassette.ts
+++ b/e2e/helpers/cassette.ts
@@ -23,3 +23,35 @@ export async function loadCassette(name: string): Promise<void> {
 export async function unloadCassette(): Promise<void> {
   await client.unloadCassette({});
 }
+
+/**
+ * Replace the server process with a fresh one and wait until the replacement is
+ * answering.
+ *
+ * Waiting for the server to go unreachable and come back does not work: the
+ * process is replaced rather than respawned, and the gap is a few milliseconds
+ * -- easily missed between two polls, which makes the wait hang rather than
+ * pass. The start time is the reliable signal, because it is the one thing the
+ * new process cannot have inherited.
+ */
+export async function restartServer(timeoutMs = 60_000): Promise<void> {
+  const before = (await client.processInfo({})).startedAt;
+  if (!before) throw new Error("server reported no start time");
+
+  await client.restartProcess({});
+
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      const now = (await client.processInfo({})).startedAt;
+      // Different start time, so this is not the process we asked to leave.
+      if (now && (now.seconds !== before.seconds || now.nanos !== before.nanos)) {
+        return;
+      }
+    } catch {
+      // Unreachable while the process is being replaced, which is expected.
+    }
+    await new Promise((r) => setTimeout(r, 100));
+  }
+  throw new Error(`server did not restart within ${timeoutMs}ms`);
+}

--- a/e2e/tests/system-archive-restart.spec.ts
+++ b/e2e/tests/system-archive-restart.spec.ts
@@ -1,0 +1,103 @@
+// E2E test: an import interrupted by the service restarting.
+//
+// The archive exists so that a rebuild does not have to be paid for twice, and a
+// rebuild is long enough that the service can be restarted in the middle of one.
+// What has to survive that is the job: its payload, which is the only copy of
+// what was being imported, and the record of which parts had already been
+// applied.
+//
+// This is the path the payload used to be lost on. Clearing it at the start of a
+// job meant a restart re-enqueued a row with nothing in it, which unmarshalled
+// cleanly as an empty document, imported nothing, and reported success.
+
+import { test, expect } from "@playwright/test";
+import { seedSession, closeRedis } from "../helpers/auth";
+import { resetAndSeedBase, closeDB, rawQuery } from "../helpers/db";
+import { restartServer } from "../helpers/cassette";
+import { getJobStatus, importSystemArchive } from "../helpers/api";
+import { writeGeneratedArchive, readArchive } from "../helpers/archive";
+import { JobStatus } from "../gen/api/v1/api_pb";
+
+// Big enough that the import is still running when the process is replaced.
+const INSTRUMENTS = 200;
+const ROWS_EACH = 250;
+const TOTAL_ROWS = INSTRUMENTS * ROWS_EACH;
+
+test.beforeAll(async () => {
+  await resetAndSeedBase();
+});
+
+test.afterAll(async () => {
+  await closeRedis();
+  await closeDB();
+});
+
+/** How many price rows have been written so far. */
+async function storedRows(): Promise<number> {
+  const rows = (await rawQuery("SELECT count(*)::int AS n FROM eod_prices")) as { n: number }[];
+  return rows[0].n;
+}
+
+test.describe("system archive import across a restart", () => {
+  test("resumes and finishes an import the service was killed in the middle of", async () => {
+    test.setTimeout(240_000);
+    const admin = await seedSession("admin");
+    const gen = writeGeneratedArchive({
+      instruments: INSTRUMENTS,
+      rowsEach: ROWS_EACH,
+      filename: "restart-archive.json",
+    });
+
+    const jobId = await importSystemArchive(admin, readArchive(gen.path));
+
+    // Wait until the import is demonstrably under way: the instrument part has
+    // finished and prices have started landing. Restarting before that would
+    // test re-enqueueing a job that had not begun, which is a weaker claim.
+    const startedBy = Date.now() + 60_000;
+    let progressed = 0;
+    while (Date.now() < startedBy) {
+      progressed = await storedRows();
+      if (progressed > 0) break;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+    expect(progressed).toBeGreaterThan(0);
+    expect(progressed).toBeLessThan(TOTAL_ROWS);
+
+    // Replace the process. Everything the import was holding goes with it.
+    await restartServer();
+
+    // The job was left mid-flight, so nothing had marked it terminal.
+    const afterRestart = await getJobStatus(admin, jobId);
+    expect([JobStatus.PENDING, JobStatus.RUNNING]).toContain(afterRestart.status);
+
+    // The new process finds the job and finishes it. Nothing here nudges it --
+    // no upload, no retry, no client -- so completing is entirely recovery.
+    const deadline = Date.now() + 180_000;
+    let final = afterRestart;
+    while (
+      Date.now() < deadline &&
+      final.status !== JobStatus.SUCCESS &&
+      final.status !== JobStatus.FAILED
+    ) {
+      await new Promise((r) => setTimeout(r, 500));
+      final = await getJobStatus(admin, jobId);
+    }
+    expect(final.status).toBe(JobStatus.SUCCESS);
+
+    // Every row is present exactly once. The parts are built from idempotent
+    // upserts, so re-running one must land the same data rather than double it.
+    expect(await storedRows()).toBe(TOTAL_ROWS);
+    const instruments = (await rawQuery(
+      "SELECT count(*)::int AS n FROM instrument_identifiers WHERE value LIKE 'E2E%'",
+    )) as { n: number }[];
+    expect(instruments[0].n).toBe(INSTRUMENTS);
+
+    // Every part reports done, and the counts are the whole part rather than
+    // what was left when the process went.
+    expect(final.parts).toHaveLength(2);
+    for (const part of final.parts) {
+      expect(part.status).toBe(JobStatus.SUCCESS);
+      expect(part.processedCount).toBe(part.totalCount);
+    }
+  });
+});

--- a/proto/e2e/v1/e2e.proto
+++ b/proto/e2e/v1/e2e.proto
@@ -1,9 +1,12 @@
 // E2E test control service. Only registered when the server is built with
 // the "e2e" build tag. Allows Playwright tests to swap VCR cassettes between
-// test suites so each suite can be run and recorded in isolation.
+// test suites so each suite can be run and recorded in isolation, and to
+// restart the server so that recovery from an interrupted job can be tested.
 syntax = "proto3";
 
 package portfoliodb.e2e.v1;
+
+import "google/protobuf/timestamp.proto";
 
 option go_package = "github.com/leedenison/portfoliodb/proto/e2e/v1;e2ev1";
 
@@ -15,6 +18,21 @@ service E2eService {
   // UnloadCassette stops the current VCR recorder and sets the HTTP
   // transport to nil so that any unexpected plugin HTTP calls fail fast.
   rpc UnloadCassette(UnloadCassetteRequest) returns (UnloadCassetteResponse);
+
+  // RestartProcess replaces the server process with a fresh copy of itself,
+  // discarding every goroutine, connection and queue it was holding. What
+  // survives is what was written down, which is the point: it is how a test
+  // reaches the recovery path a service restarted mid-job takes.
+  //
+  // The response is sent before the process goes, so a caller sees the call
+  // succeed and then the connection drop.
+  rpc RestartProcess(RestartProcessRequest) returns (RestartProcessResponse);
+
+  // ProcessInfo reports when this process started. Restarting keeps the pid --
+  // the process is replaced, not respawned -- so the start time is what tells a
+  // caller it is talking to a new one. Waiting for the server to go unreachable
+  // does not work: the replacement is fast enough to miss between two polls.
+  rpc ProcessInfo(ProcessInfoRequest) returns (ProcessInfoResponse);
 }
 
 message LoadCassetteRequest {
@@ -24,3 +42,11 @@ message LoadCassetteResponse {}
 
 message UnloadCassetteRequest {}
 message UnloadCassetteResponse {}
+
+message RestartProcessRequest {}
+message RestartProcessResponse {}
+
+message ProcessInfoRequest {}
+message ProcessInfoResponse {
+  google.protobuf.Timestamp started_at = 1;
+}

--- a/server/cmd/portfoliodb/e2e_service.go
+++ b/server/cmd/portfoliodb/e2e_service.go
@@ -10,12 +10,15 @@ import (
 	"os"
 	"regexp"
 	"sync"
+	"syscall"
+	"time"
 
 	e2ev1 "github.com/leedenison/portfoliodb/proto/e2e/v1"
 	"github.com/leedenison/portfoliodb/server/testutil/vcr"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
 	"gopkg.in/dnaeon/go-vcr.v4/pkg/recorder"
 )
 
@@ -85,6 +88,43 @@ func (s *e2eService) LoadCassette(_ context.Context, req *e2ev1.LoadCassetteRequ
 func (s *e2eService) UnloadCassette(context.Context, *e2ev1.UnloadCassetteRequest) (*e2ev1.UnloadCassetteResponse, error) {
 	unloadCassette()
 	return &e2ev1.UnloadCassetteResponse{}, nil
+}
+
+// processStartedAt is when this process began. It survives nothing: a restart
+// replaces the process, so a caller comparing this across a restart is told it
+// is talking to a new one.
+var processStartedAt = time.Now()
+
+// ProcessInfo implements the E2eService liveness and identity probe.
+func (s *e2eService) ProcessInfo(context.Context, *e2ev1.ProcessInfoRequest) (*e2ev1.ProcessInfoResponse, error) {
+	return &e2ev1.ProcessInfoResponse{StartedAt: timestamppb.New(processStartedAt)}, nil
+}
+
+// RestartProcess replaces this process with a fresh copy of itself.
+//
+// syscall.Exec rather than an exit: the container has no restart policy, and
+// giving it one would mean a server that crashed for an unrelated reason came
+// back silently in every other suite. Exec keeps the container up and the
+// process new, which is the part that matters -- every goroutine, connection
+// and queued job is gone, and the run picks up from what was written down.
+//
+// The reply goes out first and the exec runs just after, so the caller sees the
+// call succeed and then the connection drop.
+func (s *e2eService) RestartProcess(context.Context, *e2ev1.RestartProcessRequest) (*e2ev1.RestartProcessResponse, error) {
+	exe, err := os.Executable()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "locate own binary: %v", err)
+	}
+	go func() {
+		time.Sleep(250 * time.Millisecond)
+		log.Printf("e2e: restarting process")
+		if err := syscall.Exec(exe, os.Args, os.Environ()); err != nil {
+			// Exec only returns on failure, and a server that cannot replace
+			// itself is no use to the test that asked it to.
+			log.Fatalf("e2e: exec %s: %v", exe, err)
+		}
+	}()
+	return &e2ev1.RestartProcessResponse{}, nil
 }
 
 func loadCassette(name string) error {


### PR DESCRIPTION
The last gap from the archive coverage review. Based on `main`.

A rebuild is long enough that the service can be restarted in the middle of one,
and what has to survive that is the job: its payload — the only copy of what was
being imported — and the record of which parts had already been applied. Nothing
exercised that path.

### The test

Starts a 50,000 row import, waits until rows are demonstrably landing, replaces
the server process, and then only *watches*. Nothing re-uploads and nothing
retries, so finishing is recovery and nothing else. It then asserts every row is
present **exactly once**, which is what says re-running an interrupted part
reapplied its work rather than doubling it, and that each part's
`processed_count` equals its total rather than what was left when the process
went.

### Restarting

A new RPC on the e2e-only control service, alongside the cassette swapping it
already does. Two decisions worth flagging:

- **`syscall.Exec` rather than exiting.** The container has no restart policy,
  and giving it one would mean a server that crashed for an unrelated reason came
  back silently in every other suite. Exec keeps the container up and the process
  new, which is the part that matters.
- **`ProcessInfo` reports the process start time.** My first attempt waited for
  the server to go unreachable and come back — which hung, because the
  replacement takes a few milliseconds and is missed between two polls. A restart
  keeps the pid, so the start time is the one thing the new process cannot have
  inherited.

### Verified against the bug it exists for

I reintroduced the payload clear in `processSystemImport` and reran: the test
fails, and fails with that bug's exact signature — after the restart the job
already reports `SUCCESS`, having imported nothing. Then restored and confirmed
green, `--repeat-each=3`, 5.2s each.

**Full suite: 41/41 in 2.2 minutes.** `make test`, `make lint-go`,
`make lint-proto`, `make lint-ts`, `make fmt-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)