### PR TITLE
Schedule the remaining archive work as M14

### DIFF
--- a/docs/issues/0076-declaration-archive-import-export.md
+++ b/docs/issues/0076-declaration-archive-import-export.md
@@ -1,6 +1,7 @@
 ---
 status: open
 title: Carry holding declarations in the user archive
+milestone: M14
 dependencies: [0078]
 ---
 

--- a/docs/issues/0077-transaction-archive-export.md
+++ b/docs/issues/0077-transaction-archive-export.md
@@ -1,6 +1,7 @@
 ---
 status: open
 title: Carry transactions in the user archive
+milestone: M14
 dependencies: [0078]
 ---
 

--- a/docs/issues/0080-consolidated-user-export-import-page.md
+++ b/docs/issues/0080-consolidated-user-export-import-page.md
@@ -1,6 +1,7 @@
 ---
 status: open
 title: Consolidated user export and import page
+milestone: M14
 dependencies: [0078]
 ---
 

--- a/docs/issues/0083-instrument-archive-carries-lookup-results.md
+++ b/docs/issues/0083-instrument-archive-carries-lookup-results.md
@@ -1,6 +1,7 @@
 ---
 status: open
 title: Carry the expensive identifier lookup results in the instrument archive
+milestone: M14
 ---
 
 Export everything identifier resolution produced, so a rebuild does not pay for

--- a/docs/issues/0084-transaction-import-to-archive.md
+++ b/docs/issues/0084-transaction-import-to-archive.md
@@ -1,6 +1,7 @@
 ---
 status: open
 title: Move transaction import to the archive schema
+milestone: M14
 dependencies: [0078]
 ---
 

--- a/docs/issues/0085-user-preferences-in-archive.md
+++ b/docs/issues/0085-user-preferences-in-archive.md
@@ -1,6 +1,7 @@
 ---
 status: open
 title: Carry user preferences in the user archive
+milestone: M14
 dependencies: [0078]
 ---
 

--- a/docs/issues/0086-admin-curated-state-in-archive.md
+++ b/docs/issues/0086-admin-curated-state-in-archive.md
@@ -1,6 +1,7 @@
 ---
 status: open
 title: Carry admin-curated state in the system archive
+milestone: M14
 dependencies: [0078]
 ---
 

--- a/docs/issues/0089-portfolio-definition-export.md
+++ b/docs/issues/0089-portfolio-definition-export.md
@@ -1,6 +1,7 @@
 ---
 status: open
 title: Export and import portfolio definitions
+milestone: M14
 dependencies: [0078, 0080]
 ---
 

--- a/docs/issues/milestones.md
+++ b/docs/issues/milestones.md
@@ -13,6 +13,7 @@
 - **M11** - Allow users to set a display currency.
 - **M12** - Move transactions to grouped double-entry postings with exact decimal amounts and an enforced balance constraint.
 - **M13** - Automated broker transaction import via a browser extension.
+- **M14** - Complete the archive: system and user archives carry everything a rebuild needs, and the transaction CSV is retired.
 
 ## Unscheduled
 


### PR DESCRIPTION
Groups the eight remaining archive issues under a new **M14** milestone and adds the label to each.

The archive thread is half built. The format (0078), the consolidated system page (0079) and the price, instrument and corporate event parts (0081, 0082, 0087) have landed; the lookup results, the admin-curated state and the entire user archive have not. All eight remaining issues were unscheduled, so nothing recorded that they belong together or in what order they should be taken.

**M14** - Complete the archive: system and user archives carry everything a rebuild needs, and the transaction CSV is retired.

| # | Issue |
|---|---|
| 0083 | Carry the expensive identifier lookup results in the instrument archive |
| 0086 | Carry admin-curated state in the system archive |
| 0085 | Carry user preferences in the user archive |
| 0077 | Carry transactions in the user archive |
| 0076 | Carry holding declarations in the user archive |
| 0080 | Consolidated user export and import page |
| 0084 | Move transaction import to the archive schema |
| 0089 | Export and import portfolio definitions |

Two notes on the ordering the table implies:

0083 is first because it is the one that changes the manual test cycle. Until the instrument archive carries `provider_instrument_identifiers` and stops excluding CASH and FX by default, every rebuild re-runs the paid, rate-limited lookups the archive exists to avoid. 0083 and 0086 together give a system-side wipe and restore; the user-archive half is what removes the re-upload of broker files.

0089 is the tail rather than the body. Its own text defers it until both archives exist and identifier translation has been exercised by transactions and declarations, and it is the one piece of user data that does not sit cleanly on one side of the archive split.

The order is not encoded in `dependencies` -- 0084 is not formally blocked by 0077, and 0080 is not blocked by 0076/0077/0085 -- so this change is milestone labels only.

Docs only; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)