### PR TITLE
Define the four remaining system archive parts (0086, 0093)

### DIFF
--- a/client/lib/archive/codec.test.ts
+++ b/client/lib/archive/codec.test.ts
@@ -185,7 +185,7 @@ describe("archive codec", () => {
   // What makes the version gate safe to be one-sided.
   it("ignores a field added by a later writer", () => {
     const doc = JSON.parse(marshalSystem(systemFixture()));
-    doc.inflation_indices = [{ series: "CPIH" }];
+    doc.portfolios = [{ name: "a part this build has never heard of" }];
     doc.envelope.written_by = "a later portfoliodb";
     expect(() => unmarshalSystem(JSON.stringify(doc))).not.toThrow();
   });

--- a/docs/issues/0093-inflation-indices-in-archive.md
+++ b/docs/issues/0093-inflation-indices-in-archive.md
@@ -1,0 +1,35 @@
+---
+status: open
+title: Carry inflation indices in the system archive
+milestone: M14
+dependencies: [0078]
+---
+
+Export and import the monthly inflation index series as a system archive part.
+
+## Motivation
+
+Inflation indices are the fourth part the archive format was always meant to
+carry and the only one with no issue of its own. They are tier 2 in
+adr/0032-archive-preserves-inputs-not-derived-state.md -- refetchable in
+principle, through the same paid and rate-limited providers the archive exists to
+avoid paying twice.
+
+There is a wrinkle that makes them less refetchable than the tier suggests. A
+revision replaces its predecessor in place and leaves no record
+(docs/spec/bitemporality.md), so a refetch returns the current revision rather
+than the values an instance was valuing against. Losing them is not only a cost.
+
+Left undone, `/admin/archive` keeps a disabled row saying the format does not
+carry them yet, which is what 0079 recorded and what 0086 removes for the other
+three.
+
+## Design
+
+A part of the system archive, grouped by currency.
+
+Unlike the price and corporate event parts, a group carries no coverage: a series
+is dense, `inflation_indices` stores no coverage of its own, and a file must not
+claim more than the table it came from can answer for. `base_year` is on the row
+rather than on the group, because a rebasing changes it partway through a series
+and both halves travel in the one group.

--- a/docs/spec/archive-format.md
+++ b/docs/spec/archive-format.md
@@ -20,9 +20,9 @@ difference decides what it carries.
 It carries two kinds of thing:
 
 - **Irreplaceable data.** Transactions and their grouping, holding declarations,
-  portfolios, preferences, plugin configuration, fetch-block reasons, resolved
-  corporate events, and hand-recovered prices no provider still serves. Nothing
-  can reconstruct these.
+  portfolios, preferences, plugin configuration, fetch-block reasons, the
+  corporate events an admin was asked to judge and the calls made on them, and
+  hand-recovered prices no provider still serves. Nothing can reconstruct these.
 - **Data that is expensive to reacquire.** Instruments and their identifiers,
   provider identifiers, prices with their coverage, corporate events with their
   coverage, and inflation indices. These are refetchable in principle, at the
@@ -44,7 +44,7 @@ one file.
 
 - The **system archive** carries shared data and no user data: instruments and
   their identifiers, prices and coverage, corporate events and coverage,
-  inflation indices, fetch blocks, unhandled event resolutions and plugin
+  inflation indices, fetch blocks, unhandled corporate events and plugin
   configuration.
 - The **user archive** carries one user's own data and no system data:
   transactions and their grouping, holding declarations, and preferences.
@@ -189,7 +189,11 @@ to them.
               "kind": "SYSTEM"},
  "instruments": {"instruments": [...]},
  "prices": {"groups": [...]},
- "corporate_events": {"groups": [...]}}
+ "corporate_events": {"groups": [...]},
+ "inflation_indices": {"groups": [...]},
+ "fetch_blocks": {"groups": [...]},
+ "unhandled_events": {"groups": [...]},
+ "plugin_config": {"configs": [...]}}
 ```
 
 ### Instruments
@@ -308,6 +312,176 @@ stored value only ever moves backwards.
 Coverage is stored per instrument and plugin, but an import records every span
 against the `import` sentinel, so the file carries spans merged across plugins.
 The per-plugin distinction cannot survive a round trip and is not written.
+
+### Inflation indices
+
+`inflation_indices.groups[]` is one group per currency.
+
+| Level | Field | Notes |
+| --- | --- | --- |
+| group | `currency` | ISO 4217 |
+| row | `month` | the month described, written as its first day |
+| row | `index_value` | decimal; relative to `base_year` July = 100 |
+| row | `base_year` | the year in which July = 100 |
+
+```json
+{"currency": "GBP",
+ "rows": [{"month": "2024-03-01", "index_value": "133.8", "base_year": 2015}]}
+```
+
+**A group carries no `coverage[]`**, and it is the only group in the format that
+does not. A series is dense: an index is published for every month until the
+series ends, so the rows say what is held and a gap is missing data rather than a
+month a provider was asked about and had nothing to report. `inflation_indices`
+stores no coverage either, and a file must not claim more than the table it came
+from can answer for.
+
+`base_year` is on the row rather than on the group because a rebasing changes it
+partway through a series and both halves travel in the one group. Reading a
+rebased value against the wrong base is not an error but a wrong number, which
+is the same reason `share_count_basis` sits on a price row.
+
+Inflation indices are expensive to reacquire rather than irreplaceable, with one
+wrinkle: a revision replaces its predecessor in place and leaves no record, so a
+refetch returns the current revision and not what this file holds. See
+`docs/spec/bitemporality.md`.
+
+**Not carried:** `data_provider`, because an import records every row against the
+`import` sentinel, so provenance cannot survive a round trip; and
+`last_fetched_at`, which comes from the envelope's `exported_at`.
+
+### Fetch blocks
+
+`fetch_blocks.groups[]` is one group per instrument, carrying that instrument's
+blocks across both fetchers and every plugin.
+
+| Level | Field | Notes |
+| --- | --- | --- |
+| group | `instrument` | identifier triple |
+| block | `category` | `PRICE` or `CORPORATE_EVENT`: which fetcher is blocked |
+| block | `plugin_id` | as the plugin registry spells it |
+| block | `reason` | free text, as the plugin reported it |
+| block | `first_blocked_at` | optional; knowledge time |
+
+```json
+{"instrument": {"type": "MIC_TICKER", "value": "AAPL", "domain": "XNAS"},
+ "blocks": [{"category": "PRICE", "plugin_id": "eodhd",
+             "reason": "404 from provider", "first_blocked_at": "2026-03-04T09:12:00Z"}]}
+```
+
+One part covers both `price_fetch_blocks` and `corporate_event_fetch_blocks`.
+They are the same statement about two fetchers, the reason someone wrote down
+reads the same way in both, and splitting them would put two rows in the export
+menu where an admin thinks of one. `category` is the plugin category the block
+belongs to, from the same vocabulary plugin configuration uses; only `PRICE` and
+`CORPORATE_EVENT` have a fetch-block table, and a file naming another category is
+describing a table that does not exist.
+
+`reason` is free text and not a vocabulary. It is what the plugin's permanent
+error carried, it is what the column holds, and it is read by a person deciding
+whether to unblock.
+
+`first_blocked_at` is knowledge time and the column never overwrites it, so an
+import keeps the earlier of the stored and the supplied value. Absent falls back
+to the envelope's `exported_at`.
+
+A block naming a plugin the importing instance does not register is a rejected
+row rather than a failed part: nothing would ever consult it.
+
+**Not carried:** the instrument's server UUID, which every archive replaces with
+an identifier.
+
+### Unhandled corporate events
+
+`unhandled_events.groups[]` is one group per instrument.
+
+| Level | Field | Notes |
+| --- | --- | --- |
+| group | `instrument` | identifier triple |
+| event | `event_type` | `REVERSE_SPLIT`, `NON_WHOLE_SPLIT`, `SPECIAL_CASH_DIVIDEND`, ... |
+| event | `ex_date` | optional; absent for the rare event with no date |
+| event | `detail` | the sentence shown in the review queue |
+| event | `data_json` | optional; the detector's own context, as JSON text |
+| event | `resolved` | whether an admin has already made the call |
+| event | `detected_at` | optional; knowledge time |
+
+```json
+{"instrument": {"type": "MIC_TICKER", "value": "XYZ", "domain": "XNAS"},
+ "events": [{"event_type": "REVERSE_SPLIT", "ex_date": "2025-04-11",
+             "detail": "1:10 reverse split affects 3 options", "resolved": true}]}
+```
+
+**The whole row is carried, resolved and unresolved alike**, and not just the
+`resolved` flag that is the irreplaceable part of it. These rows exist only
+because a corporate-event fetch detected something it could not apply, and a
+restore writes events from the file instead of fetching them, so nothing
+re-creates the row a bare resolution would need to attach to. Carrying the row
+restores both halves of what an admin had: the judgements already made, and the
+queue still waiting for one.
+
+`resolved` is why the part exists. It is the only trace that a person looked at a
+reverse split or a merger and decided, and a rebuild without it re-surfaces every
+event for review.
+
+Import inserts an event only where no row with the same instrument, `event_type`,
+`ex_date` and `resolved` state is already stored, so importing the same file
+twice does not double the queue. It does not un-resolve anything: a stored
+resolved row and an incoming unresolved one are different rows, which is the same
+thing that happens today when a refetch re-detects an event already judged.
+
+`detail` and `data_json` are advisory. They were written for a person reading the
+queue, and both may name ids belonging to the instance that wrote the file.
+`data_json` is carried as the JSON text the column holds rather than as a
+structured value: its shape belongs to whichever detector wrote it, and protojson
+would carry its numbers as doubles.
+
+**Not carried:** the row `id`, a server UUID.
+
+### Plugin configuration
+
+`plugin_config.configs[]` is a flat list. A config row has no aggregate root
+above it -- `category` is a column on the row, not an entity the rows hang off --
+so grouping by category would invent a level the data does not have.
+
+| Level | Field | Notes |
+| --- | --- | --- |
+| row | `plugin_id` | as the plugin registry spells it |
+| row | `category` | `IDENTIFIER`, `DESCRIPTION`, `PRICE`, `INFLATION`, `CORPORATE_EVENT` |
+| row | `enabled` | |
+| row | `precedence` | higher is preferred; unique within a category |
+| row | `config_json` | optional; the plugin's own settings, as JSON text |
+| row | `max_history_days` | optional; absent means unlimited |
+
+```json
+{"plugin_id": "eodhd", "category": "PRICE", "enabled": true,
+ "precedence": 20, "config_json": "{\"eodhd_api_key\":\"...\"}",
+ "max_history_days": 3650}
+```
+
+**A document carrying this part is a secret.** `config_json` holds live API keys,
+in full and unredacted, because a rebuild that needs an admin to re-enter every
+provider credential by hand is a rebuild that has not restored. That is why the
+export menu leaves this part unticked: including it changes where the file can
+safely be kept, and that has to be a decision somebody made rather than a default
+they inherited.
+
+`precedence` is an ordering somebody chose between providers that disagree, so
+nothing can guess it back, and it is unique per category. Import applies a
+category's rows as a set: the stored precedences in that category are moved out
+of the way first, the file's rows are applied with the precedences they state,
+and any plugin the file does not name keeps its row and is given a free
+precedence below them.
+
+A row naming a plugin this build does not register is a rejected row rather than
+a failed part. A config row nothing will ever read is not worth storing, and the
+mismatch is worth saying out loud.
+
+`category` names are the archive's spelling, not the column's: `plugin_config.category`
+holds the lowercase `"corporate_event"`. It is the one controlled vocabulary
+where the file and the column differ, and the mapping lives in one place on the
+server.
+
+**Not carried:** nothing. The row is small and every column of it is a decision.
 
 ## The user archive
 
@@ -454,8 +628,11 @@ and a page can show.
 Within a document, the sections are written in the order they are applied, and a
 reader walks them in that order:
 
-- **System:** instruments, then prices, then corporate events. Prices and events
-  reference instruments.
+- **System:** instruments, then prices, then corporate events, then inflation
+  indices, fetch blocks, unhandled corporate events and plugin configuration.
+  Prices, events, fetch blocks and unhandled events reference instruments.
+  Inflation indices and plugin configuration reference nothing, and plugin
+  configuration is written last because it is what makes a document a secret.
 - **User:** preferences, then transactions, then declarations. Preferences first
   because ignored asset classes change what a transaction import keeps;
   declarations last because a checked declaration is compared against what the

--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -5,8 +5,12 @@ package portfoliodb.api.v1;
 import "archive/v1/archive.proto";
 import "archive/v1/common.proto";
 import "archive/v1/corporate_events.proto";
+import "archive/v1/fetch_blocks.proto";
+import "archive/v1/inflation.proto";
 import "archive/v1/instruments.proto";
+import "archive/v1/plugin_config.proto";
 import "archive/v1/prices.proto";
+import "archive/v1/unhandled_events.proto";
 import "buf/validate/validate.proto";
 import "google/protobuf/timestamp.proto";
 import "google/type/date.proto";
@@ -561,6 +565,11 @@ message ExportSystemArchiveResponse {
     portfoliodb.archive.v1.Instrument instrument = 3;
     portfoliodb.archive.v1.PriceGroup price_group = 4;
     portfoliodb.archive.v1.CorporateEventGroup corporate_event_group = 5;
+    portfoliodb.archive.v1.InflationGroup inflation_group = 6;
+    portfoliodb.archive.v1.FetchBlockGroup fetch_block_group = 7;
+    portfoliodb.archive.v1.UnhandledEventGroup unhandled_event_group = 8;
+    // A flat list, so one row per message rather than one group.
+    portfoliodb.archive.v1.PluginConfig plugin_config = 9;
   }
 }
 
@@ -570,8 +579,8 @@ message ArchivePartBegin {
 }
 
 // ImportSystemArchiveRequest carries one whole system archive. The parts are
-// applied server-side in restore order -- instruments, prices, corporate events
-// -- so a client that navigates away mid-import does not stop it, and the caller
+// applied server-side in restore order -- the order ArchivePart numbers them --
+// so a client that navigates away mid-import does not stop it, and the caller
 // polls one job rather than sequencing the parts itself.
 //
 // A part absent from the document is not applied. A part present and empty is

--- a/proto/archive/v1/archive.proto
+++ b/proto/archive/v1/archive.proto
@@ -5,10 +5,14 @@ package portfoliodb.archive.v1;
 import "archive/v1/common.proto";
 import "archive/v1/corporate_events.proto";
 import "archive/v1/declarations.proto";
+import "archive/v1/fetch_blocks.proto";
+import "archive/v1/inflation.proto";
 import "archive/v1/instruments.proto";
+import "archive/v1/plugin_config.proto";
 import "archive/v1/preferences.proto";
 import "archive/v1/prices.proto";
 import "archive/v1/txs.proto";
+import "archive/v1/unhandled_events.proto";
 import "buf/validate/validate.proto";
 
 option go_package = "github.com/leedenison/portfoliodb/proto/archive/v1;archivev1";
@@ -30,8 +34,12 @@ message SystemArchive {
   InstrumentPart instruments = 2;
   PricePart prices = 3;
   CorporateEventPart corporate_events = 4;
-  // 5 to 9 are the remaining parts: fetch blocks and resolutions, plugin
-  // config, inflation indices.
+  InflationPart inflation_indices = 5;
+  FetchBlockPart fetch_blocks = 6;
+  UnhandledEventPart unhandled_events = 7;
+  // Last because it is the one part that makes the document a secret, and a
+  // reader skimming a file should reach the rest before the keys.
+  PluginConfigPart plugin_config = 8;
 }
 
 // UserArchive is one user archive document: one user's own data, and no system

--- a/proto/archive/v1/common.proto
+++ b/proto/archive/v1/common.proto
@@ -66,8 +66,10 @@ enum ArchivePart {
   INSTRUMENTS = 1;
   PRICES = 2;
   CORPORATE_EVENTS = 3;
-  // 4 onwards are the remaining parts: inflation indices, fetch blocks,
-  // unhandled event resolutions, plugin config.
+  INFLATION_INDICES = 4;
+  FETCH_BLOCKS = 5;
+  UNHANDLED_EVENTS = 6;
+  PLUGIN_CONFIG = 7;
 }
 
 // Envelope carries only what cannot differ between two rows of a valid file.

--- a/proto/archive/v1/fetch_blocks.proto
+++ b/proto/archive/v1/fetch_blocks.proto
@@ -1,0 +1,57 @@
+syntax = "proto3";
+
+package portfoliodb.archive.v1;
+
+import "archive/v1/common.proto";
+import "buf/validate/validate.proto";
+import "google/protobuf/timestamp.proto";
+import "type/v1/type.proto";
+
+option go_package = "github.com/leedenison/portfoliodb/proto/archive/v1;archivev1";
+
+// FetchBlockPart is the fetch-block section of a system archive: the
+// (instrument, plugin) pairs a fetcher has been told permanently to stop asking
+// about, grouped by instrument.
+//
+// One part covers both price_fetch_blocks and corporate_event_fetch_blocks. The
+// two tables are the same statement about two fetchers, the reason someone wrote
+// down reads the same way in both, and splitting them would put two rows in the
+// export menu where an admin thinks of one.
+//
+// Losing these is not losing a cache. A rebuild without them resumes querying
+// providers that were deliberately stopped, at the cost the block was created to
+// avoid, and the reason is gone.
+message FetchBlockPart {
+  repeated FetchBlockGroup groups = 1;
+}
+
+// FetchBlockGroup is one instrument's blocks, across both fetchers and every
+// plugin.
+message FetchBlockGroup {
+  InstrumentRef instrument = 1 [(buf.validate.field).required = true];
+  repeated FetchBlock blocks = 2;
+}
+
+// FetchBlock is one blocked (instrument, plugin) pair.
+message FetchBlock {
+  // Which fetcher is blocked, named by the plugin category it runs. Only PRICE
+  // and CORPORATE_EVENT have a fetch-block table; a file naming any other
+  // category is describing a table that does not exist.
+  portfoliodb.type.v1.PluginCategory category = 1 [(buf.validate.field).enum = {
+    defined_only: true
+    in: [3, 5] // PRICE, CORPORATE_EVENT
+  }];
+  // The plugin that was blocked, as the plugin registry spells it. A block for a
+  // plugin the importing instance does not register is rejected rather than
+  // stored: nothing would ever consult it.
+  string plugin_id = 2 [(buf.validate.field).string.min_len = 1];
+  // Why the pair was blocked, as the plugin reported it -- a 404, a 403, a
+  // provider saying it has never heard of the symbol. Free text rather than a
+  // vocabulary, because that is what ErrPermanent carries and what the column
+  // holds, and because it is read by a person deciding whether to unblock.
+  string reason = 3 [(buf.validate.field).string.min_len = 1];
+  // Knowledge time: when the pair was first blocked. Never overwritten, so an
+  // import keeps the earlier of the stored and the supplied value. Absent falls
+  // back to the envelope's exported_at.
+  optional google.protobuf.Timestamp first_blocked_at = 4;
+}

--- a/proto/archive/v1/inflation.proto
+++ b/proto/archive/v1/inflation.proto
@@ -1,0 +1,44 @@
+syntax = "proto3";
+
+package portfoliodb.archive.v1;
+
+import "buf/validate/validate.proto";
+
+option go_package = "github.com/leedenison/portfoliodb/proto/archive/v1;archivev1";
+
+// InflationPart is the inflation-index section of a system archive: monthly
+// index values grouped by the currency whose purchasing power they measure.
+//
+// Index values are refetchable in principle and so are carried for cost rather
+// than for irreplaceability -- except that a revision replaces its predecessor
+// in place and leaves no record (docs/spec/bitemporality.md), so what a refetch
+// returns is the current revision and not what this file holds.
+message InflationPart {
+  repeated InflationGroup groups = 1;
+}
+
+// InflationGroup is one currency's series.
+//
+// There is no coverage list here, unlike the price and corporate-event groups.
+// A series is dense: an index is published for every month until the series
+// ends, so the rows say what is held and a gap is missing data rather than a
+// month a provider was asked about and had nothing to report. inflation_indices
+// stores no coverage either, and a file must not claim more than the table can
+// answer for.
+message InflationGroup {
+  string currency = 1; // ISO 4217
+  repeated InflationRow rows = 2;
+}
+
+// InflationRow is one month's index value.
+message InflationRow {
+  // The month described, written as its first day: "2024-03-01".
+  string month = 1 [(buf.validate.field).string.pattern = "^[0-9]{4}-[0-9]{2}-01$"];
+  // decimal; relative to base_year July = 100.
+  string index_value = 2 [(buf.validate.field).string.pattern = "^[0-9]+(\\.[0-9]+)?$"];
+  // The year the value is based on, where July = 100. It is on the row rather
+  // than on the group because a rebasing changes it partway through a series,
+  // and both halves travel in the one group; reading a rebased value against the
+  // wrong base is not an error but a wrong number.
+  int32 base_year = 3 [(buf.validate.field).int32.gte = 1900];
+}

--- a/proto/archive/v1/plugin_config.proto
+++ b/proto/archive/v1/plugin_config.proto
@@ -1,0 +1,52 @@
+syntax = "proto3";
+
+package portfoliodb.archive.v1;
+
+import "buf/validate/validate.proto";
+import "type/v1/type.proto";
+
+option go_package = "github.com/leedenison/portfoliodb/proto/archive/v1;archivev1";
+
+// PluginConfigPart is the plugin-configuration section of a system archive:
+// which plugins are on, the order they are tried in, and what each was
+// configured with.
+//
+// **A document carrying this part is a secret.** config_json holds live API
+// keys, in full and unredacted, because a rebuild that needs an admin to
+// re-enter every provider credential by hand is a rebuild that has not
+// restored. That is why the export menu leaves this part unticked: including it
+// changes where the file can safely be kept, and that has to be a decision
+// somebody made rather than a default they inherited.
+//
+// It is a flat list rather than a grouped one. A config row has no aggregate
+// root above it -- category is a column on the row, not an entity the rows hang
+// off -- so grouping by category would invent a level the data does not have.
+message PluginConfigPart {
+  repeated PluginConfig configs = 1;
+}
+
+// PluginConfig is one row of plugin_config: one plugin's settings in one
+// category.
+message PluginConfig {
+  // The plugin, as the plugin registry spells it. A row naming a plugin this
+  // build does not register is rejected: a config row nothing will ever read is
+  // not worth storing, and the mismatch is worth saying out loud.
+  string plugin_id = 1 [(buf.validate.field).string.min_len = 1];
+  // Which kind of work the plugin does. A plugin can hold a row in more than one
+  // category, so the pair is what identifies a row.
+  portfoliodb.type.v1.PluginCategory category = 2 [(buf.validate.field).enum = {
+    defined_only: true
+    not_in: [0]
+  }];
+  bool enabled = 3;
+  // Higher is preferred, and the order is unique within a category. It is an
+  // ordering somebody chose between providers that disagree, so nothing can
+  // guess it back.
+  int32 precedence = 4 [(buf.validate.field).int32.gte = 1];
+  // The plugin's own settings as the JSON text the column holds, opaque here
+  // because its shape belongs to the plugin. **This is where the API keys are.**
+  optional string config_json = 5;
+  // How far back a price or corporate-event plugin may be asked to look, in
+  // days. Absent means unlimited, which is not the same as zero.
+  optional int32 max_history_days = 6 [(buf.validate.field).int32.gt = 0];
+}

--- a/proto/archive/v1/unhandled_events.proto
+++ b/proto/archive/v1/unhandled_events.proto
@@ -1,0 +1,56 @@
+syntax = "proto3";
+
+package portfoliodb.archive.v1;
+
+import "archive/v1/common.proto";
+import "buf/validate/validate.proto";
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/leedenison/portfoliodb/proto/archive/v1;archivev1";
+
+// UnhandledEventPart is the unhandled-corporate-event section of a system
+// archive: the events PortfolioDB could not apply on its own and put in front of
+// an admin, with whatever call the admin made.
+//
+// The whole row is carried, resolved and unresolved alike, rather than only the
+// resolved flag. These rows exist only because a corporate-event fetch detected
+// something it could not process, and a restore writes events from the file
+// instead of fetching them, so nothing re-creates the row a bare resolution
+// would need to attach to. Carrying the row restores both halves of the state
+// that matters: the judgements already made, and the queue still waiting for
+// one.
+message UnhandledEventPart {
+  repeated UnhandledEventGroup groups = 1;
+}
+
+// UnhandledEventGroup is one instrument's unhandled events.
+message UnhandledEventGroup {
+  InstrumentRef instrument = 1 [(buf.validate.field).required = true];
+  repeated UnhandledEvent events = 2;
+}
+
+// UnhandledEvent is one event awaiting or holding an admin's decision.
+message UnhandledEvent {
+  // What could not be applied: REVERSE_SPLIT, NON_WHOLE_SPLIT, MERGER,
+  // EXTRAORDINARY_DIVIDEND, SPECIAL_CASH_DIVIDEND, FUTURES_SPLIT. Free text
+  // rather than a vocabulary, because the column is free text and the detector
+  // is free to name a case it has just learned to recognise.
+  string event_type = 1 [(buf.validate.field).string.min_len = 1];
+  // Valid time: when the event took effect. Absent for the rare event with no
+  // date, which the dedup index treats as distinct from every other.
+  optional string ex_date = 2 [(buf.validate.field).string.pattern = "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"];
+  // A sentence for the admin reading the queue.
+  string detail = 3;
+  // The detector's own context, carried as the JSON text it stored rather than
+  // as a structured value: it is an opaque payload whose shape belongs to
+  // whichever detector wrote it, and protojson would carry its numbers as
+  // doubles. See docs/adr/0027-decimal-values-cross-the-wire-as-strings.md.
+  optional string data_json = 4;
+  // Whether an admin has already made the call. This is the field the part
+  // exists for: it is the only trace that a person looked at a reverse split or
+  // a merger and decided, and nothing can reconstruct it.
+  bool resolved = 5;
+  // Knowledge time: when the event was detected. Absent falls back to the
+  // envelope's exported_at.
+  optional google.protobuf.Timestamp detected_at = 6;
+}

--- a/proto/type/v1/type.proto
+++ b/proto/type/v1/type.proto
@@ -120,3 +120,20 @@ enum AssetClass {
   FX = 8;
   UNKNOWN = 9;
 }
+
+// PluginCategory is the controlled vocabulary for the kind of work a plugin
+// does. Stored in plugin_config.category, and named on an archive fetch block to
+// say which fetcher was stopped.
+//
+// This is the one vocabulary here whose value names are not the strings the
+// column holds: plugin_config.category is lowercase ("corporate_event"), so
+// db.PluginCategoryToStr maps between the two. The names are what an archive
+// file spells, and those do not change.
+enum PluginCategory {
+  PLUGIN_CATEGORY_UNSPECIFIED = 0;
+  IDENTIFIER = 1;
+  DESCRIPTION = 2;
+  PRICE = 3;
+  INFLATION = 4;
+  CORPORATE_EVENT = 5;
+}

--- a/server/archive/codec_test.go
+++ b/server/archive/codec_test.go
@@ -287,7 +287,7 @@ func TestUnmarshal_IgnoresUnknownFields(t *testing.T) {
 	if err := json.Unmarshal(b, &doc); err != nil {
 		t.Fatalf("unmarshal: %v", err)
 	}
-	doc["inflation_indices"] = []any{map[string]any{"series": "CPIH"}}
+	doc["portfolios"] = []any{map[string]any{"name": "a part this build has never heard of"}}
 	doc["envelope"].(map[string]any)["written_by"] = "a later portfoliodb"
 	b, err = json.Marshal(doc)
 	if err != nil {

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -213,7 +213,9 @@ CREATE INDEX idx_ingestion_jobs_status ON ingestion_jobs (status);
 -- there is no ordinal column: readers order by the enum.
 CREATE TABLE ingestion_job_parts (
   job_id          UUID NOT NULL REFERENCES ingestion_jobs (id) ON DELETE CASCADE,
-  part            TEXT NOT NULL CHECK (part IN ('INSTRUMENTS', 'PRICES', 'CORPORATE_EVENTS')),
+  part            TEXT NOT NULL CHECK (part IN ('INSTRUMENTS', 'PRICES', 'CORPORATE_EVENTS',
+                                                'INFLATION_INDICES', 'FETCH_BLOCKS',
+                                                'UNHANDLED_EVENTS', 'PLUGIN_CONFIG')),
   status          TEXT NOT NULL CHECK (status IN ('PENDING', 'RUNNING', 'SUCCESS', 'FAILED')),
   total_count     INT NOT NULL DEFAULT 0,
   processed_count INT NOT NULL DEFAULT 0,


### PR DESCRIPTION
First of six changes finishing the system archive. This one is format only:
it adds the four sections the archive was always meant to carry -- inflation
indices, fetch blocks, unhandled corporate events and plugin configuration --
and nothing that reads or writes them. The export and import still ignore
them and the four `/admin/archive` menu rows stay disabled; each part is
wired up in its own PR.

## What is here

- Four new files in `proto/archive/v1/`, four `ArchivePart` values and four
  `SystemArchive` fields, taking the numbers the reserved comments already
  set aside, plus four `oneof` arms on `ExportSystemArchiveResponse`.
- `PluginCategory` added to `portfoliodb.type.v1`, shared by the fetch block
  and plugin config parts. It is the one vocabulary there whose value names
  are not the strings the column holds -- `plugin_config.category` is
  lowercase -- and it says so at its declaration.
- The `ingestion_job_parts.part` CHECK widened to the seven names.
- `docs/spec/archive-format.md` gains a section per part, and
  `docs/issues/0093` opens the inflation index work, which had no issue.

## Two shapes worth review

**Fetch blocks are one part, not two.** `price_fetch_blocks` and
`corporate_event_fetch_blocks` are the same statement about two fetchers,
the reason someone wrote down reads the same way in both, and splitting them
would put two rows in the export menu where an admin thinks of one. A block
names its fetcher by plugin category, constrained to `PRICE` and
`CORPORATE_EVENT`.

**Unhandled events carry whole rows, resolved and unresolved.** ADR 0032
lists only `resolved` as tier 1, and on its own that would be right. But
those rows exist only because a corporate event fetch detected something it
could not apply, and a restore writes events from the file instead of
fetching them -- so detection never re-runs and nothing re-creates the row a
bare resolution would need to attach to. Carrying the row restores the
judgements already made and the queue still waiting for one. The reasoning
is in the spec.

## Testing

`make lint` and `make test` pass. Two round-trip tests used
`inflation_indices` as a stand-in unknown field and now use a name that
stays unknown.

🤖 Generated with [Claude Code](https://claude.com/claude-code)