### PR TITLE
Export a user's preferences as an archive part (0085)

### DIFF
--- a/client/app/admin/archive/page.tsx
+++ b/client/app/admin/archive/page.tsx
@@ -9,7 +9,7 @@ import { qk } from "@/lib/query-keys";
 import { exportSystemArchive, getJob, listJobs } from "@/lib/portfolio-api";
 import { marshalSystem } from "@/lib/archive/codec";
 import { assembleSystemArchive } from "@/lib/archive/assemble";
-import { ARCHIVE_PART_OPTIONS } from "@/lib/archive/parts";
+import { SYSTEM_ARCHIVE_PART_OPTIONS } from "@/lib/archive/parts";
 import { ArchivePart } from "@/gen/archive/v1/common_pb";
 import { JobStatus } from "@/gen/api/v1/api_pb";
 import { ImportArchivePanel } from "./import-panel";
@@ -20,7 +20,7 @@ const SYSTEM_ARCHIVE_JOB_TYPE = "system_archive";
 export default function ArchivePage() {
   const queryClient = useQueryClient();
   const [selected, setSelected] = useState<Set<ArchivePart>>(
-    () => new Set(ARCHIVE_PART_OPTIONS.filter((o) => o.defaultSelected).map((o) => o.part)),
+    () => new Set(SYSTEM_ARCHIVE_PART_OPTIONS.filter((o) => o.defaultSelected).map((o) => o.part)),
   );
   const [exporting, setExporting] = useState(false);
   const [exportError, setExportError] = useState<string | null>(null);
@@ -65,7 +65,7 @@ export default function ArchivePage() {
   }
 
   const parts = useMemo(
-    () => ARCHIVE_PART_OPTIONS.filter((o) => selected.has(o.part)).map((o) => o.part),
+    () => SYSTEM_ARCHIVE_PART_OPTIONS.filter((o) => selected.has(o.part)).map((o) => o.part),
     [selected],
   );
 
@@ -125,7 +125,7 @@ export default function ArchivePage() {
           empty, which records that the export included it and there was nothing.
         </p>
         <ul className="mt-3 space-y-2">
-          {ARCHIVE_PART_OPTIONS.map((opt) => {
+          {SYSTEM_ARCHIVE_PART_OPTIONS.map((opt) => {
             const id = `part-${opt.part}`;
             return (
               <li key={id} className="flex items-start gap-2.5">

--- a/client/lib/archive/parts.ts
+++ b/client/lib/archive/parts.ts
@@ -14,8 +14,8 @@ export interface ArchivePartOption {
   defaultSelected: boolean;
 }
 
-/** The export menu, in restore order. */
-export const ARCHIVE_PART_OPTIONS: ArchivePartOption[] = [
+/** The system archive export menu, in restore order. */
+export const SYSTEM_ARCHIVE_PART_OPTIONS: ArchivePartOption[] = [
   {
     part: ArchivePart.INSTRUMENTS,
     label: "Instruments",
@@ -60,6 +60,16 @@ export const ARCHIVE_PART_OPTIONS: ArchivePartOption[] = [
   },
 ];
 
+/** The user archive export menu, in restore order. */
+export const USER_ARCHIVE_PART_OPTIONS: ArchivePartOption[] = [
+  {
+    part: ArchivePart.PREFERENCES,
+    label: "Preferences",
+    note: "Display currency, and the asset classes ignored on import.",
+    defaultSelected: true,
+  },
+];
+
 /** Display names for the parts a job reports against. */
 export const ARCHIVE_PART_LABELS: Record<number, string> = {
   [ArchivePart.INSTRUMENTS]: "Instruments",
@@ -69,4 +79,5 @@ export const ARCHIVE_PART_LABELS: Record<number, string> = {
   [ArchivePart.FETCH_BLOCKS]: "Fetch blocks",
   [ArchivePart.UNHANDLED_EVENTS]: "Unhandled corporate events",
   [ArchivePart.PLUGIN_CONFIG]: "Plugin config",
+  [ArchivePart.PREFERENCES]: "Preferences",
 };

--- a/docs/spec/archive-format.md
+++ b/docs/spec/archive-format.md
@@ -640,6 +640,12 @@ reader walks them in that order:
   declarations last because a checked declaration is compared against what the
   transactions add up to.
 
+`ArchivePart` numbers the parts in two blocks, the system parts and then the
+user parts, because no part belongs to both documents. Within a block the values
+run in restore order. An export request naming a part from the other block is
+refused rather than ignored: a part quietly missing from a document the caller
+asked for it in is a silent wrong answer.
+
 Between documents, restoring the system archive before the user archive is a
 recommendation and not a constraint. A user archive restored into an instance
 with no instruments loaded resolves its postings through the normal identifier

--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -9,6 +9,7 @@ import "archive/v1/fetch_blocks.proto";
 import "archive/v1/inflation.proto";
 import "archive/v1/instruments.proto";
 import "archive/v1/plugin_config.proto";
+import "archive/v1/preferences.proto";
 import "archive/v1/prices.proto";
 import "archive/v1/unhandled_events.proto";
 import "buf/validate/validate.proto";
@@ -185,6 +186,11 @@ service ApiService {
   // server-side. See ExportSystemArchiveRequest and ImportSystemArchiveRequest.
   rpc ExportSystemArchive(ExportSystemArchiveRequest) returns (stream ExportSystemArchiveResponse);
   rpc ImportSystemArchive(ImportSystemArchiveRequest) returns (ImportSystemArchiveResponse);
+
+  // User archive export (any authenticated user). Exports the caller's own data
+  // and no system data at all, in the same stream shape as the system export.
+  // See docs/adr/0033-system-and-user-archives-are-separate.md.
+  rpc ExportUserArchive(ExportUserArchiveRequest) returns (stream ExportUserArchiveResponse);
 
   // Identifier plugin config (admin-only). List all plugins; update enabled, precedence, and config JSON (including API keys).
   rpc ListIdentifierPlugins(ListIdentifierPluginsRequest) returns (ListIdentifierPluginsResponse);
@@ -450,7 +456,7 @@ message GetJobRequest {
   string job_id = 1;
 }
 
-// JobPartResult is one part of a system archive as applied by one job. A row
+// JobPartResult is one part of an archive as applied by one job. A row
 // exists for every part the document carried from the moment the job is created,
 // so a page rendering a row per part shows the same rows before, during and
 // after the run, including after a reload.
@@ -466,7 +472,8 @@ message JobPartResult {
   int32 processed_count = 4;
   // Row-level problems attributed to this part. row_index is the index of the
   // group (prices, corporate events) or of the instrument (instruments) the
-  // problem was found in.
+  // problem was found in. It is -1 for a part whose unit is a setting rather
+  // than a row, where there is nothing to point at.
   repeated ValidationError validation_errors = 5;
   // The hard failure that ended the part. Empty unless status is FAILED.
   string message = 6;
@@ -474,14 +481,14 @@ message JobPartResult {
 
 message GetJobResponse {
   JobStatus status = 1;
-  // Problems with no part of their own: transaction jobs, and a system archive
-  // that failed before any part was reached. Per-part problems are on the part.
+  // Problems with no part of their own: transaction jobs, and an archive that
+  // failed before any part was reached. Per-part problems are on the part.
   repeated ValidationError validation_errors = 2;
   repeated IdentificationError identification_errors = 3;
   int32 total_count = 4;
   int32 processed_count = 5;
   // One row per part the archive carried, in restore order. Empty for any job
-  // that is not a system archive import.
+  // that is not an archive import.
   repeated JobPartResult parts = 6;
 }
 
@@ -494,7 +501,7 @@ message Job {
   google.protobuf.Timestamp created_at = 5;
   int32 validation_error_count = 6;
   int32 identification_error_count = 7;
-  string job_type = 8; // "tx" or "system_archive"
+  string job_type = 8; // "tx", "system_archive" or "user_archive"
 }
 
 message ListJobsRequest {
@@ -600,6 +607,41 @@ message ImportSystemArchiveRequest {
 // progress and results are on GetJobResponse.parts.
 message ImportSystemArchiveResponse {
   string job_id = 1;
+}
+
+// ExportUserArchiveRequest asks for one user archive document: the caller's own
+// data. The include-menu works exactly as the system export's does.
+message ExportUserArchiveRequest {
+  // Naming a part of the system archive here is an error rather than a part
+  // quietly missing from the document.
+  repeated portfoliodb.archive.v1.ArchivePart parts = 1 [(buf.validate.field).repeated = {
+    min_items: 1
+    items: {
+      enum: {
+        defined_only: true
+        not_in: [0]
+      }
+    }
+  }];
+  // 2 and 3 are the bounds of the transaction window to export.
+}
+
+// ExportUserArchiveResponse is one element of the export stream, with the same
+// grammar as ExportSystemArchiveResponse: the envelope first and exactly once,
+// then for each selected part a part_begin followed by that part's items.
+//
+// A part whose unit is a setting rather than a row travels as one whole-part
+// message rather than as a series of items. part_begin still precedes it, so the
+// grammar does not fork: the marker is what creates the container, and a part
+// that was asked for and holds nothing is still present and empty.
+message ExportUserArchiveResponse {
+  oneof item {
+    portfoliodb.archive.v1.Envelope envelope = 1;
+    ArchivePartBegin part_begin = 2;
+    // The whole part in one message, sent once after its part_begin.
+    portfoliodb.archive.v1.PreferencePart preferences = 3;
+    // 4 is the transaction window, 5 is the declaration statement.
+  }
 }
 
 // IdentifierPluginConfig is one row from identifier_plugin_config (admin-only).

--- a/proto/archive/v1/common.proto
+++ b/proto/archive/v1/common.proto
@@ -59,10 +59,14 @@ enum ArchiveKind {
 // so the request that asks for a part and the result that reports on it are one
 // vocabulary.
 //
-// Values run in restore order, which is also the field order in SystemArchive:
-// a part is applied after everything it refers to.
+// The values are two blocks, one per archive, because no part belongs to both
+// documents. Within a block they run in restore order, which is also the field
+// order of the archive message they name: a part is applied after everything it
+// refers to. A request naming a part from the other block is refused rather
+// than ignored -- silently dropping it would export nothing and say nothing.
 enum ArchivePart {
   ARCHIVE_PART_UNSPECIFIED = 0;
+  // System archive.
   INSTRUMENTS = 1;
   PRICES = 2;
   CORPORATE_EVENTS = 3;
@@ -70,6 +74,10 @@ enum ArchivePart {
   FETCH_BLOCKS = 5;
   UNHANDLED_EVENTS = 6;
   PLUGIN_CONFIG = 7;
+  // User archive.
+  PREFERENCES = 8;
+  TXS = 9;
+  DECLARATIONS = 10;
 }
 
 // Envelope carries only what cannot differ between two rows of a valid file.

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -5,6 +5,8 @@ package db
 import (
 	"context"
 	"errors"
+	"regexp"
+
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
 	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
 	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
@@ -47,6 +49,7 @@ const InflationProviderImport = "import"
 const (
 	JobTypeTx            = "tx"
 	JobTypeSystemArchive = "system_archive"
+	JobTypeUserArchive   = "user_archive"
 )
 
 // DB is the database abstraction used by the service layer.
@@ -624,6 +627,29 @@ func AssetClassToStr(ac typev1.AssetClass) string {
 	return ac.String()
 }
 
+// BrokerToStr converts a proto Broker enum to the string the broker columns
+// hold, which is the enum's own name. BROKER_UNSPECIFIED and any value this
+// build does not know map to "", as AssetClassToStr does for its unspecified.
+func BrokerToStr(b typev1.Broker) string {
+	if _, ok := typev1.Broker_name[int32(b)]; !ok {
+		return ""
+	}
+	if b == typev1.Broker_BROKER_UNSPECIFIED {
+		return ""
+	}
+	return b.String()
+}
+
+// StrToBroker converts a stored broker string to its proto enum. An
+// unrecognised string maps to BROKER_UNSPECIFIED.
+func StrToBroker(s string) typev1.Broker {
+	v, ok := typev1.Broker_value[s]
+	if !ok {
+		return typev1.Broker_BROKER_UNSPECIFIED
+	}
+	return typev1.Broker(v)
+}
+
 // PluginCategoryToStr converts a proto plugin category to the string
 // plugin_config.category holds. It is the one shared vocabulary whose column
 // spelling differs from its enum name, so the mapping lives here rather than
@@ -771,6 +797,29 @@ func AssetClassToTxTypeStrings(assetClass string) []string {
 		}
 	}
 	return strs
+}
+
+// AssetClassToTxTypesMap builds the asset-class-to-tx-types mapping the ignore
+// rule writers need, covering exactly the asset classes the rules name.
+func AssetClassToTxTypesMap(rules []IgnoredAssetClass) map[string][]string {
+	mapping := make(map[string][]string)
+	for _, r := range rules {
+		if _, seen := mapping[r.AssetClass]; seen {
+			continue
+		}
+		mapping[r.AssetClass] = AssetClassToTxTypeStrings(r.AssetClass)
+	}
+	return mapping
+}
+
+// currencyCodeRE is the shape users.display_currency holds: an ISO 4217 code.
+var currencyCodeRE = regexp.MustCompile(`^[A-Z]{3}$`)
+
+// ValidCurrencyCode reports whether s is a well formed ISO 4217 code. Every
+// path that writes a currency the user chose applies the same test, so it lives
+// beside the column's other vocabularies rather than at one call site.
+func ValidCurrencyCode(s string) bool {
+	return currencyCodeRE.MatchString(s)
 }
 
 // InstrumentRow is a single instrument with its identifiers (for API responses).

--- a/server/db/vocab_test.go
+++ b/server/db/vocab_test.go
@@ -1,0 +1,72 @@
+package db
+
+import (
+	"testing"
+
+	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
+)
+
+// The broker columns hold the enum's own name, so every defined broker has to
+// survive a trip through the column and back.
+func TestBrokerToStr_RoundTrips(t *testing.T) {
+	for v, name := range typev1.Broker_name {
+		b := typev1.Broker(v)
+		if b == typev1.Broker_BROKER_UNSPECIFIED {
+			continue
+		}
+		s := BrokerToStr(b)
+		if s != name {
+			t.Fatalf("BrokerToStr(%v) = %q, want %q", b, s, name)
+		}
+		if got := StrToBroker(s); got != b {
+			t.Fatalf("StrToBroker(%q) = %v, want %v", s, got, b)
+		}
+	}
+}
+
+func TestBrokerToStr_UnknownIsEmpty(t *testing.T) {
+	if got := BrokerToStr(typev1.Broker_BROKER_UNSPECIFIED); got != "" {
+		t.Fatalf("unspecified = %q, want empty", got)
+	}
+	if got := BrokerToStr(typev1.Broker(9999)); got != "" {
+		t.Fatalf("unknown value = %q, want empty", got)
+	}
+	if got := StrToBroker("DEFUNCTBROKER"); got != typev1.Broker_BROKER_UNSPECIFIED {
+		t.Fatalf("unknown string = %v, want unspecified", got)
+	}
+}
+
+func TestValidCurrencyCode(t *testing.T) {
+	for _, s := range []string{"GBP", "USD", "JPY"} {
+		if !ValidCurrencyCode(s) {
+			t.Fatalf("%q rejected", s)
+		}
+	}
+	for _, s := range []string{"", "gbp", "GB", "GBPX", "GB1", "GBP "} {
+		if ValidCurrencyCode(s) {
+			t.Fatalf("%q accepted", s)
+		}
+	}
+}
+
+// The mapping covers exactly the asset classes the rules name, and names one
+// of them once however many rules mention it.
+func TestAssetClassToTxTypesMap_CoversEachAssetClassOnce(t *testing.T) {
+	m := AssetClassToTxTypesMap([]IgnoredAssetClass{
+		{Broker: "IBKR", AssetClass: AssetClassOption},
+		{Broker: "FIDELITY", AssetClass: AssetClassOption},
+		{Broker: "IBKR", AssetClass: AssetClassStock},
+	})
+	if len(m) != 2 {
+		t.Fatalf("mapping = %v, want two asset classes", m)
+	}
+	if len(m[AssetClassOption]) == 0 || len(m[AssetClassStock]) == 0 {
+		t.Fatalf("mapping = %v, want tx types for both", m)
+	}
+}
+
+func TestAssetClassToTxTypesMap_NoRulesIsEmpty(t *testing.T) {
+	if m := AssetClassToTxTypesMap(nil); len(m) != 0 {
+		t.Fatalf("mapping = %v, want empty", m)
+	}
+}

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -182,13 +182,13 @@ CREATE INDEX idx_txs_user_broker_time ON txs (user_id, broker, timestamp);
 CREATE INDEX idx_txs_group_id ON txs (group_id);
 
 -- Async ingestion jobs. status and validation_errors surfaced via front-end API.
--- job_type distinguishes tx uploads from system archive imports; broker/source
--- are tx-specific.
+-- job_type distinguishes tx uploads from archive imports; broker/source are
+-- tx-specific.
 -- payload stores the serialized protobuf request and is cleared after processing.
 CREATE TABLE ingestion_jobs (
   id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   user_id      UUID NOT NULL REFERENCES users (id) ON DELETE CASCADE,
-  job_type     TEXT NOT NULL DEFAULT 'tx' CHECK (job_type IN ('tx', 'system_archive')),
+  job_type     TEXT NOT NULL DEFAULT 'tx' CHECK (job_type IN ('tx', 'system_archive', 'user_archive')),
   broker       TEXT,
   source       TEXT,
   filename     TEXT,
@@ -204,7 +204,7 @@ CREATE TABLE ingestion_jobs (
 CREATE INDEX idx_ingestion_jobs_user ON ingestion_jobs (user_id);
 CREATE INDEX idx_ingestion_jobs_status ON ingestion_jobs (status);
 
--- Per-part results for a system archive import. One row per part the document
+-- Per-part results for an archive import. One row per part the document
 -- carried, created with the job so a page can render a row per part before the
 -- worker has started and after a reload. part spells the ArchivePart enum name,
 -- so the proto value, the column and the archive section are one string.
@@ -215,7 +215,8 @@ CREATE TABLE ingestion_job_parts (
   job_id          UUID NOT NULL REFERENCES ingestion_jobs (id) ON DELETE CASCADE,
   part            TEXT NOT NULL CHECK (part IN ('INSTRUMENTS', 'PRICES', 'CORPORATE_EVENTS',
                                                 'INFLATION_INDICES', 'FETCH_BLOCKS',
-                                                'UNHANDLED_EVENTS', 'PLUGIN_CONFIG')),
+                                                'UNHANDLED_EVENTS', 'PLUGIN_CONFIG',
+                                                'PREFERENCES')),
   status          TEXT NOT NULL CHECK (status IN ('PENDING', 'RUNNING', 'SUCCESS', 'FAILED')),
   total_count     INT NOT NULL DEFAULT 0,
   processed_count INT NOT NULL DEFAULT 0,
@@ -224,7 +225,7 @@ CREATE TABLE ingestion_job_parts (
 );
 
 -- Validation errors for async ingestion. row_index, field, message per API.
--- part attributes an error to one part of a system archive; NULL for a tx job
+-- part attributes an error to one part of an archive; NULL for a tx job
 -- and for a failure that happened before any part was reached.
 CREATE TABLE validation_errors (
   id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),

--- a/server/service/api/archive.go
+++ b/server/service/api/archive.go
@@ -39,7 +39,7 @@ func (s *Server) ImportSystemArchive(ctx context.Context, req *apiv1.ImportSyste
 		}
 		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
-	parts := presentParts(a)
+	parts := presentSystemParts(a)
 	if len(parts) == 0 {
 		return nil, status.Error(codes.InvalidArgument, "archive carries no parts")
 	}
@@ -66,12 +66,12 @@ func (s *Server) ImportSystemArchive(ctx context.Context, req *apiv1.ImportSyste
 	return &apiv1.ImportSystemArchiveResponse{JobId: jobID}, nil
 }
 
-// presentParts names the parts a document carries, in restore order.
+// presentSystemParts names the parts a system archive carries, in restore order.
 //
 // Presence, not emptiness: a section present but empty says the export included
 // it and there was nothing, which is a different statement from a section that
 // was never included, and the import honours the difference.
-func presentParts(a *archivev1.SystemArchive) []archivev1.ArchivePart {
+func presentSystemParts(a *archivev1.SystemArchive) []archivev1.ArchivePart {
 	var parts []archivev1.ArchivePart
 	if a.GetInstruments() != nil {
 		parts = append(parts, archivev1.ArchivePart_INSTRUMENTS)
@@ -117,7 +117,11 @@ func (s *Server) ExportSystemArchive(req *apiv1.ExportSystemArchiveRequest, stre
 	}); err != nil {
 		return err
 	}
-	for _, part := range requestedParts(req.GetParts()) {
+	parts, err := orderedParts(req.GetParts(), systemPartOrder)
+	if err != nil {
+		return err
+	}
+	for _, part := range parts {
 		if err := stream.Send(&apiv1.ExportSystemArchiveResponse{
 			Item: &apiv1.ExportSystemArchiveResponse_PartBegin{
 				PartBegin: &apiv1.ArchivePartBegin{Part: part},
@@ -125,40 +129,35 @@ func (s *Server) ExportSystemArchive(req *apiv1.ExportSystemArchiveRequest, stre
 		}); err != nil {
 			return err
 		}
-		var err error
+		var partErr error
 		switch part {
 		case archivev1.ArchivePart_INSTRUMENTS:
-			err = s.sendInstrumentPart(ctx, req, stream)
+			partErr = s.sendInstrumentPart(ctx, req, stream)
 		case archivev1.ArchivePart_PRICES:
-			err = s.sendPricePart(ctx, stream)
+			partErr = s.sendPricePart(ctx, stream)
 		case archivev1.ArchivePart_CORPORATE_EVENTS:
-			err = s.sendCorporateEventPart(ctx, stream)
+			partErr = s.sendCorporateEventPart(ctx, stream)
 		case archivev1.ArchivePart_INFLATION_INDICES:
-			err = s.sendInflationPart(ctx, stream)
+			partErr = s.sendInflationPart(ctx, stream)
 		case archivev1.ArchivePart_FETCH_BLOCKS:
-			err = s.sendFetchBlockPart(ctx, stream)
+			partErr = s.sendFetchBlockPart(ctx, stream)
 		case archivev1.ArchivePart_UNHANDLED_EVENTS:
-			err = s.sendUnhandledEventPart(ctx, stream)
+			partErr = s.sendUnhandledEventPart(ctx, stream)
 		case archivev1.ArchivePart_PLUGIN_CONFIG:
-			err = s.sendPluginConfigPart(ctx, stream)
+			partErr = s.sendPluginConfigPart(ctx, stream)
 		}
-		if err != nil {
-			return err
+		if partErr != nil {
+			return partErr
 		}
 	}
 	return nil
 }
 
-// requestedParts dedupes the menu and puts it in restore order. Order in the
-// document is the order it is applied, so it is the server's to decide and not
-// the caller's to state.
-func requestedParts(req []archivev1.ArchivePart) []archivev1.ArchivePart {
-	seen := make(map[archivev1.ArchivePart]bool, len(req))
-	for _, p := range req {
-		seen[p] = true
-	}
-	var out []archivev1.ArchivePart
-	for _, p := range []archivev1.ArchivePart{
+// systemPartOrder and userPartOrder are the two archives' parts in restore
+// order. ArchivePart numbers them in that order, but the enum spans both
+// documents and an export writes one of them, so each has its own list.
+var (
+	systemPartOrder = []archivev1.ArchivePart{
 		archivev1.ArchivePart_INSTRUMENTS,
 		archivev1.ArchivePart_PRICES,
 		archivev1.ArchivePart_CORPORATE_EVENTS,
@@ -166,12 +165,39 @@ func requestedParts(req []archivev1.ArchivePart) []archivev1.ArchivePart {
 		archivev1.ArchivePart_FETCH_BLOCKS,
 		archivev1.ArchivePart_UNHANDLED_EVENTS,
 		archivev1.ArchivePart_PLUGIN_CONFIG,
-	} {
+	}
+	userPartOrder = []archivev1.ArchivePart{
+		archivev1.ArchivePart_PREFERENCES,
+	}
+)
+
+// orderedParts dedupes the requested menu and puts it in restore order. Order in
+// the document is the order it is applied, so it is the server's to decide and
+// not the caller's to state.
+//
+// A part that belongs to the other archive is refused rather than dropped: an
+// export that quietly wrote nothing for a part the caller asked for would be a
+// silent wrong answer, and the two menus are one enum precisely so a request can
+// name a part from either.
+func orderedParts(req []archivev1.ArchivePart, order []archivev1.ArchivePart) ([]archivev1.ArchivePart, error) {
+	known := make(map[archivev1.ArchivePart]bool, len(order))
+	for _, p := range order {
+		known[p] = true
+	}
+	seen := make(map[archivev1.ArchivePart]bool, len(req))
+	for _, p := range req {
+		if !known[p] {
+			return nil, status.Errorf(codes.InvalidArgument, "%s is not a part of this archive", p)
+		}
+		seen[p] = true
+	}
+	var out []archivev1.ArchivePart
+	for _, p := range order {
 		if seen[p] {
 			out = append(out, p)
 		}
 	}
-	return out
+	return out, nil
 }
 
 // sendInstrumentPart streams the security master.

--- a/server/service/api/display_currency.go
+++ b/server/service/api/display_currency.go
@@ -2,16 +2,14 @@ package api
 
 import (
 	"context"
-	"regexp"
 
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
 	"github.com/leedenison/portfoliodb/server/auth"
+	"github.com/leedenison/portfoliodb/server/db"
 	"github.com/leedenison/portfoliodb/server/pluginutil"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
-
-var currencyCodeRE = regexp.MustCompile(`^[A-Z]{3}$`)
 
 // GetDisplayCurrency returns the authenticated user's display currency preference.
 func (s *Server) GetDisplayCurrency(ctx context.Context, _ *apiv1.GetDisplayCurrencyRequest) (*apiv1.GetDisplayCurrencyResponse, error) {
@@ -33,7 +31,7 @@ func (s *Server) SetDisplayCurrency(ctx context.Context, req *apiv1.SetDisplayCu
 		return nil, authErr
 	}
 	cc := req.GetDisplayCurrency()
-	if !currencyCodeRE.MatchString(cc) {
+	if !db.ValidCurrencyCode(cc) {
 		return nil, status.Error(codes.InvalidArgument, "display_currency must be a 3-letter ISO 4217 code")
 	}
 	if err := s.db.SetDisplayCurrency(ctx, u.ID, cc); err != nil {

--- a/server/service/api/export_user_archive_test.go
+++ b/server/service/api/export_user_archive_test.go
@@ -1,0 +1,186 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
+	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
+	dbpkg "github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/testutil"
+)
+
+// exportUserStreamMock captures a whole user archive export.
+type exportUserStreamMock struct {
+	ctx  context.Context
+	sent []*apiv1.ExportUserArchiveResponse
+}
+
+func (e *exportUserStreamMock) Context() context.Context    { return e.ctx }
+func (e *exportUserStreamMock) RecvMsg(m interface{}) error { return nil }
+func (e *exportUserStreamMock) Send(m *apiv1.ExportUserArchiveResponse) error {
+	e.sent = append(e.sent, m)
+	return nil
+}
+func (e *exportUserStreamMock) SendHeader(m metadata.MD) error { return nil }
+func (e *exportUserStreamMock) SetHeader(m metadata.MD) error  { return nil }
+func (e *exportUserStreamMock) SetTrailer(m metadata.MD)       {}
+func (e *exportUserStreamMock) SendMsg(m interface{}) error {
+	if r, ok := m.(*apiv1.ExportUserArchiveResponse); ok {
+		e.sent = append(e.sent, r)
+	}
+	return nil
+}
+
+// shape names the stream's messages in order, so a test can assert on the
+// grammar rather than on the contents.
+func (e *exportUserStreamMock) shape() []string {
+	var out []string
+	for _, m := range e.sent {
+		switch {
+		case m.GetEnvelope() != nil:
+			out = append(out, "envelope")
+		case m.GetPartBegin() != nil:
+			out = append(out, "begin:"+m.GetPartBegin().GetPart().String())
+		case m.GetPreferences() != nil:
+			out = append(out, "preferences")
+		}
+	}
+	return out
+}
+
+func (e *exportUserStreamMock) preferences() *archivev1.PreferencePart {
+	for _, m := range e.sent {
+		if v := m.GetPreferences(); v != nil {
+			return v
+		}
+	}
+	return nil
+}
+
+// exportPreferences runs a preferences-only export over the given stored state.
+func exportPreferences(t *testing.T, currency string, rules []dbpkg.IgnoredAssetClass) *exportUserStreamMock {
+	t.Helper()
+	srv, mockDB := newAPIServerWithMock(t)
+	mockDB.EXPECT().GetDisplayCurrency(gomock.Any(), "user-1").Return(currency, nil)
+	mockDB.EXPECT().ListIgnoredAssetClasses(gomock.Any(), "user-1").Return(rules, nil)
+	stream := &exportUserStreamMock{ctx: authCtx("user-1", "sub|1")}
+	if err := srv.ExportUserArchive(&apiv1.ExportUserArchiveRequest{
+		Parts: []archivev1.ArchivePart{archivev1.ArchivePart_PREFERENCES},
+	}, stream); err != nil {
+		t.Fatalf("ExportUserArchive: %v", err)
+	}
+	return stream
+}
+
+// The envelope is sent once and first, so exported_at is one reading of the
+// clock for the whole document, and the part_begin marker precedes the part
+// even though the part travels as a single message.
+func TestExportUserArchive_StreamGrammar(t *testing.T) {
+	stream := exportPreferences(t, "GBP", nil)
+	want := []string{"envelope", "begin:PREFERENCES", "preferences"}
+	if got := stream.shape(); !equalStrings(got, want) {
+		t.Fatalf("stream = %v, want %v", got, want)
+	}
+	env := stream.sent[0].GetEnvelope()
+	if env.GetKind() != archivev1.ArchiveKind_USER {
+		t.Fatalf("kind = %s, want USER", env.GetKind())
+	}
+	if env.GetExportedAt() == nil {
+		t.Fatal("envelope carries no exported_at")
+	}
+}
+
+// Broker and asset class are enums in the file and strings in the column, so
+// the export has to spell them the archive's way.
+func TestExportUserArchive_Preferences_SpellsTheEnums(t *testing.T) {
+	stream := exportPreferences(t, "GBP", []dbpkg.IgnoredAssetClass{
+		{Broker: "IBKR", Account: "U123", AssetClass: "OPTION"},
+	})
+	part := stream.preferences()
+	if part.GetDisplayCurrency() != "GBP" {
+		t.Fatalf("display_currency = %q", part.GetDisplayCurrency())
+	}
+	rules := part.GetIgnoredAssetClasses().GetRules()
+	if len(rules) != 1 {
+		t.Fatalf("rules = %v, want 1", rules)
+	}
+	if rules[0].GetBroker() != typev1.Broker_IBKR {
+		t.Fatalf("broker = %s", rules[0].GetBroker())
+	}
+	if rules[0].GetAssetClass() != typev1.AssetClass_OPTION {
+		t.Fatalf("asset_class = %s", rules[0].GetAssetClass())
+	}
+	if rules[0].GetAccount() != "U123" {
+		t.Fatalf("account = %q", rules[0].GetAccount())
+	}
+}
+
+// A user with no rules has an empty set rather than an unstated one. The empty
+// container is what says so: an absent one would tell an importer to leave the
+// stored rules alone, which is the opposite instruction.
+func TestExportUserArchive_Preferences_NoRulesIsPresentAndEmpty(t *testing.T) {
+	part := exportPreferences(t, "USD", nil).preferences()
+	if part.IgnoredAssetClasses == nil {
+		t.Fatal("ignored_asset_classes absent, want present and empty")
+	}
+	if len(part.GetIgnoredAssetClasses().GetRules()) != 0 {
+		t.Fatalf("rules = %v, want none", part.GetIgnoredAssetClasses().GetRules())
+	}
+}
+
+// A rule naming a broker this build has no enum value for is dropped: no
+// importer could apply it, and BROKER_UNSPECIFIED would fail validation on the
+// way back in and take the whole setting with it.
+func TestExportUserArchive_Preferences_SkipsUnmappableRules(t *testing.T) {
+	part := exportPreferences(t, "GBP", []dbpkg.IgnoredAssetClass{
+		{Broker: "DEFUNCTBROKER", Account: "", AssetClass: "STOCK"},
+		{Broker: "FIDELITY", Account: "", AssetClass: "OPTION"},
+	}).preferences()
+	rules := part.GetIgnoredAssetClasses().GetRules()
+	if len(rules) != 1 || rules[0].GetBroker() != typev1.Broker_FIDELITY {
+		t.Fatalf("rules = %v, want only the FIDELITY rule", rules)
+	}
+}
+
+func TestExportUserArchive_Unauthenticated(t *testing.T) {
+	srv, _ := newAPIServerWithMock(t)
+	err := srv.ExportUserArchive(&apiv1.ExportUserArchiveRequest{
+		Parts: []archivev1.ArchivePart{archivev1.ArchivePart_PREFERENCES},
+	}, &exportUserStreamMock{ctx: ctxNoAuth()})
+	testutil.RequireGRPCCode(t, err, codes.Unauthenticated)
+}
+
+// The two menus are one enum, so a request can name a part from either. Asking
+// the user export for a system part is refused rather than quietly dropped.
+func TestExportUserArchive_SystemPart_Refused(t *testing.T) {
+	srv, _ := newAPIServerWithMock(t)
+	err := srv.ExportUserArchive(&apiv1.ExportUserArchiveRequest{
+		Parts: []archivev1.ArchivePart{archivev1.ArchivePart_PRICES},
+	}, &exportUserStreamMock{ctx: authCtx("user-1", "sub|1")})
+	testutil.RequireGRPCCode(t, err, codes.InvalidArgument)
+}
+
+// The mirror of the above: the system export refuses a user part.
+func TestExportSystemArchive_UserPart_Refused(t *testing.T) {
+	srv, _ := newAPIServerWithMock(t)
+	err := srv.ExportSystemArchive(&apiv1.ExportSystemArchiveRequest{
+		Parts: []archivev1.ArchivePart{archivev1.ArchivePart_PREFERENCES},
+	}, &exportArchiveStreamMock{ctx: adminCtx("user-1", "sub|1")})
+	testutil.RequireGRPCCode(t, err, codes.InvalidArgument)
+}
+
+func TestExportUserArchive_DBError_Internal(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	mockDB.EXPECT().GetDisplayCurrency(gomock.Any(), "user-1").Return("", errors.New("boom"))
+	err := srv.ExportUserArchive(&apiv1.ExportUserArchiveRequest{
+		Parts: []archivev1.ArchivePart{archivev1.ArchivePart_PREFERENCES},
+	}, &exportUserStreamMock{ctx: authCtx("user-1", "sub|1")})
+	testutil.RequireGRPCCode(t, err, codes.Internal)
+}

--- a/server/service/api/ignored_asset_classes.go
+++ b/server/service/api/ignored_asset_classes.go
@@ -33,7 +33,7 @@ func (s *Server) SetIgnoredAssetClasses(ctx context.Context, req *apiv1.SetIgnor
 	if err != nil {
 		return nil, err
 	}
-	mapping := buildAssetClassToTxTypesMap(rules)
+	mapping := db.AssetClassToTxTypesMap(rules)
 	if err := s.db.SetIgnoredAssetClasses(ctx, u.ID, rules, mapping); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
@@ -50,7 +50,7 @@ func (s *Server) CountIgnoredTxs(ctx context.Context, req *apiv1.CountIgnoredTxs
 	if err != nil {
 		return nil, err
 	}
-	mapping := buildAssetClassToTxTypesMap(rules)
+	mapping := db.AssetClassToTxTypesMap(rules)
 	txCount, declCount, err := s.db.CountIgnoredTxs(ctx, u.ID, rules, mapping)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
@@ -87,18 +87,4 @@ func rulesFromProto(protos []*apiv1.IgnoredAssetClassRule) ([]db.IgnoredAssetCla
 		}
 	}
 	return rules, nil
-}
-
-// buildAssetClassToTxTypesMap builds the reverse mapping for the asset classes present in the rules.
-func buildAssetClassToTxTypesMap(rules []db.IgnoredAssetClass) map[string][]string {
-	seen := make(map[string]bool)
-	mapping := make(map[string][]string)
-	for _, r := range rules {
-		if seen[r.AssetClass] {
-			continue
-		}
-		seen[r.AssetClass] = true
-		mapping[r.AssetClass] = db.AssetClassToTxTypeStrings(r.AssetClass)
-	}
-	return mapping
 }

--- a/server/service/api/user_archive.go
+++ b/server/service/api/user_archive.go
@@ -1,0 +1,118 @@
+package api
+
+import (
+	"context"
+	"log"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
+	"github.com/leedenison/portfoliodb/server/archive"
+	"github.com/leedenison/portfoliodb/server/auth"
+	"github.com/leedenison/portfoliodb/server/db"
+)
+
+// ExportUserArchive streams one user archive: the envelope, then the selected
+// parts in restore order. It carries the caller's own data and no system data
+// at all, which is why it is scoped with RequireUser rather than RequireAdmin
+// and why it is a separate document.
+// See docs/adr/0033-system-and-user-archives-are-separate.md.
+//
+// The stream has the same grammar as the system export, including for a part
+// whose unit is a setting rather than a row: the part_begin marker is what
+// creates the container, so a part that was asked for and holds nothing is
+// still present and empty.
+func (s *Server) ExportUserArchive(req *apiv1.ExportUserArchiveRequest, stream apiv1.ApiService_ExportUserArchiveServer) error {
+	ctx := stream.Context()
+	u, authErr := auth.RequireUser(ctx)
+	if authErr != nil {
+		return authErr
+	}
+	// source_instance is left empty for the same reason the system export leaves
+	// it empty: nothing keys off it and this build has no configured identity.
+	if err := stream.Send(&apiv1.ExportUserArchiveResponse{
+		Item: &apiv1.ExportUserArchiveResponse_Envelope{
+			Envelope: archive.NewEnvelope("", archivev1.ArchiveKind_USER),
+		},
+	}); err != nil {
+		return err
+	}
+	parts, err := orderedParts(req.GetParts(), userPartOrder)
+	if err != nil {
+		return err
+	}
+	for _, part := range parts {
+		if err := stream.Send(&apiv1.ExportUserArchiveResponse{
+			Item: &apiv1.ExportUserArchiveResponse_PartBegin{
+				PartBegin: &apiv1.ArchivePartBegin{Part: part},
+			},
+		}); err != nil {
+			return err
+		}
+		var partErr error
+		switch part {
+		case archivev1.ArchivePart_PREFERENCES:
+			partErr = s.sendPreferencePart(ctx, u.ID, stream)
+		}
+		if partErr != nil {
+			return partErr
+		}
+	}
+	return nil
+}
+
+// sendPreferencePart sends the user's settings as one whole-part message. The
+// part is two settings rather than a list of rows, so there is nothing to
+// stream and nothing to group by.
+//
+// Both settings are always stated, because both are always known: the display
+// currency is a NOT NULL column and a user with no ignore rules has an empty
+// set rather than an unstated one. The empty IgnoredAssetClasses container is
+// what says so -- an absent one would tell an importer to leave the stored
+// rules alone, which is the opposite instruction.
+func (s *Server) sendPreferencePart(ctx context.Context, userID string, stream apiv1.ApiService_ExportUserArchiveServer) error {
+	currency, err := s.db.GetDisplayCurrency(ctx, userID)
+	if err != nil {
+		return status.Error(codes.Internal, err.Error())
+	}
+	rules, err := s.db.ListIgnoredAssetClasses(ctx, userID)
+	if err != nil {
+		return status.Error(codes.Internal, err.Error())
+	}
+	part := &archivev1.PreferencePart{
+		IgnoredAssetClasses: &archivev1.IgnoredAssetClasses{Rules: archiveIgnoredRules(rules)},
+	}
+	if currency != "" {
+		part.DisplayCurrency = proto.String(currency)
+	}
+	return stream.Send(&apiv1.ExportUserArchiveResponse{
+		Item: &apiv1.ExportUserArchiveResponse_Preferences{Preferences: part},
+	})
+}
+
+// archiveIgnoredRules turns stored ignore rules into their archive form.
+//
+// A stored broker or asset class this build has no enum value for is dropped
+// rather than written as UNSPECIFIED: no importer could apply the rule, and an
+// UNSPECIFIED enum would fail validation on the way back in, taking the whole
+// setting with it.
+func archiveIgnoredRules(rules []db.IgnoredAssetClass) []*archivev1.IgnoredAssetClassRule {
+	out := make([]*archivev1.IgnoredAssetClassRule, 0, len(rules))
+	for _, r := range rules {
+		broker := db.StrToBroker(r.Broker)
+		assetClass := db.StrToAssetClass(r.AssetClass)
+		if broker == 0 || assetClass == 0 {
+			log.Printf("user archive export: skipping ignore rule (broker %q, asset class %q): not a known value", r.Broker, r.AssetClass)
+			continue
+		}
+		out = append(out, &archivev1.IgnoredAssetClassRule{
+			Broker:     broker,
+			Account:    r.Account,
+			AssetClass: assetClass,
+		})
+	}
+	return out
+}

--- a/server/service/ingestion/server.go
+++ b/server/service/ingestion/server.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
 	ingestionv1 "github.com/leedenison/portfoliodb/proto/ingestion/v1"
-	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
 	"github.com/leedenison/portfoliodb/server/auth"
 	"github.com/leedenison/portfoliodb/server/db"
 	"google.golang.org/grpc/codes"
@@ -45,7 +44,7 @@ func (s *Server) UpsertTxs(ctx context.Context, req *ingestionv1.UpsertTxsReques
 	if err != nil {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("serialize request: %v", err))
 	}
-	brokerStr, _ := brokerToString(req.Broker)
+	brokerStr := db.BrokerToStr(req.Broker)
 	jobID, err := s.db.CreateJob(ctx, db.CreateJobParams{
 		UserID:       u.ID,
 		JobType:      "tx",
@@ -83,7 +82,7 @@ func (s *Server) CreateTx(ctx context.Context, req *ingestionv1.CreateTxRequest)
 		return nil, status.Error(codes.InvalidArgument, "tx required")
 	}
 	// Wrap single tx in UpsertTxsRequest for uniform payload format.
-	brokerStr, _ := brokerToString(req.Broker)
+	brokerStr := db.BrokerToStr(req.Broker)
 	wrapped := &ingestionv1.UpsertTxsRequest{
 		Broker:          req.Broker,
 		Source:          req.GetSource(),
@@ -110,16 +109,4 @@ func (s *Server) CreateTx(ctx context.Context, req *ingestionv1.CreateTxRequest)
 		return nil, status.Error(codes.Unavailable, "job queue full")
 	}
 	return &ingestionv1.CreateTxResponse{JobId: jobID}, nil
-}
-
-// brokerToString returns the stored form of a broker: its enum name.
-func brokerToString(b typev1.Broker) (string, error) {
-	if b == typev1.Broker_BROKER_UNSPECIFIED {
-		return "", fmt.Errorf("broker unspecified")
-	}
-	s, ok := typev1.Broker_name[int32(b)]
-	if !ok {
-		return "", fmt.Errorf("unknown broker")
-	}
-	return s, nil
 }

--- a/server/service/ingestion/worker.go
+++ b/server/service/ingestion/worker.go
@@ -6,7 +6,6 @@ import (
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
 	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
 	ingestionv1 "github.com/leedenison/portfoliodb/proto/ingestion/v1"
-	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
 	"github.com/leedenison/portfoliodb/server/db"
 	"github.com/leedenison/portfoliodb/server/identifier"
 	"github.com/leedenison/portfoliodb/server/identifier/description"
@@ -167,7 +166,7 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 		txs = []*apiv1.Tx{}
 	}
 	source := req.GetSource()
-	broker, _ := brokerToStr(req.Broker)
+	broker := db.BrokerToStr(req.Broker)
 	bulk := req.PeriodFrom != nil && req.PeriodBefore != nil
 
 	// The denomination of the whole upload. Absent means as-traded: each row is
@@ -420,17 +419,4 @@ func resolveInstruments(ctx context.Context, database db.DB, registry *identifie
 		}
 	}
 	return instrumentIDs, idErrs, nil
-}
-
-// brokerToStr converts a proto Broker enum to its string representation.
-// brokerToStr returns the stored form of a broker: its enum name.
-func brokerToStr(b typev1.Broker) (string, error) {
-	if b == typev1.Broker_BROKER_UNSPECIFIED {
-		return "", fmt.Errorf("broker unspecified")
-	}
-	s, ok := typev1.Broker_name[int32(b)]
-	if !ok {
-		return "", fmt.Errorf("unknown broker")
-	}
-	return s, nil
 }


### PR DESCRIPTION
First half of the user-archive spine, plus the export of the smallest user part.

Nothing user-archive-side existed on the server. The format and the codec were
defined and tested on both runtimes ([0078]), but no `ArchivePart` named a user
part, no RPC produced a user archive and no job type applied one. 0085 is the
first user part, so it carries the spine; the import half and the page follow in
stacked PRs.

## What changed

- **`ArchivePart` numbers its values in two blocks**, one per archive, because no
  part belongs to both documents. `PREFERENCES = 8`, `TXS = 9`, `DECLARATIONS = 10`.
- **`requestedParts` becomes `orderedParts`** over an explicit per-archive order,
  and **refuses** a part from the other block instead of dropping it. The old
  function silently exported nothing for a part it did not know, which becomes a
  live defect the moment the enum spans two menus.
- **`ExportUserArchive`**, scoped with `RequireUser`, streaming the envelope then
  the selected parts. The preferences part travels as one whole-part message
  rather than a series of items, because its unit is a setting rather than a row;
  `part_begin` still precedes it, so the grammar does not fork.
- A user with **no ignore rules** exports a present-but-empty container. An absent
  one would tell an importer to leave the stored rules alone -- the opposite
  instruction.
- The **broker enum mapping, the ISO 4217 test and the asset-class-to-tx-type
  mapping** move into `server/db` beside the other column vocabularies, since the
  archive reader needs all three and cannot import the api package. Two duplicate
  copies of the broker mapping go with them.
- Migration edited in place (pre-release): the `job_type` and
  `ingestion_job_parts.part` CHECK constraints gain `user_archive` and
  `PREFERENCES`, so PR 2 has somewhere to write.

## Testing

`make check` and `make server-test client-test` pass. New coverage: the stream
grammar and `USER` envelope; broker and asset class spelled as enums; no rules is
present-and-empty; an unmappable stored broker is skipped rather than written as
`UNSPECIFIED`; both directions of the cross-archive part refusal; and the three
moved `db` helpers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)