### PR TITLE
Import a user's preferences from an archive part (0085)

### DIFF
--- a/docs/spec/archive-format.md
+++ b/docs/spec/archive-format.md
@@ -513,6 +513,20 @@ rather than being a bare list, so that "the user has no rules" -- an empty
 state them", which import ignores. Each rule is `{broker, account, asset_class}`,
 where an empty `account` means every account for that broker.
 
+The two settings apply independently: a currency the file spells wrongly does not
+stop the rules landing, and vice versa. A rule the reader cannot use -- an
+unknown broker, an unknown asset class -- rejects the **whole**
+`ignored_asset_classes` setting rather than just that rule, and leaves the stored
+rules alone. Setting ignore rules replaces the set and deletes the transactions
+and declarations that set covers, so applying the rules a reader could read would
+delete on the strength of a file it could not read, and leave the user with a set
+they never wrote.
+
+A restored `display_currency` triggers an FX price fetch, once for the whole
+import, exactly as setting one through the UI does per change. Without it a
+rebuilt instance has no rates for its display currency until the next scheduled
+cycle.
+
 ### Transactions
 
 `txs.windows[]` is one window per (broker, period). A window is a replacement
@@ -624,6 +638,10 @@ The job reports a result per part: how much was applied, and which rows were
 rejected. A rejected row does not fail its part. A part fails only when a write
 does not land, so "completed, 12 rows rejected" is a result the format can state
 and a page can show.
+
+A part whose unit is a setting rather than a row counts settings: its total is
+how many the file states, and a rejected setting carries a row index of `-1`,
+because there is nothing to point at. Preferences is the only such part today.
 
 ## Restore order
 

--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -191,6 +191,7 @@ service ApiService {
   // and no system data at all, in the same stream shape as the system export.
   // See docs/adr/0033-system-and-user-archives-are-separate.md.
   rpc ExportUserArchive(ExportUserArchiveRequest) returns (stream ExportUserArchiveResponse);
+  rpc ImportUserArchive(ImportUserArchiveRequest) returns (ImportUserArchiveResponse);
 
   // Identifier plugin config (admin-only). List all plugins; update enabled, precedence, and config JSON (including API keys).
   rpc ListIdentifierPlugins(ListIdentifierPluginsRequest) returns (ListIdentifierPluginsResponse);
@@ -624,6 +625,30 @@ message ExportUserArchiveRequest {
     }
   }];
   // 2 and 3 are the bounds of the transaction window to export.
+}
+
+// ImportUserArchiveRequest carries one whole user archive: the caller's own
+// data, applied to the caller's own account. A user archive does not name its
+// user, so restoring one into a different account is a feature rather than an
+// accident.
+//
+// The parts are applied server-side in restore order, exactly as the system
+// import applies its own, and the caller polls one job rather than sequencing
+// the parts itself.
+//
+// Restoring into an instance whose instruments are not loaded is supported and
+// correct: postings resolve through the normal identifier path. It is merely
+// slower, which is the cost restoring the system archive first avoids -- a
+// recommendation, not a constraint.
+message ImportUserArchiveRequest {
+  portfoliodb.archive.v1.UserArchive archive = 1 [(buf.validate.field).required = true];
+  string filename = 2; // optional; shown in the job list
+}
+
+// ImportUserArchiveResponse returns immediately with the job to poll. Per-part
+// progress and results are on GetJobResponse.parts.
+message ImportUserArchiveResponse {
+  string job_id = 1;
 }
 
 // ExportUserArchiveResponse is one element of the export stream, with the same

--- a/server/archiveimport/preferences.go
+++ b/server/archiveimport/preferences.go
@@ -1,0 +1,110 @@
+package archiveimport
+
+import (
+	"context"
+	"fmt"
+
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+)
+
+// PreferenceResult says what the part actually applied. DisplayCurrency is
+// carried out so the worker can nudge the price fetcher once for the whole
+// import, as SetDisplayCurrency does once per call: a restored instance with no
+// FX rates for its display currency shows nothing until the next fetch cycle.
+type PreferenceResult struct {
+	Applied         int32
+	DisplayCurrency bool
+}
+
+// PreferencePart applies a user archive's settings and reports through rep.
+//
+// The unit here is a setting rather than a row, so the part's total is how many
+// settings the file states -- nought, one or two -- and a rejected setting is a
+// validation error with a row index of -1, because there is no row to point at.
+// A file stating neither is a part that succeeds having done nothing, which is
+// what a present but empty section means.
+//
+// The two settings apply independently: a currency the file spells wrongly does
+// not stop the ignore rules landing, and vice versa.
+func PreferencePart(ctx context.Context, database db.DB, userID string, part *archivev1.PreferencePart, rep *PartReporter) (PreferenceResult, error) {
+	var out PreferenceResult
+	total := 0
+	if part.DisplayCurrency != nil {
+		total++
+	}
+	if part.IgnoredAssetClasses != nil {
+		total++
+	}
+	rep.Total(ctx, total)
+	if total == 0 {
+		return out, nil
+	}
+
+	if part.DisplayCurrency != nil {
+		cc := part.GetDisplayCurrency()
+		if !db.ValidCurrencyCode(cc) {
+			rep.Errf(settingRow, "display_currency", fmt.Sprintf("%q is not a 3-letter ISO 4217 code; the stored display currency was left alone", cc))
+		} else {
+			if err := database.SetDisplayCurrency(ctx, userID, cc); err != nil {
+				return out, fmt.Errorf("set display currency: %w", err)
+			}
+			out.Applied++
+			out.DisplayCurrency = true
+		}
+		rep.Advance(ctx, 1)
+	}
+
+	if part.IgnoredAssetClasses != nil {
+		rules, ok := ignoredRules(part.GetIgnoredAssetClasses().GetRules(), rep)
+		if ok {
+			// An empty set is applied rather than skipped: it clears the user's
+			// rules, and telling that apart from a file that does not state them
+			// is what the wrapper message exists for.
+			if err := database.SetIgnoredAssetClasses(ctx, userID, rules, db.AssetClassToTxTypesMap(rules)); err != nil {
+				return out, fmt.Errorf("set ignored asset classes: %w", err)
+			}
+			out.Applied++
+		}
+		rep.Advance(ctx, 1)
+	}
+	return out, nil
+}
+
+// settingRow is the row index a problem with a whole setting is reported
+// against. The reporter's other users point at a row or a group; a setting has
+// neither, and -1 is already what a problem belonging to no row carries.
+const settingRow = -1
+
+// ignoredRules converts the file's rules, rejecting the setting as a whole if
+// any one of them is unusable.
+//
+// All or nothing, because SetIgnoredAssetClasses replaces the set and deletes
+// the transactions and declarations that set covers. Applying the rules the
+// reader could read would delete on the strength of a file it could not read,
+// and leave the user with a set they never wrote. Every problem is reported, not
+// just the first, so one pass over the file names all of them.
+func ignoredRules(rules []*archivev1.IgnoredAssetClassRule, rep *PartReporter) ([]db.IgnoredAssetClass, bool) {
+	out := make([]db.IgnoredAssetClass, 0, len(rules))
+	ok := true
+	for i, r := range rules {
+		broker := db.BrokerToStr(r.GetBroker())
+		if broker == "" {
+			rep.Errf(settingRow, "ignored_asset_classes", fmt.Sprintf("rule %d names no broker; the stored ignore rules were left alone", i))
+			ok = false
+			continue
+		}
+		assetClass := db.AssetClassToStr(r.GetAssetClass())
+		if !db.ValidAssetClasses[assetClass] {
+			rep.Errf(settingRow, "ignored_asset_classes", fmt.Sprintf("rule %d (%s) names no known asset class; the stored ignore rules were left alone", i, broker))
+			ok = false
+			continue
+		}
+		out = append(out, db.IgnoredAssetClass{
+			Broker:     broker,
+			Account:    r.GetAccount(),
+			AssetClass: assetClass,
+		})
+	}
+	return out, ok
+}

--- a/server/archiveimport/preferences_test.go
+++ b/server/archiveimport/preferences_test.go
@@ -1,0 +1,195 @@
+package archiveimport
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/proto"
+
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
+	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/db/mock"
+)
+
+func rule(broker typev1.Broker, account string, ac typev1.AssetClass) *archivev1.IgnoredAssetClassRule {
+	return &archivev1.IgnoredAssetClassRule{Broker: broker, Account: account, AssetClass: ac}
+}
+
+func ignored(rules ...*archivev1.IgnoredAssetClassRule) *archivev1.IgnoredAssetClasses {
+	return &archivev1.IgnoredAssetClasses{Rules: rules}
+}
+
+func applyPreferences(t *testing.T, database *mock.MockDB, rep *PartReporter, part *archivev1.PreferencePart) PreferenceResult {
+	t.Helper()
+	res, err := PreferencePart(context.Background(), database, "user-1", part, rep)
+	if err != nil {
+		t.Fatalf("PreferencePart: %v", err)
+	}
+	return res
+}
+
+func TestPreferencePart_AppliesBothSettings(t *testing.T) {
+	database, rep := newPartTest(t)
+	database.EXPECT().SetDisplayCurrency(gomock.Any(), "user-1", "GBP").Return(nil)
+	database.EXPECT().
+		SetIgnoredAssetClasses(gomock.Any(), "user-1",
+			[]db.IgnoredAssetClass{{Broker: "IBKR", Account: "U123", AssetClass: "OPTION"}},
+			gomock.Any()).
+		Return(nil)
+
+	res := applyPreferences(t, database, rep, &archivev1.PreferencePart{
+		DisplayCurrency:     proto.String("GBP"),
+		IgnoredAssetClasses: ignored(rule(typev1.Broker_IBKR, "U123", typev1.AssetClass_OPTION)),
+	})
+	if res.Applied != 2 || !res.DisplayCurrency {
+		t.Fatalf("result = %+v, want both settings applied", res)
+	}
+	if rep.ErrCount() != 0 {
+		t.Fatalf("errors = %v, want none", rep.Errors())
+	}
+}
+
+// The two settings are independent, so a file stating one says nothing about
+// the other and the other's setter is never called.
+func TestPreferencePart_CurrencyOnly(t *testing.T) {
+	database, rep := newPartTest(t)
+	database.EXPECT().SetDisplayCurrency(gomock.Any(), "user-1", "USD").Return(nil)
+
+	res := applyPreferences(t, database, rep, &archivev1.PreferencePart{DisplayCurrency: proto.String("USD")})
+	if res.Applied != 1 || !res.DisplayCurrency {
+		t.Fatalf("result = %+v", res)
+	}
+}
+
+func TestPreferencePart_RulesOnly(t *testing.T) {
+	database, rep := newPartTest(t)
+	database.EXPECT().SetIgnoredAssetClasses(gomock.Any(), "user-1", gomock.Any(), gomock.Any()).Return(nil)
+
+	res := applyPreferences(t, database, rep, &archivev1.PreferencePart{
+		IgnoredAssetClasses: ignored(rule(typev1.Broker_FIDELITY, "", typev1.AssetClass_STOCK)),
+	})
+	if res.Applied != 1 || res.DisplayCurrency {
+		t.Fatalf("result = %+v, want no display currency", res)
+	}
+}
+
+// An empty rules list is applied, which clears the user's rules. Telling that
+// apart from a file that does not state them is what the wrapper exists for.
+func TestPreferencePart_EmptyRulesClearsThem(t *testing.T) {
+	database, rep := newPartTest(t)
+	database.EXPECT().
+		SetIgnoredAssetClasses(gomock.Any(), "user-1", []db.IgnoredAssetClass{}, gomock.Any()).
+		Return(nil)
+
+	res := applyPreferences(t, database, rep, &archivev1.PreferencePart{IgnoredAssetClasses: ignored()})
+	if res.Applied != 1 {
+		t.Fatalf("result = %+v, want the empty set applied", res)
+	}
+}
+
+// A part present and empty is a part that succeeds having done nothing: the
+// export included it and there was nothing to say.
+func TestPreferencePart_NeitherSettingWritesNothing(t *testing.T) {
+	database, rep := newPartTest(t)
+	res := applyPreferences(t, database, rep, &archivev1.PreferencePart{})
+	if res.Applied != 0 || res.DisplayCurrency {
+		t.Fatalf("result = %+v, want nothing applied", res)
+	}
+	if rep.ErrCount() != 0 {
+		t.Fatalf("errors = %v, want none", rep.Errors())
+	}
+}
+
+// A rejected setting is a validation error, not a failed part, and it carries a
+// row index of -1 because there is no row to point at.
+func TestPreferencePart_BadCurrencyRejectedAloneAndRulesStillLand(t *testing.T) {
+	database, rep := newPartTest(t)
+	database.EXPECT().SetIgnoredAssetClasses(gomock.Any(), "user-1", gomock.Any(), gomock.Any()).Return(nil)
+
+	res := applyPreferences(t, database, rep, &archivev1.PreferencePart{
+		DisplayCurrency:     proto.String("gbp"),
+		IgnoredAssetClasses: ignored(rule(typev1.Broker_IBKR, "", typev1.AssetClass_STOCK)),
+	})
+	if res.DisplayCurrency {
+		t.Fatal("display currency reported as applied")
+	}
+	if res.Applied != 1 {
+		t.Fatalf("applied = %d, want only the rules", res.Applied)
+	}
+	if rep.ErrCount() != 1 {
+		t.Fatalf("errors = %v, want one", rep.Errors())
+	}
+	e := rep.Errors()[0]
+	if e.GetRowIndex() != -1 || e.GetField() != "display_currency" {
+		t.Fatalf("error = %+v", e)
+	}
+}
+
+// All or nothing: the setter replaces the whole set and deletes the txs that set
+// covers, so applying the rules the reader could read would delete on the
+// strength of a file it could not read.
+func TestPreferencePart_OneBadRuleRejectsTheWholeSetting(t *testing.T) {
+	database, rep := newPartTest(t)
+	database.EXPECT().SetDisplayCurrency(gomock.Any(), "user-1", "GBP").Return(nil)
+	// No SetIgnoredAssetClasses expectation: calling it at all is the failure.
+
+	res := applyPreferences(t, database, rep, &archivev1.PreferencePart{
+		DisplayCurrency: proto.String("GBP"),
+		IgnoredAssetClasses: ignored(
+			rule(typev1.Broker_IBKR, "", typev1.AssetClass_STOCK),
+			rule(typev1.Broker_FIDELITY, "", typev1.AssetClass_ASSET_CLASS_UNSPECIFIED),
+			rule(typev1.Broker_IBKR, "", typev1.AssetClass_OPTION),
+		),
+	})
+	if res.Applied != 1 || !res.DisplayCurrency {
+		t.Fatalf("result = %+v, want only the currency applied", res)
+	}
+	if rep.ErrCount() != 1 {
+		t.Fatalf("errors = %v, want one", rep.Errors())
+	}
+	if f := rep.Errors()[0].GetField(); f != "ignored_asset_classes" {
+		t.Fatalf("field = %q", f)
+	}
+}
+
+func TestPreferencePart_UnspecifiedBrokerRejectsTheSetting(t *testing.T) {
+	database, rep := newPartTest(t)
+	res := applyPreferences(t, database, rep, &archivev1.PreferencePart{
+		IgnoredAssetClasses: ignored(rule(typev1.Broker_BROKER_UNSPECIFIED, "", typev1.AssetClass_STOCK)),
+	})
+	if res.Applied != 0 {
+		t.Fatalf("result = %+v, want nothing applied", res)
+	}
+	if rep.ErrCount() != 1 {
+		t.Fatalf("errors = %v, want one", rep.Errors())
+	}
+}
+
+// Every problem is named on one pass, rather than the first stopping the read.
+func TestPreferencePart_ReportsEveryBadRule(t *testing.T) {
+	database, rep := newPartTest(t)
+	applyPreferences(t, database, rep, &archivev1.PreferencePart{
+		IgnoredAssetClasses: ignored(
+			rule(typev1.Broker_BROKER_UNSPECIFIED, "", typev1.AssetClass_STOCK),
+			rule(typev1.Broker_IBKR, "", typev1.AssetClass_ASSET_CLASS_UNSPECIFIED),
+		),
+	})
+	if rep.ErrCount() != 2 {
+		t.Fatalf("errors = %v, want two", rep.Errors())
+	}
+}
+
+// A write that does not land fails the part, as it does in every other part.
+func TestPreferencePart_SetterErrorFailsThePart(t *testing.T) {
+	database, rep := newPartTest(t)
+	database.EXPECT().SetDisplayCurrency(gomock.Any(), "user-1", "GBP").Return(errors.New("boom"))
+
+	_, err := PreferencePart(context.Background(), database, "user-1",
+		&archivev1.PreferencePart{DisplayCurrency: proto.String("GBP")}, rep)
+	if err == nil {
+		t.Fatal("expected a hard failure")
+	}
+}

--- a/server/archiveimport/reporter.go
+++ b/server/archiveimport/reporter.go
@@ -1,4 +1,4 @@
-// Package archiveimport applies the parts of a system archive. It sits below
+// Package archiveimport applies the parts of an archive. It sits below
 // both the API and the ingestion worker: an import runs in the worker, but the
 // synchronous per-entity RPCs still apply the same parts, and neither package
 // can import the other.

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -370,7 +370,7 @@ type JobDetail struct {
 	ProcessedCount       int32
 	ValidationErrors     []*apiv1.ValidationError // errors with no part of their own
 	IdentificationErrors []IdentificationError
-	Parts                []JobPartResult // in restore order; empty unless a system archive
+	Parts                []JobPartResult // in restore order; empty unless an archive import
 }
 
 // JobDB provides ingestion job operations.

--- a/server/service/api/import_user_archive_test.go
+++ b/server/service/api/import_user_archive_test.go
@@ -1,0 +1,109 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
+	"github.com/leedenison/portfoliodb/server/archive"
+	dbpkg "github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/testutil"
+)
+
+func userArchive(mutate func(*archivev1.UserArchive)) *apiv1.ImportUserArchiveRequest {
+	a := &archivev1.UserArchive{
+		Envelope: archive.NewEnvelope("portfoliodb.example.com", archivev1.ArchiveKind_USER),
+	}
+	if mutate != nil {
+		mutate(a)
+	}
+	return &apiv1.ImportUserArchiveRequest{Archive: a, Filename: "user-archive.json"}
+}
+
+func TestImportUserArchive_Unauthenticated(t *testing.T) {
+	srv, _ := newAPIServerWithMock(t)
+	req := userArchive(func(a *archivev1.UserArchive) { a.Preferences = &archivev1.PreferencePart{} })
+	_, err := srv.ImportUserArchive(ctxNoAuth(), req)
+	testutil.RequireGRPCCode(t, err, codes.Unauthenticated)
+}
+
+func TestImportUserArchive_NoParts_ReturnsError(t *testing.T) {
+	srv, _ := newAPIServerWithMock(t)
+	_, err := srv.ImportUserArchive(authCtx("user-1", "sub|1"), userArchive(nil))
+	testutil.RequireGRPCCode(t, err, codes.InvalidArgument)
+}
+
+// The document's message type says which archive it is, but protojson records
+// no type name, so the envelope has to carry it and the importer has to check.
+func TestImportUserArchive_SystemArchive_Refused(t *testing.T) {
+	srv, _ := newAPIServerWithMock(t)
+	req := userArchive(func(a *archivev1.UserArchive) {
+		a.Preferences = &archivev1.PreferencePart{}
+		a.Envelope.Kind = archivev1.ArchiveKind_SYSTEM
+	})
+	_, err := srv.ImportUserArchive(authCtx("user-1", "sub|1"), req)
+	testutil.RequireGRPCCode(t, err, codes.InvalidArgument)
+}
+
+// The request is well formed and this server is the thing that is out of date,
+// so this is a precondition rather than a bad argument.
+func TestImportUserArchive_NewerFormatVersion_Refused(t *testing.T) {
+	srv, _ := newAPIServerWithMock(t)
+	req := userArchive(func(a *archivev1.UserArchive) {
+		a.Preferences = &archivev1.PreferencePart{}
+		a.Envelope.FormatVersion = archive.FormatVersion + 1
+	})
+	_, err := srv.ImportUserArchive(authCtx("user-1", "sub|1"), req)
+	testutil.RequireGRPCCode(t, err, codes.FailedPrecondition)
+}
+
+func TestImportUserArchive_CreatesAndEnqueuesTheJob(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	req := userArchive(func(a *archivev1.UserArchive) {
+		a.Preferences = &archivev1.PreferencePart{}
+	})
+	var enqueuedType string
+	srv.enqueueJob = func(_, jobType string) error { enqueuedType = jobType; return nil }
+	var got dbpkg.CreateJobParams
+	mockDB.EXPECT().CreateJob(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, params dbpkg.CreateJobParams) (string, error) {
+			got = params
+			return "job-ua-1", nil
+		})
+
+	resp, err := srv.ImportUserArchive(authCtx("user-9", "sub|9"), req)
+	if err != nil {
+		t.Fatalf("ImportUserArchive: %v", err)
+	}
+	if resp.GetJobId() != "job-ua-1" {
+		t.Fatalf("job_id = %q", resp.GetJobId())
+	}
+	if got.JobType != dbpkg.JobTypeUserArchive || enqueuedType != dbpkg.JobTypeUserArchive {
+		t.Fatalf("job type = %q, enqueued as %q", got.JobType, enqueuedType)
+	}
+	// A user archive does not name its user, so the account it restores into is
+	// whoever asked.
+	if got.UserID != "user-9" {
+		t.Fatalf("user = %q", got.UserID)
+	}
+	if len(got.Parts) != 1 || got.Parts[0] != archivev1.ArchivePart_PREFERENCES {
+		t.Fatalf("parts = %v, want [PREFERENCES]", got.Parts)
+	}
+	if len(got.Payload) == 0 {
+		t.Fatal("job carries no payload")
+	}
+}
+
+func TestImportUserArchive_FullQueue_Unavailable(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	req := userArchive(func(a *archivev1.UserArchive) { a.Preferences = &archivev1.PreferencePart{} })
+	srv.enqueueJob = func(_, _ string) error { return errors.New("job queue full") }
+	mockDB.EXPECT().CreateJob(gomock.Any(), gomock.Any()).Return("job-ua-2", nil)
+	_, err := srv.ImportUserArchive(authCtx("user-1", "sub|1"), req)
+	testutil.RequireGRPCCode(t, err, codes.Unavailable)
+}

--- a/server/service/api/user_archive.go
+++ b/server/service/api/user_archive.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"context"
+	"errors"
 	"log"
 
 	"google.golang.org/grpc/codes"
@@ -14,6 +15,67 @@ import (
 	"github.com/leedenison/portfoliodb/server/auth"
 	"github.com/leedenison/portfoliodb/server/db"
 )
+
+// ImportUserArchive queues one whole user archive and returns the job to poll.
+// It applies to the caller's own account: a user archive does not name its user,
+// so restoring one into a different account is a feature rather than an
+// accident.
+//
+// The parts are applied in the worker rather than in this request, for the same
+// reason the system import is: the only thing the client has to hold on to is
+// the job id, and the per-part results outlive the page that started it.
+func (s *Server) ImportUserArchive(ctx context.Context, req *apiv1.ImportUserArchiveRequest) (*apiv1.ImportUserArchiveResponse, error) {
+	u, authErr := auth.RequireUser(ctx)
+	if authErr != nil {
+		return nil, authErr
+	}
+	a := req.GetArchive()
+	if err := archive.CheckEnvelope(a.GetEnvelope(), archivev1.ArchiveKind_USER); err != nil {
+		var ve *archive.VersionError
+		if errors.As(err, &ve) {
+			// The request is well formed and this server is the thing that is out
+			// of date, which is a precondition rather than a bad argument.
+			return nil, status.Error(codes.FailedPrecondition, err.Error())
+		}
+		return nil, status.Error(codes.InvalidArgument, err.Error())
+	}
+	parts := presentUserParts(a)
+	if len(parts) == 0 {
+		return nil, status.Error(codes.InvalidArgument, "archive carries no parts")
+	}
+
+	payload, err := proto.Marshal(a)
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	jobID, err := s.db.CreateJob(ctx, db.CreateJobParams{
+		UserID:   u.ID,
+		JobType:  db.JobTypeUserArchive,
+		Filename: req.GetFilename(),
+		Payload:  payload,
+		Parts:    parts,
+	})
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	if err := s.enqueueJob(jobID, db.JobTypeUserArchive); err != nil {
+		return nil, status.Error(codes.Unavailable, err.Error())
+	}
+	return &apiv1.ImportUserArchiveResponse{JobId: jobID}, nil
+}
+
+// presentUserParts names the parts a user archive carries, in restore order.
+//
+// Presence, not emptiness, as in the system archive: a section present but empty
+// says the export included it and there was nothing, which is a different
+// statement from a section that was never included.
+func presentUserParts(a *archivev1.UserArchive) []archivev1.ArchivePart {
+	var parts []archivev1.ArchivePart
+	if a.GetPreferences() != nil {
+		parts = append(parts, archivev1.ArchivePart_PREFERENCES)
+	}
+	return parts
+}
 
 // ExportUserArchive streams one user archive: the envelope, then the selected
 // parts in restore order. It carries the caller's own data and no system data

--- a/server/service/ingestion/user_import.go
+++ b/server/service/ingestion/user_import.go
@@ -1,0 +1,108 @@
+package ingestion
+
+import (
+	"context"
+	"log"
+
+	"google.golang.org/protobuf/proto"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
+	"github.com/leedenison/portfoliodb/server/archiveimport"
+	"github.com/leedenison/portfoliodb/server/db"
+)
+
+// userImportResult says which fetchers the import earned a nudge for. A display
+// currency that landed opens FX gaps the price fetcher has not been asked to
+// fill, exactly as setting one through the API does.
+type userImportResult struct {
+	displayCurrencySet bool
+}
+
+// processUserImport applies the parts of a user archive in restore order,
+// recording a result per part. It applies to the job's own user: a user archive
+// does not name one, so the account it restores into is whoever asked.
+//
+// A failed part does not stop the ones after it, for the same reason it does not
+// in a system import: the parts are not hard-dependent, and abandoning the rest
+// would throw away work that would otherwise land.
+func processUserImport(ctx context.Context, database db.DB, j *JobRequest) userImportResult {
+	var out userImportResult
+
+	payload, err := database.LoadJobPayload(ctx, j.JobID)
+	if err != nil {
+		log.Printf("user archive job %s: load payload: %v", j.JobID, err)
+		failWholeJob(ctx, database, j.JobID, "payload", err.Error())
+		return out
+	}
+	var a archivev1.UserArchive
+	if err := proto.Unmarshal(payload, &a); err != nil {
+		log.Printf("user archive job %s: unmarshal payload: %v", j.JobID, err)
+		failWholeJob(ctx, database, j.JobID, "payload", err.Error())
+		return out
+	}
+
+	// Which parts to run comes from the job's own rows rather than from the
+	// document, so a job resumed after a restart skips what already finished.
+	detail, err := database.GetJob(ctx, j.JobID)
+	if err != nil {
+		log.Printf("user archive job %s: read parts: %v", j.JobID, err)
+		failWholeJob(ctx, database, j.JobID, "job", err.Error())
+		return out
+	}
+
+	anyFailed := false
+	for _, pr := range detail.Parts {
+		if pr.Status == apiv1.JobStatus_SUCCESS {
+			// Already applied by a run this one is resuming.
+			continue
+		}
+		// A part being re-run starts its progress over rather than counting on
+		// from where the interrupted run left off.
+		if pr.ProcessedCount > 0 || pr.Message != "" {
+			_ = database.ResetJobPartProgress(ctx, j.JobID, pr.Part)
+		}
+		_ = database.SetJobPartStatus(ctx, j.JobID, pr.Part, apiv1.JobStatus_RUNNING)
+
+		rep := archiveimport.NewPartReporter(database, j.JobID, pr.Part)
+		var partErr error
+		switch pr.Part {
+		case archivev1.ArchivePart_PREFERENCES:
+			var res archiveimport.PreferenceResult
+			res, partErr = archiveimport.PreferencePart(ctx, database, detail.UserID, a.GetPreferences(), rep)
+			out.displayCurrencySet = out.displayCurrencySet || res.DisplayCurrency
+		default:
+			partErr = errUnknownPart
+		}
+		// Flushed before the part is marked terminal on both paths: the errors
+		// gathered before a hard failure are what explain it.
+		rep.Flush(ctx)
+
+		if partErr != nil {
+			log.Printf("user archive job %s: part %s: %v", j.JobID, pr.Part, partErr)
+			_ = database.SetJobPartFailed(ctx, j.JobID, pr.Part, partErr.Error())
+			anyFailed = true
+			continue
+		}
+		_ = database.SetJobPartStatus(ctx, j.JobID, pr.Part, apiv1.JobStatus_SUCCESS)
+	}
+
+	// The job's own counters are the sum over its parts, so a caller that only
+	// knows about jobs still sees sensible progress.
+	if final, err := database.GetJob(ctx, j.JobID); err == nil {
+		var total, processed int32
+		for _, pr := range final.Parts {
+			total += pr.TotalCount
+			processed += pr.ProcessedCount
+		}
+		_ = database.SetJobTotalCount(ctx, j.JobID, total)
+		_ = database.SetJobProcessedCount(ctx, j.JobID, processed)
+	}
+
+	status := apiv1.JobStatus_SUCCESS
+	if anyFailed {
+		status = apiv1.JobStatus_FAILED
+	}
+	finishJob(ctx, database, j.JobID, status)
+	return out
+}

--- a/server/service/ingestion/user_import_test.go
+++ b/server/service/ingestion/user_import_test.go
@@ -1,0 +1,275 @@
+package ingestion
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
+	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/db/mock"
+)
+
+// userArchivePayload is a document stating both settings, which is enough to
+// watch the part run.
+func userArchivePayload(t *testing.T) []byte {
+	t.Helper()
+	b, err := proto.Marshal(&archivev1.UserArchive{
+		Envelope: &archivev1.Envelope{
+			FormatVersion: 1,
+			ExportedAt:    timestamppb.Now(),
+			Kind:          archivev1.ArchiveKind_USER,
+		},
+		Preferences: &archivev1.PreferencePart{
+			DisplayCurrency: proto.String("GBP"),
+			IgnoredAssetClasses: &archivev1.IgnoredAssetClasses{
+				Rules: []*archivev1.IgnoredAssetClassRule{{
+					Broker:     typev1.Broker_IBKR,
+					AssetClass: typev1.AssetClass_OPTION,
+				}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+// userImportMock is a database that accepts every bookkeeping write, so a test
+// can expect only the calls it is about.
+func userImportMock(t *testing.T) *mock.MockDB {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	database := mock.NewMockDB(ctrl)
+	database.EXPECT().SetJobPartTotalCount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().AddJobPartProcessedCount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().AppendValidationErrors(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().SetJobTotalCount(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().SetJobProcessedCount(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().SetJobStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().ClearJobPayload(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	return database
+}
+
+// The part applies against the job's own user: a user archive does not name
+// one, so the account it restores into is whoever asked.
+func TestProcessUserImport_AppliesPreferencesForTheJobsUser(t *testing.T) {
+	database := userImportMock(t)
+	j := &JobRequest{JobID: "job-ua-1", JobType: db.JobTypeUserArchive}
+	database.EXPECT().LoadJobPayload(gomock.Any(), j.JobID).Return(userArchivePayload(t), nil)
+	database.EXPECT().GetJob(gomock.Any(), j.JobID).Return(&db.JobDetail{
+		UserID: "user-7",
+		Parts:  partRows(archivev1.ArchivePart_PREFERENCES),
+	}, nil).AnyTimes()
+	database.EXPECT().SetDisplayCurrency(gomock.Any(), "user-7", "GBP").Return(nil)
+	database.EXPECT().SetIgnoredAssetClasses(gomock.Any(), "user-7", gomock.Any(), gomock.Any()).Return(nil)
+
+	var transitions []string
+	database.EXPECT().SetJobPartStatus(gomock.Any(), j.JobID, gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, part archivev1.ArchivePart, st apiv1.JobStatus) error {
+			transitions = append(transitions, part.String()+":"+st.String())
+			return nil
+		}).AnyTimes()
+
+	res := processUserImport(context.Background(), database, j)
+
+	if !res.displayCurrencySet {
+		t.Fatal("display currency not reported as set, so the price fetcher is never nudged")
+	}
+	want := []string{"PREFERENCES:RUNNING", "PREFERENCES:SUCCESS"}
+	if len(transitions) != 2 || transitions[0] != want[0] || transitions[1] != want[1] {
+		t.Fatalf("transitions = %v, want %v", transitions, want)
+	}
+}
+
+// A file that states no display currency earns no nudge: there is no new FX gap
+// to fill.
+func TestProcessUserImport_NoCurrencyEarnsNoNudge(t *testing.T) {
+	database := userImportMock(t)
+	j := &JobRequest{JobID: "job-ua-2", JobType: db.JobTypeUserArchive}
+	payload, err := proto.Marshal(&archivev1.UserArchive{
+		Envelope:    &archivev1.Envelope{FormatVersion: 1, ExportedAt: timestamppb.Now(), Kind: archivev1.ArchiveKind_USER},
+		Preferences: &archivev1.PreferencePart{IgnoredAssetClasses: &archivev1.IgnoredAssetClasses{}},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	database.EXPECT().LoadJobPayload(gomock.Any(), j.JobID).Return(payload, nil)
+	database.EXPECT().GetJob(gomock.Any(), j.JobID).Return(&db.JobDetail{
+		UserID: "user-7", Parts: partRows(archivev1.ArchivePart_PREFERENCES),
+	}, nil).AnyTimes()
+	database.EXPECT().SetIgnoredAssetClasses(gomock.Any(), "user-7", gomock.Any(), gomock.Any()).Return(nil)
+	database.EXPECT().SetJobPartStatus(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	if res := processUserImport(context.Background(), database, j); res.displayCurrencySet {
+		t.Fatal("nudge earned by a file that set no display currency")
+	}
+}
+
+// A payload that cannot be read belongs to the job rather than to a part, so
+// there is no part to attribute it to and the whole job fails.
+func TestProcessUserImport_UnreadablePayloadFailsTheJob(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	database := mock.NewMockDB(ctrl)
+	j := &JobRequest{JobID: "job-ua-3", JobType: db.JobTypeUserArchive}
+	database.EXPECT().LoadJobPayload(gomock.Any(), j.JobID).Return(nil, errors.New("gone"))
+	database.EXPECT().AppendValidationErrors(gomock.Any(), j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, gomock.Any()).Return(nil)
+	database.EXPECT().SetJobStatus(gomock.Any(), j.JobID, apiv1.JobStatus_FAILED).Return(nil)
+	database.EXPECT().ClearJobPayload(gomock.Any(), j.JobID).Return(nil)
+
+	processUserImport(context.Background(), database, j)
+}
+
+// A job resumed after a restart skips what already finished rather than
+// applying it twice.
+func TestProcessUserImport_SkipsAPartAlreadyDone(t *testing.T) {
+	database := userImportMock(t)
+	j := &JobRequest{JobID: "job-ua-4", JobType: db.JobTypeUserArchive}
+	database.EXPECT().LoadJobPayload(gomock.Any(), j.JobID).Return(userArchivePayload(t), nil)
+	database.EXPECT().GetJob(gomock.Any(), j.JobID).Return(&db.JobDetail{
+		UserID: "user-7",
+		Parts:  []db.JobPartResult{{Part: archivev1.ArchivePart_PREFERENCES, Status: apiv1.JobStatus_SUCCESS}},
+	}, nil).AnyTimes()
+	// No setter expectations: applying the part again is the failure.
+	database.EXPECT().SetJobPartStatus(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
+
+	processUserImport(context.Background(), database, j)
+}
+
+// A part re-run starts its progress over rather than counting on from where the
+// interrupted run left off.
+func TestProcessUserImport_ResetsPartialProgressOnRerun(t *testing.T) {
+	database := userImportMock(t)
+	j := &JobRequest{JobID: "job-ua-5", JobType: db.JobTypeUserArchive}
+	database.EXPECT().LoadJobPayload(gomock.Any(), j.JobID).Return(userArchivePayload(t), nil)
+	database.EXPECT().GetJob(gomock.Any(), j.JobID).Return(&db.JobDetail{
+		UserID: "user-7",
+		Parts: []db.JobPartResult{{
+			Part: archivev1.ArchivePart_PREFERENCES, Status: apiv1.JobStatus_RUNNING, ProcessedCount: 1,
+		}},
+	}, nil).AnyTimes()
+	database.EXPECT().ResetJobPartProgress(gomock.Any(), j.JobID, archivev1.ArchivePart_PREFERENCES).Return(nil)
+	database.EXPECT().SetDisplayCurrency(gomock.Any(), "user-7", "GBP").Return(nil)
+	database.EXPECT().SetIgnoredAssetClasses(gomock.Any(), "user-7", gomock.Any(), gomock.Any()).Return(nil)
+	database.EXPECT().SetJobPartStatus(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	processUserImport(context.Background(), database, j)
+}
+
+// A part row this build cannot apply means a job written by a later build. It
+// fails that part rather than the whole import.
+func TestProcessUserImport_UnknownPartFailsOnlyItself(t *testing.T) {
+	database := userImportMock(t)
+	j := &JobRequest{JobID: "job-ua-6", JobType: db.JobTypeUserArchive}
+	database.EXPECT().LoadJobPayload(gomock.Any(), j.JobID).Return(userArchivePayload(t), nil)
+	database.EXPECT().GetJob(gomock.Any(), j.JobID).Return(&db.JobDetail{
+		UserID: "user-7", Parts: partRows(archivev1.ArchivePart_TXS),
+	}, nil).AnyTimes()
+	database.EXPECT().SetJobPartStatus(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().
+		SetJobPartFailed(gomock.Any(), j.JobID, archivev1.ArchivePart_TXS, errUnknownPart.Error()).
+		Return(nil)
+
+	processUserImport(context.Background(), database, j)
+}
+
+// The job's own counters are the sum over its parts, so a caller that only
+// knows about jobs still sees sensible progress.
+func TestProcessUserImport_JobCountersAreTheSumOverParts(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	database := mock.NewMockDB(ctrl)
+	database.EXPECT().SetJobPartTotalCount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().AddJobPartProcessedCount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().SetJobPartStatus(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().SetJobStatus(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().ClearJobPayload(gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	j := &JobRequest{JobID: "job-ua-7", JobType: db.JobTypeUserArchive}
+	database.EXPECT().LoadJobPayload(gomock.Any(), j.JobID).Return(userArchivePayload(t), nil)
+	// Read twice: once to decide what to run, and once afterwards to total up
+	// what the parts recorded.
+	gomock.InOrder(
+		database.EXPECT().GetJob(gomock.Any(), j.JobID).Return(&db.JobDetail{
+			UserID: "user-7", Parts: partRows(archivev1.ArchivePart_PREFERENCES),
+		}, nil),
+		database.EXPECT().GetJob(gomock.Any(), j.JobID).Return(&db.JobDetail{
+			UserID: "user-7",
+			Parts: []db.JobPartResult{{
+				Part: archivev1.ArchivePart_PREFERENCES, Status: apiv1.JobStatus_SUCCESS,
+				TotalCount: 2, ProcessedCount: 2,
+			}},
+		}, nil),
+	)
+	database.EXPECT().SetDisplayCurrency(gomock.Any(), "user-7", "GBP").Return(nil)
+	database.EXPECT().SetIgnoredAssetClasses(gomock.Any(), "user-7", gomock.Any(), gomock.Any()).Return(nil)
+	database.EXPECT().SetJobTotalCount(gomock.Any(), j.JobID, int32(2)).Return(nil)
+	database.EXPECT().SetJobProcessedCount(gomock.Any(), j.JobID, int32(2)).Return(nil)
+
+	processUserImport(context.Background(), database, j)
+}
+
+// The dispatch case, end to end: a user archive job that restored a display
+// currency earns the same price-fetcher nudge that setting one through the API
+// does, and one that did not earns nothing.
+func TestProcessJob_UserArchive_NudgesThePriceFetcherOnlyForACurrency(t *testing.T) {
+	tests := []struct {
+		name       string
+		part       *archivev1.PreferencePart
+		wantNudged bool
+	}{
+		{
+			name:       "display currency restored",
+			part:       &archivev1.PreferencePart{DisplayCurrency: proto.String("GBP")},
+			wantNudged: true,
+		},
+		{
+			name:       "rules only",
+			part:       &archivev1.PreferencePart{IgnoredAssetClasses: &archivev1.IgnoredAssetClasses{}},
+			wantNudged: false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			database := userImportMock(t)
+			j := &JobRequest{JobID: "job-ua-d", JobType: db.JobTypeUserArchive}
+			payload, err := proto.Marshal(&archivev1.UserArchive{
+				Envelope:    &archivev1.Envelope{FormatVersion: 1, ExportedAt: timestamppb.Now(), Kind: archivev1.ArchiveKind_USER},
+				Preferences: tc.part,
+			})
+			if err != nil {
+				t.Fatalf("marshal: %v", err)
+			}
+			database.EXPECT().LoadJobPayload(gomock.Any(), j.JobID).Return(payload, nil)
+			database.EXPECT().GetJob(gomock.Any(), j.JobID).Return(&db.JobDetail{
+				UserID: "user-7", Parts: partRows(archivev1.ArchivePart_PREFERENCES),
+			}, nil).AnyTimes()
+			database.EXPECT().SetDisplayCurrency(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			database.EXPECT().SetIgnoredAssetClasses(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			database.EXPECT().SetJobPartStatus(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+			trigger := make(chan struct{}, 1)
+			processJob(context.Background(), WorkerOptions{DB: database, PriceTrigger: trigger}, j)
+
+			select {
+			case <-trigger:
+				if !tc.wantNudged {
+					t.Fatal("price fetcher nudged with no display currency restored")
+				}
+			default:
+				if tc.wantNudged {
+					t.Fatal("price fetcher not nudged after a display currency was restored")
+				}
+			}
+		})
+	}
+}

--- a/server/service/ingestion/worker.go
+++ b/server/service/ingestion/worker.go
@@ -122,6 +122,14 @@ func processJob(ctx context.Context, opts WorkerOptions, j *JobRequest) {
 		if res.eventsPersisted {
 			pluginutil.Trigger(opts.CorporateEventTrigger)
 		}
+	case db.JobTypeUserArchive:
+		res := processUserImport(ctx, opts.DB, j)
+		// A restored display currency opens FX gaps nothing has been asked to
+		// fill, so the import earns the same nudge setting one through the API
+		// does. Nudged once for the whole import rather than per part.
+		if res.displayCurrencySet {
+			pluginutil.Trigger(opts.PriceTrigger)
+		}
 	default:
 		log.Printf("ingestion job %s: unknown job type %q", j.JobID, j.JobType)
 		_ = opts.DB.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_FAILED)


### PR DESCRIPTION
Stacked on #374. The second half of the user-archive spine, plus the import of the
preferences part.

## What changed

- **`ImportUserArchive`**, scoped with `RequireUser`, mirroring
  `ImportSystemArchive`: envelope kind and format-version checks, a
  `user_archive` job, and per-part results the caller polls. A user archive does
  not name its user, so it restores into whoever asked -- that is a feature, not
  an accident.
- **`archiveimport.PreferencePart`**. The unit is a setting rather than a row, so
  the total is how many settings the file states and a rejected setting carries
  `row_index = -1`.
- **The ignore rules are all or nothing.** Setting them replaces the whole set
  *and deletes the transactions and declarations that set covers*, so applying
  the rules the reader could read would delete on the strength of a file it could
  not read. One unusable rule rejects the setting and leaves the stored rules
  alone; every problem is named on one pass. An empty `rules` list is still
  applied, which clears them.
- **`processUserImport`** and the `JobTypeUserArchive` dispatch case. A restored
  display currency nudges the price fetcher once for the whole import, as
  `SetDisplayCurrency` does per call -- otherwise a rebuilt instance has no FX
  rates for its display currency until the next cycle.

## Testing

`make check` and `make server-test` pass. New coverage: both settings, each alone,
neither, an empty rule set clearing the rules, a bad currency rejected alone while
the rules still land, one bad rule among three never reaching the setter, every
bad rule reported, and a setter error failing the part. Worker side: the job's
user is the one applied to, a resumed job skips a finished part, partial progress
resets, an unknown part fails only itself, job counters sum over parts, and the
nudge fires only for a restored currency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)