### PR TITLE
Add the user archive page (0085)

### DIFF
--- a/client/app/admin/archive/page.tsx
+++ b/client/app/admin/archive/page.tsx
@@ -6,14 +6,14 @@ import { ErrorAlert } from "@/app/components/error-alert";
 import { useAuthedQuery } from "@/hooks/use-authed-query";
 import { errorMessage } from "@/lib/errors";
 import { qk } from "@/lib/query-keys";
-import { exportSystemArchive, getJob, listJobs } from "@/lib/portfolio-api";
-import { marshalSystem } from "@/lib/archive/codec";
-import { assembleSystemArchive } from "@/lib/archive/assemble";
+import { exportSystemArchive, getJob, importSystemArchive, listJobs } from "@/lib/portfolio-api";
+import { marshalSystem, unmarshalSystem } from "@/lib/archive/codec";
+import { assembleSystemArchive, systemPartCounts } from "@/lib/archive/assemble";
 import { SYSTEM_ARCHIVE_PART_OPTIONS } from "@/lib/archive/parts";
 import { ArchivePart } from "@/gen/archive/v1/common_pb";
 import { JobStatus } from "@/gen/api/v1/api_pb";
-import { ImportArchivePanel } from "./import-panel";
-import { JobPartsTable } from "./job-parts";
+import { ImportArchivePanel } from "@/app/components/archive/import-panel";
+import { JobPartsTable } from "@/app/components/archive/job-parts";
 
 const SYSTEM_ARCHIVE_JOB_TYPE = "system_archive";
 
@@ -160,7 +160,14 @@ export default function ArchivePage() {
         </button>
       </section>
 
-      <ImportArchivePanel running={running} onStarted={handleImportStarted} />
+      <ImportArchivePanel
+        running={running}
+        onStarted={handleImportStarted}
+        parse={unmarshalSystem}
+        counts={systemPartCounts}
+        submit={importSystemArchive}
+        note="The parts are applied in order on the server, so an import finishes whether or not this page stays open. To import one kind of data, upload an archive carrying only that part."
+      />
 
       {job.data && (
         <section className="rounded-lg border border-border bg-surface p-4" data-testid="archive-job">

--- a/client/app/archive/page.tsx
+++ b/client/app/archive/page.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { AppShell } from "@/app/components/app-shell";
+import { ErrorAlert } from "@/app/components/error-alert";
+import { ImportArchivePanel } from "@/app/components/archive/import-panel";
+import { JobPartsTable } from "@/app/components/archive/job-parts";
+import { useAuth } from "@/contexts/auth-context";
+import { useAuthedQuery } from "@/hooks/use-authed-query";
+import { errorMessage } from "@/lib/errors";
+import { qk } from "@/lib/query-keys";
+import { exportUserArchive, getJob, importUserArchive, listJobs } from "@/lib/portfolio-api";
+import { marshalUser, unmarshalUser } from "@/lib/archive/codec";
+import { assembleUserArchive, userPartCounts } from "@/lib/archive/assemble";
+import { USER_ARCHIVE_PART_OPTIONS } from "@/lib/archive/parts";
+import { ArchivePart } from "@/gen/archive/v1/common_pb";
+import { JobStatus } from "@/gen/api/v1/api_pb";
+
+const USER_ARCHIVE_JOB_TYPE = "user_archive";
+
+const IMPORT_NOTE = (
+  <>
+    The parts are applied in order on the server, so an import finishes whether or not this page
+    stays open. Importing ignored asset classes replaces the rules you have now and removes the
+    transactions they cover.
+  </>
+);
+
+/**
+ * Export and import the signed-in user's own archive.
+ *
+ * A separate page from /admin/archive, and a separate file: this one carries the
+ * user's own data and no shared reference data at all. Restoring it into an
+ * instance whose instruments are not loaded is supported and correct -- the
+ * postings resolve through the normal identifier path, merely slower -- so
+ * nothing here presents that as an error.
+ */
+export default function UserArchivePage() {
+  const { state } = useAuth();
+  const queryClient = useQueryClient();
+  const [selected, setSelected] = useState<Set<ArchivePart>>(
+    () => new Set(USER_ARCHIVE_PART_OPTIONS.filter((o) => o.defaultSelected).map((o) => o.part)),
+  );
+  const [exporting, setExporting] = useState(false);
+  const [exportError, setExportError] = useState<string | null>(null);
+  const [startedJobId, setStartedJobId] = useState<string | null>(null);
+
+  // An import keeps running whether or not this page is open, so the job to
+  // watch is looked up rather than remembered.
+  const recent = useAuthedQuery({
+    queryKey: qk.jobs(),
+    queryFn: () => listJobs(null, USER_ARCHIVE_JOB_TYPE),
+  });
+  const jobId = startedJobId ?? recent.data?.jobs[0]?.id ?? null;
+
+  const job = useAuthedQuery({
+    queryKey: qk.job(jobId ?? ""),
+    queryFn: () => getJob(jobId!),
+    enabled: jobId !== null,
+    refetchInterval: (query) => {
+      const s = query.state.data?.status;
+      return s === JobStatus.SUCCESS || s === JobStatus.FAILED ? false : 2000;
+    },
+  });
+
+  const running =
+    job.data !== undefined &&
+    job.data.status !== JobStatus.SUCCESS &&
+    job.data.status !== JobStatus.FAILED;
+
+  function toggle(part: ArchivePart) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(part)) {
+        next.delete(part);
+      } else {
+        next.add(part);
+      }
+      return next;
+    });
+  }
+
+  const parts = useMemo(
+    () => USER_ARCHIVE_PART_OPTIONS.filter((o) => selected.has(o.part)).map((o) => o.part),
+    [selected],
+  );
+
+  async function handleExport() {
+    setExporting(true);
+    setExportError(null);
+    try {
+      const items = [];
+      for await (const item of exportUserArchive(parts)) {
+        items.push(item);
+      }
+      const json = marshalUser(assembleUserArchive(items));
+      const blob = new Blob([json], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = "user-archive.json";
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      setExportError(errorMessage(e, "Export failed"));
+    } finally {
+      setExporting(false);
+    }
+  }
+
+  function handleImportStarted(id: string) {
+    setStartedJobId(id);
+    queryClient.invalidateQueries({ queryKey: qk.jobs() });
+  }
+
+  // What an import changes is spread across the user's own pages, so once it is
+  // done everything it could have touched is dropped rather than guessing which
+  // part landed. Ignored asset classes delete transactions, which move holdings,
+  // so those go too.
+  const terminalJobId = job.data && !running ? jobId : null;
+  useEffect(() => {
+    if (terminalJobId === null) return;
+    queryClient.invalidateQueries({ queryKey: qk.displayCurrency() });
+    queryClient.invalidateQueries({ queryKey: qk.ignoredAssetClasses() });
+    queryClient.invalidateQueries({ queryKey: qk.holdings() });
+    queryClient.invalidateQueries({ queryKey: qk.txs() });
+  }, [terminalJobId, queryClient]);
+
+  return (
+    <AppShell>
+      <div data-testid="page-archive" className="flex flex-1 flex-col px-4 py-8">
+        {state.status === "loading" && <p className="text-text-muted">Loading...</p>}
+        {state.status === "unauthenticated" && (
+          <div className="flex flex-1 flex-col items-center justify-center text-center">
+            <h1 className="font-display text-4xl font-bold tracking-tight text-text-primary">
+              Your archive
+            </h1>
+            <p className="mt-3 text-text-muted">Sign in to export or import your data.</p>
+          </div>
+        )}
+        {state.status === "authenticated" && (
+          <div className="mx-auto w-full max-w-2xl animate-fade-in space-y-5">
+            <div>
+              <h2 className="font-display text-2xl font-bold tracking-tight text-text-primary">
+                Your archive
+              </h2>
+              <p className="mt-1 text-sm text-text-muted">
+                Export and import your own data. The file carries none of the shared reference data
+                the instance is built from, which is a separate archive an administrator keeps.
+              </p>
+            </div>
+
+            <section className="rounded-lg border border-border bg-surface p-4" data-testid="archive-export">
+              <h2 className="font-display text-base font-semibold text-text-primary">Export</h2>
+              <p className="mt-1 text-sm text-text-muted">
+                A part left unticked is absent from the file. A part ticked but holding nothing is
+                written empty, which records that the export included it and there was nothing.
+              </p>
+              <ul className="mt-3 space-y-2">
+                {USER_ARCHIVE_PART_OPTIONS.map((opt) => {
+                  const id = `part-${opt.part}`;
+                  return (
+                    <li key={id} className="flex items-start gap-2.5">
+                      <input
+                        id={id}
+                        type="checkbox"
+                        className="mt-0.5 h-4 w-4 shrink-0 accent-primary"
+                        checked={selected.has(opt.part)}
+                        onChange={() => toggle(opt.part)}
+                      />
+                      <label htmlFor={id}>
+                        <span className="text-sm font-medium text-text-primary">{opt.label}</span>
+                        <span className="block text-xs text-text-muted">{opt.note}</span>
+                      </label>
+                    </li>
+                  );
+                })}
+              </ul>
+              {exportError && (
+                <div className="mt-3">
+                  <ErrorAlert>{exportError}</ErrorAlert>
+                </div>
+              )}
+              <button
+                type="button"
+                onClick={handleExport}
+                disabled={exporting || parts.length === 0}
+                data-testid="export-archive"
+                className="mt-4 rounded-md border border-border bg-surface px-3 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-primary-light/15 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {exporting ? "Exporting…" : "Export archive"}
+              </button>
+            </section>
+
+            <ImportArchivePanel
+              running={running}
+              onStarted={handleImportStarted}
+              parse={unmarshalUser}
+              counts={userPartCounts}
+              submit={importUserArchive}
+              note={IMPORT_NOTE}
+            />
+
+            {job.data && (
+              <section className="rounded-lg border border-border bg-surface p-4" data-testid="archive-job">
+                <h2 className="font-display text-base font-semibold text-text-primary">
+                  Last import
+                </h2>
+                <p className="mt-1 text-sm text-text-muted">
+                  {running
+                    ? "Running. This continues whether or not this page is open."
+                    : "Finished."}
+                </p>
+                <JobPartsTable job={job.data} />
+              </section>
+            )}
+          </div>
+        )}
+      </div>
+    </AppShell>
+  );
+}

--- a/client/app/components/archive/import-panel.tsx
+++ b/client/app/components/archive/import-panel.tsx
@@ -2,29 +2,43 @@
 
 import { useRef, useState } from "react";
 import { ErrorAlert } from "@/app/components/error-alert";
-import { archiveErrorMessage, unmarshalSystem } from "@/lib/archive/codec";
-import { partCounts } from "@/lib/archive/assemble";
-import { importSystemArchive } from "@/lib/portfolio-api";
+import { archiveErrorMessage } from "@/lib/archive/codec";
 import { errorMessage } from "@/lib/errors";
-import type { SystemArchive } from "@/gen/archive/v1/archive_pb";
 
 /**
- * Upload one system archive.
+ * Upload one archive, of either kind.
  *
- * The file is parsed here so that a file that is not an archive at all is
- * refused before anything is queued: whether a file is a valid archive is an
- * all-or-nothing question answered at parse time. Whether its contents resolve
- * against this instance is a separate, per-part question the job answers.
+ * The file is parsed here so that a file that is not an archive at all -- or is
+ * the other kind of archive -- is refused before anything is queued: whether a
+ * file is a valid archive of this kind is an all-or-nothing question answered at
+ * parse time. Whether its contents resolve against this instance is a separate,
+ * per-part question the job answers.
+ *
+ * Both pages share this rather than each writing it, because the sequence of
+ * states is the behaviour, not the decoration: parse before queue, say what the
+ * file carries, and refuse to start a second import over a running one.
  */
-export function ImportArchivePanel({
+export function ImportArchivePanel<T>({
   running,
   onStarted,
+  parse,
+  counts,
+  submit,
+  note,
 }: {
   running: boolean;
   onStarted: (jobId: string) => void;
+  /** Parse the file's text into a document, throwing if it is not one. */
+  parse: (text: string) => T;
+  /** What the parsed document carries, for the preview line. */
+  counts: (archive: T) => { label: string; count: number }[];
+  /** Queue the document, returning the job to poll. */
+  submit: (archive: T, filename: string) => Promise<string>;
+  /** What this page's import does, in a sentence or two. */
+  note: React.ReactNode;
 }) {
   const [file, setFile] = useState<File | null>(null);
-  const [archive, setArchive] = useState<SystemArchive | null>(null);
+  const [archive, setArchive] = useState<T | null>(null);
   const [parseError, setParseError] = useState<string | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
@@ -47,7 +61,7 @@ export function ImportArchivePanel({
     const reader = new FileReader();
     reader.onload = (ev) => {
       try {
-        setArchive(unmarshalSystem(ev.target?.result as string));
+        setArchive(parse(ev.target?.result as string));
         setParseError(null);
       } catch (err) {
         setArchive(null);
@@ -62,7 +76,7 @@ export function ImportArchivePanel({
     setSubmitting(true);
     setSubmitError(null);
     try {
-      const jobId = await importSystemArchive(archive, file.name);
+      const jobId = await submit(archive, file.name);
       onStarted(jobId);
       reset();
     } catch (e) {
@@ -72,15 +86,12 @@ export function ImportArchivePanel({
     }
   }
 
-  const counts = archive ? partCounts(archive) : [];
+  const partCounts = archive ? counts(archive) : [];
 
   return (
     <section className="rounded-lg border border-border bg-surface p-4" data-testid="archive-import">
       <h2 className="font-display text-base font-semibold text-text-primary">Import</h2>
-      <p className="mt-1 text-sm text-text-muted">
-        The parts are applied in order on the server, so an import finishes whether or not this page
-        stays open. To import one kind of data, upload an archive carrying only that part.
-      </p>
+      <div className="mt-1 text-sm text-text-muted">{note}</div>
 
       <div className="mt-3 space-y-3">
         <input
@@ -116,15 +127,15 @@ export function ImportArchivePanel({
         {archive && !parseError && (
           <>
             <p className="text-sm text-text-primary">
-              {counts.length === 0
+              {partCounts.length === 0
                 ? "This archive carries no parts."
-                : `Carries ${counts.map((c) => `${c.count.toLocaleString()} ${c.label}`).join(", ")}.`}
+                : `Carries ${partCounts.map((c) => `${c.count.toLocaleString()} ${c.label}`).join(", ")}.`}
             </p>
             <div className="flex gap-2">
               <button
                 type="button"
                 onClick={handleImport}
-                disabled={submitting || running || counts.length === 0}
+                disabled={submitting || running || partCounts.length === 0}
                 data-testid="start-archive-import"
                 className="rounded-md bg-primary px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-dark disabled:cursor-not-allowed disabled:opacity-50"
               >

--- a/client/app/components/archive/job-parts.tsx
+++ b/client/app/components/archive/job-parts.tsx
@@ -104,7 +104,11 @@ function PartProblems({ part }: { part: JobPartResult }) {
             <tbody>
               {part.validationErrors.map((e, i) => (
                 <tr key={i} className="border-b border-border/40 last:border-0">
-                  <td className="px-3 py-1.5 font-mono text-text-muted">{e.rowIndex}</td>
+                  {/* A part whose unit is a setting rather than a row reports -1:
+                      there is nothing to point at. */}
+                  <td className="px-3 py-1.5 font-mono text-text-muted">
+                    {e.rowIndex < 0 ? "\u2014" : e.rowIndex}
+                  </td>
                   <td className="px-3 py-1.5 font-mono text-text-primary">{e.field}</td>
                   <td className="px-3 py-1.5 text-accent-dark">{e.message}</td>
                 </tr>

--- a/client/app/components/user-menu.tsx
+++ b/client/app/components/user-menu.tsx
@@ -88,6 +88,12 @@ export function UserMenu({ inverted }: { inverted?: boolean }) {
               Uploads
             </Link>
             <Link
+              href="/archive"
+              className="block px-4 py-2 text-sm text-text-primary transition-colors hover:bg-primary-light/10"
+            >
+              Archive
+            </Link>
+            <Link
               href="/settings"
               className="block px-4 py-2 text-sm text-text-primary transition-colors hover:bg-primary-light/10"
             >

--- a/client/lib/archive/assemble.test.ts
+++ b/client/lib/archive/assemble.test.ts
@@ -1,11 +1,11 @@
 import { describe, expect, it } from "vitest";
 import { create } from "@bufbuild/protobuf";
-import { assembleSystemArchive, partCounts } from "./assemble";
-import { marshalSystem } from "./codec";
-import { ExportSystemArchiveResponseSchema } from "@/gen/api/v1/api_pb";
+import { assembleSystemArchive, assembleUserArchive, systemPartCounts, userPartCounts } from "./assemble";
+import { marshalSystem, marshalUser } from "./codec";
+import { ExportSystemArchiveResponseSchema, ExportUserArchiveResponseSchema } from "@/gen/api/v1/api_pb";
 import { ArchivePart } from "@/gen/archive/v1/common_pb";
 import { PluginCategory } from "@/gen/type/v1/type_pb";
-import type { ExportSystemArchiveResponse } from "@/gen/api/v1/api_pb";
+import type { ExportSystemArchiveResponse, ExportUserArchiveResponse } from "@/gen/api/v1/api_pb";
 
 const ENVELOPE = {
   formatVersion: 1,
@@ -93,7 +93,7 @@ describe("assembleSystemArchive", () => {
     expect(doc.inflationIndices?.groups).toHaveLength(1);
     expect(doc.inflationIndices?.groups[0].currency).toBe("GBP");
     expect(doc.inflationIndices?.groups[0].rows[0].baseYear).toBe(2015);
-    expect(partCounts(doc)).toEqual([{ label: "inflation index values", count: 1 }]);
+    expect(systemPartCounts(doc)).toEqual([{ label: "inflation index values", count: 1 }]);
   });
 
   // Both fetch-block tables travel in one part, so a group holds blocks of more
@@ -119,7 +119,7 @@ describe("assembleSystemArchive", () => {
     );
     expect(doc.fetchBlocks?.groups).toHaveLength(1);
     expect(doc.fetchBlocks?.groups[0].blocks).toHaveLength(2);
-    expect(partCounts(doc)).toEqual([{ label: "fetch blocks", count: 2 }]);
+    expect(systemPartCounts(doc)).toEqual([{ label: "fetch blocks", count: 2 }]);
   });
 
   // Resolved and unresolved events travel together: the flag is the point of
@@ -146,7 +146,7 @@ describe("assembleSystemArchive", () => {
     expect(doc.unhandledEvents?.groups[0].events).toHaveLength(2);
     expect(doc.unhandledEvents?.groups[0].events[0].resolved).toBe(true);
     expect(doc.unhandledEvents?.groups[0].events[1].resolved).toBe(false);
-    expect(partCounts(doc)).toEqual([{ label: "unhandled corporate events", count: 2 }]);
+    expect(systemPartCounts(doc)).toEqual([{ label: "unhandled corporate events", count: 2 }]);
   });
 
   // Plugin config is the one flat part: the stream carries a row per message
@@ -171,11 +171,11 @@ describe("assembleSystemArchive", () => {
     );
     expect(doc.pluginConfig?.configs).toHaveLength(1);
     expect(doc.pluginConfig?.configs[0].pluginId).toBe("eodhd");
-    expect(partCounts(doc)).toEqual([{ label: "plugin config rows", count: 1 }]);
+    expect(systemPartCounts(doc)).toEqual([{ label: "plugin config rows", count: 1 }]);
   });
 });
 
-describe("partCounts", () => {
+describe("systemPartCounts", () => {
   it("counts rows rather than groups, and says nothing about absent parts", () => {
     const doc = assembleSystemArchive(
       stream(
@@ -192,6 +192,80 @@ describe("partCounts", () => {
         },
       ),
     );
-    expect(partCounts(doc)).toEqual([{ label: "prices", count: 2 }]);
+    expect(systemPartCounts(doc)).toEqual([{ label: "prices", count: 2 }]);
+  });
+});
+
+describe("assembleUserArchive", () => {
+  const USER_ENVELOPE = { ...ENVELOPE, kind: 2 };
+
+  function userStream(
+    ...items: Parameters<typeof create<typeof ExportUserArchiveResponseSchema>>[1][]
+  ): ExportUserArchiveResponse[] {
+    return items.map((i) => create(ExportUserArchiveResponseSchema, i));
+  }
+
+  it("refuses a stream that carried no envelope", () => {
+    expect(() =>
+      assembleUserArchive(userStream({ item: { case: "partBegin", value: { part: ArchivePart.PREFERENCES } } })),
+    ).toThrow(/no envelope/);
+  });
+
+  // The marker creates the container for a whole-part message just as it does
+  // for a series of items, so a part asked for and holding nothing survives.
+  it("keeps a selected empty part present", () => {
+    const doc = assembleUserArchive(
+      userStream(
+        { item: { case: "envelope", value: USER_ENVELOPE } },
+        { item: { case: "partBegin", value: { part: ArchivePart.PREFERENCES } } },
+      ),
+    );
+    expect(doc.preferences).toBeDefined();
+    expect(doc.preferences?.displayCurrency).toBeUndefined();
+    expect(marshalUser(doc)).toContain('"preferences":{}');
+  });
+
+  it("files the whole-part message under its marker", () => {
+    const doc = assembleUserArchive(
+      userStream(
+        { item: { case: "envelope", value: USER_ENVELOPE } },
+        { item: { case: "partBegin", value: { part: ArchivePart.PREFERENCES } } },
+        {
+          item: {
+            case: "preferences",
+            value: {
+              displayCurrency: "GBP",
+              ignoredAssetClasses: { rules: [{ broker: 2, account: "U123", assetClass: 5 }] },
+            },
+          },
+        },
+      ),
+    );
+    expect(doc.preferences?.displayCurrency).toBe("GBP");
+    expect(doc.preferences?.ignoredAssetClasses?.rules).toHaveLength(1);
+  });
+});
+
+describe("userPartCounts", () => {
+  // Settings rather than rows, so the preview and the job's own total agree.
+  it("counts the settings the file states", () => {
+    const doc = assembleUserArchive([
+      create(ExportUserArchiveResponseSchema, { item: { case: "envelope", value: { ...ENVELOPE, kind: 2 } } }),
+      create(ExportUserArchiveResponseSchema, { item: { case: "partBegin", value: { part: ArchivePart.PREFERENCES } } }),
+      create(ExportUserArchiveResponseSchema, {
+        item: { case: "preferences", value: { displayCurrency: "GBP" } },
+      }),
+    ]);
+    expect(userPartCounts(doc)).toEqual([{ label: "preference settings", count: 1 }]);
+  });
+
+  // A part present and empty is present with nothing in it, which is a
+  // different statement from a part that was never asked for.
+  it("reports an empty part as zero settings rather than omitting it", () => {
+    const doc = assembleUserArchive([
+      create(ExportUserArchiveResponseSchema, { item: { case: "envelope", value: { ...ENVELOPE, kind: 2 } } }),
+      create(ExportUserArchiveResponseSchema, { item: { case: "partBegin", value: { part: ArchivePart.PREFERENCES } } }),
+    ]);
+    expect(userPartCounts(doc)).toEqual([{ label: "preference settings", count: 0 }]);
   });
 });

--- a/client/lib/archive/assemble.ts
+++ b/client/lib/archive/assemble.ts
@@ -5,10 +5,11 @@ import { FetchBlockPartSchema } from "@/gen/archive/v1/fetch_blocks_pb";
 import { InflationPartSchema } from "@/gen/archive/v1/inflation_pb";
 import { InstrumentPartSchema } from "@/gen/archive/v1/instruments_pb";
 import { PluginConfigPartSchema } from "@/gen/archive/v1/plugin_config_pb";
+import { PreferencePartSchema } from "@/gen/archive/v1/preferences_pb";
 import { PricePartSchema } from "@/gen/archive/v1/prices_pb";
 import { UnhandledEventPartSchema } from "@/gen/archive/v1/unhandled_events_pb";
-import type { ExportSystemArchiveResponse } from "@/gen/api/v1/api_pb";
-import type { SystemArchive } from "@/gen/archive/v1/archive_pb";
+import type { ExportSystemArchiveResponse, ExportUserArchiveResponse } from "@/gen/api/v1/api_pb";
+import type { SystemArchive, UserArchive } from "@/gen/archive/v1/archive_pb";
 
 /**
  * Rebuild a system archive from its export stream.
@@ -80,8 +81,41 @@ export function assembleSystemArchive(items: ExportSystemArchiveResponse[]): Sys
   return doc as SystemArchive;
 }
 
-/** How many rows each part of a document carries, for a preview. */
-export function partCounts(archive: SystemArchive): { label: string; count: number }[] {
+/**
+ * Rebuild a user archive from its export stream.
+ *
+ * Same grammar as the system stream, including for a part whose unit is a
+ * setting rather than a row: the marker creates the container and the
+ * whole-part message that follows replaces it, so a part that was asked for and
+ * holds nothing stays present and empty.
+ */
+export function assembleUserArchive(items: ExportUserArchiveResponse[]): UserArchive {
+  const doc: Partial<UserArchive> = {};
+  for (const item of items) {
+    switch (item.item.case) {
+      case "envelope":
+        doc.envelope = item.item.value;
+        break;
+      case "partBegin":
+        switch (item.item.value.part) {
+          case ArchivePart.PREFERENCES:
+            doc.preferences ??= create(PreferencePartSchema, {});
+            break;
+        }
+        break;
+      case "preferences":
+        doc.preferences = item.item.value;
+        break;
+    }
+  }
+  if (!doc.envelope) {
+    throw new Error("export stream sent no envelope");
+  }
+  return doc as UserArchive;
+}
+
+/** How many rows each part of a system document carries, for a preview. */
+export function systemPartCounts(archive: SystemArchive): { label: string; count: number }[] {
   const out: { label: string; count: number }[] = [];
   if (archive.instruments) {
     out.push({ label: "instruments", count: archive.instruments.instruments.length });
@@ -108,6 +142,23 @@ export function partCounts(archive: SystemArchive): { label: string; count: numb
   }
   if (archive.pluginConfig) {
     out.push({ label: "plugin config rows", count: archive.pluginConfig.configs.length });
+  }
+  return out;
+}
+
+/**
+ * How much each part of a user document carries, for a preview.
+ *
+ * Preferences counts settings rather than rows, which is what the part reports
+ * progress against, so the preview and the job's own total agree.
+ */
+export function userPartCounts(archive: UserArchive): { label: string; count: number }[] {
+  const out: { label: string; count: number }[] = [];
+  if (archive.preferences) {
+    let count = 0;
+    if (archive.preferences.displayCurrency !== undefined) count++;
+    if (archive.preferences.ignoredAssetClasses !== undefined) count++;
+    out.push({ label: "preference settings", count });
   }
   return out;
 }

--- a/client/lib/portfolio-api.ts
+++ b/client/lib/portfolio-api.ts
@@ -6,11 +6,11 @@ import { create, fromBinary, toBinary } from "@bufbuild/protobuf";
 import { timestampDate, timestampFromDate } from "@bufbuild/protobuf/wkt";
 import { DateSchema } from "@/gen/google/type/date_pb";
 import type { Date as ProtoDate } from "@/gen/google/type/date_pb";
-import { GetPortfolioValuationRequestSchema, GetPortfolioValuationResponseSchema, CreatePortfolioRequestSchema, CreatePortfolioResponseSchema, DeletePortfolioRequestSchema, GetHoldingsRequestSchema, GetHoldingsResponseSchema, GetJobRequestSchema, GetJobResponseSchema, GetPortfolioRequestSchema, GetPortfolioResponseSchema, GetPortfolioFiltersRequestSchema, GetPortfolioFiltersResponseSchema, ListBrokersAndAccountsRequestSchema, ListBrokersAndAccountsResponseSchema, ListDescriptionPluginsRequestSchema, ListDescriptionPluginsResponseSchema, ListIdentifierPluginsRequestSchema, ListIdentifierPluginsResponseSchema, ListPriceFetchBlocksRequestSchema, ListPriceFetchBlocksResponseSchema, DeletePriceFetchBlockRequestSchema, ListPricesRequestSchema, ListPricesResponseSchema, ExportSystemArchiveRequestSchema, ExportSystemArchiveResponseSchema, ImportSystemArchiveRequestSchema, ImportSystemArchiveResponseSchema, ListPricePluginsRequestSchema, ListPricePluginsResponseSchema, ListInstrumentsRequestSchema, ListInstrumentsResponseSchema, ListJobsRequestSchema, ListJobsResponseSchema, ListPortfoliosRequestSchema, ListPortfoliosResponseSchema, ListTelemetryCountersRequestSchema, ListTelemetryCountersResponseSchema, ListTxsRequestSchema, ListTxsResponseSchema, SetPortfolioFiltersRequestSchema, UpdateDescriptionPluginRequestSchema, UpdateDescriptionPluginResponseSchema, UpdateIdentifierPluginRequestSchema, UpdateIdentifierPluginResponseSchema, UpdatePricePluginRequestSchema, UpdatePricePluginResponseSchema, UpdatePortfolioRequestSchema, UpdatePortfolioResponseSchema, ReorderPluginsRequestSchema, CreateHoldingDeclarationRequestSchema, CreateHoldingDeclarationResponseSchema, UpdateHoldingDeclarationRequestSchema, UpdateHoldingDeclarationResponseSchema, DeleteHoldingDeclarationRequestSchema, ListHoldingDeclarationsRequestSchema, ListHoldingDeclarationsResponseSchema, ListWorkersRequestSchema, ListWorkersResponseSchema, GetDisplayCurrencyRequestSchema, GetDisplayCurrencyResponseSchema, SetDisplayCurrencyRequestSchema, SetDisplayCurrencyResponseSchema, GetIgnoredAssetClassesRequestSchema, GetIgnoredAssetClassesResponseSchema, SetIgnoredAssetClassesRequestSchema, CountIgnoredTxsRequestSchema, CountIgnoredTxsResponseSchema, IgnoredAssetClassRuleSchema, ListInflationIndicesRequestSchema, ListInflationIndicesResponseSchema, ListInflationPluginsRequestSchema, ListInflationPluginsResponseSchema, UpdateInflationPluginRequestSchema, UpdateInflationPluginResponseSchema, TriggerInflationFetchRequestSchema, TriggerPriceFetchRequestSchema, CountUnhandledCorporateEventsRequestSchema, CountUnhandledCorporateEventsResponseSchema, ListUnhandledCorporateEventsRequestSchema, ListUnhandledCorporateEventsResponseSchema, ResolveUnhandledCorporateEventRequestSchema, ListResidualBalancesRequestSchema, ListResidualBalancesResponseSchema, CountResidualBalancesRequestSchema, CountResidualBalancesResponseSchema, JobStatus, WorkerState } from "@/gen/api/v1/api_pb";
+import { GetPortfolioValuationRequestSchema, GetPortfolioValuationResponseSchema, CreatePortfolioRequestSchema, CreatePortfolioResponseSchema, DeletePortfolioRequestSchema, GetHoldingsRequestSchema, GetHoldingsResponseSchema, GetJobRequestSchema, GetJobResponseSchema, GetPortfolioRequestSchema, GetPortfolioResponseSchema, GetPortfolioFiltersRequestSchema, GetPortfolioFiltersResponseSchema, ListBrokersAndAccountsRequestSchema, ListBrokersAndAccountsResponseSchema, ListDescriptionPluginsRequestSchema, ListDescriptionPluginsResponseSchema, ListIdentifierPluginsRequestSchema, ListIdentifierPluginsResponseSchema, ListPriceFetchBlocksRequestSchema, ListPriceFetchBlocksResponseSchema, DeletePriceFetchBlockRequestSchema, ListPricesRequestSchema, ListPricesResponseSchema, ExportSystemArchiveRequestSchema, ExportSystemArchiveResponseSchema, ImportSystemArchiveRequestSchema, ImportSystemArchiveResponseSchema, ExportUserArchiveRequestSchema, ExportUserArchiveResponseSchema, ImportUserArchiveRequestSchema, ImportUserArchiveResponseSchema, ListPricePluginsRequestSchema, ListPricePluginsResponseSchema, ListInstrumentsRequestSchema, ListInstrumentsResponseSchema, ListJobsRequestSchema, ListJobsResponseSchema, ListPortfoliosRequestSchema, ListPortfoliosResponseSchema, ListTelemetryCountersRequestSchema, ListTelemetryCountersResponseSchema, ListTxsRequestSchema, ListTxsResponseSchema, SetPortfolioFiltersRequestSchema, UpdateDescriptionPluginRequestSchema, UpdateDescriptionPluginResponseSchema, UpdateIdentifierPluginRequestSchema, UpdateIdentifierPluginResponseSchema, UpdatePricePluginRequestSchema, UpdatePricePluginResponseSchema, UpdatePortfolioRequestSchema, UpdatePortfolioResponseSchema, ReorderPluginsRequestSchema, CreateHoldingDeclarationRequestSchema, CreateHoldingDeclarationResponseSchema, UpdateHoldingDeclarationRequestSchema, UpdateHoldingDeclarationResponseSchema, DeleteHoldingDeclarationRequestSchema, ListHoldingDeclarationsRequestSchema, ListHoldingDeclarationsResponseSchema, ListWorkersRequestSchema, ListWorkersResponseSchema, GetDisplayCurrencyRequestSchema, GetDisplayCurrencyResponseSchema, SetDisplayCurrencyRequestSchema, SetDisplayCurrencyResponseSchema, GetIgnoredAssetClassesRequestSchema, GetIgnoredAssetClassesResponseSchema, SetIgnoredAssetClassesRequestSchema, CountIgnoredTxsRequestSchema, CountIgnoredTxsResponseSchema, IgnoredAssetClassRuleSchema, ListInflationIndicesRequestSchema, ListInflationIndicesResponseSchema, ListInflationPluginsRequestSchema, ListInflationPluginsResponseSchema, UpdateInflationPluginRequestSchema, UpdateInflationPluginResponseSchema, TriggerInflationFetchRequestSchema, TriggerPriceFetchRequestSchema, CountUnhandledCorporateEventsRequestSchema, CountUnhandledCorporateEventsResponseSchema, ListUnhandledCorporateEventsRequestSchema, ListUnhandledCorporateEventsResponseSchema, ResolveUnhandledCorporateEventRequestSchema, ListResidualBalancesRequestSchema, ListResidualBalancesResponseSchema, CountResidualBalancesRequestSchema, CountResidualBalancesResponseSchema, JobStatus, WorkerState } from "@/gen/api/v1/api_pb";
 import { AccountType, AssetClass } from "@/gen/type/v1/type_pb";
 import { ArchivePart } from "@/gen/archive/v1/common_pb";
-import type { SystemArchive } from "@/gen/archive/v1/archive_pb";
-import type { DescriptionPluginConfig, EODPriceProto, ExportSystemArchiveResponse, InflationIndexProto, InflationPluginConfig, Holding, HoldingDeclaration, IdentificationError, IdentifierPluginConfig, Instrument, PriceFetchBlock, PricePluginConfig, Portfolio as GenPortfolio, PortfolioFilterProto, PortfolioTx, ResidualBalance as ResidualBalanceProto, ValidationError, Worker as WorkerProto } from "@/gen/api/v1/api_pb";
+import type { SystemArchive, UserArchive } from "@/gen/archive/v1/archive_pb";
+import type { DescriptionPluginConfig, EODPriceProto, ExportSystemArchiveResponse, ExportUserArchiveResponse, InflationIndexProto, InflationPluginConfig, Holding, HoldingDeclaration, IdentificationError, IdentifierPluginConfig, Instrument, PriceFetchBlock, PricePluginConfig, Portfolio as GenPortfolio, PortfolioFilterProto, PortfolioTx, ResidualBalance as ResidualBalanceProto, ValidationError, Worker as WorkerProto } from "@/gen/api/v1/api_pb";
 import type { Broker } from "@/gen/type/v1/type_pb";
 import { streamingFetch, unaryFetch } from "./grpc-web";
 
@@ -549,6 +549,32 @@ export async function importSystemArchive(archive: SystemArchive, filename: stri
     credentials: "include",
   });
   return fromBinary(ImportSystemArchiveResponseSchema, resBytes).jobId;
+}
+
+/**
+ * Stream the signed-in user's own archive, in the same shape as the system
+ * export. A part whose unit is a setting rather than a row arrives as one
+ * whole-part message after its part_begin.
+ */
+export async function* exportUserArchive(parts: ArchivePart[]): AsyncGenerator<ExportUserArchiveResponse> {
+  const base = getBaseUrl();
+  const req = create(ExportUserArchiveRequestSchema, { parts });
+  for await (const bytes of streamingFetch(base, ApiServicePrefix + "ExportUserArchive", toBinary(ExportUserArchiveRequestSchema, req), { credentials: "include" })) {
+    yield fromBinary(ExportUserArchiveResponseSchema, bytes);
+  }
+}
+
+/**
+ * Queue the signed-in user's own archive for import, returning the job to poll.
+ * It restores into the caller's account: a user archive does not name its user.
+ */
+export async function importUserArchive(archive: UserArchive, filename: string): Promise<string> {
+  const base = getBaseUrl();
+  const req = create(ImportUserArchiveRequestSchema, { archive, filename });
+  const resBytes = await unaryFetch(base, ApiServicePrefix + "ImportUserArchive", toBinary(ImportUserArchiveRequestSchema, req), {
+    credentials: "include",
+  });
+  return fromBinary(ImportUserArchiveResponseSchema, resBytes).jobId;
 }
 
 /** A single day's portfolio value point. */

--- a/docs/spec/information-architecture.md
+++ b/docs/spec/information-architecture.md
@@ -16,6 +16,8 @@ The informantion architecture describes key concepts for users (and admin users)
         + **Errors** are the errors associated with processing a transaction.  Identification errors and validation errors are presented to the user - ideally with links directly to UI that allows corrective action, or with a helpful, actionable error message. 
      - **Trade Notifications** are the single transaction uploads which are likely to have been automated.  They are kept separate from the (manual) uploads.
 
+ * **Your Archive** is the single file a user's own data is exported to and restored from: their preferences, and in time their transactions and holding declarations.  It is its own concept rather than an attribute of any one page, because it spans all three.  It carries none of the shared reference data the instance is built from -- that is The Archive below, which an admin keeps -- so the two never mix and neither reaches the other's page.  A user cares about getting their data out, and about knowing what an import actually applied.  Restoring an archive into an instance whose instruments are not loaded is supported and correct; it is merely slower, and must not be presented as an error.
+
  ## Key Admin User Concepts
 
  * **The Archive** is the single file the shared data of an instance is exported to and rebuilt from.  It is its own concept rather than an attribute of any one page, because it spans Reference Data, Plugins and Diagnostics: instruments, prices and corporate events sit under Reference Data, plugin configuration under Plugins, and fetch blocks and unhandled corporate events under Diagnostics.  An admin user cares about producing a file that is complete enough to rebuild from, and about knowing what an import actually applied.  The archive carries no user data at all, and a user's own archive is a separate file with a separate page.
@@ -61,10 +63,14 @@ The user menu is a dropdown anchored to the user's email address on the right si
 |------|------|------------|
 | User email | Display only | Always |
 | **Uploads** | Link (`/uploads`) | Always |
+| **Archive** | Link (`/archive`) | Always |
+| **Settings** | Link (`/settings`) | Always |
 | **Admin** | Link (`/admin`) | Admin role only |
 | **Log out** | Action | Always |
 
  * **Uploads** shows all uploads regardless of the selected portfolio.  However, when a portfolio other than "All Holdings" is selected, rows containing transactions relevant to that portfolio should be visually highlighted.  Note: the upload flow itself is a modal launched from the Holdings page, not a separate route; the `/uploads` page is the upload history list.
+ * **Archive** is where a user produces and consumes their own archive.  Export offers a menu of what to include: a part left out is absent from the file, and a part included but holding nothing is written empty, which records that the export asked and there was nothing.  Import takes a whole file, runs on the server and reports a result per part, so it finishes whether or not the page stays open.  The page states plainly that importing ignored asset classes replaces the rules the user has and removes the transactions those rules cover.  It is a separate affordance from the transaction upload modal, which converts a broker's own file: different input, different failure modes, different frequency.
+ * **Settings** is where a user sets their display currency and the asset classes to ignore on import.
  * **Admin** navigates to the admin area.  Only visible to users with the admin role.
 
 ### Left Sidebar


### PR DESCRIPTION
Stacked on #375. One page where a user exports and imports their own data.

## What changed

- **`/archive`**, mirroring `/admin/archive`. Top level rather than under
  `/settings`, because the page spans preferences, transactions and declarations,
  so filing it under one of the three would misdescribe it. Nav entry between
  Uploads and Settings.
- **`import-panel.tsx` and `job-parts.tsx` move to `app/components/archive`** and
  are shared by both pages. The panel is generic over the document type: the
  sequence of states is the behaviour rather than the decoration -- parse before
  queue, say what the file carries, refuse to start a second import over a running
  one. Both pages keep the same `data-testid`s so one e2e selector set covers them.
- **`partCounts` becomes `systemPartCounts`** and gains a user twin that counts
  settings rather than rows, which is what the preferences part reports progress
  against, so the panel's preview and the job's own total agree.
- A validation error with `row_index = -1` renders as an em dash: a setting has no
  row to point at.
- `docs/spec/information-architecture.md` gains a "Your Archive" user concept, the
  `/archive` menu row and its behaviour note (including that importing ignored
  asset classes removes the transactions those rules cover). The Settings row,
  which the table had been missing, goes in at the same time.

Restoring into an instance whose instruments are not loaded is supported and
correct, so nothing on the page presents it as an error.

## Testing

`make check` and `make client-test` pass. New coverage for `assembleUserArchive`
(no envelope refused, a selected empty part stays present through serialisation,
the whole-part message files under its marker) and `userPartCounts` (settings
stated, and an empty part reported as zero rather than omitted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)