### PR TITLE
Remove real names, account numbers and references from the repo

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,10 +1,10 @@
 {
   "permissions": {
     "allow": [
-      "Read(path:/home/lee/Projects/portfoliodb/**)",
+      "Read(path:~/Projects/portfoliodb/**)",
       "mcp__github__merge_pull_request",
       "mcp__github__create_pull_request",
-      "Bash(find /home/lee/Projects/portfoliodb/docs -type f -name *.md)",
+      "Bash(find ~/Projects/portfoliodb/docs -type f -name *.md)",
       "Bash(go get:*)",
       "Bash(go mod:*)",
       "Bash(make:*)",

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -4,7 +4,7 @@
       "Read(path:~/Projects/portfoliodb/**)",
       "mcp__github__merge_pull_request",
       "mcp__github__create_pull_request",
-      "Bash(find ~/Projects/portfoliodb/docs -type f -name *.md)",
+      "Bash(find docs -type f -name *.md)",
       "Bash(go get:*)",
       "Bash(go mod:*)",
       "Bash(make:*)",

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,3 +135,32 @@ skills (`.claude/skills/`).
 
 Testing guidance lives in the `unit-testing`, `integration-testing`, and
 `e2e-testing` skills (`.claude/skills/`).
+
+## Personal Data
+
+The repository must contain no personal data belonging to a real person. This
+applies to code, tests, fixtures, comments, commit messages, issues, specs and
+plans alike. `local/` is gitignored and is where real broker exports live; it is
+the only place they belong.
+
+Never commit any of the following:
+
+* Real people's names, including in a comment describing where test data came
+  from, in an issue discussing it, and in the name of a file that holds it. Refer
+  to the account or the export rather than to whoever owns it.
+* Real broker account numbers, and any identifier that embeds one.
+* Real transaction, order or statement reference numbers issued by a broker.
+* Real email addresses, postal addresses and telephone numbers.
+
+Public security identifiers -- tickers, ISINs, CUSIPs, MICs, exchange codes --
+are reference data rather than personal data, and are fine to use as they are.
+
+Test data modelled on a real broker export is the normal way to pin down a
+format, and it stays welcome: copy the shape, the column order and the quirks,
+then replace every account number and reference with an invented one before
+committing. Invent them so that the properties the test depends on survive --
+distinctness, ordering, and the numeric distance between references where a test
+compares them -- and say in a comment that the file is modelled on a real export
+with its identifiers replaced, so the next reader does not restore them from the
+original. Amounts, dates and instruments carry no identifier and may stay as they
+are.

--- a/client/lib/csv/converters/fidelity-csv.test.ts
+++ b/client/lib/csv/converters/fidelity-csv.test.ts
@@ -31,7 +31,7 @@ describe("convertFidelityToStandard", () => {
   it("parses a single Sell row and uses Completion date", () => {
     const csv = [
       "Order date,Completion date,Transaction type,Investments,Product Wrapper,Account Number,Source investment,Amount,Quantity,Price per unit,Reference Number,Status",
-      '21 Jan 2026,23 Jan 2026,Sell,"INVESCO MARKETS III PLC, INVESCO EQQQ NASDAQ 100 UCITS ETF (EQQQ)",Investment Account,AG10041188,,-31826.24,70,454.66,1229145354,Completed,',
+      '21 Jan 2026,23 Jan 2026,Sell,"INVESCO MARKETS III PLC, INVESCO EQQQ NASDAQ 100 UCITS ETF (EQQQ)",Investment Account,AG10000001,,-31826.24,70,454.66,1107095237,Completed,',
     ].join("\n");
     const result = convertFidelityToStandard(csv, { currency: "GBP" });
     expect(result.errors).toEqual([]);
@@ -41,7 +41,7 @@ describe("convertFidelityToStandard", () => {
     expect(result.txs[0]!.type).toBe(10); // SELLSTOCK
     expect(result.txs[0]!.settlementCurrency).toBe("GBP");
     expect(result.txs[0]!.tradingCurrency).toBe(""); // Sell is not Cash type
-    expect(result.txs[0]!.account).toBe("AG10041188");
+    expect(result.txs[0]!.account).toBe("AG10000001");
     expect(result.periodFrom.getFullYear()).toBe(2026);
     expect(result.periodFrom.getMonth()).toBe(0); // Jan
     expect(result.periodFrom.getDate()).toBe(23);
@@ -76,7 +76,7 @@ describe("convertFidelityToStandard", () => {
   it("parses Cash Interest as INCOME", () => {
     const csv = [
       "Order date,Completion date,Transaction type,Investments,Account Number,Quantity,Price per unit",
-      "16 Feb 2026,23 Feb 2026,Cash Interest,Cash,AP10013127,3.27,1",
+      "16 Feb 2026,23 Feb 2026,Cash Interest,Cash,AP10000001,3.27,1",
     ].join("\n");
     const result = convertFidelityToStandard(csv, { currency: "USD" });
     expect(result.errors).toEqual([]);
@@ -128,27 +128,27 @@ describe("convertFidelityToStandard", () => {
     const cases: { name: string; row: string; want: string }[] = [
       {
         name: "a fee is an outflow",
-        row: '03 Jul 2026,08 Jul 2026,Service Fee,"Cash",Cash Management Account,AW10075724,,-5.20,5.2,1,1314200860,Completed,',
+        row: '03 Jul 2026,08 Jul 2026,Service Fee,"Cash",Cash Management Account,AW10000001,,-5.20,5.2,1,1192150743,Completed,',
         want: "-5.2",
       },
       {
         name: "interest is an inflow",
-        row: '15 Jul 2026,21 Jul 2026,Cash Interest,"Cash",Investment ISA,AS10110796,"Cash",1.26,1.26,1,1319149500,Completed,',
+        row: '15 Jul 2026,21 Jul 2026,Cash Interest,"Cash",Investment ISA,AS10000001,"Cash",1.26,1.26,1,1197099383,Completed,',
         want: "1.26",
       },
       {
         name: "a transfer out is an outflow",
-        row: '03 Jul 2026,03 Jul 2026,Transfer To Cash Management Account For Fees,"Cash",Investment ISA,AS10110796,,-2.30,2.3,1,1313264690,Completed,',
+        row: '03 Jul 2026,03 Jul 2026,Transfer To Cash Management Account For Fees,"Cash",Investment ISA,AS10000001,,-2.30,2.3,1,1191214573,Completed,',
         want: "-2.3",
       },
       {
         name: "the matching transfer in is an inflow",
-        row: '03 Jul 2026,03 Jul 2026,Cash In Ring-fenced For Fees,"Cash",Cash Management Account,AW10075724,,2.30,2.3,1,1313264694,Completed,',
+        row: '03 Jul 2026,03 Jul 2026,Cash In Ring-fenced For Fees,"Cash",Cash Management Account,AW10000001,,2.30,2.3,1,1191214577,Completed,',
         want: "2.3",
       },
       {
         name: "Quantity of zero does not lose the amount",
-        row: '15 Jul 2026,21 Jul 2026,Tax On Interest,"Cash",Investment Account,AG10041188,,-0.20,0,0,267898807,Completed,',
+        row: '15 Jul 2026,21 Jul 2026,Tax On Interest,"Cash",Investment Account,AG10000001,,-0.20,0,0,145848690,Completed,',
         want: "-0.2",
       },
     ];
@@ -181,7 +181,7 @@ describe("convertFidelityToStandard", () => {
     (type) => {
       const csv = [
         FULL_HEADER,
-        `10 Apr 2025,14 Apr 2025,${type},"Cash",Investment ISA,AS10110796,,-100.00,100,1,123,Completed,`,
+        `10 Apr 2025,14 Apr 2025,${type},"Cash",Investment ISA,AS10000001,,-100.00,100,1,123,Completed,`,
       ].join("\n");
       const result = convertFidelityToStandard(csv, { currency: "GBP" });
       expect(result.errors).toEqual([]);
@@ -193,7 +193,7 @@ describe("convertFidelityToStandard", () => {
   it("keeps share counts for security rows, negating sells", () => {
     const csv = [
       FULL_HEADER,
-      '21 Jan 2026,23 Jan 2026,Sell,"INVESCO MARKETS III PLC, INVESCO EQQQ NASDAQ 100 UCITS ETF (EQQQ)",Investment Account,AG10041188,,-31826.24,70,454.66,1229145354,Completed,',
+      '21 Jan 2026,23 Jan 2026,Sell,"INVESCO MARKETS III PLC, INVESCO EQQQ NASDAQ 100 UCITS ETF (EQQQ)",Investment Account,AG10000001,,-31826.24,70,454.66,1107095237,Completed,',
     ].join("\n");
     const result = convertFidelityToStandard(csv, { currency: "GBP" });
     // Quantity is a share count here, not money, so Amount must not replace it.
@@ -203,7 +203,7 @@ describe("convertFidelityToStandard", () => {
   it("falls back to Quantity when the export has no Amount column", () => {
     const csv = [
       HEADER,
-      "15 Jul 2026,21 Jul 2026,Cash Interest,Cash,AS10110796,1.26,1",
+      "15 Jul 2026,21 Jul 2026,Cash Interest,Cash,AS10000001,1.26,1",
     ].join("\n");
     const result = convertFidelityToStandard(csv, { currency: "GBP" });
     expect(result.txs[0]!.quantity).toBe("1.26");
@@ -212,17 +212,17 @@ describe("convertFidelityToStandard", () => {
   // Fidelity reports money leaving an account as a sale of the account's cash.
   // Mapping on the transaction type alone made each one a security position sold
   // in units of money, and left the account's balance short by the amount that
-  // moved. Rows from the Lee export, 2023-03-01, AG10041188, with the completion
-  // date in the format the broker's own download carries.
+  // moved. Rows taken from a real Fidelity export, 2023-03-01, with the
+  // completion date in the format the broker's own download carries.
   describe("a Buy or Sell of cash", () => {
     const CASH_ASSET_HEADER =
       "Order date,Completion date,Transaction type,Investments,Product Wrapper,Account Number,Source investment,Amount,Quantity,Price per unit,Reference Number,Status,Exchange,Symbol,Type,Action";
     const TRANSFER =
-      "2023-03-01,01 Mar 2023,Transfer To Cash Management Account,Cash,Investment Account,AG10041188,,-401,401,1,730492674,Completed,,GBP,CASH,Cash";
+      "2023-03-01,01 Mar 2023,Transfer To Cash Management Account,Cash,Investment Account,AG10000001,,-401,401,1,608442557,Completed,,GBP,CASH,Cash";
     const SELL =
-      "2023-03-01,01 Mar 2023,Sell,Cash,Investment Account,AG10041188,,-401,401,1,730492678,Completed,,GBP,CASH,Cash";
+      "2023-03-01,01 Mar 2023,Sell,Cash,Investment Account,AG10000001,,-401,401,1,608442561,Completed,,GBP,CASH,Cash";
     const CASH_IN =
-      "2023-03-01,01 Mar 2023,Cash In From Sell,Cash,Investment Account,AG10041188,,401,401,1,730492680,Completed,,GBP,CASH,Cash";
+      "2023-03-01,01 Mar 2023,Cash In From Sell,Cash,Investment Account,AG10000001,,401,401,1,608442563,Completed,,GBP,CASH,Cash";
 
     const convert = (rows: string[]) =>
       convertFidelityToStandard([CASH_ASSET_HEADER, ...rows].join("\n"), { currency: "GBP" });
@@ -239,8 +239,8 @@ describe("convertFidelityToStandard", () => {
 
     it("groups with its cash in, and the pair weighs nothing", () => {
       const result = convert([SELL, CASH_IN]);
-      expect(result.txs[0]!.groupRef).toBe("730492678");
-      expect(result.txs[1]!.groupRef).toBe("730492678");
+      expect(result.txs[0]!.groupRef).toBe("608442561");
+      expect(result.txs[1]!.groupRef).toBe("608442561");
       expectGroupsBalance(result.txs);
     });
 
@@ -258,7 +258,7 @@ describe("convertFidelityToStandard", () => {
 
     it("still reads a security sale as one", () => {
       const result = convert([
-        '2022-02-08,10 Feb 2022,Sell,"WISE PLC, CLS A ORD GBP0.01 (WISE)",SIPP - Pension Savings Account,AP10013127,,-7266.49,1242,5.85,563466569,Completed,LON,WISE,STOCK,Sell',
+        '2022-02-08,10 Feb 2022,Sell,"WISE PLC, CLS A ORD GBP0.01 (WISE)",SIPP - Pension Savings Account,AP10000001,,-7266.49,1242,5.85,441416452,Completed,LON,WISE,STOCK,Sell',
       ]);
       expect(result.txs[0]!.type).toBe(TxType.SELLSTOCK);
       expect(result.txs[0]!.quantity).toBe("-1242");
@@ -268,16 +268,16 @@ describe("convertFidelityToStandard", () => {
       // Both settle in the same account on the same day. Amount separates them,
       // and a security sale picks first regardless of export order.
       const result = convert([
-        "2024-04-10,10 Apr 2024,Sell,Cash,Investment Account,AG10041188,,-19999,19999,1,917882556,Completed,,GBP,CASH,Cash",
-        "2024-04-10,10 Apr 2024,Cash In From Sell,Cash,Investment Account,AG10041188,,19999,19999,1,917882557,Completed,,GBP,CASH,Cash",
-        '2024-04-10,10 Apr 2024,Sell,"VANGUARD FUNDS PLC, S&P 500 (VUSA)",Investment Account,AG10041188,,-19502.15,325,60.0066,913741900,Completed,LON,VUSA,ETF,Sell',
-        "2024-04-10,10 Apr 2024,Cash In From Sell,Cash,Investment Account,AG10041188,,19502.15,19502.15,1,913741902,Completed,,GBP,CASH,Cash",
+        "2024-04-10,10 Apr 2024,Sell,Cash,Investment Account,AG10000001,,-19999,19999,1,795832439,Completed,,GBP,CASH,Cash",
+        "2024-04-10,10 Apr 2024,Cash In From Sell,Cash,Investment Account,AG10000001,,19999,19999,1,795832440,Completed,,GBP,CASH,Cash",
+        '2024-04-10,10 Apr 2024,Sell,"VANGUARD FUNDS PLC, S&P 500 (VUSA)",Investment Account,AG10000001,,-19502.15,325,60.0066,791691783,Completed,LON,VUSA,ETF,Sell',
+        "2024-04-10,10 Apr 2024,Cash In From Sell,Cash,Investment Account,AG10000001,,19502.15,19502.15,1,791691785,Completed,,GBP,CASH,Cash",
       ]);
 
-      expect(result.txs[0]!.groupRef).toBe("917882556");
-      expect(result.txs[1]!.groupRef).toBe("917882556");
-      expect(result.txs[2]!.groupRef).toBe("913741900");
-      expect(result.txs[3]!.groupRef).toBe("913741900");
+      expect(result.txs[0]!.groupRef).toBe("795832439");
+      expect(result.txs[1]!.groupRef).toBe("795832439");
+      expect(result.txs[2]!.groupRef).toBe("791691783");
+      expect(result.txs[3]!.groupRef).toBe("791691783");
     });
 
     // The map-completeness test above feeds security rows through a header with
@@ -285,8 +285,8 @@ describe("convertFidelityToStandard", () => {
     it("falls back to the instrument description when the export omits Type", () => {
       const csv = [
         HEADER,
-        "8 Feb 2022,10 Feb 2022,Sell,Cash,AG10041188,401,1",
-        "8 Feb 2022,10 Feb 2022,Sell,ISHARES II PLC INRG,AG10041188,100,7.16",
+        "8 Feb 2022,10 Feb 2022,Sell,Cash,AG10000001,401,1",
+        "8 Feb 2022,10 Feb 2022,Sell,ISHARES II PLC INRG,AG10000001,100,7.16",
       ].join("\n");
       const result = convertFidelityToStandard(csv, { currency: "GBP" });
       expect(result.txs[0]!.type).toBe(TxType.CASHFLOW);
@@ -329,32 +329,32 @@ describe("transaction grouping", () => {
 
   it("pairs a sell with the cash in of the same amount", () => {
     const result = convert([
-      row("Sell", "WISE PLC (WISE)", "AG1", "-7266.49", "1242", "5.85", "563466569"),
-      row("Cash In From Sell", "Cash", "AG1", "7266.49", "7266.49", "1", "563466571"),
+      row("Sell", "WISE PLC (WISE)", "AG1", "-7266.49", "1242", "5.85", "441416452"),
+      row("Cash In From Sell", "Cash", "AG1", "7266.49", "7266.49", "1", "441416454"),
     ]);
 
     expect(result.txs).toHaveLength(2);
-    expect(result.txs[0].groupRef).toBe("563466569");
-    expect(result.txs[1].groupRef).toBe("563466569");
+    expect(result.txs[0].groupRef).toBe("441416452");
+    expect(result.txs[1].groupRef).toBe("441416452");
   });
 
   it("pairs a buy with the cash out despite the fee gap", () => {
     // The buy row's Amount includes a 10.00 dealing fee that Fidelity posts as its
     // own row, so the cash out is 10.00 smaller.
     const result = convert([
-      row("Cash Out For Buy", "Cash", "AG1", "-7380.19", "7380.19", "1", "563466631"),
-      row("Buy", "INVESCO EQQQ (EQQQ)", "AG1", "7390.19", "28", "263.58", "563466632"),
+      row("Cash Out For Buy", "Cash", "AG1", "-7380.19", "7380.19", "1", "441416514"),
+      row("Buy", "INVESCO EQQQ (EQQQ)", "AG1", "7390.19", "28", "263.58", "441416515"),
     ]);
 
-    expect(result.txs[0].groupRef).toBe("563466632");
-    expect(result.txs[1].groupRef).toBe("563466632");
+    expect(result.txs[0].groupRef).toBe("441416515");
+    expect(result.txs[1].groupRef).toBe("441416515");
   });
 
   it("keeps a separately reported charge out of the trade's group", () => {
     const result = convert([
-      row("Sell", "WISE PLC (WISE)", "AG1", "-7266.49", "1242", "5.85", "563466569"),
-      row("Cash In From Sell", "Cash", "AG1", "7266.49", "7266.49", "1", "563466571"),
-      row("Dealing Fee", "Cash", "AG1", "-10", "0", "0", "563466600", "8 Feb 2022"),
+      row("Sell", "WISE PLC (WISE)", "AG1", "-7266.49", "1242", "5.85", "441416452"),
+      row("Cash In From Sell", "Cash", "AG1", "7266.49", "7266.49", "1", "441416454"),
+      row("Dealing Fee", "Cash", "AG1", "-10", "0", "0", "441416483", "8 Feb 2022"),
     ]);
 
     // It has a group of its own -- it needs one to hold its expense leg -- but
@@ -384,16 +384,16 @@ describe("transaction grouping", () => {
     // The 29939.31 buy sits one reference from the 36946.72 cash out, but a fee
     // cannot be negative, so that cash row can only belong to the larger buy.
     const result = convert([
-      row("Cash Out For Buy", "Cash", "AP1", "-29931.81", "29931.81", "1", "819092458"),
-      row("Buy", "VANGUARD S&P 500 (VUSA)", "AP1", "29939.31", "100", "299.39", "819092460"),
-      row("Cash Out For Buy", "Cash", "AP1", "-36946.72", "36946.72", "1", "819092461"),
-      row("Buy", "INVESCO EQQQ (EQQQ)", "AP1", "36954.22", "120", "307.95", "819092463"),
+      row("Cash Out For Buy", "Cash", "AP1", "-29931.81", "29931.81", "1", "697042341"),
+      row("Buy", "VANGUARD S&P 500 (VUSA)", "AP1", "29939.31", "100", "299.39", "697042343"),
+      row("Cash Out For Buy", "Cash", "AP1", "-36946.72", "36946.72", "1", "697042344"),
+      row("Buy", "INVESCO EQQQ (EQQQ)", "AP1", "36954.22", "120", "307.95", "697042346"),
     ]);
 
-    expect(result.txs[1].groupRef).toBe("819092460");
-    expect(result.txs[0].groupRef).toBe("819092460");
-    expect(result.txs[3].groupRef).toBe("819092463");
-    expect(result.txs[2].groupRef).toBe("819092463");
+    expect(result.txs[1].groupRef).toBe("697042343");
+    expect(result.txs[0].groupRef).toBe("697042343");
+    expect(result.txs[3].groupRef).toBe("697042346");
+    expect(result.txs[2].groupRef).toBe("697042346");
   });
 
   it("does not pair a sell across accounts or settlement dates", () => {
@@ -463,7 +463,7 @@ describe("transaction grouping", () => {
 
   it("leaves a cash row with no trade ungrouped rather than failing", () => {
     const result = convert([
-      row("Cash Out For Buy", "Cash", "AG1", "-401", "401", "1", "730493547"),
+      row("Cash Out For Buy", "Cash", "AG1", "-401", "401", "1", "608443430"),
     ]);
 
     expect(result.errors).toHaveLength(0);
@@ -485,32 +485,32 @@ describe("deposits into a product account", () => {
   const convert = (rows: string[]) =>
     convertFidelityToStandard([FULL, ...rows].join("\n"), { currency: "GBP" });
 
-  // The 2025-04-15 lump sum into Lee's ISA, and the cash management account row
+  // The 2025-04-15 lump sum into an ISA, and the cash management account row
   // that paid for it.
   const LUMP_SUM =
-    "2025-04-15,2025-04-15,Cash In Lump Sum,Cash,Investment ISA,AS10110796,,20000,20000,1,1093663545,Completed,,GBP,CASH,Cash";
+    "2025-04-15,2025-04-15,Cash In Lump Sum,Cash,Investment ISA,AS10000001,,20000,20000,1,971613428,Completed,,GBP,CASH,Cash";
   const SPEND =
-    "2025-04-15,2025-04-15,Cash Out For Buy,Cash,Investment ISA,AS10110796,,-20000,20000,1,1093663546,Completed,,GBP,CASH,Cash";
+    "2025-04-15,2025-04-15,Cash Out For Buy,Cash,Investment ISA,AS10000001,,-20000,20000,1,971613429,Completed,,GBP,CASH,Cash";
   const DEPARTURE =
-    "2025-04-15,2025-04-15,Transfer Out From Cash Management Account,Cash,Cash Management Account,AW10075724,,-20000,20000,1,1093663547,Completed,,GBP,CASH,Cash";
+    "2025-04-15,2025-04-15,Transfer Out From Cash Management Account,Cash,Cash Management Account,AW10000001,,-20000,20000,1,971613430,Completed,,GBP,CASH,Cash";
   const ARRIVAL =
-    "2025-04-15,2025-04-15,Cash In,Cash,Investment ISA,AS10110796,,20000,20000,1,1093663548,Completed,,GBP,CASH,Cash";
+    "2025-04-15,2025-04-15,Cash In,Cash,Investment ISA,AS10000001,,20000,20000,1,971613431,Completed,,GBP,CASH,Cash";
 
   it("groups the run so one deposit leaves one residual, not three", () => {
     const result = convert([LUMP_SUM, SPEND, DEPARTURE, ARRIVAL]);
 
     expect(result.errors).toEqual([]);
     expect(result.txs.map((tx) => tx.groupRef)).toEqual([
-      "1093663545",
-      "1093663545",
+      "971613428",
+      "971613428",
       "",
-      "1093663545",
+      "971613428",
     ]);
     // What each account is left with: the arrival and the departure it answers,
     // equal and opposite, which is the pair 0068 has to match. Ungrouped the ISA
     // offered two identical credits and an unexplained debit instead.
     expect(residuals(result.txs)).toEqual({
-      "1093663545": { GBP: "20000" },
+      "971613428": { GBP: "20000" },
       "#2": { GBP: "-20000" },
     });
   });
@@ -532,7 +532,7 @@ describe("deposits into a product account", () => {
     // A deposit straight into the cash management account is money from outside
     // with nothing beside it to cancel. All three in the sample are this shape.
     const result = convert([
-      "2024-05-30,2024-05-30,Cash In Lump Sum,Cash,Cash Management Account,AW10075724,,19999,19999,1,944992689,Completed,,GBP,CASH,Cash",
+      "2024-05-30,2024-05-30,Cash In Lump Sum,Cash,Cash Management Account,AW10000001,,19999,19999,1,822942572,Completed,,GBP,CASH,Cash",
     ]);
 
     expect(result.txs).toHaveLength(1);
@@ -541,19 +541,19 @@ describe("deposits into a product account", () => {
   });
 
   it("groups a run whose rows settled on different days", () => {
-    // From the Helen export: the subscription and its spend completed on the 11th
+    // From a real export: the subscription and its spend completed on the 11th
     // and the arrival on the 14th, so the settlement date the trade passes group
     // on would split this run. The reference run does not.
     const result = convert([
-      "2022-11-14,11 Nov 2022,Cash In Lump Sum,Cash,Investment Account,AG10045534,,19996,19996,1,681655048,Completed,,GBP,CASH,Cash",
-      "2022-11-14,11 Nov 2022,Cash Out For Buy,Cash,Investment Account,AG10045534,,-19996,19996,1,681655049,Completed,,GBP,CASH,Cash",
-      "2022-11-14,14 Nov 2022,Cash In,Cash,Investment Account,AG10045534,,19996,19996,1,681655050,Completed,,GBP,CASH,Cash",
+      "2022-11-14,11 Nov 2022,Cash In Lump Sum,Cash,Investment Account,AG10000002,,19996,19996,1,559604931,Completed,,GBP,CASH,Cash",
+      "2022-11-14,11 Nov 2022,Cash Out For Buy,Cash,Investment Account,AG10000002,,-19996,19996,1,559604932,Completed,,GBP,CASH,Cash",
+      "2022-11-14,14 Nov 2022,Cash In,Cash,Investment Account,AG10000002,,19996,19996,1,559604933,Completed,,GBP,CASH,Cash",
     ]);
 
     expect(result.txs.map((tx) => tx.groupRef)).toEqual([
-      "681655048",
-      "681655048",
-      "681655048",
+      "559604931",
+      "559604931",
+      "559604931",
     ]);
   });
 
@@ -561,17 +561,17 @@ describe("deposits into a product account", () => {
     // Both completed on the 14th, 19,996 and 19,995, references interleaved. Only
     // the amount agreeing to the penny keeps one run's rows out of the other's.
     const result = convert([
-      "2022-11-14,14 Nov 2022,Cash In Lump Sum,Cash,Investment Account,AG10045534,,19995,19995,1,681727827,Completed,,GBP,CASH,Cash",
-      "2022-11-14,14 Nov 2022,Cash In,Cash,Investment Account,AG10045534,,19996,19996,1,681655050,Completed,,GBP,CASH,Cash",
-      "2022-11-14,14 Nov 2022,Cash Out For Buy,Cash,Investment Account,AG10045534,,-19995,19995,1,681727828,Completed,,GBP,CASH,Cash",
-      "2022-11-14,14 Nov 2022,Cash In,Cash,Investment Account,AG10045534,,19995,19995,1,681727829,Completed,,GBP,CASH,Cash",
+      "2022-11-14,14 Nov 2022,Cash In Lump Sum,Cash,Investment Account,AG10000002,,19995,19995,1,559677710,Completed,,GBP,CASH,Cash",
+      "2022-11-14,14 Nov 2022,Cash In,Cash,Investment Account,AG10000002,,19996,19996,1,559604933,Completed,,GBP,CASH,Cash",
+      "2022-11-14,14 Nov 2022,Cash Out For Buy,Cash,Investment Account,AG10000002,,-19995,19995,1,559677711,Completed,,GBP,CASH,Cash",
+      "2022-11-14,14 Nov 2022,Cash In,Cash,Investment Account,AG10000002,,19995,19995,1,559677712,Completed,,GBP,CASH,Cash",
     ]);
 
     expect(result.txs.map((tx) => tx.groupRef)).toEqual([
-      "681727827",
+      "559677710",
       "",
-      "681727827",
-      "681727827",
+      "559677710",
+      "559677710",
     ]);
   });
 
@@ -582,24 +582,25 @@ describe("deposits into a product account", () => {
       LUMP_SUM,
       SPEND,
       ARRIVAL,
-      "2025-04-15,2025-04-17,Cash Out For Buy,Cash,Investment ISA,AS10110796,,-19969.2,19969.2,1,1093663610,Completed,,GBP,CASH,Cash",
-      '2025-04-15,2025-04-17,Buy,"VANECK UCITS ETFS PLC, SEMICONDUCTOR UCITS ETF A GBP ACC (SMGB)",Investment ISA,AS10110796,,19976.7,769,25.97,1093663611,Completed,LON,SMGB,ETF,Buy',
+      "2025-04-15,2025-04-17,Cash Out For Buy,Cash,Investment ISA,AS10000001,,-19969.2,19969.2,1,971613493,Completed,,GBP,CASH,Cash",
+      '2025-04-15,2025-04-17,Buy,"VANECK UCITS ETFS PLC, SEMICONDUCTOR UCITS ETF A GBP ACC (SMGB)",Investment ISA,AS10000001,,19976.7,769,25.97,971613494,Completed,LON,SMGB,ETF,Buy',
     ]);
 
     expect(result.txs.map((tx) => tx.groupRef)).toEqual([
-      "1093663545",
-      "1093663545",
-      "1093663545",
-      "1093663611",
-      "1093663611",
+      "971613428",
+      "971613428",
+      "971613428",
+      "971613494",
+      "971613494",
     ]);
   });
 });
 
 // Fidelity names a trade for the reason it happened, and names its cash leg to
-// match. Every row below is verbatim from the Helen export; before these types
-// were mapped the client rejected each one while the conversion script kept it,
-// so the two disagreed about which rows survived.
+// match. Every row below is taken from a real export, with the account numbers
+// and references replaced; before these types were mapped the client rejected
+// each one while the conversion script kept it, so the two disagreed about which
+// rows survived.
 describe("trades the broker names for their reason", () => {
   const FULL =
     "Order date,Completion date,Transaction type,Investments,Product Wrapper,Account Number,Source investment,Amount,Quantity,Price per unit,Reference Number,Status,Exchange,Symbol,Type,Action";
@@ -608,8 +609,8 @@ describe("trades the broker names for their reason", () => {
 
   it("pairs a dividend reinvestment with the cash out that funded it", () => {
     const result = convert([
-      '2022-02-11,15 Feb 2022,Buy From Dividend,"BAILLIE GIFFORD EUROPEAN GROWTH TST, ORD GBP0.025 (BGEU)",Investment ISA,AS10123702,"BAILLIE GIFFORD EUROPEAN GROWTH TST, ORD GBP0.025 (BGEU)",21.75,17,1.19,564234496,Completed,LON,BGEU,ETF,Buy',
-      '2022-02-11,15 Feb 2022,Cash Out For Dividend Reinvestment,Cash,Investment ISA,AS10123702,"BAILLIE GIFFORD EUROPEAN GROWTH TST, ORD GBP0.025 (BGEU)",-20.15,20.15,1,564234491,Completed,,GBP,CASH,Cash',
+      '2022-02-11,15 Feb 2022,Buy From Dividend,"BAILLIE GIFFORD EUROPEAN GROWTH TST, ORD GBP0.025 (BGEU)",Investment ISA,AS10000002,"BAILLIE GIFFORD EUROPEAN GROWTH TST, ORD GBP0.025 (BGEU)",21.75,17,1.19,442184379,Completed,LON,BGEU,ETF,Buy',
+      '2022-02-11,15 Feb 2022,Cash Out For Dividend Reinvestment,Cash,Investment ISA,AS10000002,"BAILLIE GIFFORD EUROPEAN GROWTH TST, ORD GBP0.025 (BGEU)",-20.15,20.15,1,442184374,Completed,,GBP,CASH,Cash',
     ]);
 
     expect(result.errors).toEqual([]);
@@ -618,32 +619,32 @@ describe("trades the broker names for their reason", () => {
     expect(result.txs[0]!.type).toBe(TxType.BUYSTOCK);
     expect(result.txs[0]!.quantity).toBe("17");
     expect(result.txs[1]!.type).toBe(TxType.CASHFLOW);
-    expect(result.txs[0]!.groupRef).toBe("564234496");
-    expect(result.txs[1]!.groupRef).toBe("564234496");
+    expect(result.txs[0]!.groupRef).toBe("442184379");
+    expect(result.txs[1]!.groupRef).toBe("442184379");
   });
 
   it("pairs a rebate reinvestment with its cash out", () => {
     const result = convert([
-      "2022-03-04,10 Mar 2022,Cash Out,Cash,SIPP - Pension Savings Account,AP10024612,M&G European Index Tracker,-7.81,7.81,1,574652308,Completed,,GBP,CASH,Cash",
-      "2022-03-04,10 Mar 2022,Buy From Rebate,M&G European Index Tracker,SIPP - Pension Savings Account,AP10024612,M&G European Index Tracker,7.81,9.24,0.85,574652321,Completed,LON,M&G European Index Tracker,FUND,Buy",
+      "2022-03-04,10 Mar 2022,Cash Out,Cash,SIPP - Pension Savings Account,AP10000002,M&G European Index Tracker,-7.81,7.81,1,452602191,Completed,,GBP,CASH,Cash",
+      "2022-03-04,10 Mar 2022,Buy From Rebate,M&G European Index Tracker,SIPP - Pension Savings Account,AP10000002,M&G European Index Tracker,7.81,9.24,0.85,452602204,Completed,LON,M&G European Index Tracker,FUND,Buy",
     ]);
 
     expect(result.errors).toEqual([]);
     expect(result.txs[1]!.type).toBe(TxType.BUYSTOCK);
-    expect(result.txs[0]!.groupRef).toBe("574652321");
-    expect(result.txs[1]!.groupRef).toBe("574652321");
+    expect(result.txs[0]!.groupRef).toBe("452602204");
+    expect(result.txs[1]!.groupRef).toBe("452602204");
     // The group does not weigh zero, and cannot: 9.24 units at the printed price
     // of 0.85 is 7.854 against a cash out of 7.81. The price is rounded to the
     // penny and the units are not, so the 0.044 is the source disagreeing with
     // itself. The imbalance report is where that belongs.
-    expect(residuals(result.txs)).toEqual({ "574652321": { GBP: "0.044" } });
+    expect(residuals(result.txs)).toEqual({ "452602204": { GBP: "0.044" } });
   });
 
   it("derives the income a reinvestment consumed, since no row reports it", () => {
     // The one trade in either export with no cash row anywhere beside it: the
     // income buys the units without arriving as money first.
     const result = convert([
-      "2022-03-24,06 Apr 2022,Reinvestment From Income,Baillie Gifford Responsible Global Equity Income B Inc,Investment ISA,AS10123702,Baillie Gifford Responsible Global Equity Income B Inc,31.65,21.09,1.5,582193319,Completed,LON,Baillie Gifford Responsible Global Equity Income B Inc,FUND,Buy",
+      "2022-03-24,06 Apr 2022,Reinvestment From Income,Baillie Gifford Responsible Global Equity Income B Inc,Investment ISA,AS10000002,Baillie Gifford Responsible Global Equity Income B Inc,31.65,21.09,1.5,460143202,Completed,LON,Baillie Gifford Responsible Global Equity Income B Inc,FUND,Buy",
     ]);
 
     expect(result.errors).toEqual([]);
@@ -661,36 +662,36 @@ describe("trades the broker names for their reason", () => {
 
   it("settles a switch through the rows the broker used for it", () => {
     const result = convert([
-      "2023-06-28,29 Jun 2023,Cash Out,Cash,SIPP - Pension Savings Account,AP10024612,,-12091.15,12091.15,1,783688689,Completed,,GBP,CASH,Cash",
-      "2023-06-28,04 Jul 2023,Sell For Switch,M&G European Index Tracker,SIPP - Pension Savings Account,AP10024612,,-12091.15,12147.03,1,783688687,Completed,LON,M&G European Index Tracker,FUND,Sell",
-      "2023-06-28,29 Jun 2023,Buy For Switch,Cash,SIPP - Pension Savings Account,AP10024612,,12091.15,12091.15,1,783688692,Completed,,GBP,CASH,Cash",
-      "2023-06-28,04 Jul 2023,Cash In,Cash,SIPP - Pension Savings Account,AP10024612,,12091.15,12091.15,1,783688691,Completed,,GBP,CASH,Cash",
+      "2023-06-28,29 Jun 2023,Cash Out,Cash,SIPP - Pension Savings Account,AP10000002,,-12091.15,12091.15,1,661638572,Completed,,GBP,CASH,Cash",
+      "2023-06-28,04 Jul 2023,Sell For Switch,M&G European Index Tracker,SIPP - Pension Savings Account,AP10000002,,-12091.15,12147.03,1,661638570,Completed,LON,M&G European Index Tracker,FUND,Sell",
+      "2023-06-28,29 Jun 2023,Buy For Switch,Cash,SIPP - Pension Savings Account,AP10000002,,12091.15,12091.15,1,661638575,Completed,,GBP,CASH,Cash",
+      "2023-06-28,04 Jul 2023,Cash In,Cash,SIPP - Pension Savings Account,AP10000002,,12091.15,12091.15,1,661638574,Completed,,GBP,CASH,Cash",
     ]);
 
     expect(result.errors).toEqual([]);
     // The buy side names cash as the asset, so it is a movement of money rather
     // than a purchase of a security called Cash, and it nets against its cash out.
     expect(result.txs[2]!.type).toBe(TxType.CASHFLOW);
-    expect(result.txs[0]!.groupRef).toBe("783688692");
-    expect(result.txs[2]!.groupRef).toBe("783688692");
+    expect(result.txs[0]!.groupRef).toBe("661638575");
+    expect(result.txs[2]!.groupRef).toBe("661638575");
     // The sale side is a real disposal, and its proceeds arrive as a Cash In.
     expect(result.txs[1]!.type).toBe(TxType.SELLSTOCK);
-    expect(result.txs[1]!.groupRef).toBe("783688687");
-    expect(result.txs[3]!.groupRef).toBe("783688687");
+    expect(result.txs[1]!.groupRef).toBe("661638570");
+    expect(result.txs[3]!.groupRef).toBe("661638570");
   });
 
   it("retypes a Cash In that turned out to be a sale's proceeds", () => {
     // Cash In is normally money from outside the account, and no lookup on the
     // broker's name can tell the two apart -- only whether the row paired.
     const paired = convert([
-      "2023-06-28,04 Jul 2023,Sell For Switch,M&G European Index Tracker,SIPP - Pension Savings Account,AP10024612,,-12091.15,12147.03,1,783688687,Completed,LON,M&G European Index Tracker,FUND,Sell",
-      "2023-06-28,04 Jul 2023,Cash In,Cash,SIPP - Pension Savings Account,AP10024612,,12091.15,12091.15,1,783688691,Completed,,GBP,CASH,Cash",
+      "2023-06-28,04 Jul 2023,Sell For Switch,M&G European Index Tracker,SIPP - Pension Savings Account,AP10000002,,-12091.15,12147.03,1,661638570,Completed,LON,M&G European Index Tracker,FUND,Sell",
+      "2023-06-28,04 Jul 2023,Cash In,Cash,SIPP - Pension Savings Account,AP10000002,,12091.15,12091.15,1,661638574,Completed,,GBP,CASH,Cash",
     ]);
     expect(paired.txs[1]!.type).toBe(TxType.CASHFLOW);
     expect(paired.txs[1]!.tradingCurrency).toBe("GBP");
 
     const alone = convert([
-      "2023-06-28,04 Jul 2023,Cash In,Cash,SIPP - Pension Savings Account,AP10024612,,12091.15,12091.15,1,783688691,Completed,,GBP,CASH,Cash",
+      "2023-06-28,04 Jul 2023,Cash In,Cash,SIPP - Pension Savings Account,AP10000002,,12091.15,12091.15,1,661638574,Completed,,GBP,CASH,Cash",
     ]);
     expect(alone.txs[0]!.type).toBe(TxType.JRNLFUND);
     expect(alone.txs[0]!.groupRef).toBe("");
@@ -698,9 +699,9 @@ describe("trades the broker names for their reason", () => {
 
   it("skips a cancelled transaction and its cancelled cash row", () => {
     const result = convert([
-      '2024-07-22,22 Jul 2024,Sell,"INVESCO MARKETS III PLC, INVESCO EQQQ (EQQQ)",Investment Account,AG10041188,,0,0,373.51,969683719,Cancelled,LON,EQQQ,ETF,Sell',
-      "2024-07-22,22 Jul 2024,Cash In From Sell,Cash,Investment Account,AG10041188,,0,0,1,969683721,Cancelled,,GBP,CASH,Cash",
-      "2024-07-22,22 Jul 2024,Dealing Fee,Cash,Investment Account,AG10041188,,-7.5,0,0,222050117,Completed,,GBP,CASH,Cash",
+      '2024-07-22,22 Jul 2024,Sell,"INVESCO MARKETS III PLC, INVESCO EQQQ (EQQQ)",Investment Account,AG10000001,,0,0,373.51,847633602,Cancelled,LON,EQQQ,ETF,Sell',
+      "2024-07-22,22 Jul 2024,Cash In From Sell,Cash,Investment Account,AG10000001,,0,0,1,847633604,Cancelled,,GBP,CASH,Cash",
+      "2024-07-22,22 Jul 2024,Dealing Fee,Cash,Investment Account,AG10000001,,-7.5,0,0,100000000,Completed,,GBP,CASH,Cash",
     ]);
 
     expect(result.errors).toEqual([]);
@@ -721,7 +722,7 @@ describe("what a posting resolves to", () => {
 
   it("describes a cash posting by its currency and hints at it", () => {
     const result = convert([
-      "2022-01-11,11 Jan 2022,Service Fee,Cash,Cash Management Account,AW10075724,,-3.24,3.24,1,550895422,Completed,,GBP,CASH,Cash",
+      "2022-01-11,11 Jan 2022,Service Fee,Cash,Cash Management Account,AW10000001,,-3.24,3.24,1,428845305,Completed,,GBP,CASH,Cash",
     ]);
 
     expect(result.txs[0]!.instrumentDescription).toBe("GBP");
@@ -737,7 +738,7 @@ describe("what a posting resolves to", () => {
     // by the payer would resolve the money into that holding; carrying the payer
     // elsewhere is 0049's to decide.
     const result = convert([
-      '2022-02-11,11 Feb 2022,Cash Dividend,Cash,Investment ISA,AS10123702,"BAILLIE GIFFORD EUROPEAN GROWTH TST, ORD GBP0.025 (BGEU)",22.67,22.67,1,564233724,Completed,,GBP,CASH,Cash',
+      '2022-02-11,11 Feb 2022,Cash Dividend,Cash,Investment ISA,AS10000002,"BAILLIE GIFFORD EUROPEAN GROWTH TST, ORD GBP0.025 (BGEU)",22.67,22.67,1,442183607,Completed,,GBP,CASH,Cash',
     ]);
 
     expect(result.txs[0]!.instrumentDescription).toBe("GBP");
@@ -746,7 +747,7 @@ describe("what a posting resolves to", () => {
 
   it("keeps a security's own description and offers its ticker", () => {
     const result = convert([
-      '2022-02-08,10 Feb 2022,Sell,"WISE PLC, CLS A ORD GBP0.01 (WISE)",SIPP - Pension Savings Account,AP10013127,,-7266.49,1242,5.85,563466569,Completed,LON,WISE,STOCK,Sell',
+      '2022-02-08,10 Feb 2022,Sell,"WISE PLC, CLS A ORD GBP0.01 (WISE)",SIPP - Pension Savings Account,AP10000001,,-7266.49,1242,5.85,441416452,Completed,LON,WISE,STOCK,Sell',
     ]);
 
     expect(result.txs[0]!.instrumentDescription).toContain("WISE PLC");
@@ -760,7 +761,7 @@ describe("what a posting resolves to", () => {
     // exchange. Passing that on as a ticker would resolve to nothing and leave the
     // name in the security master twice, so the row goes on its description alone.
     const result = convert([
-      "2022-03-24,06 Apr 2022,Reinvestment From Income,Baillie Gifford Responsible Global Equity Income B Inc,Investment ISA,AS10123702,,31.65,21.09,1.5,582193319,Completed,LON,Baillie Gifford Responsible Global Equity Income B Inc,FUND,Buy",
+      "2022-03-24,06 Apr 2022,Reinvestment From Income,Baillie Gifford Responsible Global Equity Income B Inc,Investment ISA,AS10000002,,31.65,21.09,1.5,460143202,Completed,LON,Baillie Gifford Responsible Global Equity Income B Inc,FUND,Buy",
     ]);
 
     expect(result.txs[0]!.identifierHints).toEqual([]);
@@ -771,8 +772,8 @@ describe("what a posting resolves to", () => {
     // A ticker identifies an instrument only within an exchange. An exchange with
     // no MIC here is passed on bare rather than under a guess.
     const result = convert([
-      '2024-06-03,05 Jun 2024,Buy,"RHEINMETALL AG, ORD NPV (RHM)",Investment Account,AG10041188,,5000,10,500,1000000001,Completed,ETR,RHM,STOCK,Buy',
-      '2024-06-03,05 Jun 2024,Buy,"SAFRAN SA, ORD EUR0.20 (SAF)",Investment Account,AG10041188,,5000,25,200,1000000002,Completed,XXX,SAF,STOCK,Buy',
+      '2024-06-03,05 Jun 2024,Buy,"RHEINMETALL AG, ORD NPV (RHM)",Investment Account,AG10000001,,5000,10,500,1000000001,Completed,ETR,RHM,STOCK,Buy',
+      '2024-06-03,05 Jun 2024,Buy,"SAFRAN SA, ORD EUR0.20 (SAF)",Investment Account,AG10000001,,5000,25,200,1000000002,Completed,XXX,SAF,STOCK,Buy',
     ]);
 
     expect(result.txs[0]!.identifierHints[0]!.domain).toBe("XETR");
@@ -800,7 +801,7 @@ describe("counter-legs", () => {
     convertFidelityToStandard([HEAD, ...rows].join("\n"), { currency: "GBP" });
 
   it("names the account a charge went to", () => {
-    const result = convert([row("Dealing Fee", "Cash", "AG1", "-10", "10", "1", "563466600")]);
+    const result = convert([row("Dealing Fee", "Cash", "AG1", "-10", "10", "1", "441416483")]);
 
     expect(result.txs).toHaveLength(2);
     expect(result.txs[1].type).toBe(TxType.INVEXPENSE);
@@ -811,7 +812,7 @@ describe("counter-legs", () => {
   });
 
   it("names the account a dividend came from", () => {
-    const result = convert([row("Cash Dividend", "Cash", "AG1", "23.40", "23.40", "1", "563466601")]);
+    const result = convert([row("Cash Dividend", "Cash", "AG1", "23.40", "23.40", "1", "441416484")]);
 
     expect(result.txs).toHaveLength(2);
     expect(result.txs[1].accountType).toBe(AccountType.INCOME);
@@ -821,8 +822,8 @@ describe("counter-legs", () => {
 
   it("leaves a trade and its cash leg alone -- the source supplied both", () => {
     const result = convert([
-      row("Sell", "WISE PLC (WISE)", "AG1", "-7265.70", "1242", "5.85", "563466569"),
-      row("Cash In From Sell", "Cash", "AG1", "7265.70", "7265.70", "1", "563466571"),
+      row("Sell", "WISE PLC (WISE)", "AG1", "-7265.70", "1242", "5.85", "441416452"),
+      row("Cash In From Sell", "Cash", "AG1", "7265.70", "7265.70", "1", "441416454"),
     ]);
 
     expect(result.txs).toHaveLength(2);
@@ -831,9 +832,9 @@ describe("counter-legs", () => {
 
   it("balances a trade, its cash leg and the charge reported beside it", () => {
     const result = convert([
-      row("Sell", "WISE PLC (WISE)", "AG1", "-7265.70", "1242", "5.85", "563466569"),
-      row("Cash In From Sell", "Cash", "AG1", "7265.70", "7265.70", "1", "563466571"),
-      row("Dealing Fee", "Cash", "AG1", "-10", "10", "1", "563466600", "8 Feb 2022"),
+      row("Sell", "WISE PLC (WISE)", "AG1", "-7265.70", "1242", "5.85", "441416452"),
+      row("Cash In From Sell", "Cash", "AG1", "7265.70", "7265.70", "1", "441416454"),
+      row("Dealing Fee", "Cash", "AG1", "-10", "10", "1", "441416483", "8 Feb 2022"),
     ]);
 
     expect(result.txs).toHaveLength(4);
@@ -841,7 +842,7 @@ describe("counter-legs", () => {
   });
 
   it("does not invent a leg for a journal, whose other side is another account", () => {
-    const result = convert([row("Cash In", "Cash", "AG1", "5000", "5000", "1", "563466602")]);
+    const result = convert([row("Cash In", "Cash", "AG1", "5000", "5000", "1", "441416485")]);
 
     expect(result.txs).toHaveLength(1);
     expect(result.txs[0].type).toBe(TxType.JRNLFUND);
@@ -858,8 +859,8 @@ describe("trade cash legs", () => {
   // residual was routed to TRANSFER_CLEARING instead of IMBALANCE.
   it("are CASHFLOW, keeping their direction and currency", () => {
     const result = convert([
-      "8 Feb 2022,10 Feb 2022,Cash Out For Buy,Cash,Investment Account,AG1,,-401,401,1,730493547,Completed",
-      "8 Feb 2022,10 Feb 2022,Cash In From Sell,Cash,Investment Account,AG1,,7265.70,7265.70,1,563466571,Completed",
+      "8 Feb 2022,10 Feb 2022,Cash Out For Buy,Cash,Investment Account,AG1,,-401,401,1,608443430,Completed",
+      "8 Feb 2022,10 Feb 2022,Cash In From Sell,Cash,Investment Account,AG1,,7265.70,7265.70,1,441416454,Completed",
     ]);
 
     expect(result.txs[0].type).toBe(TxType.CASHFLOW);
@@ -881,13 +882,13 @@ describe("source references", () => {
   // last month's when the amounts are identical.
   it("carries the broker's reference onto every transcribed posting", () => {
     const result = convert([
-      "2022-05-06,2022-05-06,Transfer To Cash Management Account For Fees,Cash,SIPP,AP1,,-2.19,2.19,1,603102266,Completed",
-      "2022-05-06,2022-05-06,Cash In Ring-fenced For Fees,Cash,Cash Management Account,AW1,,2.19,2.19,1,603102269,Completed",
+      "2022-05-06,2022-05-06,Transfer To Cash Management Account For Fees,Cash,SIPP,AP1,,-2.19,2.19,1,481052149,Completed",
+      "2022-05-06,2022-05-06,Cash In Ring-fenced For Fees,Cash,Cash Management Account,AW1,,2.19,2.19,1,481052152,Completed",
     ]);
 
     expect(result.txs).toHaveLength(2);
-    expect(result.txs[0].brokerRef).toBe("603102266");
-    expect(result.txs[1].brokerRef).toBe("603102269");
+    expect(result.txs[0].brokerRef).toBe("481052149");
+    expect(result.txs[1].brokerRef).toBe("481052152");
   });
 
   // The export's "Source investment" column holds an asset name rather than an
@@ -895,7 +896,7 @@ describe("source references", () => {
   // not pretend otherwise.
   it("names no counterparty, because the CSV export carries none", () => {
     const result = convert([
-      "8 Feb 2022,10 Feb 2022,Sell,\"WISE PLC (WISE)\",Investment Account,AG1,Cash,-7266.49,1242,5.85,563466569,Completed",
+      "8 Feb 2022,10 Feb 2022,Sell,\"WISE PLC (WISE)\",Investment Account,AG1,Cash,-7266.49,1242,5.85,441416452,Completed",
     ]);
 
     expect(result.txs[0].counterpartyAccount).toBe("");
@@ -914,11 +915,11 @@ describe("source references", () => {
   // invention indistinguishable from a transcription.
   it("does not give a derived counter-leg a reference it never had", () => {
     const result = convert([
-      "8 Feb 2022,10 Feb 2022,Cash Dividend,Cash,Investment Account,AG1,,23.40,23.40,1,563466600,Completed",
+      "8 Feb 2022,10 Feb 2022,Cash Dividend,Cash,Investment Account,AG1,,23.40,23.40,1,441416483,Completed",
     ]);
 
     expect(result.txs).toHaveLength(2);
-    expect(result.txs[0].brokerRef).toBe("563466600");
+    expect(result.txs[0].brokerRef).toBe("441416483");
     expect(result.txs[1].accountType).toBe(AccountType.INCOME);
     expect(result.txs[1].brokerRef).toBe("");
     // Both legs still belong to one event.

--- a/client/lib/csv/converters/ibkr-ofx.test.ts
+++ b/client/lib/csv/converters/ibkr-ofx.test.ts
@@ -4,7 +4,7 @@ import { AccountType, IdentifierType, TxType } from "@/gen/type/v1/type_pb";
 import { expectGroupsBalance } from "@/lib/csv/group-balance.test-utils";
 
 /**
- * An option trade taken verbatim from local/masters/U7033034_20250107_20260107.qfx,
+ * An option trade taken verbatim from local/masters/U1000001_20250107_20260107.qfx,
  * with the OPTINFO that names it. It is here because it is the arithmetic the
  * contract size has to reproduce: 8 x 20.1105585 x 100 = 16088.4468, and only
  * with the multiplier does that plus the 7.420248 commission reach the
@@ -13,7 +13,7 @@ import { expectGroupsBalance } from "@/lib/csv/group-balance.test-utils";
  */
 const OPT_BUY = `<BUYOPT>
   <INVBUY>
-    <INVTRAN><FITID>20250123U70330347171218488</FITID><DTTRADE>20250123030529.000[-5:EST]</DTTRADE></INVTRAN>
+    <INVTRAN><FITID>20250123U10000017171218488</FITID><DTTRADE>20250123030529.000[-5:EST]</DTTRADE></INVTRAN>
     <SECID><UNIQUEID>731401093</UNIQUEID><UNIQUEIDTYPE>CONID</UNIQUEIDTYPE></SECID>
     <UNITS>8
     <UNITPRICE>20.1105585
@@ -42,7 +42,7 @@ VERSION:102
     <INVSTMTTRNRS>
       <INVSTMTRS>
         <CURDEF>GBP
-        <INVACCTFROM><BROKERID>4705</BROKERID><ACCTID>U7033034</ACCTID></INVACCTFROM>
+        <INVACCTFROM><BROKERID>4705</BROKERID><ACCTID>U1000001</ACCTID></INVACCTFROM>
         <INVTRANLIST>
           <DTSTART>20250101
           <DTEND>20250401

--- a/client/lib/csv/postings.test.ts
+++ b/client/lib/csv/postings.test.ts
@@ -143,7 +143,7 @@ describe("reinvestLeg", () => {
     instrumentDescription: "Baillie Gifford Responsible Global Equity Income B Inc",
     quantity: "21.09",
     unitPrice: "1.5",
-    groupRef: "582193319",
+    groupRef: "460143202",
   });
 
   it("names the income the units cost, in the income account", () => {
@@ -154,7 +154,7 @@ describe("reinvestLeg", () => {
     // the posting this balances, so the group comes out at exactly zero.
     expect(leg.quantity).toBe("-31.635");
     expect(leg.unitPrice).toBe("1");
-    expect(leg.groupRef).toBe("582193319");
+    expect(leg.groupRef).toBe("460143202");
     // Money, so it resolves to the currency rather than to the fund.
     expect(leg.instrumentDescription).toBe("GBP");
     expect(leg.identifierHints.map((h) => [h.type, h.value])).toEqual([
@@ -184,7 +184,7 @@ describe("refPrefix", () => {
   });
 
   it("leaves broker refs that share no prefix alone", () => {
-    expect(refPrefix([tx({ type: TxType.INCOME, groupRef: "563466569" })])).toBe("p");
+    expect(refPrefix([tx({ type: TxType.INCOME, groupRef: "441416452" })])).toBe("p");
   });
 });
 
@@ -200,9 +200,9 @@ describe("counterLegs", () => {
   });
 
   it("keeps a group the converter already assigned", () => {
-    const txs = [tx({ type: TxType.INVEXPENSE, quantity: "-3.24", groupRef: "563466600" })];
+    const txs = [tx({ type: TxType.INVEXPENSE, quantity: "-3.24", groupRef: "441416483" })];
     txs.push(...counterLegs(txs));
-    expect(txs[1]!.groupRef).toBe("563466600");
+    expect(txs[1]!.groupRef).toBe("441416483");
   });
 
   it("gives each one-sided row a group of its own", () => {

--- a/client/lib/csv/standard.test.ts
+++ b/client/lib/csv/standard.test.ts
@@ -366,16 +366,16 @@ describe("share count basis", () => {
 describe("group_ref", () => {
   it("carries the grouping key onto each posting", () => {
     const csv = `date,instrument_description,type,quantity,unit_price,account,group_ref
-2024-03-01,VOD - Vodafone,SELLSTOCK,-100,1.25,ACC1,563466569
-2024-03-01,Cash,CASHFLOW,125,1,ACC1,563466569
+2024-03-01,VOD - Vodafone,SELLSTOCK,-100,1.25,ACC1,441416452
+2024-03-01,Cash,CASHFLOW,125,1,ACC1,441416452
 2024-03-01,Dealing Fee,INVEXPENSE,-7.5,1,ACC1,`;
 
     const result = parseStandardCSV(csv);
 
     expect(result.errors).toHaveLength(0);
     expect(result.txs).toHaveLength(3);
-    expect(result.txs[0].groupRef).toBe("563466569");
-    expect(result.txs[1].groupRef).toBe("563466569");
+    expect(result.txs[0].groupRef).toBe("441416452");
+    expect(result.txs[1].groupRef).toBe("441416452");
     // A separately-reported charge is its own event, so it names no group.
     expect(result.txs[2].groupRef).toBe("");
   });
@@ -394,18 +394,18 @@ describe("group_ref", () => {
 describe("source references", () => {
   it("carries the broker's own reference and the account it names", () => {
     const csv = `date,instrument_description,type,quantity,account,group_ref,broker_ref,counterparty_account
-2025-04-15,GBP,TRANSFER,-20000,AG10041188,,1093663528,
-2025-04-15,GBP,TRANSFER,20000,AW10075724,,1093663531,AG10041188`;
+2025-04-15,GBP,TRANSFER,-20000,AG10000001,,971613411,
+2025-04-15,GBP,TRANSFER,20000,AW10000001,,971613414,AG10000001`;
 
     const result = parseStandardCSV(csv);
 
     expect(result.errors).toHaveLength(0);
     expect(result.txs).toHaveLength(2);
-    expect(result.txs[0].brokerRef).toBe("1093663528");
+    expect(result.txs[0].brokerRef).toBe("971613411");
     // Only the receiving side names the counterparty; the departure does not.
     expect(result.txs[0].counterpartyAccount).toBe("");
-    expect(result.txs[1].brokerRef).toBe("1093663531");
-    expect(result.txs[1].counterpartyAccount).toBe("AG10041188");
+    expect(result.txs[1].brokerRef).toBe("971613414");
+    expect(result.txs[1].counterpartyAccount).toBe("AG10000001");
   });
 
   it("is opaque: a reference that is not a number survives verbatim", () => {

--- a/client/lib/ofx/parser.test.ts
+++ b/client/lib/ofx/parser.test.ts
@@ -377,13 +377,13 @@ VERSION:102
 
 describe("groups and charges", () => {
   /**
-   * Verbatim from local/masters/U7033034_20250107_20260107.qfx, which is the
+   * Verbatim from local/masters/U1000001_20250107_20260107.qfx, which is the
    * arithmetic this has to reproduce: 378 x 61.06 + 11.54034 = 23092.22034, so
    * TOTAL is the consideration with the commission already in it.
    */
   const GBP_BUY = `<BUYSTOCK>
     <INVBUY>
-      <INVTRAN><FITID>20251015U70330348371888432</FITID><DTTRADE>20251015092129.000[-4:EDT]</DTTRADE></INVTRAN>
+      <INVTRAN><FITID>20251015U10000018371888432</FITID><DTTRADE>20251015092129.000[-4:EDT]</DTTRADE></INVTRAN>
       <SECID><UNIQUEID>IE00B4ND3602</UNIQUEID><UNIQUEIDTYPE>ISIN</UNIQUEIDTYPE></SECID>
       <UNITS>378
       <UNITPRICE>61.06
@@ -414,7 +414,7 @@ describe("groups and charges", () => {
   it("groups a trade with its cash leg on the broker's own reference", () => {
     const result = parse(GBP_BUY);
     const refs = new Set(result.txs.map((t) => t.groupRef));
-    expect(refs).toEqual(new Set(["20251015U70330348371888432"]));
+    expect(refs).toEqual(new Set(["20251015U10000018371888432"]));
   });
 
   // The same id says two different things: which postings are one event, and
@@ -423,7 +423,7 @@ describe("groups and charges", () => {
   it("keeps the FITID as the transcribed leg's source reference", () => {
     const result = parse(GBP_BUY);
     const refs = result.txs.map((t) => t.brokerRef);
-    expect(refs.filter((r) => r !== "")).toEqual(["20251015U70330348371888432"]);
+    expect(refs.filter((r) => r !== "")).toEqual(["20251015U10000018371888432"]);
   });
 
   it("splits the commission out of the netted total", () => {
@@ -472,7 +472,7 @@ describe("groups and charges", () => {
   });
 
   it("groups a trade whose source gave no reference", () => {
-    const result = parse(GBP_BUY.replace("<FITID>20251015U70330348371888432", "<FITID>"));
+    const result = parse(GBP_BUY.replace("<FITID>20251015U10000018371888432", "<FITID>"));
     const refs = new Set(result.txs.map((t) => t.groupRef));
     expect(refs.size).toBe(1);
     expect([...refs][0]).not.toBe("");

--- a/client/lib/ofx/sgml.test.ts
+++ b/client/lib/ofx/sgml.test.ts
@@ -91,7 +91,7 @@ ENCODING:USASCII
         <CURDEF>GBP
         <INVACCTFROM>
           <BROKERID>4705</BROKERID>
-          <ACCTID>U7033034</ACCTID>
+          <ACCTID>U1000001</ACCTID>
         </INVACCTFROM>
         <INVTRANLIST>
           <DTSTART>20260107202000.000[-5:EST]
@@ -132,7 +132,7 @@ ENCODING:USASCII
 
     expect(stmtRs.CURDEF).toBe("GBP");
     const acct = stmtRs.INVACCTFROM as Record<string, unknown>;
-    expect(acct.ACCTID).toBe("U7033034");
+    expect(acct.ACCTID).toBe("U1000001");
 
     const tranList = stmtRs.INVTRANLIST as Record<string, unknown>;
     expect(tranList.DTSTART).toBe("20260107202000.000[-5:EST]");

--- a/docs/issues/0040-csv-fees-net-amount.md
+++ b/docs/issues/0040-csv-fees-net-amount.md
@@ -65,7 +65,7 @@ before.
 
 ## Why IBKR's CSV keeps its commission in the residual
 
-`local/masters/Lee-IBKR-CWSY.csv` has no commission column, and its `Price` is
+The IBKR master in `local/masters/` has no commission column, and its `Price` is
 IBKR's own intraday conversion into the account's base currency while `Amount` is
 in the instrument's. Both candidate rates for the conversion were measured against
 the 599 trades in that master, and neither yields a commission:
@@ -90,11 +90,11 @@ masters are disjoint, the CSV ending 2025-01-06 and the QFX starting 2025-01-23.
 
 - Fidelity `JRNLFUND` and `TRANSFER` single-posting groups, about 636k and 200k --
   external transfers, matched by 0068.
-- Helen-Fidelity's 23 unpaired `BUYSTOCK` groups and one `SELLSTOCK` -- trade and
-  cash pairing failures. Closed by 0065: neither master leaves an unpaired trade
-  group now. 0069 was a different failure in the same list -- a lone `CASHFLOW`
-  group per deposit, 8 in Lee and 13 in Helen -- and closing it left none of those
-  either.
+- One Fidelity master's 23 unpaired `BUYSTOCK` groups and one `SELLSTOCK` -- trade
+  and cash pairing failures. Closed by 0065: neither master leaves an unpaired
+  trade group now. 0069 was a different failure in the same list -- a lone
+  `CASHFLOW` group per deposit, 8 in one master and 13 in the other -- and closing
+  it left none of those either.
 - Schwab's three groups worth 667,750 -- the export's quantities are split adjusted
   while its prices are as traded, so pre-split GOOG and TSLA rows cannot balance.
   That is 0057.

--- a/docs/issues/0064-fidelity-converter-groups.md
+++ b/docs/issues/0064-fidelity-converter-groups.md
@@ -18,7 +18,7 @@ in the raw export and is discarded by the converters, which keep neither
 
 ## Pairing rules
 
-Measured against `local/masters/Lee-Fidelity-CWSY.csv`:
+Measured against the Fidelity master in `local/masters/`:
 
 - `Sell` -> `Cash In From Sell`: exact `|Amount|` match within (Account Number,
   Completion date). 55/55, no residual.

--- a/docs/issues/0073-schwab-client-converter.md
+++ b/docs/issues/0073-schwab-client-converter.md
@@ -33,7 +33,7 @@ to update.
 
 ## Blocked on sample data
 
-No genuine Schwab export is in the repo. `local/masters/Helen-Schwab-CWSY.csv` has
+No genuine Schwab export is in the repo. The Schwab master in `local/masters/` has
 been through CWSY pre-processing: columns 0-7 are the raw Schwab view and 8-13 are
 added. Writing the converter against those first eight columns would leave every
 real-export quirk unverified -- the preamble and total rows, `"02/08/2022 as of
@@ -43,5 +43,5 @@ first.
 ## Out of scope
 
 The mixed share count basis noted above is 0057, not this issue. It is what leaves
-three groups in `Helen-Schwab.csv` unbalanced by 667,750 USD, and no fee handling
+three groups in the Schwab master unbalanced by 667,750 USD, and no fee handling
 will close that gap.

--- a/docs/spec/auth.md
+++ b/docs/spec/auth.md
@@ -153,7 +153,7 @@ Implement two interceptors:
 
 - Configurable allowlist as a list of patterns. Support at least one of:
   - Regex patterns, or
-  - Glob-like patterns (e.g. `*@example.com`, `lee+*@gmail.com`)
+  - Glob-like patterns (e.g. `*@example.com`, `user+*@example.org`)
 - Matching is performed against the verified email from the authenticated session identity.
 - If not matched: return **PermissionDenied** with a generic message.
 
@@ -166,7 +166,7 @@ Implement two interceptors:
 ### Example patterns
 
 - `*@mycompany.com`
-- `lee.denison@*`
+- `first.last@*`
 - `*@example.org`
 
 ## Envoy / gRPC-Web Requirements (non-auth)

--- a/extension/src/brokers/fidelity-json.test.ts
+++ b/extension/src/brokers/fidelity-json.test.ts
@@ -190,10 +190,10 @@ describe("convertFidelityJson", () => {
 // out is reported as a Buy or Sell of it against a pseudo-ISIN. Mapping on the
 // transaction type alone made each one a security trade in units of money, and
 // lost the movement the third row of the sequence records. Rows from the
-// captured payload, AP10013127 on 18/05/2026 and AG10041188 on 15/04/2025.
+// captured payload, AP10000001 on 18/05/2026 and AG10000001 on 15/04/2025.
 describe("convertFidelityJson cash-asset rows", () => {
   const cash = (fields: Record<string, unknown>) => ({
-    accountNumber: "AP10013127",
+    accountNumber: "AP10000001",
     assetName: "Cash",
     isin: "AA00R0000000",
     sedol: "R000000",
@@ -210,17 +210,17 @@ describe("convertFidelityJson cash-asset rows", () => {
   const BUY_CASH = cash({
     transactionType: "Buy",
     debitCreditIndicator: "CREDIT",
-    referenceId: "1288903396",
+    referenceId: "1166853279",
   });
   const CASH_OUT = cash({
     transactionType: "Cash Out For Buy From Transfer",
     debitCreditIndicator: "DEBIT",
-    referenceId: "1288903394",
+    referenceId: "1166853277",
   });
   const ARRIVAL = cash({
     transactionType: "Cash In For Transfer",
     debitCreditIndicator: "CREDIT",
-    referenceId: "1288903395",
+    referenceId: "1166853278",
   });
 
   it("is a cash movement, not a security trade", () => {
@@ -239,8 +239,8 @@ describe("convertFidelityJson cash-asset rows", () => {
 
   it("groups a purchase of cash with the cash out beside it", () => {
     const result = convertFidelityJson(json(CASH_OUT, BUY_CASH));
-    expect(result.txs[0]!.groupRef).toBe("1288903396");
-    expect(result.txs[1]!.groupRef).toBe("1288903396");
+    expect(result.txs[0]!.groupRef).toBe("1166853279");
+    expect(result.txs[1]!.groupRef).toBe("1166853279");
     expectGroupsBalance(result.txs);
   });
 
@@ -257,31 +257,31 @@ describe("convertFidelityJson cash-asset rows", () => {
 
   it("reads a sale of cash the same way", () => {
     const sell = cash({
-      accountNumber: "AG10041188",
+      accountNumber: "AG10000001",
       isin: "AA00S0000000",
       sedol: "S000000",
       transactionType: "Sell",
       debitCreditIndicator: "DEBIT",
       units: 20000,
       valuation: 20000,
-      referenceId: "1093663529",
+      referenceId: "971613412",
     });
     const cashIn = cash({
-      accountNumber: "AG10041188",
+      accountNumber: "AG10000001",
       isin: "AA00S0000000",
       sedol: "S000000",
       transactionType: "Cash In From Sell",
       debitCreditIndicator: "CREDIT",
       units: 20000,
       valuation: 20000,
-      referenceId: "1093663530",
+      referenceId: "971613413",
     });
 
     const result = convertFidelityJson(json(sell, cashIn));
     expect(result.txs[0]!.type).toBe(TxType.CASHFLOW);
     expect(result.txs[0]!.quantity).toBe("-20000");
-    expect(result.txs[0]!.groupRef).toBe("1093663529");
-    expect(result.txs[1]!.groupRef).toBe("1093663529");
+    expect(result.txs[0]!.groupRef).toBe("971613412");
+    expect(result.txs[1]!.groupRef).toBe("971613412");
     expectGroupsBalance(result.txs);
   });
 
@@ -301,21 +301,21 @@ describe("convertFidelityJson cash-asset rows", () => {
       debitCreditIndicator: "DEBIT",
       units: 12147.03,
       valuation: 12091.15,
-      referenceId: "783688687",
+      referenceId: "661638570",
     });
     const proceeds = cash({
       transactionType: "Cash In",
       debitCreditIndicator: "CREDIT",
       units: 12091.15,
       valuation: 12091.15,
-      referenceId: "783688691",
+      referenceId: "661638574",
     });
 
     const result = convertFidelityJson(json(sale, proceeds));
     expect(result.txs[0]!.type).toBe(TxType.SELLSTOCK);
     expect(result.txs[1]!.type).toBe(TxType.CASHFLOW);
     expect(result.txs[1]!.tradingCurrency).toBe("GBP");
-    expect(result.txs[1]!.groupRef).toBe("783688687");
+    expect(result.txs[1]!.groupRef).toBe("661638570");
   });
 });
 
@@ -339,7 +339,7 @@ describe("convertFidelityJson grouping", () => {
           valuation: 7266.49,
           pricePerUnit: 5.85,
           debitCreditIndicator: "DEBIT",
-          referenceId: "563466569",
+          referenceId: "441416452",
         }),
         trade({
           transactionType: "Cash In From Sell",
@@ -347,14 +347,14 @@ describe("convertFidelityJson grouping", () => {
           units: 7266.49,
           valuation: 7266.49,
           debitCreditIndicator: "CREDIT",
-          referenceId: "563466571",
+          referenceId: "441416454",
         })
       )
     );
 
     expect(result.txs).toHaveLength(2);
-    expect(result.txs[0]!.groupRef).toBe("563466569");
-    expect(result.txs[1]!.groupRef).toBe("563466569");
+    expect(result.txs[0]!.groupRef).toBe("441416452");
+    expect(result.txs[1]!.groupRef).toBe("441416452");
   });
 
   it("pairs a buy with the cash out despite the fee gap", () => {
@@ -366,7 +366,7 @@ describe("convertFidelityJson grouping", () => {
           units: 7380.19,
           valuation: 7380.19,
           debitCreditIndicator: "DEBIT",
-          referenceId: "563466631",
+          referenceId: "441416514",
         }),
         trade({
           transactionType: "Buy",
@@ -375,13 +375,13 @@ describe("convertFidelityJson grouping", () => {
           valuation: 7390.19,
           pricePerUnit: 263.58,
           debitCreditIndicator: "CREDIT",
-          referenceId: "563466632",
+          referenceId: "441416515",
         })
       )
     );
 
-    expect(result.txs[0]!.groupRef).toBe("563466632");
-    expect(result.txs[1]!.groupRef).toBe("563466632");
+    expect(result.txs[0]!.groupRef).toBe("441416515");
+    expect(result.txs[1]!.groupRef).toBe("441416515");
   });
 
   it("keeps a separately reported charge out of any trade's group", () => {
@@ -393,7 +393,7 @@ describe("convertFidelityJson grouping", () => {
           units: 10,
           valuation: 10,
           debitCreditIndicator: "DEBIT",
-          referenceId: "563466600",
+          referenceId: "441416483",
         })
       )
     );
@@ -411,7 +411,7 @@ describe("convertFidelityJson grouping", () => {
     // lands. Grouped, the account is left with one residual for one deposit.
     const deposit = (fields: Record<string, unknown>) =>
       trade({
-        accountNumber: "AS10110796",
+        accountNumber: "AS10000001",
         assetName: "Cash",
         isin: "AA00S0000000",
         units: 20000,
@@ -426,26 +426,26 @@ describe("convertFidelityJson grouping", () => {
         deposit({
           transactionType: "Cash In Lump Sum",
           debitCreditIndicator: "CREDIT",
-          referenceId: "1093663545",
+          referenceId: "971613428",
         }),
         deposit({
           transactionType: "Cash Out For Buy",
           debitCreditIndicator: "DEBIT",
-          referenceId: "1093663546",
+          referenceId: "971613429",
         }),
         deposit({
           transactionType: "Cash In",
           debitCreditIndicator: "CREDIT",
-          referenceId: "1093663548",
+          referenceId: "971613431",
         })
       )
     );
 
     expect(result.errors).toEqual([]);
     expect(result.txs.map((tx) => tx.groupRef)).toEqual([
-      "1093663545",
-      "1093663545",
-      "1093663545",
+      "971613428",
+      "971613428",
+      "971613428",
     ]);
     // The journals stay journals, which is what routes the group's residual to
     // TRANSFER_CLEARING rather than IMBALANCE.
@@ -484,7 +484,7 @@ describe("convertFidelityJson grouping", () => {
 
 describe("source references", () => {
   const base = {
-    accountNumber: "AW10075724",
+    accountNumber: "AW10000001",
     assetName: "Cash",
     isin: "AA00K0000000",
     currency: "GBP",
@@ -502,14 +502,14 @@ describe("source references", () => {
         debitCreditIndicator: "CREDIT",
         units: 20000,
         valuation: 20000,
-        referenceId: "1093663531",
-        sourceOrTargetAccount: "AG10041188",
+        referenceId: "971613414",
+        sourceOrTargetAccount: "AG10000001",
       })
     );
 
     expect(result.errors).toEqual([]);
-    expect(result.txs[0]!.brokerRef).toBe("1093663531");
-    expect(result.txs[0]!.counterpartyAccount).toBe("AG10041188");
+    expect(result.txs[0]!.brokerRef).toBe("971613414");
+    expect(result.txs[0]!.counterpartyAccount).toBe("AG10000001");
   });
 
   it("leaves the counterparty empty where the source names none", () => {
@@ -520,11 +520,11 @@ describe("source references", () => {
         debitCreditIndicator: "DEBIT",
         units: 20000,
         valuation: 20000,
-        referenceId: "1093663547",
+        referenceId: "971613430",
       })
     );
 
-    expect(result.txs[0]!.brokerRef).toBe("1093663547");
+    expect(result.txs[0]!.brokerRef).toBe("971613430");
     expect(result.txs[0]!.counterpartyAccount).toBe("");
   });
 
@@ -542,14 +542,14 @@ describe("source references", () => {
         debitCreditIndicator: "DEBIT",
         units: 5.13,
         valuation: 5.13,
-        referenceId: "1299133228",
-        sourceOrTargetAccount: "AP10013127",
+        referenceId: "1177083111",
+        sourceOrTargetAccount: "AP10000001",
       })
     );
 
     const fee = result.txs[0]!;
     expect(fee.type).toBe(TxType.INVEXPENSE);
-    expect(fee.counterpartyAccount).toBe("AP10013127");
+    expect(fee.counterpartyAccount).toBe("AP10000001");
     // The derived expense leg is the converter's own, so it names no source row.
     const expense = result.txs.find((tx) => tx.accountType === AccountType.EXPENSE)!;
     expect(expense.brokerRef).toBe("");

--- a/extension/src/lib/api.test.ts
+++ b/extension/src/lib/api.test.ts
@@ -37,12 +37,12 @@ describe("api", () => {
   });
 
   it("sends the session as a bearer token and omits credentials", async () => {
-    const res = create(GetSessionResponseSchema, { user: { email: "lee@example.com" } });
+    const res = create(GetSessionResponseSchema, { user: { email: "user@example.com" } });
     const spy = mockFetch(toBinary(GetSessionResponseSchema, res));
 
     const got = await getSession(ORIGIN, SESSION);
 
-    expect(got.user?.email).toBe("lee@example.com");
+    expect(got.user?.email).toBe("user@example.com");
     const [url, init] = spy.mock.calls[0]!;
     expect(url).toBe(`${ORIGIN}/portfoliodb.auth.v1.AuthService/GetSession`);
     expect(init?.headers).toMatchObject({ Authorization: `Bearer ${SESSION}` });

--- a/server/db/postgres/transfer_matches_test.go
+++ b/server/db/postgres/transfer_matches_test.go
@@ -37,8 +37,8 @@ func transferFixture(t *testing.T, p *Postgres, userID, instID string) (from, to
 		}
 	}
 	f, b := period()
-	txs := append(side("AG10041188", "-20000", "1093663528", ""),
-		side("AW10075724", "20000", "1093663531", "AG10041188")...)
+	txs := append(side("AG10000001", "-20000", "971613411", ""),
+		side("AW10000001", "20000", "971613414", "AG10000001")...)
 	ids := []string{instID, instID, instID, instID}
 	if err := p.ReplaceTxsInPeriod(ctx, userID, "FIDELITY", "", f, b, txs, ids, nil, nil); err != nil {
 		t.Fatalf("replace: %v", err)
@@ -101,7 +101,7 @@ func TestListUnmatchedTransferSides_ReadsBothSidesWithTheirEvidence(t *testing.T
 	for _, s := range sides {
 		byAccount[s.Account] = s
 	}
-	departure, arrival := byAccount["AG10041188"], byAccount["AW10075724"]
+	departure, arrival := byAccount["AG10000001"], byAccount["AW10000001"]
 	if !departure.Amount.Add(arrival.Amount).IsZero() {
 		t.Errorf("sides sum to %v, want a pair summing to exactly zero",
 			departure.Amount.Add(arrival.Amount))
@@ -110,15 +110,15 @@ func TestListUnmatchedTransferSides_ReadsBothSidesWithTheirEvidence(t *testing.T
 		t.Errorf("departure amount = %v, want positive: the value left this account", departure.Amount)
 	}
 	// The evidence comes from the journal leg, not from the residual beside it.
-	if len(departure.BrokerRefs) != 1 || departure.BrokerRefs[0] != "1093663528" {
-		t.Errorf("departure broker refs = %v, want [1093663528]", departure.BrokerRefs)
+	if len(departure.BrokerRefs) != 1 || departure.BrokerRefs[0] != "971613411" {
+		t.Errorf("departure broker refs = %v, want [971613411]", departure.BrokerRefs)
 	}
 	if len(departure.CounterpartyAccounts) != 0 {
 		t.Errorf("departure counterparties = %v, want none: only the receiving side names one",
 			departure.CounterpartyAccounts)
 	}
-	if len(arrival.CounterpartyAccounts) != 1 || arrival.CounterpartyAccounts[0] != "AG10041188" {
-		t.Errorf("arrival counterparties = %v, want [AG10041188]", arrival.CounterpartyAccounts)
+	if len(arrival.CounterpartyAccounts) != 1 || arrival.CounterpartyAccounts[0] != "AG10000001" {
+		t.Errorf("arrival counterparties = %v, want [AG10000001]", arrival.CounterpartyAccounts)
 	}
 }
 

--- a/server/db/postgres/txs_test.go
+++ b/server/db/postgres/txs_test.go
@@ -902,9 +902,9 @@ func TestReplaceTxsInPeriod_RoundTripsSourceReferences(t *testing.T) {
 	// references, and only the receiving side naming where the money came from.
 	txs := []*apiv1.Tx{
 		{Timestamp: timestamppb.New(base), InstrumentDescription: "GBP", Type: typev1.TxType_TRANSFER,
-			Quantity: "-20000", Account: "AG10041188", BrokerRef: "1093663528"},
+			Quantity: "-20000", Account: "AG10000001", BrokerRef: "971613411"},
 		{Timestamp: timestamppb.New(base), InstrumentDescription: "GBP", Type: typev1.TxType_TRANSFER,
-			Quantity: "20000", Account: "AW10075724", BrokerRef: "1093663531", CounterpartyAccount: "AG10041188"},
+			Quantity: "20000", Account: "AW10000001", BrokerRef: "971613414", CounterpartyAccount: "AG10000001"},
 	}
 	from, to := timestamppb.New(base), timestamppb.New(base.Add(24*time.Hour))
 	if err := p.ReplaceTxsInPeriod(ctx, userID, "Fidelity", "", from, to, txs, []string{instID, instID}, nil, nil); err != nil {
@@ -938,20 +938,20 @@ func TestReplaceTxsInPeriod_RoundTripsSourceReferences(t *testing.T) {
 	if len(got) != 2 {
 		t.Fatalf("stored %d postings, want 2", len(got))
 	}
-	departure, arrival := got["AG10041188"], got["AW10075724"]
-	if departure.ref == nil || *departure.ref != "1093663528" {
-		t.Errorf("departure broker_ref = %v, want 1093663528", departure.ref)
+	departure, arrival := got["AG10000001"], got["AW10000001"]
+	if departure.ref == nil || *departure.ref != "971613411" {
+		t.Errorf("departure broker_ref = %v, want 971613411", departure.ref)
 	}
 	// The source named no counterparty on the departure, so nothing is stored --
 	// not an empty string.
 	if departure.counterparty != nil {
 		t.Errorf("departure counterparty_account = %q, want NULL", *departure.counterparty)
 	}
-	if arrival.ref == nil || *arrival.ref != "1093663531" {
-		t.Errorf("arrival broker_ref = %v, want 1093663531", arrival.ref)
+	if arrival.ref == nil || *arrival.ref != "971613414" {
+		t.Errorf("arrival broker_ref = %v, want 971613414", arrival.ref)
 	}
-	if arrival.counterparty == nil || *arrival.counterparty != "AG10041188" {
-		t.Errorf("arrival counterparty_account = %v, want AG10041188", arrival.counterparty)
+	if arrival.counterparty == nil || *arrival.counterparty != "AG10000001" {
+		t.Errorf("arrival counterparty_account = %v, want AG10000001", arrival.counterparty)
 	}
 }
 

--- a/server/service/ingestion/balance_test.go
+++ b/server/service/ingestion/balance_test.go
@@ -120,7 +120,7 @@ func TestRouteResiduals(t *testing.T) {
 	}, {
 		// An option is quoted per share and traded per contract, so its leg only
 		// reaches the cash it was exchanged for once the contract size is applied.
-		// Figures from local/masters/U7033034_20250107_20260107.qfx: 8 contracts at
+		// Figures from local/masters/U1000001_20250107_20260107.qfx: 8 contracts at
 		// 20.1105585 settles at -16088.4468 before commission.
 		name: "option trade balances against the cash it settled for",
 		postings: []posting{

--- a/server/transfermatch/match.go
+++ b/server/transfermatch/match.go
@@ -286,7 +286,8 @@ func names(accounts []string, account string) bool {
 //
 // The nearest gap over both sets, not between two chosen values: a group is several
 // source rows and the reference nearest the other side is the one that matters. The
-// sample's lump sum is 545/546/548 against 547, where the nearest is 1.
+// sample's lump sum is three consecutive references against a fourth, where the
+// nearest gap is 1 and the widest is 3.
 //
 // A reference that is not a number simply makes this pass inapplicable. An OFX FITID
 // is opaque and unique within one statement, so two of them are never comparable

--- a/server/transfermatch/match_test.go
+++ b/server/transfermatch/match_test.go
@@ -69,8 +69,8 @@ func TestMatch(t *testing.T) {
 		// source outright, which is the only evidence that needs no proximity.
 		name: "the source names the other account",
 		sides: []db.TransferSide{
-			side("g-fund", "AG10041188", "20000", 0, "1093663528"),
-			pointing(side("g-cma", "AW10075724", "-20000", 0, "1093663531"), "AG10041188"),
+			side("g-fund", "AG10000001", "20000", 0, "971613411"),
+			pointing(side("g-cma", "AW10000001", "-20000", 0, "971613414"), "AG10000001"),
 		},
 		want: []link{{"g-fund", "g-cma", db.TransferMatchPointer}},
 	}, {
@@ -78,8 +78,8 @@ func TestMatch(t *testing.T) {
 		// window it names a different transfer between the same two accounts.
 		name: "a pointer outside the window matches nothing",
 		sides: []db.TransferSide{
-			side("g-fund", "AG10041188", "20000", 0, "1093663528"),
-			pointing(side("g-cma", "AW10075724", "-20000", 30, "1099999999"), "AG10041188"),
+			side("g-fund", "AG10000001", "20000", 0, "971613411"),
+			pointing(side("g-cma", "AW10000001", "-20000", 30, "1099999999"), "AG10000001"),
 		},
 		want: nil,
 	}, {
@@ -87,9 +87,9 @@ func TestMatch(t *testing.T) {
 		// far away to separate them either. Surfacing both beats guessing.
 		name: "a pointer with two identical candidates matches neither",
 		sides: []db.TransferSide{
-			side("g-fund", "AG10041188", "20000", 0, "1000000000"),
-			pointing(side("g-cma-a", "AW10075724", "-20000", 0, "2000000000"), "AG10041188"),
-			pointing(side("g-cma-b", "AW10075724", "-20000", 0, "3000000000"), "AG10041188"),
+			side("g-fund", "AG10000001", "20000", 0, "1000000000"),
+			pointing(side("g-cma-a", "AW10000001", "-20000", 0, "2000000000"), "AG10000001"),
+			pointing(side("g-cma-b", "AW10000001", "-20000", 0, "3000000000"), "AG10000001"),
 		},
 		want: nil,
 	}, {
@@ -98,8 +98,8 @@ func TestMatch(t *testing.T) {
 		// one group, so its references are a run and the nearest is 1.
 		name: "adjacent references pair the hop no pointer names",
 		sides: []db.TransferSide{
-			side("g-cma", "AW10075724", "20000", 0, "1093663547"),
-			side("g-isa", "AS10110796", "-20000", 0, "1093663545", "1093663546", "1093663548"),
+			side("g-cma", "AW10000001", "20000", 0, "971613430"),
+			side("g-isa", "AS10000001", "-20000", 0, "971613428", "971613429", "971613431"),
 		},
 		want: []link{{"g-cma", "g-isa", db.TransferMatchReference}},
 	}, {
@@ -108,15 +108,15 @@ func TestMatch(t *testing.T) {
 		// the span is not the eight the deposit-run heuristic uses.
 		name: "a wide but real reference gap still pairs",
 		sides: []db.TransferSide{
-			side("g-cma", "AW10218541", "5.31", 0, "1044926841"),
-			side("g-sipp", "AP10024612", "-5.31", 0, "1044926900"),
+			side("g-cma", "AW10000002", "5.31", 0, "922876724"),
+			side("g-sipp", "AP10000002", "-5.31", 0, "922876783"),
 		},
 		want: []link{{"g-cma", "g-sipp", db.TransferMatchReference}},
 	}, {
 		name: "references far apart are not proximity",
 		sides: []db.TransferSide{
-			side("g-a", "AG10041188", "20000", 0, "1000000000"),
-			side("g-b", "AW10075724", "-20000", 0, "1000000400"),
+			side("g-a", "AG10000001", "20000", 0, "1000000000"),
+			side("g-b", "AW10000001", "-20000", 0, "1000000400"),
 		},
 		want: nil,
 	}, {
@@ -125,12 +125,12 @@ func TestMatch(t *testing.T) {
 		// one month from the next.
 		name: "monthly fee transfers pair within their own month",
 		sides: []db.TransferSide{
-			side("jan-isa", "AS10110796", "2.16", 0, "1046659862"),
-			side("jan-cma", "AW10075724", "-2.16", 0, "1046659864"),
-			side("feb-isa", "AS10110796", "2.17", 30, "1062159454"),
-			side("feb-cma", "AW10075724", "-2.17", 30, "1062159457"),
-			side("mar-isa", "AS10110796", "2.16", 58, "1075213007"),
-			side("mar-cma", "AW10075724", "-2.16", 58, "1075213009"),
+			side("jan-isa", "AS10000001", "2.16", 0, "924609745"),
+			side("jan-cma", "AW10000001", "-2.16", 0, "924609747"),
+			side("feb-isa", "AS10000001", "2.17", 30, "940109337"),
+			side("feb-cma", "AW10000001", "-2.17", 30, "940109340"),
+			side("mar-isa", "AS10000001", "2.16", 58, "953162890"),
+			side("mar-cma", "AW10000001", "-2.16", 58, "953162892"),
 		},
 		want: []link{
 			{"jan-isa", "jan-cma", db.TransferMatchReference},
@@ -144,9 +144,9 @@ func TestMatch(t *testing.T) {
 		// stops the report finding the side that really is missing.
 		name: "equally near candidates match neither",
 		sides: []db.TransferSide{
-			side("g-a", "AS10110796", "2.16", 0, "1046659864"),
-			side("g-b1", "AW10075724", "-2.16", 0, "1046659862"),
-			side("g-b2", "AW10075724", "-2.16", 0, "1046659866"),
+			side("g-a", "AS10000001", "2.16", 0, "924609747"),
+			side("g-b1", "AW10000001", "-2.16", 0, "924609745"),
+			side("g-b2", "AW10000001", "-2.16", 0, "924609749"),
 		},
 		want: nil,
 	}, {
@@ -155,10 +155,10 @@ func TestMatch(t *testing.T) {
 		// accounts in one window are distinguishable after all.
 		name: "references separate two same-amount transfers in one window",
 		sides: []db.TransferSide{
-			side("g-a1", "AS10110796", "2.16", 0, "1046659862"),
-			side("g-a2", "AS10110796", "2.16", 0, "1046659872"),
-			side("g-b1", "AW10075724", "-2.16", 0, "1046659864"),
-			side("g-b2", "AW10075724", "-2.16", 0, "1046659874"),
+			side("g-a1", "AS10000001", "2.16", 0, "924609745"),
+			side("g-a2", "AS10000001", "2.16", 0, "924609755"),
+			side("g-b1", "AW10000001", "-2.16", 0, "924609747"),
+			side("g-b2", "AW10000001", "-2.16", 0, "924609757"),
 		},
 		want: []link{
 			{"g-a1", "g-b1", db.TransferMatchReference},
@@ -169,7 +169,7 @@ func TestMatch(t *testing.T) {
 		// pair it with and it must stay unmatched: it is a real external flow.
 		name: "a deposit with no counterpart stays unmatched",
 		sides: []db.TransferSide{
-			side("g-isa", "AS10110796", "-19599", 0, "675163172"),
+			side("g-isa", "AS10000001", "-19599", 0, "553113055"),
 		},
 		want: nil,
 	}, {
@@ -178,9 +178,9 @@ func TestMatch(t *testing.T) {
 		// an amount and a date alone are not evidence.
 		name: "a cross-broker pair is left unmatched",
 		sides: []db.TransferSide{
-			side("g-fid", "AG10041188", "20000", 0, "1093663528"),
+			side("g-fid", "AG10000001", "20000", 0, "971613411"),
 			func() db.TransferSide {
-				s := side("g-ibkr", "U7033034", "-20000", 0, "1093663531")
+				s := side("g-ibkr", "U1000001", "-20000", 0, "971613414")
 				s.Broker = typev1.Broker_IBKR
 				return s
 			}(),
@@ -191,9 +191,9 @@ func TestMatch(t *testing.T) {
 		// outside the broker that issued it.
 		name: "a cross-broker pointer is not a pointer",
 		sides: []db.TransferSide{
-			side("g-fid", "AG10041188", "20000", 0, "1093663528"),
+			side("g-fid", "AG10000001", "20000", 0, "971613411"),
 			func() db.TransferSide {
-				s := pointing(side("g-ibkr", "U7033034", "-20000", 0, "9999999999"), "AG10041188")
+				s := pointing(side("g-ibkr", "U1000001", "-20000", 0, "9999999999"), "AG10000001")
 				s.Broker = typev1.Broker_IBKR
 				return s
 			}(),
@@ -202,8 +202,8 @@ func TestMatch(t *testing.T) {
 	}, {
 		name: "money moving within one account is not a transfer",
 		sides: []db.TransferSide{
-			side("g-a", "AP10013127", "12772.83", 0, "1288903394"),
-			side("g-b", "AP10013127", "-12772.83", 0, "1288903395"),
+			side("g-a", "AP10000001", "12772.83", 0, "1166853277"),
+			side("g-b", "AP10000001", "-12772.83", 0, "1166853278"),
 		},
 		want: nil,
 	}, {
@@ -212,16 +212,16 @@ func TestMatch(t *testing.T) {
 		// find, and the matcher must not invent one.
 		name: "two sides of the same sign are not a pair",
 		sides: []db.TransferSide{
-			side("g-a", "AG10041188", "20000", 0, "1093663528"),
-			side("g-b", "AW10075724", "20000", 0, "1093663531"),
+			side("g-a", "AG10000001", "20000", 0, "971613411"),
+			side("g-b", "AW10000001", "20000", 0, "971613414"),
 		},
 		want: nil,
 	}, {
 		name: "a transfer never crosses a commodity",
 		sides: []db.TransferSide{
-			side("g-a", "AG10041188", "20000", 0, "1093663528"),
+			side("g-a", "AG10000001", "20000", 0, "971613411"),
 			func() db.TransferSide {
-				s := side("g-b", "AW10075724", "-20000", 0, "1093663531")
+				s := side("g-b", "AW10000001", "-20000", 0, "971613414")
 				s.InstrumentID = "usd"
 				return s
 			}(),
@@ -230,9 +230,9 @@ func TestMatch(t *testing.T) {
 	}, {
 		name: "a transfer never crosses a user",
 		sides: []db.TransferSide{
-			side("g-a", "AG10041188", "20000", 0, "1093663528"),
+			side("g-a", "AG10000001", "20000", 0, "971613411"),
 			func() db.TransferSide {
-				s := side("g-b", "AW10075724", "-20000", 0, "1093663531")
+				s := side("g-b", "AW10000001", "-20000", 0, "971613414")
 				s.UserID = "u2"
 				return s
 			}(),
@@ -243,8 +243,8 @@ func TestMatch(t *testing.T) {
 		// weekend still has to pair.
 		name: "the two sides need not share a date",
 		sides: []db.TransferSide{
-			side("g-a", "AG10041188", "20000", 0, "1093663528"),
-			side("g-b", "AW10075724", "-20000", 2, "1093663531"),
+			side("g-a", "AG10000001", "20000", 0, "971613411"),
+			side("g-b", "AW10000001", "-20000", 2, "971613414"),
 		},
 		want: []link{{"g-a", "g-b", db.TransferMatchReference}},
 	}, {
@@ -253,8 +253,8 @@ func TestMatch(t *testing.T) {
 		// than producing a nonsense distance.
 		name: "an opaque reference is no proximity signal",
 		sides: []db.TransferSide{
-			side("g-a", "U7033034", "20000", 0, "20251015U70330348371888432"),
-			side("g-b", "U7033035", "-20000", 0, "20251015U70330348371888433"),
+			side("g-a", "U1000001", "20000", 0, "20251015U10000018371888432"),
+			side("g-b", "U1000002", "-20000", 0, "20251015U10000018371888433"),
 		},
 		want: nil,
 	}, {
@@ -262,8 +262,8 @@ func TestMatch(t *testing.T) {
 		// is not matchable however alone it looks.
 		name: "a side with no reference is not matchable",
 		sides: []db.TransferSide{
-			side("g-a", "AG10041188", "20000", 0),
-			side("g-b", "AW10075724", "-20000", 0),
+			side("g-a", "AG10000001", "20000", 0),
+			side("g-b", "AW10000001", "-20000", 0),
 		},
 		want: nil,
 	}, {
@@ -272,9 +272,9 @@ func TestMatch(t *testing.T) {
 		// the merely-adjacent departure is left over.
 		name: "a pointer beats mere proximity for the same side",
 		sides: []db.TransferSide{
-			side("g-near", "AG10041188", "20000", 0, "1093663530"),
-			side("g-named", "AS10110796", "20000", 0, "1099999999"),
-			pointing(side("g-cma", "AW10075724", "-20000", 0, "1093663531"), "AS10110796"),
+			side("g-near", "AG10000001", "20000", 0, "971613413"),
+			side("g-named", "AS10000001", "20000", 0, "1099999999"),
+			pointing(side("g-cma", "AW10000001", "-20000", 0, "971613414"), "AS10000001"),
 		},
 		want: []link{{"g-named", "g-cma", db.TransferMatchPointer}},
 	}}
@@ -302,8 +302,8 @@ func TestMatch_DirectionFollowsTheSign(t *testing.T) {
 	// Deliberately given arrival-first, so the order of the input cannot be what
 	// decides the direction.
 	got := Match([]db.TransferSide{
-		side("g-arrival", "AW10075724", "-20000", 0, "1093663531"),
-		side("g-departure", "AG10041188", "20000", 0, "1093663528"),
+		side("g-arrival", "AW10000001", "-20000", 0, "971613414"),
+		side("g-departure", "AG10000001", "20000", 0, "971613411"),
 	}, DefaultOpts())
 	if len(got) != 1 {
 		t.Fatalf("got %d matches, want 1", len(got))
@@ -319,13 +319,13 @@ func TestMatch_DirectionFollowsTheSign(t *testing.T) {
 // that would pair differently between two runs over the same data.
 func TestMatch_IsOrderIndependent(t *testing.T) {
 	sides := []db.TransferSide{
-		side("jan-isa", "AS10110796", "2.16", 0, "1046659862"),
-		side("jan-cma", "AW10075724", "-2.16", 0, "1046659864"),
-		side("feb-isa", "AS10110796", "2.17", 30, "1062159454"),
-		side("feb-cma", "AW10075724", "-2.17", 30, "1062159457"),
-		side("lone", "AS10110796", "-19599", 5, "675163172"),
-		side("g-fund", "AG10041188", "20000", 1, "1093663528"),
-		pointing(side("g-cma", "AW10075724", "-20000", 1, "1093663531"), "AG10041188"),
+		side("jan-isa", "AS10000001", "2.16", 0, "924609745"),
+		side("jan-cma", "AW10000001", "-2.16", 0, "924609747"),
+		side("feb-isa", "AS10000001", "2.17", 30, "940109337"),
+		side("feb-cma", "AW10000001", "-2.17", 30, "940109340"),
+		side("lone", "AS10000001", "-19599", 5, "553113055"),
+		side("g-fund", "AG10000001", "20000", 1, "971613411"),
+		pointing(side("g-cma", "AW10000001", "-20000", 1, "971613414"), "AG10000001"),
 	}
 	want := match(sides)
 	if len(want) != 3 {

--- a/server/transfermatch/worker_test.go
+++ b/server/transfermatch/worker_test.go
@@ -19,8 +19,8 @@ func TestRunCycle_WritesThePairsItFinds(t *testing.T) {
 
 	mockDB.EXPECT().ListUnmatchedTransferSides(gomock.Any(), db.TransferSideOpts{}).
 		Return([]db.TransferSide{
-			side("g-cma", "AW10075724", "20000", 0, "1093663547"),
-			side("g-isa", "AS10110796", "-20000", 0, "1093663548"),
+			side("g-cma", "AW10000001", "20000", 0, "971613430"),
+			side("g-isa", "AS10000001", "-20000", 0, "971613431"),
 		}, nil)
 	mockDB.EXPECT().CreateTransferMatches(gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, ms []db.TransferMatch) (int, error) {
@@ -61,7 +61,7 @@ func TestRunCycle_WritesNothingWhenNothingPairs(t *testing.T) {
 	mockDB := mock.NewMockDB(ctrl)
 
 	mockDB.EXPECT().ListUnmatchedTransferSides(gomock.Any(), gomock.Any()).
-		Return([]db.TransferSide{side("g-isa", "AS10110796", "-19599", 0, "675163172")}, nil)
+		Return([]db.TransferSide{side("g-isa", "AS10000001", "-19599", 0, "553113055")}, nil)
 	// No CreateTransferMatches call is expected: gomock fails the test if one comes.
 
 	runCycle(context.Background(), mockDB, nil, nil, nil)
@@ -87,8 +87,8 @@ func TestRunCycle_SurvivesAWriteError(t *testing.T) {
 
 	mockDB.EXPECT().ListUnmatchedTransferSides(gomock.Any(), gomock.Any()).
 		Return([]db.TransferSide{
-			side("g-cma", "AW10075724", "20000", 0, "1093663547"),
-			side("g-isa", "AS10110796", "-20000", 0, "1093663548"),
+			side("g-cma", "AW10000001", "20000", 0, "971613430"),
+			side("g-isa", "AS10000001", "-20000", 0, "971613431"),
 		}, nil)
 	mockDB.EXPECT().CreateTransferMatches(gomock.Any(), gomock.Any()).
 		Return(0, errors.New("deadlock detected"))


### PR DESCRIPTION
An audit for personal data turned up the real thing in test fixtures and issue
prose. This removes it and adds a CLAUDE.md rule so it does not come back.

## What was there

- **8 Fidelity account numbers and 2 IBKR ones**, across 11 files.
- **74 broker transaction references**, and **3 IBKR transfer references** with an
  account number embedded in each.
- **Comments and prose naming the two people** whose exports the data came from,
  in the converter tests and in issues 0040, 0064 and 0073.
- `lee.denison@*` and `lee+*@gmail.com` as example allowlist patterns in
  `docs/spec/auth.md`.
- A home-directory path with a username in two `.claude/settings.json` permission
  rules.

The CSV rows in `fidelity-csv.test.ts` were verbatim statement lines -- account
number, date, instrument, quantity, price, settled amount and the broker's own
reference -- which makes them a partial transaction history rather than merely an
identifier.

## How it was substituted

**Account numbers** are renumbered sequentially, keeping the two-letter prefix
because the tests read account type off it, and keeping the length so the IBKR
references that embed one stay the shape the matcher sees.

**Transaction references** are shifted by one constant. That is the only
substitution that preserves what the tests depend on: `referenceFeasible` compares
references by *numeric distance* against `refSpan = 64`, so a pair one apart has
to stay one apart, and one deliberately far away has to stay far. A single offset
preserves every pairwise distance exactly.

**Not substituted:** CUSIPs and other public security identifiers, which are
reference data rather than personal data; and the values the tests already
invented. The script asserts that no shifted value collides with one of these or
lands within the 64-unit span of one, which would turn a deliberate non-match into
a match.

The comment in `match.go` quoting four references by their last three digits is
reworded to describe the shape instead, since the digits no longer exist.

**Settings paths** now use the `~/` home-relative anchor that Read and Edit rules
accept, so the rule means the same thing without naming a user. The `find` rule is
a command-prefix match rather than a path pattern, so its `~` is the shell's
rather than the permission system's, and it now matches the command written that
way.

## Testing

`make check`, `make server-test`, `make client-test`, `make extension-test`,
`make db-test` and the full `make e2e-test` (41 passed) all pass. The transfer
matcher tests are the ones that would catch a bad substitution, and they are green.
`.claude/settings.json` is valid JSON with all 19 rules intact.

## Not covered

**Git history still contains all of it.** Removing it there means a rewrite, and
whether that is worth doing depends on whether this repo is or will be public.

🤖 Generated with [Claude Code](https://claude.com/claude-code)