### PR TITLE
Export a user's transactions as an archive part (0077)

### DIFF
--- a/docs/issues/0094-replace-period-without-destroying-straddling-group.md
+++ b/docs/issues/0094-replace-period-without-destroying-straddling-group.md
@@ -1,0 +1,71 @@
+---
+status: open
+title: Replace a period without destroying a straddling group
+milestone: M14
+dependencies: [0077]
+---
+
+Make a period-scoped export and a period-scoped replace safe for a transaction
+group whose postings fall on both sides of the boundary.
+
+## Motivation
+
+A group's postings need not share a timestamp, and one grouping rule spans days
+deliberately: the Fidelity deposit-run pass keys on reference proximity rather
+than on the date bucket, because a run in the sample export settles across two
+days. `client/lib/csv/converters/fidelity-csv.ts` says so and a test pins it.
+
+`ReplaceTxsInPeriod` deletes whole groups, selected by an `EXISTS` over postings
+inside the window. One posting inside the window therefore destroys the whole
+group, including legs outside it, and the upload that triggered the delete holds
+only the rows its own period covers. The legs outside are gone and nothing
+re-inserts them. Today the extension's 14-day lookback usually re-fetches them by
+accident; that is protection sized for a different problem, and it disappears
+when the lookback is lowered, when a user uploads a hand-picked file, or when a
+straddle exceeds it.
+
+Nothing states an invariant that a group's postings lie inside the uploaded
+period, nothing enforces one at ingest, and no issue or ADR discusses the case.
+
+## Design
+
+Export and delete are one contract, so they are settled together.
+
+**The export adheres strictly to the period asked for.** A group straddling the
+boundary contributes only its in-period legs, and the exported group therefore
+does not balance. That is already legal: the format accepts a group whose
+postings do not sum to zero, and the importer routes the residual. Whether the UI
+should warn that a group is being split is a later question.
+
+This fills `ExportUserArchiveRequest` fields 2 and 3, reserved by comment for the
+bounds of the transaction window. 0077 exports one window per broker derived from
+that broker's own data, so the window contains every posting it carries and the
+case cannot arise; this issue is what makes a narrower period expressible.
+
+**The delete removes only the postings inside the period**, and re-routes the
+survivors' residual rather than deleting the group. `weight` and
+`weight_commodity` are stored columns, so the residual is
+`SUM(weight) GROUP BY weight_commodity` over the surviving postings and the whole
+operation is expressible in SQL without lifting the balancer out of the worker.
+
+The routed leg takes the account type `routeResiduals` would give it --
+`IMBALANCE`, `TRANSFER_CLEARING` or `SOURCE_ROUNDING`, chosen from the surviving
+legs' tx types and the existing tolerances -- rather than always `IMBALANCE`. The
+one group shape that straddles today is the deposit run, which is transfer
+family; a plain `IMBALANCE` would hide the surviving half from the transfer
+matcher, which keys strictly on `TRANSFER_CLEARING`. Using one rule everywhere
+also means a group's residual does not depend on whether it was created whole or
+by a partial delete.
+
+`check_tx_group_balance()` is `DEFERRABLE INITIALLY DEFERRED`, so the delete and
+the routed insert commit together and the group is never observed unbalanced.
+
+## Consequences
+
+The result is stable under repetition rather than identical to what came before:
+re-importing a period leaves the out-of-period legs where they were and the
+in-period legs in a new group, each balanced by a routed residual. Two groups
+where a converter once wrote one. Rejoining them is 0095.
+
+This fixes broker statement uploads as well as archive imports; both paths go
+through `ReplaceTxsInPeriod`.

--- a/docs/issues/0095-match-imbalanced-groups-that-should-be-one.md
+++ b/docs/issues/0095-match-imbalanced-groups-that-should-be-one.md
@@ -1,0 +1,61 @@
+---
+status: open
+title: Match imbalanced groups that should be one
+dependencies: [0068]
+---
+
+Repair, after the fact, postings that belong to one economic event but were
+stored in separate unbalanced groups.
+
+## Motivation
+
+Grouping is the converter's job and a converter sees one file
+(adr/0021-converters-own-transaction-grouping.md), so several paths leave the
+legs of one event in distinct groups, each balanced by a routed residual:
+
+- Two legs arriving in two broker logs. No converter can see both.
+- A straddling group split by the partial delete in 0094.
+
+The transfer matcher from 0068 already repairs one case of this, and is
+deliberately narrow: it keys on `account_type = 'TRANSFER_CLEARING'`, requires
+the same broker, an exact equal-and-opposite amount and a window of seven days,
+and refuses ambiguity. Everything else stays unmatched, which reads as an
+imbalance that never resolves.
+
+## Design
+
+Two questions, and the second is the harder one.
+
+**Which evidence justifies a match.** Where a sufficiently reliable rule exists,
+match automatically as 0068 does. Where it does not, present likely candidates
+and defer to the user for the final call. A wrong pair is worse than no pair, so
+the bar for automatic matching stays where 0068 put it: evidence that identifies
+the occurrence, not merely the amount and a window.
+
+**Whether a match is a link or a merge, which depends on what is being matched.**
+
+adr/0037-transfer-matches-are-links-not-postings.md chose a link, and its reason
+is specific to transfers: the link records *which account holds the other side*,
+because the portfolio membership test in
+adr/0022-typed-per-account-cash-flow-boundary.md asks whether both accounts are
+members before it nets a pair or values what is in transit. Merging two transfer
+groups would erase the account boundary money-weighted return depends on, which
+is the whole reason the pairing exists.
+
+An `IMBALANCE` residual carries no such boundary. Both halves of a split trade
+sit in one account, and the residual is an artefact of the split rather than an
+economic fact, so the right repair is a merge: reassign `group_id` and delete
+both residuals. 0037 calls that unreachable, but that argument is about clearing
+one side of a pair; `check_tx_group_balance()` is `DEFERRABLE INITIALLY
+DEFERRED`, so a merge performed in one transaction is evaluated at COMMIT, where
+the merged group balances.
+
+Amend 0037 to say it is scoped to transfers and why, rather than leaving it
+reading as a rule about matching in general.
+
+## Relationship to 0091
+
+0091 covers hand-pairing transfers the matcher left alone and breaking pairs it
+got wrong, on the transfers view of `/admin/imbalance`. This is that generalised
+past transfers, with a different repair for the non-transfer case. Decide whether
+0095 subsumes 0091 or sits on top of it before either is picked up.

--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -11,6 +11,7 @@ import "archive/v1/instruments.proto";
 import "archive/v1/plugin_config.proto";
 import "archive/v1/preferences.proto";
 import "archive/v1/prices.proto";
+import "archive/v1/txs.proto";
 import "archive/v1/unhandled_events.proto";
 import "buf/validate/validate.proto";
 import "google/protobuf/timestamp.proto";
@@ -665,7 +666,9 @@ message ExportUserArchiveResponse {
     ArchivePartBegin part_begin = 2;
     // The whole part in one message, sent once after its part_begin.
     portfoliodb.archive.v1.PreferencePart preferences = 3;
-    // 4 is the transaction window, 5 is the declaration statement.
+    // One window per broker, each carrying its own groups.
+    portfoliodb.archive.v1.TxWindow tx_window = 4;
+    // 5 is the declaration statement.
   }
 }
 

--- a/proto/archive/v1/txs.proto
+++ b/proto/archive/v1/txs.proto
@@ -31,14 +31,11 @@ message TxWindow {
   // resolution, and as the domain of the (source, description) identifier a
   // posting with no hints falls back to.
   string source = 4 [(buf.validate.field).string.min_len = 1];
-  // The share count every quantity and unit price in this window is denominated
-  // in, as "YYYY-MM-DD". Absent means each posting is denominated in its own
-  // timestamp's date -- the as-traded convention a broker log follows, since a
-  // log line accounts only for events prior to the trade. Set it only for a
-  // source that restates historical rows in current share terms, such as a
-  // broker web view showing post-split quantities against pre-split trades.
-  // See docs/spec/bitemporality.md.
-  optional string share_count_basis = 5 [(buf.validate.field).string.pattern = "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"];
+  // 5 was a window-wide share_count_basis. It is on the posting instead: a
+  // window-wide value can only say "one date for everything", which cannot
+  // express the ordinary case, where every posting is as-traded and so carries a
+  // different basis from its neighbours.
+  reserved 5;
   repeated TxGroup groups = 6;
 }
 
@@ -106,4 +103,12 @@ message Posting {
   // so it is read as a transfer pointer only where the group turns out to be
   // one.
   optional string counterparty_account = 12;
+  // The share count this posting's quantity and unit price are denominated in,
+  // as "YYYY-MM-DD". Absent means this posting's own timestamp date -- the
+  // as-traded convention a broker log follows, since a log line accounts only
+  // for events prior to the trade, and what an ordinary export writes. Set it
+  // only for a source that restates a historical row in current share terms,
+  // such as a broker web view showing post-split quantities against pre-split
+  // trades. See docs/spec/bitemporality.md.
+  optional string share_count_basis = 13 [(buf.validate.field).string.pattern = "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"];
 }

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -5,7 +5,9 @@ package db
 import (
 	"context"
 	"errors"
+	"fmt"
 	"regexp"
+	"strings"
 
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
 	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
@@ -275,24 +277,67 @@ type Weight struct {
 	Commodity string
 }
 
-// TxDB provides transaction write and list.
+// ExportPosting is one stored posting with the best identifier of the instrument
+// it names, plus the group identity an archive needs to nest it.
+//
+// GroupID and GroupTimestamp are here to group and order the scan, not to be
+// written: a group id means nothing in another instance, and a group's timestamp
+// is the timestamp of the first posting that names it, so both are derived. See
+// docs/adr/0035-archive-nests-by-aggregate-root.md.
+type ExportPosting struct {
+	Broker         string
+	GroupID        string
+	GroupTimestamp time.Time
+	Timestamp      time.Time
+	Account        string
+	AccountType    string
+	TxType         string
+	Description    string
+	// The instrument's best identifier, or all three empty for a posting whose
+	// instrument never resolved. Chosen by bestIdentifierJoin so that every
+	// export naming one identifier per instrument agrees which one.
+	IdentifierType      string
+	IdentifierValue     string
+	IdentifierDomain    string
+	Quantity            decimal.Decimal
+	UnitPrice           *decimal.Decimal
+	TradingCurrency     string
+	SettlementCurrency  string
+	BrokerRef           string
+	CounterpartyAccount string
+	// The share count this posting is denominated in, or nil when it is the
+	// posting's own timestamp date. The column is NOT NULL and the insert
+	// trigger defaults it to that date, so only a value that differs from it
+	// says anything, and only that value is worth writing to a file.
+	ShareCountBasis *time.Time
+}
+
+// TxDB provides transaction write, list and export.
 type TxDB interface {
 	// Txs sharing a group_ref are written as postings of one tx group; the rest get
 	// a group each. Every group is stamped with the ingestion job that created it.
-	// shareCountBasis is the date the uploaded quantities and unit prices are
-	// denominated in. nil means as-traded: each row uses its own timestamp.
+	//
+	// shareCountBasis is parallel to txs and is the date each row's quantity and
+	// unit price are denominated in. A nil entry, and a nil slice, mean as-traded:
+	// the row uses its own timestamp. It is per row rather than per call because a
+	// file can restate one row and leave its neighbours alone.
 	//
 	// weights is parallel to txs and carries what each posting contributes to its
 	// group's balance. A nil slice means the caller has none, and each posting then
 	// weighs its own quantity in its own instrument -- which is what the weight rule
 	// returns for a posting with no price.
-	ReplaceTxsInPeriod(ctx context.Context, userID, broker, jobID string, periodFrom, periodBefore *timestamppb.Timestamp, txs []*apiv1.Tx, instrumentIDs []string, weights []Weight, shareCountBasis *time.Time) error
+	ReplaceTxsInPeriod(ctx context.Context, userID, broker, jobID string, periodFrom, periodBefore *timestamppb.Timestamp, txs []*apiv1.Tx, instrumentIDs []string, weights []Weight, shareCountBasis []*time.Time) error
 	// CreateTxGroup appends the postings of one economic event as a single group.
 	// It takes a slice rather than a tx so that the append path can carry a routed
 	// counterparty, without which its groups could never balance.
-	CreateTxGroup(ctx context.Context, userID, broker, account, jobID string, txs []*apiv1.Tx, instrumentIDs []string, weights []Weight, shareCountBasis *time.Time) error
+	CreateTxGroup(ctx context.Context, userID, broker, account, jobID string, txs []*apiv1.Tx, instrumentIDs []string, weights []Weight, shareCountBasis []*time.Time) error
 	ListTxs(ctx context.Context, userID string, broker *typev1.Broker, account string, periodFrom, periodBefore *timestamppb.Timestamp, descending bool, pageSize int32, pageToken string) ([]*apiv1.PortfolioTx, string, error)
 	ListTxsByPortfolio(ctx context.Context, portfolioID string, broker *typev1.Broker, periodFrom, periodBefore *timestamppb.Timestamp, descending bool, pageSize int32, pageToken string) ([]*apiv1.PortfolioTx, string, error)
+	// ListTxsForExport reads one user's own postings in archive order: by broker,
+	// then by group, then by posting. Synthetic INITIALIZE groups are excluded --
+	// they are derived from holding declarations, which the archive carries as the
+	// declarations they come from.
+	ListTxsForExport(ctx context.Context, userID string) ([]ExportPosting, error)
 }
 
 // HoldingsDB computes holdings at a point in time.
@@ -648,6 +693,62 @@ func StrToBroker(s string) typev1.Broker {
 		return typev1.Broker_BROKER_UNSPECIFIED
 	}
 	return typev1.Broker(v)
+}
+
+// TxTypeToStr returns the stored form of a tx type, which is its enum name.
+// Unspecified is an error rather than an empty string: a posting has to say what
+// kind of event it transcribes.
+func TxTypeToStr(t typev1.TxType) (string, error) {
+	if t == typev1.TxType_TX_TYPE_UNSPECIFIED {
+		return "", fmt.Errorf("tx type unspecified")
+	}
+	s := t.String()
+	if s == "TX_TYPE_UNSPECIFIED" {
+		return "", fmt.Errorf("tx type unspecified")
+	}
+	return s, nil
+}
+
+// StrToTxType converts a stored tx type string to its proto enum. An
+// unrecognised string maps to TX_TYPE_UNSPECIFIED.
+func StrToTxType(s string) typev1.TxType {
+	v, ok := typev1.TxType_value[s]
+	if !ok {
+		return typev1.TxType_TX_TYPE_UNSPECIFIED
+	}
+	return typev1.TxType(v)
+}
+
+// accountTypePrefix is stripped from the enum name to get the stored form. The proto
+// values are prefixed because enum values share package scope and TxType already
+// defines INCOME and TRANSFER; the column stores the bare vocabulary the CHECK
+// constraint and the specs use.
+const accountTypePrefix = "ACCOUNT_TYPE_"
+
+// AccountTypeToStr returns the stored form of an account type: its enum name without
+// the prefix. Unspecified is USER rather than an error -- an upload that says nothing
+// about a posting's kind is an ordinary broker account posting, which is what almost
+// every row is. Derived from the generated names rather than mapped by hand so a new
+// type cannot be stored under a spelling that StrToAccountType does not recognise.
+func AccountTypeToStr(a typev1.AccountType) (string, error) {
+	if a == typev1.AccountType_ACCOUNT_TYPE_UNSPECIFIED {
+		return "USER", nil
+	}
+	s, ok := typev1.AccountType_name[int32(a)]
+	if !ok {
+		return "", fmt.Errorf("unknown account type: %v", a)
+	}
+	return strings.TrimPrefix(s, accountTypePrefix), nil
+}
+
+// StrToAccountType converts a stored account type string to its proto enum. An
+// unrecognised string maps to ACCOUNT_TYPE_UNSPECIFIED.
+func StrToAccountType(s string) typev1.AccountType {
+	v, ok := typev1.AccountType_value[accountTypePrefix+s]
+	if !ok {
+		return typev1.AccountType_ACCOUNT_TYPE_UNSPECIFIED
+	}
+	return typev1.AccountType(v)
 }
 
 // PluginCategoryToStr converts a proto plugin category to the string

--- a/server/db/postgres/postgres.go
+++ b/server/db/postgres/postgres.go
@@ -68,54 +68,18 @@ func strToBroker(s string) typev1.Broker {
 	return typev1.Broker(v)
 }
 
-func txTypeToStr(t typev1.TxType) (string, error) {
-	if t == typev1.TxType_TX_TYPE_UNSPECIFIED {
-		return "", fmt.Errorf("tx type unspecified")
-	}
-	s := t.String()
-	if s == "TX_TYPE_UNSPECIFIED" {
-		return "", fmt.Errorf("tx type unspecified")
-	}
-	return s, nil
-}
+// The tx type and account type vocabularies live in the db package, beside the
+// broker and asset class ones, so that a caller outside this package -- the
+// archive export, which names an account type in a file -- reads them without
+// importing a driver.
 
-func strToTxType(s string) typev1.TxType {
-	v, ok := typev1.TxType_value[s]
-	if !ok {
-		return typev1.TxType_TX_TYPE_UNSPECIFIED
-	}
-	return typev1.TxType(v)
-}
+func txTypeToStr(t typev1.TxType) (string, error) { return db.TxTypeToStr(t) }
 
-// accountTypePrefix is stripped from the enum name to get the stored form. The proto
-// values are prefixed because enum values share package scope and TxType already
-// defines INCOME and TRANSFER; the column stores the bare vocabulary the CHECK
-// constraint and the specs use.
-const accountTypePrefix = "ACCOUNT_TYPE_"
+func strToTxType(s string) typev1.TxType { return db.StrToTxType(s) }
 
-// accountTypeToStr returns the stored form of an account type: its enum name without
-// the prefix. Unspecified is USER rather than an error -- an upload that says nothing
-// about a posting's kind is an ordinary broker account posting, which is what almost
-// every row is. Derived from the generated names rather than mapped by hand so a new
-// type cannot be stored under a spelling that strToAccountType does not recognise.
-func accountTypeToStr(a typev1.AccountType) (string, error) {
-	if a == typev1.AccountType_ACCOUNT_TYPE_UNSPECIFIED {
-		return "USER", nil
-	}
-	s, ok := typev1.AccountType_name[int32(a)]
-	if !ok {
-		return "", fmt.Errorf("unknown account type: %v", a)
-	}
-	return strings.TrimPrefix(s, accountTypePrefix), nil
-}
+func accountTypeToStr(a typev1.AccountType) (string, error) { return db.AccountTypeToStr(a) }
 
-func strToAccountType(s string) typev1.AccountType {
-	v, ok := typev1.AccountType_value[accountTypePrefix+s]
-	if !ok {
-		return typev1.AccountType_ACCOUNT_TYPE_UNSPECIFIED
-	}
-	return typev1.AccountType(v)
-}
+func strToAccountType(s string) typev1.AccountType { return db.StrToAccountType(s) }
 
 func jobStatusToStr(s apiv1.JobStatus) string {
 	switch s {

--- a/server/db/postgres/postgres_test.go
+++ b/server/db/postgres/postgres_test.go
@@ -66,7 +66,7 @@ func testDBTx(t *testing.T) *Postgres {
 // seed row, and CreateTxGroup takes a slice so that the append path can carry a
 // routed counterparty alongside the posting it balances.
 func createTx(ctx context.Context, p *Postgres, userID, broker, account, jobID string, tx *apiv1.Tx, instrumentID string, shareCountBasis *time.Time) error {
-	return p.CreateTxGroup(ctx, userID, broker, account, jobID, []*apiv1.Tx{tx}, []string{instrumentID}, nil, shareCountBasis)
+	return p.CreateTxGroup(ctx, userID, broker, account, jobID, []*apiv1.Tx{tx}, []string{instrumentID}, nil, []*time.Time{shareCountBasis})
 }
 
 // newTxGroup creates an empty tx group and returns its id, for the fixtures that

--- a/server/db/postgres/txs.go
+++ b/server/db/postgres/txs.go
@@ -74,7 +74,7 @@ func (r *groupResolver) record(ref string, id uuid.UUID) {
 }
 
 // ReplaceTxsInPeriod implements db.TxDB.
-func (p *Postgres) ReplaceTxsInPeriod(ctx context.Context, userID, broker, jobID string, periodFrom, periodBefore *timestamppb.Timestamp, txs []*apiv1.Tx, instrumentIDs []string, weights []db.Weight, shareCountBasis *time.Time) error {
+func (p *Postgres) ReplaceTxsInPeriod(ctx context.Context, userID, broker, jobID string, periodFrom, periodBefore *timestamppb.Timestamp, txs []*apiv1.Tx, instrumentIDs []string, weights []db.Weight, shareCountBasis []*time.Time) error {
 	userUUID, err := uuid.Parse(userID)
 	if err != nil {
 		return fmt.Errorf("invalid user id: %w", err)
@@ -123,9 +123,9 @@ func (p *Postgres) ReplaceTxsInPeriod(ctx context.Context, userID, broker, jobID
 // account on every posting when non-empty, for the append path where the whole
 // group belongs to one named account.
 //
-// weights is parallel to txs, or nil when the caller has none. See db.TxDB for what
-// a missing weight means.
-func insertPostings(ctx context.Context, exec queryable, userUUID uuid.UUID, broker string, jobUUID interface{}, txs []*apiv1.Tx, instrumentIDs []string, weights []db.Weight, shareCountBasis *time.Time, account string) error {
+// weights and shareCountBasis are parallel to txs, or nil when the caller has
+// none. See db.TxDB for what a missing entry in either means.
+func insertPostings(ctx context.Context, exec queryable, userUUID uuid.UUID, broker string, jobUUID interface{}, txs []*apiv1.Tx, instrumentIDs []string, weights []db.Weight, shareCountBasis []*time.Time, account string) error {
 	resolver := newGroupResolver()
 	for i, t := range txs {
 		instUUID, err := uuid.Parse(instrumentIDs[i])
@@ -165,10 +165,17 @@ func insertPostings(ctx context.Context, exec queryable, userUUID uuid.UUID, bro
 		if i < len(weights) {
 			w = weights[i]
 		}
+		// NULL leaves the basis to the insert trigger, which seeds it from the
+		// posting's own timestamp -- the as-traded convention, and what all but a
+		// restating source wants.
+		var basis *time.Time
+		if i < len(shareCountBasis) {
+			basis = shareCountBasis[i]
+		}
 		args := []interface{}{
 			userUUID, broker, acc, ts, t.InstrumentDescription, txTypeStr, qty,
 			nullStr(t.TradingCurrency), nullStr(t.SettlementCurrency), nullDecimal(price),
-			instUUID, shareCountBasis, acctTypeStr, w.Amount, w.Commodity,
+			instUUID, basis, acctTypeStr, w.Amount, w.Commodity,
 			// Stored as the source wrote them, and NULL where it wrote nothing:
 			// absent evidence is not the same as an empty reference, and only a
 			// derived posting is expected to carry none at all.
@@ -197,7 +204,7 @@ func insertPostings(ctx context.Context, exec queryable, userUUID uuid.UUID, bro
 // group that could never be balanced would put the balance invariant permanently
 // out of reach. The postings share the named account. group_ref is ignored -- the
 // whole call is one group -- so the resolver never splits it.
-func (p *Postgres) CreateTxGroup(ctx context.Context, userID, broker, account, jobID string, txs []*apiv1.Tx, instrumentIDs []string, weights []db.Weight, shareCountBasis *time.Time) error {
+func (p *Postgres) CreateTxGroup(ctx context.Context, userID, broker, account, jobID string, txs []*apiv1.Tx, instrumentIDs []string, weights []db.Weight, shareCountBasis []*time.Time) error {
 	userUUID, err := uuid.Parse(userID)
 	if err != nil {
 		return fmt.Errorf("invalid user id: %w", err)
@@ -347,4 +354,83 @@ func (p *Postgres) ListTxsByPortfolio(ctx context.Context, portfolioID string, b
 		out[i] = trows[i].toProto()
 	}
 	return out, nextToken, nil
+}
+
+// exportPosting is a sqlx-scannable version of db.ExportPosting.
+type exportPosting struct {
+	Broker              string           `db:"broker"`
+	GroupID             string           `db:"group_id"`
+	GroupTimestamp      time.Time        `db:"group_timestamp"`
+	Timestamp           time.Time        `db:"timestamp"`
+	Account             string           `db:"account"`
+	AccountType         string           `db:"account_type"`
+	TxType              string           `db:"tx_type"`
+	Description         string           `db:"instrument_description"`
+	IdentifierType      string           `db:"identifier_type"`
+	IdentifierValue     string           `db:"value"`
+	IdentifierDomain    string           `db:"domain"`
+	Quantity            decimal.Decimal  `db:"quantity"`
+	UnitPrice           *decimal.Decimal `db:"unit_price"`
+	TradingCurrency     string           `db:"trading_currency"`
+	SettlementCurrency  string           `db:"settlement_currency"`
+	BrokerRef           string           `db:"broker_ref"`
+	CounterpartyAccount string           `db:"counterparty_account"`
+	ShareCountBasis     *time.Time       `db:"share_count_basis"`
+}
+
+// ListTxsForExport implements db.TxDB.
+//
+// The raw quantity and unit price travel, never the split-adjusted pair: those
+// are a recomputable cache carrying a rounding, and the importing instance
+// rebuilds them. Weights are left behind for the same reason -- they are
+// computed at ingest from the raw columns and the tx type.
+//
+// The identifier join is a LEFT JOIN so a posting whose instrument never
+// resolved survives, travelling with no identifier and resolving from its
+// description on the way back in. bestIdentifierJoinOn rather than a
+// hand-written lateral so this export agrees with every other one about which
+// identifier is best.
+func (p *Postgres) ListTxsForExport(ctx context.Context, userID string) ([]db.ExportPosting, error) {
+	userUUID, err := uuid.Parse(userID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid user id: %w", err)
+	}
+	q := `
+		SELECT t.broker, t.group_id::text AS group_id, g.timestamp AS group_timestamp,
+			t.timestamp, t.account, t.account_type, t.tx_type, t.instrument_description,
+			COALESCE(best_id.identifier_type, '') AS identifier_type,
+			COALESCE(best_id.value, '') AS value,
+			COALESCE(best_id.domain, '') AS domain,
+			t.quantity, t.unit_price,
+			COALESCE(t.trading_currency, '') AS trading_currency,
+			COALESCE(t.settlement_currency, '') AS settlement_currency,
+			COALESCE(t.broker_ref, '') AS broker_ref,
+			COALESCE(t.counterparty_account, '') AS counterparty_account,
+			-- A basis equal to the posting's own date is the as-traded
+			-- convention and says nothing a reader cannot infer. The column is
+			-- NOT NULL and the insert trigger defaults it to that date, so
+			-- selecting it raw would stamp a redundant date onto every posting.
+			CASE WHEN t.share_count_basis = t.timestamp::date THEN NULL
+				ELSE t.share_count_basis END AS share_count_basis
+		FROM txs t
+		JOIN tx_groups g ON g.id = t.group_id
+		` + bestIdentifierJoinOn("LEFT JOIN", "t.instrument_id", "best_id") + `
+		WHERE t.user_id = $1
+		  -- Excluded whole rather than per posting: a pad and its EQUITY
+		  -- counterparty share one group, and half a group is not a group.
+		  AND NOT EXISTS (
+		    SELECT 1 FROM txs s
+		    WHERE s.group_id = t.group_id AND s.synthetic_purpose IS NOT NULL
+		  )
+		ORDER BY t.broker, g.timestamp, g.id, t.timestamp, t.id
+	`
+	var rows []exportPosting
+	if err := p.q.SelectContext(ctx, &rows, q, userUUID); err != nil {
+		return nil, fmt.Errorf("list txs for export: %w", err)
+	}
+	out := make([]db.ExportPosting, len(rows))
+	for i, r := range rows {
+		out[i] = db.ExportPosting(r)
+	}
+	return out, nil
 }

--- a/server/db/postgres/txs_test.go
+++ b/server/db/postgres/txs_test.go
@@ -1110,3 +1110,167 @@ func TestReplaceTxsInPeriod_DefaultsWeightWhenAbsent(t *testing.T) {
 		t.Errorf("weight_commodity = %q, want %q", commodity, want)
 	}
 }
+
+// The export names an instrument by the identifier bestIdentifierJoin picks, so
+// that every export surfacing one identifier per instrument agrees which one. An
+// instrument carrying both a ticker and the broker description it resolved under
+// exports as the ticker.
+func TestListTxsForExport_UsesTheBestIdentifier(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|exp-id", "U", "u@exp-id.com")
+	instID, err := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{
+		{Type: "BROKER_DESCRIPTION", Domain: "Fidelity:web:fidelity-csv", Value: "APPLE INC", Canonical: false},
+		{Type: "MIC_TICKER", Domain: "XNAS", Value: "AAPL", Canonical: true},
+	}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+	now := time.Now().Truncate(time.Second)
+	tx := &apiv1.Tx{Timestamp: timestamppb.New(now), InstrumentDescription: "APPLE INC", Type: typev1.TxType_BUYSTOCK, Quantity: "10"}
+	if err := createTx(ctx, p, userID, "FIDELITY", "acct", "", tx, instID, nil); err != nil {
+		t.Fatalf("create tx: %v", err)
+	}
+
+	rows, err := p.ListTxsForExport(ctx, userID)
+	if err != nil {
+		t.Fatalf("list txs for export: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want 1", len(rows))
+	}
+	if rows[0].IdentifierType != "MIC_TICKER" || rows[0].IdentifierValue != "AAPL" || rows[0].IdentifierDomain != "XNAS" {
+		t.Fatalf("identifier = %s/%s/%s, want MIC_TICKER/AAPL/XNAS",
+			rows[0].IdentifierType, rows[0].IdentifierValue, rows[0].IdentifierDomain)
+	}
+	if rows[0].Broker != "FIDELITY" || rows[0].Account != "acct" || rows[0].AccountType != "USER" {
+		t.Fatalf("row = %+v", rows[0])
+	}
+	if !rows[0].Quantity.Equal(decimal.RequireFromString("10")) {
+		t.Fatalf("quantity = %s", rows[0].Quantity)
+	}
+}
+
+// A synthetic INITIALIZE pad and its EQUITY counterparty are both excluded. They
+// are derived from a holding declaration, which the archive carries as the
+// declaration it came from, and re-importing one as a real transaction would
+// collide with the partial unique index that allows one per holding.
+func TestListTxsForExport_ExcludesSyntheticGroups(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|exp-syn", "U", "u@exp-syn.com")
+	instID, err := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{
+		{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "SYN", Canonical: false},
+	}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+	now := time.Now().Truncate(time.Second)
+	if err := p.UpsertInitializeTx(ctx, userID, "IBKR", "acct1", instID, initTx(now, 50)); err != nil {
+		t.Fatalf("upsert initialize tx: %v", err)
+	}
+	tx := &apiv1.Tx{Timestamp: timestamppb.New(now), InstrumentDescription: "SYN", Type: typev1.TxType_BUYSTOCK, Quantity: "10"}
+	if err := createTx(ctx, p, userID, "IBKR", "acct1", "", tx, instID, nil); err != nil {
+		t.Fatalf("create tx: %v", err)
+	}
+
+	rows, err := p.ListTxsForExport(ctx, userID)
+	if err != nil {
+		t.Fatalf("list txs for export: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("rows = %d, want only the real posting: %+v", len(rows), rows)
+	}
+	if rows[0].Description == "INITIALIZE" {
+		t.Fatalf("exported a synthetic posting: %+v", rows[0])
+	}
+}
+
+// The basis is reported only where it differs from the posting's own date. The
+// column is NOT NULL and the insert trigger seeds it from the timestamp, so a
+// raw select would stamp a redundant date onto every posting in the file.
+func TestListTxsForExport_ShareCountBasisOnlyWhenRestated(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|exp-scb", "U", "u@exp-scb.com")
+	instID, err := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{
+		{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "SCB", Canonical: false},
+	}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+	asTraded := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	restatedAt := time.Date(2024, 2, 20, 10, 0, 0, 0, time.UTC)
+	basis := time.Date(2025, 7, 1, 0, 0, 0, 0, time.UTC)
+	if err := createTx(ctx, p, userID, "IBKR", "a", "",
+		&apiv1.Tx{Timestamp: timestamppb.New(asTraded), InstrumentDescription: "SCB", Type: typev1.TxType_BUYSTOCK, Quantity: "1"},
+		instID, nil); err != nil {
+		t.Fatalf("create as-traded tx: %v", err)
+	}
+	if err := createTx(ctx, p, userID, "IBKR", "a", "",
+		&apiv1.Tx{Timestamp: timestamppb.New(restatedAt), InstrumentDescription: "SCB", Type: typev1.TxType_BUYSTOCK, Quantity: "2"},
+		instID, &basis); err != nil {
+		t.Fatalf("create restated tx: %v", err)
+	}
+
+	rows, err := p.ListTxsForExport(ctx, userID)
+	if err != nil {
+		t.Fatalf("list txs for export: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(rows))
+	}
+	if rows[0].ShareCountBasis != nil {
+		t.Fatalf("as-traded posting reports a basis: %v", rows[0].ShareCountBasis)
+	}
+	if rows[1].ShareCountBasis == nil || !rows[1].ShareCountBasis.Equal(basis) {
+		t.Fatalf("restated basis = %v, want %s", rows[1].ShareCountBasis, basis)
+	}
+}
+
+// Ordered by broker, then group, then posting, so the export assembles its
+// windows and groups in a single scan and two exports of the same data agree.
+func TestListTxsForExport_OrderedForGrouping(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|exp-ord", "U", "u@exp-ord.com")
+	instID, err := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{
+		{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "ORDX", Canonical: false},
+	}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+	base := time.Date(2024, 5, 1, 12, 0, 0, 0, time.UTC)
+	// Written newest first and under two brokers, so passing means the query
+	// ordered them rather than the insert order surviving.
+	seed := []struct {
+		broker string
+		offset time.Duration
+		qty    string
+	}{
+		{"IBKR", 2 * time.Hour, "3"},
+		{"FIDELITY", time.Hour, "2"},
+		{"FIDELITY", 0, "1"},
+	}
+	for _, s := range seed {
+		tx := &apiv1.Tx{Timestamp: timestamppb.New(base.Add(s.offset)), InstrumentDescription: "ORDX", Type: typev1.TxType_BUYSTOCK, Quantity: s.qty}
+		if err := createTx(ctx, p, userID, s.broker, "a", "", tx, instID, nil); err != nil {
+			t.Fatalf("create tx: %v", err)
+		}
+	}
+
+	rows, err := p.ListTxsForExport(ctx, userID)
+	if err != nil {
+		t.Fatalf("list txs for export: %v", err)
+	}
+	got := make([]string, len(rows))
+	for i, r := range rows {
+		got[i] = r.Broker + ":" + r.Quantity.String()
+	}
+	want := []string{"FIDELITY:1", "FIDELITY:2", "IBKR:3"}
+	for i := range want {
+		if i >= len(got) || got[i] != want[i] {
+			t.Fatalf("order = %v, want %v", got, want)
+		}
+	}
+}

--- a/server/service/api/archive.go
+++ b/server/service/api/archive.go
@@ -168,6 +168,7 @@ var (
 	}
 	userPartOrder = []archivev1.ArchivePart{
 		archivev1.ArchivePart_PREFERENCES,
+		archivev1.ArchivePart_TXS,
 	}
 )
 

--- a/server/service/api/export_user_archive_test.go
+++ b/server/service/api/export_user_archive_test.go
@@ -50,6 +50,8 @@ func (e *exportUserStreamMock) shape() []string {
 			out = append(out, "begin:"+m.GetPartBegin().GetPart().String())
 		case m.GetPreferences() != nil:
 			out = append(out, "preferences")
+		case m.GetTxWindow() != nil:
+			out = append(out, "tx_window:"+m.GetTxWindow().GetBroker().String())
 		}
 	}
 	return out
@@ -183,4 +185,44 @@ func TestExportUserArchive_DBError_Internal(t *testing.T) {
 		Parts: []archivev1.ArchivePart{archivev1.ArchivePart_PREFERENCES},
 	}, &exportUserStreamMock{ctx: authCtx("user-1", "sub|1")})
 	testutil.RequireGRPCCode(t, err, codes.Internal)
+}
+
+// Both parts in one request travel in restore order, whatever order they were
+// asked for in: preferences before transactions, because which asset classes are
+// ignored changes what a transaction import keeps.
+func TestExportUserArchive_PartsTravelInRestoreOrder(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	mockDB.EXPECT().GetDisplayCurrency(gomock.Any(), "user-1").Return("GBP", nil)
+	mockDB.EXPECT().ListIgnoredAssetClasses(gomock.Any(), "user-1").Return(nil, nil)
+	mockDB.EXPECT().ListTxsForExport(gomock.Any(), "user-1").Return([]dbpkg.ExportPosting{
+		exportPostingFixture("FIDELITY", "g1", "2024-01-15T10:00:00Z"),
+	}, nil)
+	stream := &exportUserStreamMock{ctx: authCtx("user-1", "sub|1")}
+	if err := srv.ExportUserArchive(&apiv1.ExportUserArchiveRequest{
+		Parts: []archivev1.ArchivePart{archivev1.ArchivePart_TXS, archivev1.ArchivePart_PREFERENCES},
+	}, stream); err != nil {
+		t.Fatalf("ExportUserArchive: %v", err)
+	}
+	want := []string{"envelope", "begin:PREFERENCES", "preferences", "begin:TXS", "tx_window:FIDELITY"}
+	if got := stream.shape(); !equalStrings(got, want) {
+		t.Fatalf("stream = %v, want %v", got, want)
+	}
+}
+
+// A part that was asked for and holds nothing is still present: the part_begin
+// marker is what creates the container, so an export over no transactions says
+// it asked and there were none.
+func TestExportUserArchive_TxPart_AskedForAndEmpty(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	mockDB.EXPECT().ListTxsForExport(gomock.Any(), "user-1").Return(nil, nil)
+	stream := &exportUserStreamMock{ctx: authCtx("user-1", "sub|1")}
+	if err := srv.ExportUserArchive(&apiv1.ExportUserArchiveRequest{
+		Parts: []archivev1.ArchivePart{archivev1.ArchivePart_TXS},
+	}, stream); err != nil {
+		t.Fatalf("ExportUserArchive: %v", err)
+	}
+	want := []string{"envelope", "begin:TXS"}
+	if got := stream.shape(); !equalStrings(got, want) {
+		t.Fatalf("stream = %v, want %v", got, want)
+	}
 }

--- a/server/service/api/txs_export.go
+++ b/server/service/api/txs_export.go
@@ -1,0 +1,111 @@
+package api
+
+import (
+	"time"
+
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// txWindows turns the flat export postings into archive windows, one per broker,
+// each nesting its groups and each group its postings.
+//
+// A window is a replacement scope, so there is exactly one per broker: two
+// windows naming one broker would overlap in time, and an import replaces a
+// period rather than appending to it, so the second would delete what the first
+// had just written. See docs/adr/0002-transaction-ingestion-model.md.
+//
+// The period is derived from the postings the window carries -- the first
+// posting's instant to the day after the last one's -- so the window provably
+// contains everything in it and no group straddles its edge. A period-scoped
+// export, which can split a group, is 0094.
+//
+// The rows arrive ordered by broker, then group, then posting, so the whole
+// thing is a scan and the output order follows the query's.
+func txWindows(rows []db.ExportPosting) []*archivev1.TxWindow {
+	var out []*archivev1.TxWindow
+	var cur *archivev1.TxWindow
+	var curGroup *archivev1.TxGroup
+	var curBroker, curGroupID string
+	var from, last time.Time
+
+	closeWindow := func() {
+		if cur != nil {
+			cur.PeriodFrom = timestamppb.New(from)
+			cur.PeriodBefore = timestamppb.New(last.UTC().Truncate(24*time.Hour).AddDate(0, 0, 1))
+		}
+	}
+	for _, r := range rows {
+		if cur == nil || r.Broker != curBroker {
+			closeWindow()
+			cur = &archivev1.TxWindow{
+				Broker: db.StrToBroker(r.Broker),
+				// The window says where the file came from, and it came from an
+				// export. A posting's own source, where one was recorded, is the
+				// domain of its BROKER_DESCRIPTION identifier, which is where it
+				// was stored and where it travels; the window's is only the
+				// fallback for a posting carrying no identifier at all.
+				Source: r.Broker + ":archive:export",
+			}
+			curBroker = r.Broker
+			from = r.Timestamp
+			curGroup = nil
+			out = append(out, cur)
+		}
+		if curGroup == nil || r.GroupID != curGroupID {
+			curGroup = &archivev1.TxGroup{}
+			curGroupID = r.GroupID
+			cur.Groups = append(cur.Groups, curGroup)
+		}
+		last = r.Timestamp
+		curGroup.Postings = append(curGroup.Postings, posting(r))
+	}
+	closeWindow()
+	return out
+}
+
+// posting converts one export row to its archive form.
+//
+// Every optional field is written only where the column held something: an
+// absent unit price is not a price of zero, and an absent share count basis is
+// the posting's own timestamp date rather than an unstated one.
+func posting(r db.ExportPosting) *archivev1.Posting {
+	p := &archivev1.Posting{
+		Timestamp:             timestamppb.New(r.Timestamp),
+		Account:               r.Account,
+		AccountType:           db.StrToAccountType(r.AccountType),
+		Type:                  db.StrToTxType(r.TxType),
+		InstrumentDescription: r.Description,
+		Quantity:              r.Quantity.String(),
+	}
+	// A posting whose instrument never resolved has no identifier to name, and
+	// resolves from its description on the way back in.
+	if r.IdentifierType != "" {
+		p.IdentifierHints = []*archivev1.InstrumentRef{{
+			Type:   identifierTypeFromString(r.IdentifierType),
+			Value:  r.IdentifierValue,
+			Domain: r.IdentifierDomain,
+		}}
+	}
+	if r.UnitPrice != nil {
+		p.UnitPrice = proto.String(r.UnitPrice.String())
+	}
+	if r.TradingCurrency != "" {
+		p.TradingCurrency = proto.String(r.TradingCurrency)
+	}
+	if r.SettlementCurrency != "" {
+		p.SettlementCurrency = proto.String(r.SettlementCurrency)
+	}
+	if r.BrokerRef != "" {
+		p.BrokerRef = proto.String(r.BrokerRef)
+	}
+	if r.CounterpartyAccount != "" {
+		p.CounterpartyAccount = proto.String(r.CounterpartyAccount)
+	}
+	if r.ShareCountBasis != nil {
+		p.ShareCountBasis = proto.String(r.ShareCountBasis.Format("2006-01-02"))
+	}
+	return p
+}

--- a/server/service/api/txs_export_test.go
+++ b/server/service/api/txs_export_test.go
@@ -1,0 +1,198 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
+	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
+	dbpkg "github.com/leedenison/portfoliodb/server/db"
+)
+
+func mustTime(t *testing.T, s string) time.Time {
+	t.Helper()
+	v, err := time.Parse(time.RFC3339, s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return v
+}
+
+// exportPostingFixture is a minimal stored posting, enough to drive the window
+// and group assembly without stating every column.
+func exportPostingFixture(broker, groupID, ts string) dbpkg.ExportPosting {
+	at, _ := time.Parse(time.RFC3339, ts)
+	return dbpkg.ExportPosting{
+		Broker:          broker,
+		GroupID:         groupID,
+		GroupTimestamp:  at,
+		Timestamp:       at,
+		Account:         "acct",
+		AccountType:     "USER",
+		TxType:          "BUYSTOCK",
+		Description:     "APPLE INC",
+		IdentifierType:  "MIC_TICKER",
+		IdentifierValue: "AAPL",
+		Quantity:        decimal.RequireFromString("10"),
+	}
+}
+
+// One window per broker, and its period derived from the postings it holds, so
+// the window provably contains everything in it. Import replaces a period, so
+// two windows naming one broker would delete each other's groups.
+func TestTxWindows_OneWindowPerBrokerBoundedByItsOwnRows(t *testing.T) {
+	rows := []dbpkg.ExportPosting{
+		exportPostingFixture("FIDELITY", "g1", "2024-01-15T10:00:00Z"),
+		exportPostingFixture("FIDELITY", "g2", "2024-03-02T14:30:00Z"),
+		exportPostingFixture("IBKR", "g3", "2023-06-01T09:00:00Z"),
+	}
+	got := txWindows(rows)
+	if len(got) != 2 {
+		t.Fatalf("windows = %d, want 2", len(got))
+	}
+	if got[0].GetBroker() != typev1.Broker_FIDELITY {
+		t.Fatalf("window 0 broker = %s", got[0].GetBroker())
+	}
+	if want := mustTime(t, "2024-01-15T10:00:00Z"); !got[0].GetPeriodFrom().AsTime().Equal(want) {
+		t.Fatalf("period_from = %s, want %s", got[0].GetPeriodFrom().AsTime(), want)
+	}
+	// Exclusive, and past the last posting's day, so the last posting is inside.
+	if want := mustTime(t, "2024-03-03T00:00:00Z"); !got[0].GetPeriodBefore().AsTime().Equal(want) {
+		t.Fatalf("period_before = %s, want %s", got[0].GetPeriodBefore().AsTime(), want)
+	}
+	if got[1].GetBroker() != typev1.Broker_IBKR {
+		t.Fatalf("window 1 broker = %s", got[1].GetBroker())
+	}
+	if want := mustTime(t, "2023-06-02T00:00:00Z"); !got[1].GetPeriodBefore().AsTime().Equal(want) {
+		t.Fatalf("window 1 period_before = %s, want %s", got[1].GetPeriodBefore().AsTime(), want)
+	}
+}
+
+// The window's source names the export rather than an ingestion job. A posting's
+// own source, where one was recorded, travels as the domain of its
+// BROKER_DESCRIPTION identifier.
+func TestTxWindows_SourceNamesTheExport(t *testing.T) {
+	got := txWindows([]dbpkg.ExportPosting{exportPostingFixture("FIDELITY", "g1", "2024-01-15T10:00:00Z")})
+	if got[0].GetSource() != "FIDELITY:archive:export" {
+		t.Fatalf("source = %q", got[0].GetSource())
+	}
+}
+
+// Grouping is structural: postings sharing a group id nest inside one group, and
+// the group carries no id of its own.
+func TestTxWindows_PostingsNestByGroup(t *testing.T) {
+	rows := []dbpkg.ExportPosting{
+		exportPostingFixture("FIDELITY", "g1", "2024-01-15T10:00:00Z"),
+		exportPostingFixture("FIDELITY", "g1", "2024-01-15T10:00:00Z"),
+		exportPostingFixture("FIDELITY", "g2", "2024-01-16T10:00:00Z"),
+	}
+	got := txWindows(rows)
+	if len(got) != 1 {
+		t.Fatalf("windows = %d, want 1", len(got))
+	}
+	groups := got[0].GetGroups()
+	if len(groups) != 2 {
+		t.Fatalf("groups = %d, want 2", len(groups))
+	}
+	if len(groups[0].GetPostings()) != 2 || len(groups[1].GetPostings()) != 1 {
+		t.Fatalf("postings per group = %d, %d; want 2, 1",
+			len(groups[0].GetPostings()), len(groups[1].GetPostings()))
+	}
+}
+
+// A routed residual travels with its group. It is server-generated, but a group
+// exported with its residual sums to zero and the balancer routes nothing for a
+// commodity that does, so re-importing routes nothing a second time.
+func TestTxWindows_CarriesRoutedResiduals(t *testing.T) {
+	residual := exportPostingFixture("FIDELITY", "g1", "2024-01-15T10:00:00Z")
+	residual.AccountType = "IMBALANCE"
+	got := txWindows([]dbpkg.ExportPosting{
+		exportPostingFixture("FIDELITY", "g1", "2024-01-15T10:00:00Z"),
+		residual,
+	})
+	postings := got[0].GetGroups()[0].GetPostings()
+	if len(postings) != 2 {
+		t.Fatalf("postings = %d, want 2", len(postings))
+	}
+	if postings[1].GetAccountType() != typev1.AccountType_ACCOUNT_TYPE_IMBALANCE {
+		t.Fatalf("account_type = %s, want IMBALANCE", postings[1].GetAccountType())
+	}
+}
+
+// Absent is not zero. A column that held nothing is left out rather than
+// written as an empty string, so a reader can tell "the file does not state it"
+// from "it is empty".
+func TestPosting_OptionalFieldsWrittenOnlyWhenHeld(t *testing.T) {
+	bare := posting(exportPostingFixture("FIDELITY", "g1", "2024-01-15T10:00:00Z"))
+	if bare.UnitPrice != nil || bare.TradingCurrency != nil || bare.SettlementCurrency != nil ||
+		bare.BrokerRef != nil || bare.CounterpartyAccount != nil || bare.ShareCountBasis != nil {
+		t.Fatalf("bare posting states an absent field: %v", bare)
+	}
+
+	r := exportPostingFixture("FIDELITY", "g1", "2024-01-15T10:00:00Z")
+	price := decimal.RequireFromString("185.9")
+	r.UnitPrice = &price
+	r.TradingCurrency = "USD"
+	r.SettlementCurrency = "GBP"
+	r.BrokerRef = "REF-1"
+	r.CounterpartyAccount = "other"
+	full := posting(r)
+	if full.GetUnitPrice() != "185.9" {
+		t.Fatalf("unit_price = %q", full.GetUnitPrice())
+	}
+	if full.GetTradingCurrency() != "USD" || full.GetSettlementCurrency() != "GBP" {
+		t.Fatalf("currencies = %q, %q", full.GetTradingCurrency(), full.GetSettlementCurrency())
+	}
+	if full.GetBrokerRef() != "REF-1" || full.GetCounterpartyAccount() != "other" {
+		t.Fatalf("refs = %q, %q", full.GetBrokerRef(), full.GetCounterpartyAccount())
+	}
+}
+
+// The basis is written only where it differs from the posting's own date. The
+// query reports as-traded as nil, which is what the great majority of postings
+// are, and stamping a redundant date on every one of them would say nothing.
+func TestPosting_ShareCountBasisOnlyWhenRestated(t *testing.T) {
+	r := exportPostingFixture("FIDELITY", "g1", "2024-01-15T10:00:00Z")
+	basis := mustTime(t, "2025-07-01T00:00:00Z")
+	r.ShareCountBasis = &basis
+	if got := posting(r).GetShareCountBasis(); got != "2025-07-01" {
+		t.Fatalf("share_count_basis = %q, want 2025-07-01", got)
+	}
+}
+
+// A posting whose instrument never resolved has no identifier to name. It
+// travels with none and resolves from its description on the way back in, rather
+// than carrying an UNSPECIFIED type that would fail validation.
+func TestPosting_UnresolvedInstrumentCarriesNoHint(t *testing.T) {
+	r := exportPostingFixture("FIDELITY", "g1", "2024-01-15T10:00:00Z")
+	r.IdentifierType = ""
+	r.IdentifierValue = ""
+	if hints := posting(r).GetIdentifierHints(); len(hints) != 0 {
+		t.Fatalf("identifier_hints = %v, want none", hints)
+	}
+}
+
+// The identifier bestIdentifierJoin picked becomes the posting's one hint, with
+// its domain, so a broker-description instrument keeps the source it resolved
+// under.
+func TestPosting_CarriesTheBestIdentifier(t *testing.T) {
+	r := exportPostingFixture("FIDELITY", "g1", "2024-01-15T10:00:00Z")
+	r.IdentifierType = "BROKER_DESCRIPTION"
+	r.IdentifierValue = "APPLE INC"
+	r.IdentifierDomain = "Fidelity:web:fidelity-csv"
+	hints := posting(r).GetIdentifierHints()
+	if len(hints) != 1 {
+		t.Fatalf("identifier_hints = %v, want 1", hints)
+	}
+	want := &archivev1.InstrumentRef{
+		Type:   typev1.IdentifierType_BROKER_DESCRIPTION,
+		Value:  "APPLE INC",
+		Domain: "Fidelity:web:fidelity-csv",
+	}
+	if hints[0].GetType() != want.GetType() || hints[0].GetValue() != want.GetValue() ||
+		hints[0].GetDomain() != want.GetDomain() {
+		t.Fatalf("hint = %v, want %v", hints[0], want)
+	}
+}

--- a/server/service/api/user_archive.go
+++ b/server/service/api/user_archive.go
@@ -74,6 +74,9 @@ func presentUserParts(a *archivev1.UserArchive) []archivev1.ArchivePart {
 	if a.GetPreferences() != nil {
 		parts = append(parts, archivev1.ArchivePart_PREFERENCES)
 	}
+	if a.GetTxs() != nil {
+		parts = append(parts, archivev1.ArchivePart_TXS)
+	}
 	return parts
 }
 
@@ -118,6 +121,8 @@ func (s *Server) ExportUserArchive(req *apiv1.ExportUserArchiveRequest, stream a
 		switch part {
 		case archivev1.ArchivePart_PREFERENCES:
 			partErr = s.sendPreferencePart(ctx, u.ID, stream)
+		case archivev1.ArchivePart_TXS:
+			partErr = s.sendTxPart(ctx, u.ID, stream)
 		}
 		if partErr != nil {
 			return partErr
@@ -177,4 +182,32 @@ func archiveIgnoredRules(rules []db.IgnoredAssetClass) []*archivev1.IgnoredAsset
 		})
 	}
 	return out
+}
+
+// sendTxPart streams one window per broker, each nesting its groups.
+//
+// Grouping is what makes this a part rather than a list of rows. It is the
+// converter's output and nothing can rebuild it -- the server does not pair rows
+// or infer a missing leg -- so an export that flattened it would lose the
+// balance invariant, residual attribution and the association between a fee and
+// its trade, permanently. See
+// docs/adr/0021-converters-own-transaction-grouping.md.
+//
+// The routed residual postings travel with their groups. They are
+// server-generated, but a group exported with its residual already sums to zero
+// and the balancer routes nothing for a commodity that does, so re-importing one
+// is idempotent rather than doubling.
+func (s *Server) sendTxPart(ctx context.Context, userID string, stream apiv1.ApiService_ExportUserArchiveServer) error {
+	rows, err := s.db.ListTxsForExport(ctx, userID)
+	if err != nil {
+		return status.Error(codes.Internal, err.Error())
+	}
+	for _, w := range txWindows(rows) {
+		if err := stream.Send(&apiv1.ExportUserArchiveResponse{
+			Item: &apiv1.ExportUserArchiveResponse_TxWindow{TxWindow: w},
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/server/service/ingestion/worker.go
+++ b/server/service/ingestion/worker.go
@@ -289,12 +289,23 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 	instrumentIDs = append(instrumentIDs, routedIDs...)
 	txWeights = append(txWeights, routedWeights...)
 
+	// The upload declares one basis for every row it carries, so the per-posting
+	// slice the store takes is that value repeated. A file that restates only
+	// some of its rows is the archive's shape, not the CSV's.
+	var basis []*time.Time
+	if shareCountBasis != nil {
+		basis = make([]*time.Time, len(txsToProcess))
+		for i := range basis {
+			basis[i] = shareCountBasis
+		}
+	}
+
 	// Store transactions.
 	var storeErr error
 	if bulk {
-		storeErr = database.ReplaceTxsInPeriod(ctx, userID, broker, j.JobID, req.PeriodFrom, req.PeriodBefore, txsToProcess, instrumentIDs, txWeights, shareCountBasis)
+		storeErr = database.ReplaceTxsInPeriod(ctx, userID, broker, j.JobID, req.PeriodFrom, req.PeriodBefore, txsToProcess, instrumentIDs, txWeights, basis)
 	} else {
-		storeErr = database.CreateTxGroup(ctx, userID, broker, txsToProcess[0].GetAccount(), j.JobID, txsToProcess, instrumentIDs, txWeights, shareCountBasis)
+		storeErr = database.CreateTxGroup(ctx, userID, broker, txsToProcess[0].GetAccount(), j.JobID, txsToProcess, instrumentIDs, txWeights, basis)
 	}
 	if storeErr != nil {
 		log.Printf("ingestion job %s: %v", j.JobID, storeErr)

--- a/server/service/ingestion/worker_test.go
+++ b/server/service/ingestion/worker_test.go
@@ -220,7 +220,7 @@ func TestProcessBulk_DropsTxTypeSplitTransactions(t *testing.T) {
 		Return([]*db.InstrumentRow{{ID: "aapl-id"}}, nil)
 	database.EXPECT().
 		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", "job-split", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
-		DoAndReturn(func(_ context.Context, _, _, _ string, _, _ *timestamppb.Timestamp, storedTxs []*apiv1.Tx, ids []string, ws []db.Weight, _ *time.Time) error {
+		DoAndReturn(func(_ context.Context, _, _, _ string, _, _ *timestamppb.Timestamp, storedTxs []*apiv1.Tx, ids []string, ws []db.Weight, _ []*time.Time) error {
 			supplied := userPostings(storedTxs)
 			if len(supplied) != 1 || supplied[0].InstrumentDescription != "AAPL" || supplied[0].Type != typev1.TxType_BUYSTOCK {
 				t.Errorf("ReplaceTxsInPeriod called with %d supplied txs, expected 1 (AAPL BUYSTOCK)", len(supplied))


### PR DESCRIPTION
First of three for 0077. Adds the `TxPart` writer to the user archive export: one window per broker, each nesting its groups and each group its postings. The import reader and the client menu row follow in the next two.

Grouping is what makes this a part rather than a list of rows. It is the converter's output and nothing can rebuild it -- the server does not pair rows or infer a missing leg -- so a flat export would lose the balance invariant, residual attribution and the association between a fee and its trade, permanently. Routed residuals travel with their groups: the balancer routes nothing for a commodity that already sums to zero, so re-importing an exported group is idempotent rather than doubling. Synthetic `INITIALIZE` pads and their `EQUITY` counterparties are excluded whole, since 0076 exports them as the declarations they come from.

## Three decisions worth calling out

**`share_count_basis` moves from `TxWindow` to `Posting`.** A window-wide value can only say "one date for everything", which cannot express the ordinary case, where every posting is as-traded and therefore carries a different basis from its neighbours. The stored column stays `NOT NULL` and `default_split_adjusted_tx()` already seeds it from the posting's own timestamp, so an absent field costs no query a null check. `ReplaceTxsInPeriod` and `CreateTxGroup` take a per-row slice to match; the CSV upload path, which declares one basis for the whole file, passes that value repeated.

**The window's `source` names the export**, as `"<broker>:archive:export"`. A window is one replacement scope per broker so it carries one source, but `txs` has no source column and one broker's postings come from several jobs. Nothing is lost: a posting's own source, where one was recorded, is the `domain` of its `BROKER_DESCRIPTION` identifier, which is where it was stored and where it travels.

**The window's period is derived from the postings it carries** -- the first posting's instant to the day after the last one's -- so the window provably contains all of them and no group can straddle its edge. `ExportUserArchiveRequest` fields 2 and 3 stay reserved.

## Two issues opened

Planning this turned up a defect that is not the archive's. `ReplaceTxsInPeriod` deletes whole groups on an `EXISTS` over postings in the window, and a group's postings need not share a date -- the Fidelity deposit-run pass groups by reference proximity precisely so a run can span days. A later upload whose window catches one leg destroys legs it will not replace. **0094** covers that, together with the strict-period export it implies. **0095** asks how to rejoin groups that should be one, and records that adr/0037's link-not-merge is scoped to transfers: the link is what preserves the account boundary MWR needs, and an `IMBALANCE` residual has no such boundary.

## Testing

- `server/service/api/txs_export_test.go` -- window and group assembly, period derivation, the source label, routed residuals carried, optional fields written only where held, an unresolved instrument carrying no hint.
- `server/db/postgres/txs_test.go` -- `ListTxsForExport` against real postgres: `bestIdentifierJoin` priority, synthetic groups excluded, the basis reported only where restated, ordering stable.
- `server/service/api/export_user_archive_test.go` -- both parts travel in restore order whatever order they were asked for in, and a TXS part asked for over no transactions is present and empty.

`make test`, `make db-test` and `make lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)