### PR TITLE
Import a user's transactions from an archive part (0077)

### DIFF
--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -216,7 +216,7 @@ CREATE TABLE ingestion_job_parts (
   part            TEXT NOT NULL CHECK (part IN ('INSTRUMENTS', 'PRICES', 'CORPORATE_EVENTS',
                                                 'INFLATION_INDICES', 'FETCH_BLOCKS',
                                                 'UNHANDLED_EVENTS', 'PLUGIN_CONFIG',
-                                                'PREFERENCES')),
+                                                'PREFERENCES', 'TXS')),
   status          TEXT NOT NULL CHECK (status IN ('PENDING', 'RUNNING', 'SUCCESS', 'FAILED')),
   total_count     INT NOT NULL DEFAULT 0,
   processed_count INT NOT NULL DEFAULT 0,

--- a/server/service/ingestion/ingest.go
+++ b/server/service/ingestion/ingest.go
@@ -1,0 +1,233 @@
+package ingestion
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	"github.com/leedenison/portfoliodb/server/archiveimport"
+	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/identifier"
+	"github.com/leedenison/portfoliodb/server/identifier/description"
+	"github.com/leedenison/portfoliodb/server/telemetry"
+)
+
+// errBatchRejected reports that a batch was not stored because its contents
+// were rejected. What was wrong is on the reporter, a problem at a time; this
+// only says that the caller should mark its job or its part failed.
+//
+// A rejected posting fails its whole batch rather than being dropped, which is
+// what the archive format allows a part to do for a row. Postings are not
+// independent: a group balances or it does not, so storing the survivors of a
+// group would store something that never happened.
+var errBatchRejected = errors.New("batch rejected")
+
+// ingestDeps are the collaborators a batch needs, distinct from what it is
+// ingesting.
+type ingestDeps struct {
+	DB           db.DB
+	Registry     *identifier.Registry
+	DescRegistry *description.Registry
+	Counter      telemetry.CounterIncrementer
+}
+
+// ingestParams is one batch of postings and the scope they are stored under.
+type ingestParams struct {
+	UserID string
+	// Broker in its stored form, not the enum.
+	Broker string
+	Source string
+	// JobID stamps the groups this batch creates, so a group can be traced back
+	// to the upload or import that wrote it.
+	JobID string
+	Txs   []*apiv1.Tx
+	// ShareCountBasis is parallel to Txs, or nil when every row is as-traded.
+	ShareCountBasis []*time.Time
+	// PeriodFrom and PeriodBefore make this a replacement rather than an append.
+	// Both nil appends the batch as one group, which is the manual-entry path.
+	PeriodFrom, PeriodBefore *timestamppb.Timestamp
+	// RowIndices maps each tx back to the index the caller wants a problem
+	// reported against, so an error points at the file rather than at the
+	// filtered slice. nil means the tx's own position.
+	RowIndices []int
+	// TotalDeclared says the caller has already told the reporter how much work
+	// there is, counting the postings handed to this batch. A caller running
+	// several batches -- one per archive window -- declares one total across all
+	// of them, and the batch then advances past what it filters out so the
+	// progress still reaches that total. Left false, the batch declares its own
+	// total, which is what an upload of one file wants: the count is what will
+	// be stored.
+	TotalDeclared bool
+}
+
+// ingestResult reports what a batch did, for a caller deciding what to nudge.
+
+type ingestResult struct {
+	Stored int
+	// InstrumentIDs is every instrument the batch touched, routed residuals
+	// included, so a caller can recompute split adjustments once for several
+	// batches rather than once per batch.
+	InstrumentIDs []string
+}
+
+// ingestBatch resolves, balances and stores one batch of postings.
+//
+// It is the whole of the ingestion pipeline below the payload: shared by the
+// broker upload, which is one batch per job, and by the archive transaction
+// part, which is one batch per window. Problems go to the reporter and a
+// rejection comes back as errBatchRejected, so the caller decides whether a
+// rejection fails a job or only a part.
+func ingestBatch(ctx context.Context, deps ingestDeps, p ingestParams, rep *archiveimport.PartReporter) (ingestResult, error) {
+	var out ingestResult
+
+	if errs := ValidateTxs(p.Txs); len(errs) > 0 {
+		rep.Errs(errs)
+		return out, errBatchRejected
+	}
+	// A rule this reader cannot load is not a reason to reject the batch: the
+	// filter narrows what is stored, and storing more than asked is better than
+	// storing nothing.
+	ignoredClasses, err := deps.DB.ListIgnoredAssetClasses(ctx, p.UserID)
+	if err != nil {
+		log.Printf("ingest: load ignored asset classes: %v", err)
+		ignoredClasses = nil
+	}
+	// Drop non-stored tx types (SPLIT, which the corporate event path owns) and
+	// whatever the user's ignore rules cover. Where the caller declared the
+	// total, a dropped posting still counts as processed: its total is what the
+	// file carried, and a job that ended below its own total would read as
+	// unfinished.
+	txs, filteredIdx := filterStoredTxs(p.Txs, p.Broker, ignoredClasses)
+	if p.TotalDeclared {
+		rep.Advance(ctx, len(p.Txs)-len(txs))
+	}
+	replacing := p.PeriodFrom != nil && p.PeriodBefore != nil
+	// A batch handed no postings at all, over a period, is an instruction to
+	// clear that period -- which is what an archive window holding no groups
+	// says, and the reason a window states its period rather than having one
+	// inferred from its groups.
+	//
+	// A batch whose postings were all filtered out is not the same statement.
+	// Nothing asked for those rows to be removed; a filter decided this instance
+	// does not store them, and acting on that by emptying the period would
+	// delete rows the file never mentioned.
+	clearing := replacing && len(p.Txs) == 0
+	if len(txs) == 0 && !clearing {
+		return out, nil
+	}
+	if !p.TotalDeclared {
+		rep.Total(ctx, len(txs))
+	}
+	rowIdx := make([]int, len(filteredIdx))
+	for i, f := range filteredIdx {
+		rowIdx[i] = f
+		if p.RowIndices != nil && f < len(p.RowIndices) {
+			rowIdx[i] = p.RowIndices[f]
+		}
+	}
+
+	if clearing {
+		// Nothing to resolve or balance: the delete is the whole instruction.
+		if err := deps.DB.ReplaceTxsInPeriod(ctx, p.UserID, p.Broker, p.JobID, p.PeriodFrom, p.PeriodBefore, nil, nil, nil, nil); err != nil {
+			rep.Errf(-1, "txs", err.Error())
+			return out, fmt.Errorf("clear period: %w", err)
+		}
+		return out, nil
+	}
+
+	cache, extractedHints, err := extractDescHints(ctx, deps.DB, deps.DescRegistry, deps.Counter, p.Source, p.Broker, txs)
+	if err != nil {
+		rep.Errf(-1, "txs", err.Error())
+		return out, fmt.Errorf("extract description hints: %w", err)
+	}
+	instrumentIDs, idErrs, err := resolveInstruments(ctx, deps.DB, deps.Registry, p.Broker, p.Source, deps.Counter, txs, rowIdx, cache, extractedHints, rep)
+	if err != nil {
+		rep.Errf(-1, "instrument_description", err.Error())
+		return out, fmt.Errorf("resolve instruments: %w", err)
+	}
+	if len(idErrs) > 0 {
+		_ = deps.DB.AppendIdentificationErrors(ctx, p.JobID, idErrs)
+	}
+	// The resolved instruments feed both the asset-class check and balancing.
+	instByID, err := instrumentsByID(ctx, deps.DB, instrumentIDs)
+	if err != nil {
+		rep.Errf(-1, "txs", err.Error())
+		return out, fmt.Errorf("load instruments: %w", err)
+	}
+	// Catches contradictions that arise when two txs share (source, description)
+	// but their tx types imply different asset classes (e.g. BUYSTOCK + INCOME),
+	// as well as any other path where resolution lands on the wrong class.
+	if classErrs := validateAssetClasses(txs, rowIdx, instrumentIDs, instByID); len(classErrs) > 0 {
+		rep.Errs(classErrs)
+		return out, errBatchRejected
+	}
+	// Balance every group by routing whatever its postings leave over to an
+	// explicit counterparty. This runs after filtering, so a dropped SPLIT leg
+	// cannot contribute a residual, and after resolution, because telling a
+	// currency commodity from a security one is a property of the instrument.
+	balanceInsts := balanceInstruments(instByID)
+	routed := routeResiduals(txs, instrumentIDs, balanceInsts)
+	routedTxs, routedIDs, routedWeights, unresolved := resolveRouted(ctx, deps.DB, routed)
+	// A residual with no instrument to post it against leaves its group
+	// unbalanced, which the balance constraint rejects at COMMIT and which would
+	// surface as a constraint violation naming nothing. Naming the commodity
+	// here is what makes it legible. Currencies are seeded, so this is a safety
+	// net rather than a live path.
+	if len(unresolved) > 0 {
+		for _, cur := range unresolved {
+			log.Printf("ingest: no instrument for residual commodity %q", cur)
+			rep.Errf(-1, "instrument_description",
+				fmt.Sprintf("no instrument for residual commodity %q; the group it balances cannot be stored", cur))
+		}
+		return out, errBatchRejected
+	}
+	// Weighed after routing, which is what assigns a synthetic group_ref to a
+	// posting that had none, and before the routed postings are appended, since
+	// those carry the weight of the residual they negate rather than one derived
+	// from the tx.
+	txWeights := weights(txs, instrumentIDs, balanceInsts)
+	basis := filterBasis(p.ShareCountBasis, filteredIdx)
+	txs = append(txs, routedTxs...)
+	instrumentIDs = append(instrumentIDs, routedIDs...)
+	txWeights = append(txWeights, routedWeights...)
+	// A routed posting is denominated the way the leg it negates is, which is
+	// what a nil entry says: the store leaves it to the insert trigger, which
+	// takes the posting's own date, and a routed leg clones the first leg's
+	// timestamp.
+	for len(basis) > 0 && len(basis) < len(txs) {
+		basis = append(basis, nil)
+	}
+
+	if replacing {
+		err = deps.DB.ReplaceTxsInPeriod(ctx, p.UserID, p.Broker, p.JobID, p.PeriodFrom, p.PeriodBefore, txs, instrumentIDs, txWeights, basis)
+	} else {
+		err = deps.DB.CreateTxGroup(ctx, p.UserID, p.Broker, txs[0].GetAccount(), p.JobID, txs, instrumentIDs, txWeights, basis)
+	}
+	if err != nil {
+		rep.Errf(-1, "txs", err.Error())
+		return out, fmt.Errorf("store postings: %w", err)
+	}
+	out.Stored = len(txs)
+	out.InstrumentIDs = instrumentIDs
+	return out, nil
+}
+
+// filterBasis narrows a per-row basis slice to the rows that survived
+// filtering, so it stays parallel to the postings actually being stored.
+func filterBasis(basis []*time.Time, filteredIdx []int) []*time.Time {
+	if len(basis) == 0 {
+		return nil
+	}
+	out := make([]*time.Time, len(filteredIdx))
+	for i, f := range filteredIdx {
+		if f < len(basis) {
+			out[i] = basis[f]
+		}
+	}
+	return out
+}

--- a/server/service/ingestion/tx_import.go
+++ b/server/service/ingestion/tx_import.go
@@ -1,0 +1,166 @@
+package ingestion
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"google.golang.org/protobuf/proto"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
+	"github.com/leedenison/portfoliodb/server/archiveimport"
+	"github.com/leedenison/portfoliodb/server/db"
+)
+
+// importTxPart applies an archive's transaction part, one window at a time.
+//
+// A window is a replacement scope, so each one is stored with the period it
+// states rather than with a period inferred from its groups: a window holding no
+// groups is a valid instruction to clear that period, and an inferred one could
+// never say that. See docs/adr/0002-transaction-ingestion-model.md.
+//
+// Split adjustments are recomputed once for the whole part rather than once per
+// window. The pass rescans every posting of each instrument it is given, so
+// running it per window would rescan the same instruments repeatedly for a
+// result that only the last run decides.
+func importTxPart(ctx context.Context, deps ingestDeps, userID, jobID string, part *archivev1.TxPart, rep *archiveimport.PartReporter) (bool, error) {
+	windows := part.GetWindows()
+	// The part's unit is a posting, which is what a window's own progress counts
+	// and what a reader watching the job expects to see move.
+	total := 0
+	for _, w := range windows {
+		for _, g := range w.GetGroups() {
+			total += len(g.GetPostings())
+		}
+	}
+	rep.Total(ctx, total)
+
+	var touched []string
+	stored := false
+	// Row indices run across the whole part rather than restarting per window,
+	// so a problem points at a posting in the document.
+	offset := 0
+	for _, w := range windows {
+		broker := db.BrokerToStr(w.GetBroker())
+		if broker == "" {
+			rep.Errf(offset, "broker", fmt.Sprintf("unknown broker %q", w.GetBroker()))
+			return stored, fmt.Errorf("window names broker %q", w.GetBroker())
+		}
+		txs, basis, rowIdx, err := windowTxs(w, offset, rep)
+		if err != nil {
+			return stored, err
+		}
+		offset += len(txs)
+
+		res, err := ingestBatch(ctx, deps, ingestParams{
+			UserID:          userID,
+			Broker:          broker,
+			Source:          w.GetSource(),
+			JobID:           jobID,
+			Txs:             txs,
+			ShareCountBasis: basis,
+			PeriodFrom:      w.GetPeriodFrom(),
+			PeriodBefore:    w.GetPeriodBefore(),
+			RowIndices:      rowIdx,
+			TotalDeclared:   true,
+		}, rep)
+		if err != nil {
+			return stored, err
+		}
+		if res.Stored > 0 {
+			stored = true
+		}
+		touched = append(touched, res.InstrumentIDs...)
+	}
+
+	recomputeSplitAdjustedTxs(ctx, deps.DB, touched)
+	return stored, nil
+}
+
+// windowTxs flattens one window's nested groups into the postings the ingestion
+// pipeline takes, with a synthesised group_ref per group.
+//
+// The archive nests its groups and the store rebuilds them from a shared key, so
+// the key is invented here and thrown away with the call. That is what group_ref
+// always was: an opaque token scoped to one upload, never stored, and the reason
+// the format replaced it with structure.
+func windowTxs(w *archivev1.TxWindow, offset int, rep *archiveimport.PartReporter) ([]*apiv1.Tx, []*time.Time, []int, error) {
+	var txs []*apiv1.Tx
+	var basis []*time.Time
+	var rowIdx []int
+	anyBasis := false
+	for gi, g := range w.GetGroups() {
+		ref := fmt.Sprintf("g%d", gi)
+		for _, pos := range g.GetPostings() {
+			row := offset + len(txs)
+			b, err := postingBasis(pos)
+			if err != nil {
+				rep.Errf(row, "share_count_basis", err.Error())
+				return nil, nil, nil, fmt.Errorf("posting %d: %w", row, err)
+			}
+			if b != nil {
+				anyBasis = true
+			}
+			txs = append(txs, archiveTx(pos, ref))
+			basis = append(basis, b)
+			rowIdx = append(rowIdx, row)
+		}
+	}
+	// A window that restates nothing carries no basis slice at all, which is
+	// what leaves every posting to the insert trigger and its own date.
+	if !anyBasis {
+		basis = nil
+	}
+	return txs, basis, rowIdx, nil
+}
+
+// postingBasis parses a restated share count basis. Absent is nil, which the
+// store reads as the posting's own timestamp date.
+func postingBasis(p *archivev1.Posting) (*time.Time, error) {
+	b := p.GetShareCountBasis()
+	if b == "" {
+		return nil, nil
+	}
+	parsed, err := time.Parse("2006-01-02", b)
+	if err != nil {
+		return nil, fmt.Errorf("invalid date %q: want YYYY-MM-DD", b)
+	}
+	return &parsed, nil
+}
+
+// archiveTx converts one archive posting into the ingestion form.
+//
+// account_type travels as it was stored, routed residuals included. A group
+// exported with its residual already sums to zero, and the balancer routes
+// nothing for a commodity that does, so re-importing one is idempotent rather
+// than doubling.
+func archiveTx(p *archivev1.Posting, groupRef string) *apiv1.Tx {
+	tx := &apiv1.Tx{
+		Timestamp:             p.GetTimestamp(),
+		InstrumentDescription: p.GetInstrumentDescription(),
+		Type:                  p.GetType(),
+		Quantity:              p.GetQuantity(),
+		Account:               p.GetAccount(),
+		AccountType:           p.GetAccountType(),
+		GroupRef:              groupRef,
+		BrokerRef:             p.GetBrokerRef(),
+		CounterpartyAccount:   p.GetCounterpartyAccount(),
+		TradingCurrency:       p.GetTradingCurrency(),
+		SettlementCurrency:    p.GetSettlementCurrency(),
+	}
+	if p.UnitPrice != nil {
+		tx.UnitPrice = proto.String(p.GetUnitPrice())
+	}
+	// The archive can name several identifiers per posting, which the flat CSV
+	// could not. They are hints rather than an assertion: resolution still runs,
+	// and an instrument the importing instance already holds wins.
+	for _, h := range p.GetIdentifierHints() {
+		tx.IdentifierHints = append(tx.IdentifierHints, &apiv1.InstrumentIdentifier{
+			Type:   h.GetType(),
+			Value:  h.GetValue(),
+			Domain: h.GetDomain(),
+		})
+	}
+	return tx
+}

--- a/server/service/ingestion/tx_import_test.go
+++ b/server/service/ingestion/tx_import_test.go
@@ -1,0 +1,272 @@
+package ingestion
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
+	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
+	"github.com/leedenison/portfoliodb/server/archiveimport"
+	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/db/mock"
+)
+
+func archivePosting(desc, qty string, txType typev1.TxType) *archivev1.Posting {
+	return &archivev1.Posting{
+		Timestamp:             timestamppb.New(mustParseDay("2024-01-15")),
+		Account:               "acct",
+		Type:                  txType,
+		InstrumentDescription: desc,
+		Quantity:              qty,
+		IdentifierHints: []*archivev1.InstrumentRef{{
+			Type: typev1.IdentifierType_BROKER_DESCRIPTION, Value: desc, Domain: "IBKR",
+		}},
+	}
+}
+
+func mustParseDay(s string) time.Time {
+	v, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+// The archive nests its groups; the store rebuilds them from a shared key. The
+// key is invented per group and thrown away with the call, which is what
+// group_ref always was.
+func TestWindowTxs_SynthesisesAGroupRefPerGroup(t *testing.T) {
+	w := &archivev1.TxWindow{
+		Broker: typev1.Broker_IBKR,
+		Source: "IBKR:archive:export",
+		Groups: []*archivev1.TxGroup{
+			{Postings: []*archivev1.Posting{
+				archivePosting("AAPL", "10", typev1.TxType_BUYSTOCK),
+				archivePosting("USD", "-1000", typev1.TxType_BUYSTOCK),
+			}},
+			{Postings: []*archivev1.Posting{
+				archivePosting("MSFT", "5", typev1.TxType_BUYSTOCK),
+			}},
+		},
+	}
+	txs, basis, rowIdx, err := windowTxs(w, 0, archiveimport.NewDetachedReporter())
+	if err != nil {
+		t.Fatalf("windowTxs: %v", err)
+	}
+	if len(txs) != 3 {
+		t.Fatalf("txs = %d, want 3", len(txs))
+	}
+	if txs[0].GetGroupRef() != txs[1].GetGroupRef() {
+		t.Fatalf("legs of one group have refs %q and %q", txs[0].GetGroupRef(), txs[1].GetGroupRef())
+	}
+	if txs[2].GetGroupRef() == txs[0].GetGroupRef() {
+		t.Fatalf("two groups share ref %q", txs[2].GetGroupRef())
+	}
+	// A window that restates nothing carries no basis slice, which is what
+	// leaves every posting to the insert trigger and its own date.
+	if basis != nil {
+		t.Fatalf("basis = %v, want nil for an as-traded window", basis)
+	}
+	want := []int{0, 1, 2}
+	for i := range want {
+		if rowIdx[i] != want[i] {
+			t.Fatalf("row indices = %v, want %v", rowIdx, want)
+		}
+	}
+}
+
+// Row indices run across the whole part rather than restarting per window, so a
+// problem points at a posting in the document.
+func TestWindowTxs_RowIndicesContinueAcrossWindows(t *testing.T) {
+	w := &archivev1.TxWindow{
+		Broker: typev1.Broker_IBKR,
+		Groups: []*archivev1.TxGroup{{Postings: []*archivev1.Posting{
+			archivePosting("AAPL", "10", typev1.TxType_BUYSTOCK),
+		}}},
+	}
+	_, _, rowIdx, err := windowTxs(w, 7, archiveimport.NewDetachedReporter())
+	if err != nil {
+		t.Fatalf("windowTxs: %v", err)
+	}
+	if len(rowIdx) != 1 || rowIdx[0] != 7 {
+		t.Fatalf("row indices = %v, want [7]", rowIdx)
+	}
+}
+
+// Absent means the posting's own timestamp date, so only a restated posting
+// gets an entry and a window with one gets a slice.
+func TestWindowTxs_CarriesARestatedBasis(t *testing.T) {
+	restated := archivePosting("AAPL", "10", typev1.TxType_BUYSTOCK)
+	restated.ShareCountBasis = proto.String("2025-07-01")
+	w := &archivev1.TxWindow{
+		Broker: typev1.Broker_IBKR,
+		Groups: []*archivev1.TxGroup{{Postings: []*archivev1.Posting{
+			archivePosting("MSFT", "5", typev1.TxType_BUYSTOCK),
+			restated,
+		}}},
+	}
+	_, basis, _, err := windowTxs(w, 0, archiveimport.NewDetachedReporter())
+	if err != nil {
+		t.Fatalf("windowTxs: %v", err)
+	}
+	if len(basis) != 2 {
+		t.Fatalf("basis = %v, want one entry per posting", basis)
+	}
+	if basis[0] != nil {
+		t.Fatalf("as-traded posting carries a basis: %v", basis[0])
+	}
+	if basis[1] == nil || !basis[1].Equal(mustParseDay("2025-07-01")) {
+		t.Fatalf("restated basis = %v, want 2025-07-01", basis[1])
+	}
+}
+
+// A routed residual travels as an ordinary posting carrying the account type it
+// was stored under, so the group it balances still sums to zero on the way in
+// and nothing is routed a second time.
+func TestArchiveTx_CarriesTheRoutedAccountType(t *testing.T) {
+	p := archivePosting("USD", "-3.5", typev1.TxType_BUYSTOCK)
+	p.AccountType = typev1.AccountType_ACCOUNT_TYPE_IMBALANCE
+	tx := archiveTx(p, "g0")
+	if tx.GetAccountType() != typev1.AccountType_ACCOUNT_TYPE_IMBALANCE {
+		t.Fatalf("account_type = %s, want IMBALANCE", tx.GetAccountType())
+	}
+}
+
+// Optional fields that the file does not state stay unset rather than becoming
+// an empty string or a zero price.
+func TestArchiveTx_UnstatedFieldsStayUnset(t *testing.T) {
+	tx := archiveTx(archivePosting("AAPL", "10", typev1.TxType_BUYSTOCK), "g0")
+	if tx.UnitPrice != nil {
+		t.Fatalf("unit_price = %v, want unset", tx.UnitPrice)
+	}
+	if tx.GetBrokerRef() != "" || tx.GetCounterpartyAccount() != "" {
+		t.Fatalf("refs = %q, %q, want empty", tx.GetBrokerRef(), tx.GetCounterpartyAccount())
+	}
+	if len(tx.GetIdentifierHints()) != 1 {
+		t.Fatalf("identifier_hints = %v, want the one the export chose", tx.GetIdentifierHints())
+	}
+}
+
+// A window is a replacement scope, so it is stored with the period it states
+// rather than one inferred from its groups.
+//
+// The group here already sums to zero, as an exported one does, and comes back
+// with exactly the postings the file stated: the balancer routes nothing for a
+// commodity that already balances, so a re-imported group is not given a second
+// residual. That is what makes the round trip idempotent.
+func TestImportTxPart_StoresEachWindowWithItsOwnPeriod(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	database := mock.NewMockDB(ctrl)
+	database.EXPECT().ListIgnoredAssetClasses(gomock.Any(), "user-1").Return(nil, nil).AnyTimes()
+	database.EXPECT().FindInstrumentBySourceDescription(gomock.Any(), gomock.Any(), gomock.Any()).Return("inst-1", nil).AnyTimes()
+	database.EXPECT().FindInstrumentByIdentifier(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("inst-1", nil).AnyTimes()
+	database.EXPECT().ListInstrumentsByIDs(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	database.EXPECT().AppendIdentificationErrors(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().InstrumentsWithSplits(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	from := timestamppb.New(mustParseDay("2024-01-01"))
+	before := timestamppb.New(mustParseDay("2024-02-01"))
+	database.EXPECT().
+		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", "job-tx", from, before,
+			gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _ string, _, _ *timestamppb.Timestamp,
+			txs []*apiv1.Tx, _ []string, _ []db.Weight, _ []*time.Time) error {
+			if len(txs) != 2 {
+				t.Errorf("stored %d postings, want the 2 the file stated", len(txs))
+			}
+			for _, tx := range txs {
+				if tx.GetAccountType() == typev1.AccountType_ACCOUNT_TYPE_IMBALANCE {
+					t.Errorf("a balanced group was routed a residual: %v", tx)
+				}
+			}
+			return nil
+		})
+
+	part := &archivev1.TxPart{Windows: []*archivev1.TxWindow{{
+		Broker:       typev1.Broker_IBKR,
+		PeriodFrom:   from,
+		PeriodBefore: before,
+		Source:       "IBKR:archive:export",
+		Groups: []*archivev1.TxGroup{{Postings: []*archivev1.Posting{
+			archivePosting("AAPL", "10", typev1.TxType_BUYSTOCK),
+			archivePosting("AAPL", "-10", typev1.TxType_SELLSTOCK),
+		}}},
+	}}}
+	stored, err := importTxPart(context.Background(), ingestDeps{DB: database}, "user-1", "job-tx", part, archiveimport.NewDetachedReporter())
+	if err != nil {
+		t.Fatalf("importTxPart: %v", err)
+	}
+	if !stored {
+		t.Fatal("stored = false, want true")
+	}
+}
+
+// A window holding no groups still runs, and clears the period it names. An
+// import that skipped it would leave the period as it found it, which is the
+// opposite instruction.
+func TestImportTxPart_EmptyWindowClearsItsPeriod(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	database := mock.NewMockDB(ctrl)
+	database.EXPECT().ListIgnoredAssetClasses(gomock.Any(), "user-1").Return(nil, nil).AnyTimes()
+	database.EXPECT().InstrumentsWithSplits(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	from := timestamppb.New(mustParseDay("2024-01-01"))
+	before := timestamppb.New(mustParseDay("2024-02-01"))
+	database.EXPECT().
+		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", "job-tx", from, before,
+			gomock.Len(0), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil)
+
+	part := &archivev1.TxPart{Windows: []*archivev1.TxWindow{{
+		Broker: typev1.Broker_IBKR, PeriodFrom: from, PeriodBefore: before,
+		Source: "IBKR:archive:export",
+	}}}
+	if _, err := importTxPart(context.Background(), ingestDeps{DB: database}, "user-1", "job-tx", part, archiveimport.NewDetachedReporter()); err != nil {
+		t.Fatalf("importTxPart: %v", err)
+	}
+}
+
+// The part's unit is a posting, which is what a reader watching the job's
+// progress expects to see move.
+func TestImportTxPart_TotalCountsPostings(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	database := mock.NewMockDB(ctrl)
+	database.EXPECT().ListIgnoredAssetClasses(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	database.EXPECT().FindInstrumentBySourceDescription(gomock.Any(), gomock.Any(), gomock.Any()).Return("inst-1", nil).AnyTimes()
+	database.EXPECT().FindInstrumentByIdentifier(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("inst-1", nil).AnyTimes()
+	database.EXPECT().ListInstrumentsByIDs(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	database.EXPECT().AppendIdentificationErrors(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().InstrumentsWithSplits(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	database.EXPECT().ReplaceTxsInPeriod(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().AddJobPartProcessedCount(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().
+		SetJobPartTotalCount(gomock.Any(), "job-tx", archivev1.ArchivePart_TXS, int32(3)).
+		Return(nil)
+
+	part := &archivev1.TxPart{Windows: []*archivev1.TxWindow{{
+		Broker:       typev1.Broker_IBKR,
+		PeriodFrom:   timestamppb.New(mustParseDay("2024-01-01")),
+		PeriodBefore: timestamppb.New(mustParseDay("2024-02-01")),
+		Source:       "IBKR:archive:export",
+		Groups: []*archivev1.TxGroup{
+			{Postings: []*archivev1.Posting{
+				archivePosting("AAPL", "10", typev1.TxType_BUYSTOCK),
+				archivePosting("USD", "-1000", typev1.TxType_BUYSTOCK),
+			}},
+			{Postings: []*archivev1.Posting{archivePosting("MSFT", "5", typev1.TxType_BUYSTOCK)}},
+		},
+	}}}
+	rep := archiveimport.NewPartReporter(database, "job-tx", archivev1.ArchivePart_TXS)
+	if _, err := importTxPart(context.Background(), ingestDeps{DB: database}, "user-1", "job-tx", part, rep); err != nil {
+		t.Fatalf("importTxPart: %v", err)
+	}
+}

--- a/server/service/ingestion/user_import.go
+++ b/server/service/ingestion/user_import.go
@@ -9,14 +9,17 @@ import (
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
 	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
 	"github.com/leedenison/portfoliodb/server/archiveimport"
-	"github.com/leedenison/portfoliodb/server/db"
 )
 
 // userImportResult says which fetchers the import earned a nudge for. A display
 // currency that landed opens FX gaps the price fetcher has not been asked to
-// fill, exactly as setting one through the API does.
+// fill, exactly as setting one through the API does, and stored postings earn
+// whatever a broker upload earns.
 type userImportResult struct {
 	displayCurrencySet bool
+	txsStored          bool
+	// userID is whose archive this was, for the recalc a stored posting earns.
+	userID string
 }
 
 // processUserImport applies the parts of a user archive in restore order,
@@ -26,7 +29,8 @@ type userImportResult struct {
 // A failed part does not stop the ones after it, for the same reason it does not
 // in a system import: the parts are not hard-dependent, and abandoning the rest
 // would throw away work that would otherwise land.
-func processUserImport(ctx context.Context, database db.DB, j *JobRequest) userImportResult {
+func processUserImport(ctx context.Context, deps ingestDeps, j *JobRequest) userImportResult {
+	database := deps.DB
 	var out userImportResult
 
 	payload, err := database.LoadJobPayload(ctx, j.JobID)
@@ -51,6 +55,7 @@ func processUserImport(ctx context.Context, database db.DB, j *JobRequest) userI
 		return out
 	}
 
+	out.userID = detail.UserID
 	anyFailed := false
 	for _, pr := range detail.Parts {
 		if pr.Status == apiv1.JobStatus_SUCCESS {
@@ -71,6 +76,10 @@ func processUserImport(ctx context.Context, database db.DB, j *JobRequest) userI
 			var res archiveimport.PreferenceResult
 			res, partErr = archiveimport.PreferencePart(ctx, database, detail.UserID, a.GetPreferences(), rep)
 			out.displayCurrencySet = out.displayCurrencySet || res.DisplayCurrency
+		case archivev1.ArchivePart_TXS:
+			var stored bool
+			stored, partErr = importTxPart(ctx, deps, detail.UserID, j.JobID, a.GetTxs(), rep)
+			out.txsStored = out.txsStored || stored
 		default:
 			partErr = errUnknownPart
 		}

--- a/server/service/ingestion/user_import_test.go
+++ b/server/service/ingestion/user_import_test.go
@@ -79,7 +79,7 @@ func TestProcessUserImport_AppliesPreferencesForTheJobsUser(t *testing.T) {
 			return nil
 		}).AnyTimes()
 
-	res := processUserImport(context.Background(), database, j)
+	res := processUserImport(context.Background(), ingestDeps{DB: database}, j)
 
 	if !res.displayCurrencySet {
 		t.Fatal("display currency not reported as set, so the price fetcher is never nudged")
@@ -109,7 +109,7 @@ func TestProcessUserImport_NoCurrencyEarnsNoNudge(t *testing.T) {
 	database.EXPECT().SetIgnoredAssetClasses(gomock.Any(), "user-7", gomock.Any(), gomock.Any()).Return(nil)
 	database.EXPECT().SetJobPartStatus(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
-	if res := processUserImport(context.Background(), database, j); res.displayCurrencySet {
+	if res := processUserImport(context.Background(), ingestDeps{DB: database}, j); res.displayCurrencySet {
 		t.Fatal("nudge earned by a file that set no display currency")
 	}
 }
@@ -126,7 +126,7 @@ func TestProcessUserImport_UnreadablePayloadFailsTheJob(t *testing.T) {
 	database.EXPECT().SetJobStatus(gomock.Any(), j.JobID, apiv1.JobStatus_FAILED).Return(nil)
 	database.EXPECT().ClearJobPayload(gomock.Any(), j.JobID).Return(nil)
 
-	processUserImport(context.Background(), database, j)
+	processUserImport(context.Background(), ingestDeps{DB: database}, j)
 }
 
 // A job resumed after a restart skips what already finished rather than
@@ -142,7 +142,7 @@ func TestProcessUserImport_SkipsAPartAlreadyDone(t *testing.T) {
 	// No setter expectations: applying the part again is the failure.
 	database.EXPECT().SetJobPartStatus(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 
-	processUserImport(context.Background(), database, j)
+	processUserImport(context.Background(), ingestDeps{DB: database}, j)
 }
 
 // A part re-run starts its progress over rather than counting on from where the
@@ -162,7 +162,7 @@ func TestProcessUserImport_ResetsPartialProgressOnRerun(t *testing.T) {
 	database.EXPECT().SetIgnoredAssetClasses(gomock.Any(), "user-7", gomock.Any(), gomock.Any()).Return(nil)
 	database.EXPECT().SetJobPartStatus(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
-	processUserImport(context.Background(), database, j)
+	processUserImport(context.Background(), ingestDeps{DB: database}, j)
 }
 
 // A part row this build cannot apply means a job written by a later build. It
@@ -172,14 +172,14 @@ func TestProcessUserImport_UnknownPartFailsOnlyItself(t *testing.T) {
 	j := &JobRequest{JobID: "job-ua-6", JobType: db.JobTypeUserArchive}
 	database.EXPECT().LoadJobPayload(gomock.Any(), j.JobID).Return(userArchivePayload(t), nil)
 	database.EXPECT().GetJob(gomock.Any(), j.JobID).Return(&db.JobDetail{
-		UserID: "user-7", Parts: partRows(archivev1.ArchivePart_TXS),
+		UserID: "user-7", Parts: partRows(archivev1.ArchivePart_DECLARATIONS),
 	}, nil).AnyTimes()
 	database.EXPECT().SetJobPartStatus(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	database.EXPECT().
-		SetJobPartFailed(gomock.Any(), j.JobID, archivev1.ArchivePart_TXS, errUnknownPart.Error()).
+		SetJobPartFailed(gomock.Any(), j.JobID, archivev1.ArchivePart_DECLARATIONS, errUnknownPart.Error()).
 		Return(nil)
 
-	processUserImport(context.Background(), database, j)
+	processUserImport(context.Background(), ingestDeps{DB: database}, j)
 }
 
 // The job's own counters are the sum over its parts, so a caller that only
@@ -215,7 +215,7 @@ func TestProcessUserImport_JobCountersAreTheSumOverParts(t *testing.T) {
 	database.EXPECT().SetJobTotalCount(gomock.Any(), j.JobID, int32(2)).Return(nil)
 	database.EXPECT().SetJobProcessedCount(gomock.Any(), j.JobID, int32(2)).Return(nil)
 
-	processUserImport(context.Background(), database, j)
+	processUserImport(context.Background(), ingestDeps{DB: database}, j)
 }
 
 // The dispatch case, end to end: a user archive job that restored a display

--- a/server/service/ingestion/worker.go
+++ b/server/service/ingestion/worker.go
@@ -6,6 +6,7 @@ import (
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
 	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
 	ingestionv1 "github.com/leedenison/portfoliodb/proto/ingestion/v1"
+	"github.com/leedenison/portfoliodb/server/archiveimport"
 	"github.com/leedenison/portfoliodb/server/db"
 	"github.com/leedenison/portfoliodb/server/identifier"
 	"github.com/leedenison/portfoliodb/server/identifier/description"
@@ -123,11 +124,28 @@ func processJob(ctx context.Context, opts WorkerOptions, j *JobRequest) {
 			pluginutil.Trigger(opts.CorporateEventTrigger)
 		}
 	case db.JobTypeUserArchive:
-		res := processUserImport(ctx, opts.DB, j)
-		// A restored display currency opens FX gaps nothing has been asked to
-		// fill, so the import earns the same nudge setting one through the API
-		// does. Nudged once for the whole import rather than per part.
-		if res.displayCurrencySet {
+		deps := ingestDeps{
+			DB:           opts.DB,
+			Registry:     opts.IdentifierRegistry,
+			DescRegistry: opts.DescriptionRegistry,
+			Counter:      opts.Counter,
+		}
+		res := processUserImport(ctx, deps, j)
+		// Nudged once for the whole import rather than per part.
+		//
+		// Restored postings earn what a broker upload earns: the pads a
+		// declaration implies are recomputed, the price fetcher is asked to fill
+		// the gaps the new holdings opened, and the transfer matcher is given a
+		// chance at a side whose counterpart was already stored. A restored
+		// display currency opens FX gaps of its own, so either alone is reason
+		// enough to nudge the price fetcher.
+		if res.txsStored {
+			if err := recalcAfterIngestion(ctx, opts.DB, res.userID); err != nil {
+				log.Printf("user archive job %s: recalc INITIALIZE txs: %v", j.JobID, err)
+			}
+			pluginutil.Trigger(opts.TransferMatchTrigger)
+		}
+		if res.displayCurrencySet || res.txsStored {
 			pluginutil.Trigger(opts.PriceTrigger)
 		}
 	default:
@@ -173,152 +191,58 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 	if txs == nil {
 		txs = []*apiv1.Tx{}
 	}
-	source := req.GetSource()
-	broker := db.BrokerToStr(req.Broker)
-	bulk := req.PeriodFrom != nil && req.PeriodBefore != nil
+	// A tx job has no part rows, so its reporter is the unscoped kind: it writes
+	// progress and problems against the job itself.
+	rep := archiveimport.NewPartReporter(database, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED)
 
-	// The denomination of the whole upload. Absent means as-traded: each row is
-	// expressed in the share count current on its own transaction date.
-	var shareCountBasis *time.Time
-	if b := req.GetShareCountBasis(); b != "" {
-		parsed, err := time.Parse("2006-01-02", b)
-		if err != nil {
-			_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, []*apiv1.ValidationError{
-				{RowIndex: -1, Field: "share_count_basis", Message: fmt.Sprintf("invalid date %q: want YYYY-MM-DD", b)},
-			})
-			finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
-			return false, ""
-		}
-		shareCountBasis = &parsed
-	}
-
-	// Validate.
-	errs := ValidateTxs(txs)
-	if len(errs) > 0 {
-		_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, errs)
-		finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
-		return false, ""
-	}
-	// Load ignored asset classes for this user.
-	ignoredClasses, err := database.ListIgnoredAssetClasses(ctx, userID)
-	if err != nil {
-		log.Printf("ingestion job %s: load ignored asset classes: %v", j.JobID, err)
-		ignoredClasses = nil // non-fatal: proceed without filtering
-	}
-	// Filter non-stored tx types (e.g. SPLIT) and ignored asset classes.
-	txsToProcess, originalIndices := filterStoredTxs(txs, broker, ignoredClasses)
-	if len(txsToProcess) == 0 {
-		finishJob(ctx, database, j.JobID, apiv1.JobStatus_SUCCESS)
-		return true, userID
-	}
-	_ = database.SetJobTotalCount(ctx, j.JobID, int32(len(txsToProcess)))
-	// Extract description hints.
-	cache, extractedHintsCache, err := extractDescHints(ctx, database, descRegistry, counter, source, broker, txsToProcess)
-	if err != nil {
-		log.Printf("ingestion job %s: extract description hints: %v", j.JobID, err)
-		_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, []*apiv1.ValidationError{
-			{RowIndex: -1, Field: "txs", Message: err.Error()},
-		})
-		finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
-		return false, ""
-	}
-	// Resolve instruments.
-	instrumentIDs, idErrs, err := resolveInstruments(ctx, database, registry, broker, source, j.JobID, counter, txsToProcess, originalIndices, cache, extractedHintsCache)
-	if err != nil {
-		log.Printf("ingestion job %s: resolve instrument: %v", j.JobID, err)
-		_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, []*apiv1.ValidationError{
-			{RowIndex: -1, Field: "instrument_description", Message: err.Error()},
-		})
-		finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
-		return false, ""
-	}
-	if len(idErrs) > 0 {
-		_ = database.AppendIdentificationErrors(ctx, j.JobID, idErrs)
-	}
-	// The resolved instruments feed both the asset-class check and balancing.
-	instByID, err := instrumentsByID(ctx, database, instrumentIDs)
-	if err != nil {
-		log.Printf("ingestion job %s: load instruments: %v", j.JobID, err)
-		_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, []*apiv1.ValidationError{
-			{RowIndex: -1, Field: "txs", Message: err.Error()},
-		})
-		finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
-		return false, ""
-	}
-	// Validate that each resolved instrument's asset class is compatible with
-	// the asset class implied by the tx type. Catches contradictions that
-	// arise when two txs share (source, description) but their tx types imply
-	// different asset classes (e.g. BUYSTOCK + INCOME), as well as any other
-	// path where resolution lands on an instrument of the wrong class.
-	if classErrs := validateAssetClasses(txsToProcess, originalIndices, instrumentIDs, instByID); len(classErrs) > 0 {
-		_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, classErrs)
-		finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
-		return false, ""
-	}
-	// Balance every group by routing whatever its postings leave over to an
-	// explicit counterparty. This runs after filtering, so a dropped SPLIT leg
-	// cannot contribute a residual, and after resolution, because telling a
-	// currency commodity from a security one is a property of the instrument.
-	balanceInsts := balanceInstruments(instByID)
-	routed := routeResiduals(txsToProcess, instrumentIDs, balanceInsts)
-	routedTxs, routedIDs, routedWeights, unresolved := resolveRouted(ctx, database, routed)
-	// A residual with no instrument to post it against used to be dropped with a log
-	// line, leaving its group unbalanced. The balance constraint now rejects that
-	// group at COMMIT, taking the whole upload with it, so failing the job here names
-	// the commodity instead of surfacing a constraint violation that does not.
-	// Currencies are seeded, so this is a safety net rather than a live path.
-	if len(unresolved) > 0 {
-		errs := make([]*apiv1.ValidationError, len(unresolved))
-		for i, cur := range unresolved {
-			log.Printf("ingestion job %s: no instrument for residual commodity %q", j.JobID, cur)
-			errs[i] = &apiv1.ValidationError{
-				RowIndex: -1,
-				Field:    "instrument_description",
-				Message:  fmt.Sprintf("no instrument for residual commodity %q; the group it balances cannot be stored", cur),
-			}
-		}
-		_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, errs)
-		finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
-		return false, ""
-	}
-	// Weighed after routing, which is what assigns a synthetic group_ref to a posting
-	// that had none, and before the routed postings are appended, since those carry
-	// the weight of the residual they negate rather than one derived from the tx.
-	txWeights := weights(txsToProcess, instrumentIDs, balanceInsts)
-	txsToProcess = append(txsToProcess, routedTxs...)
-	instrumentIDs = append(instrumentIDs, routedIDs...)
-	txWeights = append(txWeights, routedWeights...)
-
-	// The upload declares one basis for every row it carries, so the per-posting
+	// The upload declares one basis for every row it carries, so the per-row
 	// slice the store takes is that value repeated. A file that restates only
 	// some of its rows is the archive's shape, not the CSV's.
 	var basis []*time.Time
-	if shareCountBasis != nil {
-		basis = make([]*time.Time, len(txsToProcess))
+	if b := req.GetShareCountBasis(); b != "" {
+		parsed, err := time.Parse("2006-01-02", b)
+		if err != nil {
+			rep.Errf(-1, "share_count_basis", fmt.Sprintf("invalid date %q: want YYYY-MM-DD", b))
+			rep.Flush(ctx)
+			finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
+			return false, ""
+		}
+		basis = make([]*time.Time, len(txs))
 		for i := range basis {
-			basis[i] = shareCountBasis
+			basis[i] = &parsed
 		}
 	}
 
-	// Store transactions.
-	var storeErr error
-	if bulk {
-		storeErr = database.ReplaceTxsInPeriod(ctx, userID, broker, j.JobID, req.PeriodFrom, req.PeriodBefore, txsToProcess, instrumentIDs, txWeights, basis)
-	} else {
-		storeErr = database.CreateTxGroup(ctx, userID, broker, txsToProcess[0].GetAccount(), j.JobID, txsToProcess, instrumentIDs, txWeights, basis)
-	}
-	if storeErr != nil {
-		log.Printf("ingestion job %s: %v", j.JobID, storeErr)
-		_ = database.AppendValidationErrors(ctx, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED, []*apiv1.ValidationError{
-			{RowIndex: -1, Field: "txs", Message: storeErr.Error()},
-		})
+	res, err := ingestBatch(ctx, ingestDeps{
+		DB:           database,
+		Registry:     registry,
+		DescRegistry: descRegistry,
+		Counter:      counter,
+	}, ingestParams{
+		UserID:          userID,
+		Broker:          db.BrokerToStr(req.Broker),
+		Source:          req.GetSource(),
+		JobID:           j.JobID,
+		Txs:             txs,
+		ShareCountBasis: basis,
+		// Both bounds present makes this a replacement rather than an append.
+		// CreateTx wraps its one tx in the same request with no period, which is
+		// where the two paths diverge.
+		PeriodFrom:   req.PeriodFrom,
+		PeriodBefore: req.PeriodBefore,
+	}, rep)
+	// Flushed before the job is marked terminal on both paths: the problems
+	// gathered before a failure are what explain it.
+	rep.Flush(ctx)
+	if err != nil {
+		log.Printf("ingestion job %s: %v", j.JobID, err)
 		finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
 		return false, ""
 	}
 
 	// Recompute split-adjusted values for instruments that have split rows.
 	// The INSERT trigger on txs copies raw values; this pass corrects them.
-	recomputeSplitAdjustedTxs(ctx, database, instrumentIDs)
+	recomputeSplitAdjustedTxs(ctx, database, res.InstrumentIDs)
 
 	finishJob(ctx, database, j.JobID, apiv1.JobStatus_SUCCESS)
 	return true, userID
@@ -370,9 +294,24 @@ func filterStoredTxs(txs []*apiv1.Tx, broker string, ignored []db.IgnoredAssetCl
 // extractDescHints looks up each distinct (source, description) in DB and runs
 // batch description extraction for misses. Returns a resolve cache pre-populated
 // with DB hits and an extracted hints cache keyed by cacheKey(source, desc).
+//
+// A description every one of whose postings already names an identifier is not
+// extracted. Extraction exists to find an identifier in a description, so it has
+// nothing to add there, and it is a paid plugin call. It matters most to an
+// archive import, whose every posting carries the identifier the export chose
+// under a source no stored description was resolved against: without this the
+// lookup would miss for the whole document and pay for extracting it. The test
+// is over every posting sharing the description, so one posting arriving without
+// a hint still gets the description extracted.
 func extractDescHints(ctx context.Context, database db.DB, descRegistry *description.Registry, counter telemetry.CounterIncrementer, source, broker string, txs []*apiv1.Tx) (map[string]resolveResult, map[string][]identifier.Identifier, error) {
 	cache := make(map[string]resolveResult)
 	var extractedHintsCache map[string][]identifier.Identifier
+	needsExtraction := make(map[string]bool)
+	for _, tx := range txs {
+		if len(tx.GetIdentifierHints()) == 0 {
+			needsExtraction[cacheKey(source, tx.GetInstrumentDescription())] = true
+		}
+	}
 	seen := make(map[string]bool)
 	var batchItems []description.BatchItem
 	idByKey := make(map[string]string)
@@ -389,7 +328,7 @@ func extractDescHints(ctx context.Context, database db.DB, descRegistry *descrip
 		}
 		if id != "" {
 			cache[key] = resolveResult{InstrumentID: id}
-		} else {
+		} else if needsExtraction[key] {
 			batchID := shortHashForBatch(key)
 			idByKey[key] = batchID
 			batchItems = append(batchItems, description.BatchItem{
@@ -414,7 +353,7 @@ func extractDescHints(ctx context.Context, database db.DB, descRegistry *descrip
 // resolveInstruments resolves each tx to an instrument ID using the pre-populated
 // cache and extracted hints. Returns the instrument IDs (parallel to txs) and any
 // identification errors collected from the cache.
-func resolveInstruments(ctx context.Context, database db.DB, registry *identifier.Registry, broker, source, jobID string, counter telemetry.CounterIncrementer, txs []*apiv1.Tx, originalIndices []int, cache map[string]resolveResult, extractedHintsCache map[string][]identifier.Identifier) ([]string, []db.IdentificationError, error) {
+func resolveInstruments(ctx context.Context, database db.DB, registry *identifier.Registry, broker, source string, counter telemetry.CounterIncrementer, txs []*apiv1.Tx, originalIndices []int, cache map[string]resolveResult, extractedHintsCache map[string][]identifier.Identifier, rep *archiveimport.PartReporter) ([]string, []db.IdentificationError, error) {
 	instrumentIDs := make([]string, len(txs))
 	for i, tx := range txs {
 		desc := tx.GetInstrumentDescription()
@@ -429,7 +368,7 @@ func resolveInstruments(ctx context.Context, database db.DB, registry *identifie
 			return nil, nil, fmt.Errorf("row %d: %w", rowIndex, err)
 		}
 		instrumentIDs[i] = r.InstrumentID
-		_ = database.IncrJobProcessedCount(ctx, jobID)
+		rep.Advance(ctx, 1)
 	}
 	var idErrs []db.IdentificationError
 	for _, r := range cache {


### PR DESCRIPTION
Second of three for 0077. Stacked on #379, which adds the export; review that one first. Adds the `TxPart` reader, so an exported archive restores.

A window is applied with the period it states rather than one inferred from its groups. That is what lets a window holding no groups clear a period, and it is the reason the format has the window state its own bounds.

## The pipeline is extracted rather than written twice

`processTx` and the archive reader want the same work below the payload: validate, filter, extract description hints, resolve, check asset classes, balance and route, store. That is now `ingestBatch`, shared by both. Two changes make it reusable:

- **It returns an error instead of terminating the job**, so a caller can fail one archive part and let the rest run, as `processSystemImport` does.
- **It reports through `archiveimport.PartReporter`.** No new reporter type was needed: the unscoped form of that reporter is already exactly what a tx job wants, since a job has no part rows and its progress and problems go against the job itself. Its doc comment already said so.

**Who owns the total is explicit**, because the two callers want different things. An upload is one batch and its total is what will be stored, which is today's behaviour unchanged. An archive part is one batch per window and declares a single total for the document, so a batch then advances past what it filters out and the progress still reaches that total.

## Two behaviours worth reviewing

**A batch handed no postings over a period clears that period; a batch whose postings were all filtered out does not.** The first is an explicit instruction -- an empty window. The second is not: nothing asked for those rows to be removed, a filter decided this instance does not store them, and emptying the period on that basis would delete rows the file never mentioned. The upload path is unchanged.

**Description extraction is skipped for a description whose every posting already names an identifier.** Extraction exists to find an identifier in a description, so it has nothing to add there, and it is a paid plugin call. It matters most to an archive import, whose postings all carry the identifier the export chose under a source no stored description was resolved against: without the guard, `FindInstrumentBySourceDescription` misses for the whole document and the import pays to extract every description in it. The test is over *every* posting sharing the description, so one arriving without a hint still gets it extracted -- which is why the upload path is unaffected in practice.

A restored posting earns what a broker upload earns: declaration pads recomputed, the price fetcher nudged for the gaps new holdings opened, and the transfer matcher given a chance at a side whose counterpart was already stored.

`'TXS'` joins the `ingestion_job_parts.part` CHECK. Existing migration modified rather than a new one, per the pre-release convention.

## Testing

`server/service/ingestion/tx_import_test.go` covers group_ref synthesis per group, row indices continuing across windows, a restated basis carried and an as-traded window carrying none, a routed residual travelling as its stored account type, unstated fields staying unset, an empty window clearing its period, and the total counting postings.

The load-bearing one is `TestImportTxPart_StoresEachWindowWithItsOwnPeriod`: a group that already sums to zero comes back with exactly the postings the file stated and no second residual. That is the idempotency claim the issue asked to confirm against the balancer.

`TestProcessUserImport_UnknownPartFailsOnlyItself` now uses `DECLARATIONS`, which is the user part still without a reader.

`make test`, `make db-test` and `make lint` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)