### PR TITLE
Cover the user transaction archive round trip, and close 0077

### DIFF
--- a/client/lib/archive/assemble.test.ts
+++ b/client/lib/archive/assemble.test.ts
@@ -244,6 +244,54 @@ describe("assembleUserArchive", () => {
     expect(doc.preferences?.displayCurrency).toBe("GBP");
     expect(doc.preferences?.ignoredAssetClasses?.rules).toHaveLength(1);
   });
+
+  // Transactions arrive a window at a time, so the assembler accumulates them
+  // rather than replacing the container as a whole-part message does.
+  it("accumulates transaction windows across the stream", () => {
+    const doc = assembleUserArchive(
+      userStream(
+        { item: { case: "envelope", value: USER_ENVELOPE } },
+        { item: { case: "partBegin", value: { part: ArchivePart.TXS } } },
+        {
+          item: {
+            case: "txWindow",
+            value: {
+              broker: 1,
+              source: "FIDELITY:archive:export",
+              groups: [{ postings: [{ quantity: "10", instrumentDescription: "AAPL", type: 1 }] }],
+            },
+          },
+        },
+        {
+          item: {
+            case: "txWindow",
+            value: {
+              broker: 2,
+              source: "IBKR:archive:export",
+              groups: [{ postings: [{ quantity: "5", instrumentDescription: "MSFT", type: 1 }] }],
+            },
+          },
+        },
+      ),
+    );
+    expect(doc.txs?.windows).toHaveLength(2);
+    expect(doc.txs?.windows[0].source).toBe("FIDELITY:archive:export");
+    expect(doc.txs?.windows[1].source).toBe("IBKR:archive:export");
+  });
+
+  // A transaction part asked for over no transactions is present and empty, the
+  // same statement the marker makes for every other part.
+  it("keeps an empty transaction part present", () => {
+    const doc = assembleUserArchive(
+      userStream(
+        { item: { case: "envelope", value: USER_ENVELOPE } },
+        { item: { case: "partBegin", value: { part: ArchivePart.TXS } } },
+      ),
+    );
+    expect(doc.txs).toBeDefined();
+    expect(doc.txs?.windows).toHaveLength(0);
+    expect(marshalUser(doc)).toContain('"txs":{}');
+  });
 });
 
 describe("userPartCounts", () => {
@@ -257,6 +305,29 @@ describe("userPartCounts", () => {
       }),
     ]);
     expect(userPartCounts(doc)).toEqual([{ label: "preference settings", count: 1 }]);
+  });
+
+  // Postings rather than windows or groups, so the preview reads the same
+  // number the import job counts.
+  it("counts postings for the transaction part", () => {
+    const doc = assembleUserArchive([
+      create(ExportUserArchiveResponseSchema, { item: { case: "envelope", value: { ...ENVELOPE, kind: 2 } } }),
+      create(ExportUserArchiveResponseSchema, { item: { case: "partBegin", value: { part: ArchivePart.TXS } } }),
+      create(ExportUserArchiveResponseSchema, {
+        item: {
+          case: "txWindow",
+          value: {
+            broker: 1,
+            source: "FIDELITY:archive:export",
+            groups: [
+              { postings: [{ quantity: "10", instrumentDescription: "AAPL", type: 1 }, { quantity: "-1000", instrumentDescription: "USD", type: 1 }] },
+              { postings: [{ quantity: "5", instrumentDescription: "MSFT", type: 1 }] },
+            ],
+          },
+        },
+      }),
+    ]);
+    expect(userPartCounts(doc)).toEqual([{ label: "postings", count: 3 }]);
   });
 
   // A part present and empty is present with nothing in it, which is a

--- a/client/lib/archive/assemble.ts
+++ b/client/lib/archive/assemble.ts
@@ -7,6 +7,7 @@ import { InstrumentPartSchema } from "@/gen/archive/v1/instruments_pb";
 import { PluginConfigPartSchema } from "@/gen/archive/v1/plugin_config_pb";
 import { PreferencePartSchema } from "@/gen/archive/v1/preferences_pb";
 import { PricePartSchema } from "@/gen/archive/v1/prices_pb";
+import { TxPartSchema } from "@/gen/archive/v1/txs_pb";
 import { UnhandledEventPartSchema } from "@/gen/archive/v1/unhandled_events_pb";
 import type { ExportSystemArchiveResponse, ExportUserArchiveResponse } from "@/gen/api/v1/api_pb";
 import type { SystemArchive, UserArchive } from "@/gen/archive/v1/archive_pb";
@@ -101,10 +102,17 @@ export function assembleUserArchive(items: ExportUserArchiveResponse[]): UserArc
           case ArchivePart.PREFERENCES:
             doc.preferences ??= create(PreferencePartSchema, {});
             break;
+          case ArchivePart.TXS:
+            doc.txs ??= create(TxPartSchema, {});
+            break;
         }
         break;
       case "preferences":
         doc.preferences = item.item.value;
+        break;
+      case "txWindow":
+        doc.txs ??= create(TxPartSchema, {});
+        doc.txs.windows.push(item.item.value);
         break;
     }
   }
@@ -159,6 +167,15 @@ export function userPartCounts(archive: UserArchive): { label: string; count: nu
     if (archive.preferences.displayCurrency !== undefined) count++;
     if (archive.preferences.ignoredAssetClasses !== undefined) count++;
     out.push({ label: "preference settings", count });
+  }
+  if (archive.txs) {
+    // Postings rather than windows or groups, so the preview reads the same
+    // number the import job counts.
+    const postings = archive.txs.windows.reduce(
+      (n, w) => n + w.groups.reduce((m, g) => m + g.postings.length, 0),
+      0,
+    );
+    out.push({ label: "postings", count: postings });
   }
   return out;
 }

--- a/client/lib/archive/parts.ts
+++ b/client/lib/archive/parts.ts
@@ -68,6 +68,12 @@ export const USER_ARCHIVE_PART_OPTIONS: ArchivePartOption[] = [
     note: "Display currency, and the asset classes ignored on import.",
     defaultSelected: true,
   },
+  {
+    part: ArchivePart.TXS,
+    label: "Transactions",
+    note: "Every posting, grouped as the broker converter grouped it. Nothing can rebuild the grouping, so it travels with them.",
+    defaultSelected: true,
+  },
 ];
 
 /** Display names for the parts a job reports against. */
@@ -80,4 +86,5 @@ export const ARCHIVE_PART_LABELS: Record<number, string> = {
   [ArchivePart.UNHANDLED_EVENTS]: "Unhandled corporate events",
   [ArchivePart.PLUGIN_CONFIG]: "Plugin config",
   [ArchivePart.PREFERENCES]: "Preferences",
+  [ArchivePart.TXS]: "Transactions",
 };

--- a/docs/issues/0077-transaction-archive-export.md
+++ b/docs/issues/0077-transaction-archive-export.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Carry transactions in the user archive
 milestone: M14
 dependencies: [0078]
@@ -103,3 +103,47 @@ it.
 The user archive export stream, the client assembler and the include menu landed
 under 0085. This needs the `TxPart` writer, its `ExportUserArchiveResponse` item,
 the `archiveimport` reader and one menu row.
+
+Closed. Transactions travel in the user archive both ways, and the round trip is
+pinned end to end: a seeded corpus exports, is deleted, imports back, and every
+group balances again with no residual routed on top. Four things settled here,
+and two issues opened.
+
+`share_count_basis` moved from the window to the posting. A window-wide value can
+only say "one date for everything", which cannot express the ordinary case, where
+every posting is as-traded and so carries a different basis from its neighbours.
+It costs nothing: the column is NOT NULL and its insert trigger already seeds it
+from the posting's own timestamp, so an absent field needs no reader to test for
+null.
+
+The window's `source` names the export rather than an ingestion job. A window is
+one replacement scope per broker so it carries one source, but `txs` has no
+source column and one broker's postings come from several jobs. Nothing is lost:
+a posting's own source, where one was recorded, is the `domain` of its
+`BROKER_DESCRIPTION` identifier.
+
+The window's period is derived from the postings it carries, so it contains all
+of them and the straddling question does not arise. A period-scoped export is
+0094, along with the defect it exposed: `ReplaceTxsInPeriod` deletes whole groups
+on an `EXISTS` over postings in the window, so a later upload catching one leg of
+a group that spans days destroys legs it will not replace. Real today, and not
+about the archive.
+
+Routed residuals are exported, and the balancer was checked rather than assumed:
+`routeResiduals` skips a commodity whose postings already sum to zero, so a group
+exported with its residual routes nothing a second time.
+
+The ingestion pipeline below the payload became `ingestBatch`, shared with the
+broker upload rather than written twice, reporting through the reporter
+`archiveimport` already had.
+
+0095 asks how to rejoin groups that should be one, and records that adr/0037's
+link-not-merge is scoped to transfers: the link is what preserves the account
+boundary money-weighted return needs, and an `IMBALANCE` residual has no such
+boundary.
+
+One documentation defect fell out. Account types are the one vocabulary whose
+file spelling is not the column's -- protojson writes `ACCOUNT_TYPE_EQUITY`,
+because `AccountType` cannot be unprefixed the way `AssetClass` was while
+`TxType` defines `INCOME` and `TRANSFER` in the same package scope.
+docs/spec/archive-format.md said otherwise and now says this.

--- a/docs/spec/archive-format.md
+++ b/docs/spec/archive-format.md
@@ -144,10 +144,16 @@ had nothing; dropping it leaves valuation treating the days between reported
 bars as unpriced. See `docs/adr/0023-price-coverage-is-stored-not-inferred.md`.
 
 **Vocabularies** -- asset classes, identifier types, transaction types, account
-types, brokers -- are written by name, and the names are the same strings the
-database stores: `"STOCK"`, `"ISIN"`, `"BUYSTOCK"`. They come from
-`proto/type/v1/type.proto`, which does not remove or rename a value. See
-`docs/adr/0038-controlled-vocabularies-are-shared.md`.
+types, brokers -- are written by name: `"STOCK"`, `"ISIN"`, `"BUYSTOCK"`. They
+come from `proto/type/v1/type.proto`, which does not remove or rename a value.
+See `docs/adr/0038-controlled-vocabularies-are-shared.md`.
+
+The names are the strings the database stores, with one exception. An account
+type keeps its prefix -- `"ACCOUNT_TYPE_EQUITY"` in a file, `EQUITY` in the
+column -- because protojson writes an enum by its own name and `AccountType`
+cannot be unprefixed the way `AssetClass` was: enum values share package scope
+and `TxType` already defines `INCOME` and `TRANSFER`. The mapping lives in one
+place on the server, as the plugin category's does.
 
 ## The envelope
 
@@ -538,18 +544,33 @@ The window has to state its own period rather than have one inferred from the
 postings it holds, because **a window holding no groups is a valid instruction to
 clear that period**, and an inferred window could never say that.
 
+An export writes one window per broker, running from its first posting to the
+day after its last, so the window provably contains everything it carries and no
+group straddles its edge. Its `source` names the export -- `"FIDELITY:archive:export"`
+-- rather than an ingestion job: a window carries one source and a broker's
+postings come from several. Nothing is lost, because a posting's own source,
+where one was recorded, is the `domain` of its `BROKER_DESCRIPTION` identifier,
+which is where it was stored and where it travels.
+
 | Level | Field | Notes |
 | --- | --- | --- |
 | window | `broker` | |
 | window | `period_from`, `period_before` | half-open, instants |
 | window | `source` | `"<broker>:<client>:<source>"`; the domain of the fallback description identifier |
-| window | `share_count_basis` | optional; absent means as-traded |
 | group | `postings[]` | at least one |
 | posting | `timestamp`, `instrument_description`, `type`, `quantity` | |
 | posting | `account`, `account_type` | `account_type` absent reads as `ACCOUNT_TYPE_USER` |
 | posting | `identifier_hints[]` | zero or more identifier triples |
 | posting | `unit_price`, `trading_currency`, `settlement_currency` | optional |
 | posting | `broker_ref`, `counterparty_account` | optional |
+| posting | `share_count_basis` | optional; absent means the posting's own timestamp date |
+
+`share_count_basis` is on the posting rather than on the window for the same
+reason it is on a price row rather than on its group: a window-wide value can
+only say "one date for everything", which cannot express the ordinary case,
+where every posting is as-traded and so carries a different basis from its
+neighbours. Absent is what an ordinary export writes, and the importing instance
+takes the posting's own date.
 
 Grouping is structural: a group is a list of postings, not a shared key. It is
 the converter's output and nothing can rebuild it -- the server does not pair

--- a/e2e/fixtures/user-archive-txs.sql
+++ b/e2e/fixtures/user-archive-txs.sql
@@ -1,0 +1,71 @@
+-- Transactions for the user archive round trip: three balanced groups under one
+-- broker, on pre-identified instruments.
+--
+-- Separate from instruments.sql, which seeds the same shape for the holdings and
+-- valuation specs, because its balancing leg carries the trade's own BUYSTOCK
+-- type against a currency instrument. Raw SQL bypasses validation so it stores,
+-- but ingestion would reject it -- BUYSTOCK implies STOCK and the instrument is
+-- CASH -- and a round trip has to be re-importable to prove anything. The cash
+-- leg here carries CASHFLOW, which implies CASH, as a converter's derived money
+-- leg does.
+--
+-- Pre-identified because the round trip is about the archive rather than about
+-- identification: an instrument carrying the identifier the export writes is
+-- found in the database on the way back in, so no plugin is called and the suite
+-- needs no cassette.
+
+INSERT INTO instruments (id, asset_class, currency, name)
+VALUES
+  ('e2e00000-0000-0000-0000-000000000401', 'STOCK', 'USD', 'Amazon.com Inc.'),
+  ('e2e00000-0000-0000-0000-000000000402', 'STOCK', 'USD', 'NVIDIA Corp.'),
+  ('e2e00000-0000-0000-0000-000000000403', 'STOCK', 'USD', 'Tesla Inc.')
+ON CONFLICT (id) DO NOTHING;
+
+-- Two identifiers each, so the export has a priority order to apply: MIC_TICKER
+-- outranks ISIN, and bestIdentifierJoin is what decides.
+INSERT INTO instrument_identifiers (instrument_id, identifier_type, value, canonical)
+VALUES
+  ('e2e00000-0000-0000-0000-000000000401', 'ISIN', 'US0231351067', true),
+  ('e2e00000-0000-0000-0000-000000000401', 'MIC_TICKER', 'AMZN', true),
+  ('e2e00000-0000-0000-0000-000000000402', 'ISIN', 'US67066G1040', true),
+  ('e2e00000-0000-0000-0000-000000000402', 'MIC_TICKER', 'NVDA', true),
+  ('e2e00000-0000-0000-0000-000000000403', 'ISIN', 'US88160R1014', true),
+  ('e2e00000-0000-0000-0000-000000000403', 'MIC_TICKER', 'TSLA', true)
+ON CONFLICT DO NOTHING;
+
+-- Every posting belongs to a group, and the ids are explicit because the
+-- postings reference them.
+INSERT INTO tx_groups (id, user_id, timestamp)
+VALUES
+  ('e2e00000-0000-0000-0000-000000000411', 'e2e00000-0000-0000-0000-000000000001', '2024-01-15'),
+  ('e2e00000-0000-0000-0000-000000000412', 'e2e00000-0000-0000-0000-000000000001', '2024-01-16'),
+  ('e2e00000-0000-0000-0000-000000000413', 'e2e00000-0000-0000-0000-000000000001', '2024-01-17')
+ON CONFLICT (id) DO NOTHING;
+
+-- The trades. A priced BUYSTOCK converts, so it weighs its consideration in the
+-- settlement currency: quantity * unit_price.
+INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type, quantity,
+                 trading_currency, settlement_currency, unit_price, instrument_id,
+                 weight, weight_commodity, group_id)
+VALUES
+  ('e2e00000-0000-0000-0000-000000000001', 'FIDELITY', 'ACC-1', '2024-01-15', 'AMZN - Amazon.com Inc.', 'BUYSTOCK', 8, 'USD', 'USD', 155.20, 'e2e00000-0000-0000-0000-000000000401', 1241.60, 'cur:USD', 'e2e00000-0000-0000-0000-000000000411'),
+  ('e2e00000-0000-0000-0000-000000000001', 'FIDELITY', 'ACC-1', '2024-01-16', 'NVDA - NVIDIA Corp.', 'BUYSTOCK', 15, 'USD', 'USD', 560.50, 'e2e00000-0000-0000-0000-000000000402', 8407.50, 'cur:USD', 'e2e00000-0000-0000-0000-000000000412'),
+  ('e2e00000-0000-0000-0000-000000000001', 'FIDELITY', 'ACC-1', '2024-01-17', 'TSLA - Tesla Inc.', 'BUYSTOCK', 12, 'USD', 'USD', 218.90, 'e2e00000-0000-0000-0000-000000000403', 2626.80, 'cur:USD', 'e2e00000-0000-0000-0000-000000000413')
+ON CONFLICT DO NOTHING;
+
+-- The money that paid for each trade. EQUITY rather than a USER cash row,
+-- because this seeds an opening position rather than a cash trail: only USER
+-- postings reach holdings and valuation, so the counterparty cannot show up as a
+-- negative cash balance. No unit price, so it weighs its own quantity in its own
+-- currency and the group sums to zero.
+INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type, quantity,
+                 trading_currency, settlement_currency, instrument_id, account_type,
+                 weight, weight_commodity, group_id)
+SELECT 'e2e00000-0000-0000-0000-000000000001', 'FIDELITY', 'ACC-1', v.at::timestamptz, 'USD', 'CASHFLOW',
+       v.qty, 'USD', 'USD', i.instrument_id, 'EQUITY', v.qty, 'cur:USD', v.group_id::uuid
+FROM (VALUES ('2024-01-15', -1241.60, 'e2e00000-0000-0000-0000-000000000411'),
+             ('2024-01-16', -8407.50, 'e2e00000-0000-0000-0000-000000000412'),
+             ('2024-01-17', -2626.80, 'e2e00000-0000-0000-0000-000000000413')) AS v(at, qty, group_id),
+     (SELECT instrument_id FROM instrument_identifiers
+      WHERE identifier_type = 'CURRENCY' AND value = 'USD' LIMIT 1) i
+ON CONFLICT DO NOTHING;

--- a/e2e/tests/user-archive-roundtrip.spec.ts
+++ b/e2e/tests/user-archive-roundtrip.spec.ts
@@ -2,21 +2,33 @@
 //
 // Exports a user's own archive through the UI, wipes what it carried, imports
 // the same file back and then checks the database. The round trip is the point:
-// a file this instance produced has to be one it can consume, and preferences
-// are the settings nothing can recover -- a rebuild that silently reset the
-// display currency to the column default would be a rebuild that changed the
-// user's data.
+// a file this instance produced has to be one it can consume. Preferences are
+// settings nothing can recover -- a rebuild that silently reset the display
+// currency to the column default would be a rebuild that changed the user's
+// data -- and transactions are the data a rebuild exists for.
 //
-// The seeded state is written through the RPCs rather than through SQL, so what
-// the export reads is the shape the API stores.
+// The preferences are written through the RPCs rather than through SQL, so what
+// the export reads is the shape the API stores. The transactions come from a
+// fixture because seeding them through an upload would mean identifying them,
+// which is a paid lookup and a cassette this suite has no other need of.
 
 import { test, expect } from "@playwright/test";
 import path from "path";
 import { readFile, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import { TIMEOUT_SLOW } from "../helpers/timeouts";
-import { seedSession, injectSession, closeRedis, TEST_USER_ID } from "../helpers/auth";
-import { resetAndSeedBase, closeDB, rawQuery } from "../helpers/db";
+import {
+  seedSession,
+  injectSession,
+  closeRedis,
+  TEST_USER_ID,
+} from "../helpers/auth";
+import {
+  resetAndSeedBase,
+  closeDB,
+  rawQuery,
+  seedFixture,
+} from "../helpers/db";
 import { setDisplayCurrency, setIgnoredAssetClasses } from "../helpers/api";
 import { AssetClass } from "../gen/type/v1/type_pb";
 
@@ -41,13 +53,28 @@ test.describe("user archive page", () => {
     await setIgnoredAssetClasses(sessionId, [RULE]);
   });
 
-  test("exports the user's preferences and imports them back", async ({ context, page }) => {
+  // Three balanced groups under one broker: a priced BUYSTOCK and the EQUITY
+  // counterparty that makes it sum to zero.
+  test.beforeAll(async () => {
+    await seedFixture("user-archive-txs.sql");
+  });
+
+  test("exports the user's preferences and imports them back", async ({
+    context,
+    page,
+  }) => {
     await injectSession(context, sessionId);
     await page.goto("/archive");
-    await expect(page.getByRole("heading", { name: "Your archive" })).toBeVisible();
+    await expect(
+      page.getByRole("heading", { name: "Your archive" }),
+    ).toBeVisible();
 
     const preferences = page.getByLabel(/Preferences/);
     await expect(preferences).toBeChecked();
+    // Both parts are on by default, which is what a rebuild wants. This test is
+    // about the settings, so it asks for them alone and the assertions below
+    // can be exact about what the document holds.
+    await page.getByLabel(/Transactions/).uncheck();
 
     const downloadPromise = page.waitForEvent("download");
     await page.locator("[data-testid='export-archive']").click();
@@ -68,17 +95,25 @@ test.describe("user archive page", () => {
     expect(doc.preferences.ignored_asset_classes.rules).toEqual([
       { broker: "IBKR", account: "U123", asset_class: "OPTION" },
     ]);
-    // No system data reaches a user archive.
+    // No system data reaches a user archive, and a part left out of the menu is
+    // absent rather than present and empty.
     expect(doc.instruments).toBeUndefined();
     expect(doc.prices).toBeUndefined();
+    expect(doc.txs).toBeUndefined();
 
     // Put both settings back to what they were, so what lands afterwards came
     // from the file rather than from what was already there.
-    await rawQuery(`UPDATE users SET display_currency = 'USD' WHERE id = $1`, [TEST_USER_ID]);
-    await rawQuery(`DELETE FROM ignored_asset_classes WHERE user_id = $1`, [TEST_USER_ID]);
+    await rawQuery(`UPDATE users SET display_currency = 'USD' WHERE id = $1`, [
+      TEST_USER_ID,
+    ]);
+    await rawQuery(`DELETE FROM ignored_asset_classes WHERE user_id = $1`, [
+      TEST_USER_ID,
+    ]);
 
     await page.locator("[data-testid='choose-archive-file']").click();
-    await page.locator("input[aria-label='Choose archive file']").setInputFiles(exported);
+    await page
+      .locator("input[aria-label='Choose archive file']")
+      .setInputFiles(exported);
     // Preferences counts settings rather than rows, so the preview says two.
     await expect(page.locator("[data-testid='archive-import']")).toContainText(
       "Carries 2 preference settings",
@@ -87,42 +122,194 @@ test.describe("user archive page", () => {
 
     const parts = page.locator("[data-testid='job-parts']");
     await expect(parts).toBeVisible({ timeout: TIMEOUT_SLOW });
-    await expect(parts.getByText("Done")).toHaveCount(1, { timeout: TIMEOUT_SLOW });
+    await expect(parts.getByText("Done")).toHaveCount(1, {
+      timeout: TIMEOUT_SLOW,
+    });
     // Both settings applied, none rejected.
     await expect(parts).toContainText("2 / 2");
 
     // What the page said happened, checked against what is stored.
-    const users = (await rawQuery(`SELECT display_currency FROM users WHERE id = $1`, [
-      TEST_USER_ID,
-    ])) as { display_currency: string }[];
+    const users = (await rawQuery(
+      `SELECT display_currency FROM users WHERE id = $1`,
+      [TEST_USER_ID],
+    )) as { display_currency: string }[];
     expect(users[0].display_currency).toBe(CURRENCY);
 
     const rules = (await rawQuery(
       `SELECT broker, account, asset_class FROM ignored_asset_classes WHERE user_id = $1`,
       [TEST_USER_ID],
     )) as { broker: string; account: string; asset_class: string }[];
-    expect(rules).toEqual([{ broker: "IBKR", account: "U123", asset_class: "OPTION" }]);
+    expect(rules).toEqual([
+      { broker: "IBKR", account: "U123", asset_class: "OPTION" },
+    ]);
   });
 
-  test("refuses a file that is not a user archive", async ({ context, page }) => {
+  test("exports the user's transactions and imports them back", async ({
+    context,
+    page,
+  }) => {
     await injectSession(context, sessionId);
     await page.goto("/archive");
 
-    const systemArchive = path.join(tmpdir(), "system-archive-on-user-page.json");
+    await page.getByLabel(/Preferences/).uncheck();
+    await expect(page.getByLabel(/Transactions/)).toBeChecked();
+
+    const downloadPromise = page.waitForEvent("download");
+    await page.locator("[data-testid='export-archive']").click();
+    const exported = path.join(tmpdir(), "user-archive-txs-e2e.json");
+    await (await downloadPromise).saveAs(exported);
+    const doc = JSON.parse(await readFile(exported, "utf8"));
+
+    // One window per broker, bounded by the postings it carries, so the window
+    // provably contains all of them.
+    expect(doc.txs.windows).toHaveLength(1);
+    const window = doc.txs.windows[0];
+    expect(window.broker).toBe("FIDELITY");
+    // The window names the export rather than an ingestion job: a window carries
+    // one source and a broker's postings can come from several.
+    expect(window.source).toBe("FIDELITY:archive:export");
+    expect(window.period_from).toBe("2024-01-15T00:00:00Z");
+    expect(window.period_before).toBe("2024-01-18T00:00:00Z");
+
+    // Grouping is structural, and nothing can rebuild it, so it is what the
+    // part exists to carry: three trades, each with the leg that balances it.
+    expect(window.groups).toHaveLength(3);
+    for (const group of window.groups) {
+      expect(group.postings).toHaveLength(2);
+    }
+    // Order within a group carries no meaning -- the legs of a trade share a
+    // timestamp, so nothing stored distinguishes them -- and neither the file
+    // nor a reader depends on it.
+    const postings = window.groups.flatMap(
+      (g: { postings: Record<string, unknown>[] }) => g.postings,
+    );
+    const first = postings.find(
+      (p) =>
+        typeof p.instrument_description === "string" &&
+        p.instrument_description.startsWith("AMZN"),
+    ) as Record<string, unknown>;
+    // Decimals are strings, never JSON numbers: a double cannot carry an exact
+    // decimal and a value that does not reimport identically is a bug.
+    expect(first.quantity).toBe("8");
+    expect(first.unit_price).toBe("155.2");
+    // Named by identifier and never by id, and by the one bestIdentifierJoin
+    // picks: MIC_TICKER outranks the ISIN the same instrument also carries.
+    expect(first.identifier_hints).toEqual([
+      { type: "MIC_TICKER", value: "AMZN" },
+    ]);
+    // The counterparty travels with its account type, so the group still sums to
+    // zero on the way back in and nothing is routed a second time.
+    //
+    // Spelled with its prefix, unlike every other vocabulary in the format.
+    // AccountType cannot be unprefixed the way AssetClass was: enum values share
+    // package scope and TxType already defines INCOME and TRANSFER.
+    expect(
+      postings.filter((p) => p.account_type === "ACCOUNT_TYPE_EQUITY"),
+    ).toHaveLength(3);
+    // Derived state is not carried: the split-adjusted pair is a recomputable
+    // cache and the weights are computed at ingest.
+    expect(first.split_adjusted_quantity).toBeUndefined();
+    expect(first.weight).toBeUndefined();
+
+    // Clear what the file carried, so what lands afterwards came from the file
+    // rather than from what was already there. Deleting the groups takes their
+    // postings with them.
+    await rawQuery(`DELETE FROM tx_groups WHERE user_id = $1`, [TEST_USER_ID]);
+
+    await page.locator("[data-testid='choose-archive-file']").click();
+    await page
+      .locator("input[aria-label='Choose archive file']")
+      .setInputFiles(exported);
+    // Postings rather than windows or groups, so the preview and the job's own
+    // total agree.
+    await expect(page.locator("[data-testid='archive-import']")).toContainText(
+      "Carries 6 postings",
+    );
+    await page.locator("[data-testid='start-archive-import']").click();
+
+    const parts = page.locator("[data-testid='job-parts']");
+    await expect(parts).toBeVisible({ timeout: TIMEOUT_SLOW });
+    await expect(parts.getByText("Done")).toHaveCount(1, {
+      timeout: TIMEOUT_SLOW,
+    });
+    await expect(parts).toContainText("6 / 6");
+
+    // Every posting back, in three groups, with no residual routed on top: the
+    // groups the file carried already balanced.
+    const restored = (await rawQuery(
+      `SELECT t.instrument_description, t.tx_type, t.quantity, t.unit_price, t.account_type,
+              t.weight, t.weight_commodity, t.group_id
+       FROM txs t WHERE t.user_id = $1 ORDER BY t.timestamp, t.account_type`,
+      [TEST_USER_ID],
+    )) as {
+      instrument_description: string;
+      quantity: string;
+      account_type: string;
+      weight: string;
+      weight_commodity: string;
+      group_id: string;
+    }[];
+    expect(restored).toHaveLength(6);
+    expect(new Set(restored.map((r) => r.group_id)).size).toBe(3);
+    expect(restored.filter((r) => r.account_type === "IMBALANCE")).toHaveLength(
+      0,
+    );
+
+    // The weights are recomputed from the raw columns rather than carried, and
+    // they come back the same, which is what lets the group balance again.
+    const amzn = restored.find((r) =>
+      r.instrument_description.startsWith("AMZN"),
+    );
+    expect(amzn?.quantity).toBe("8");
+    // Compared as a number: the seeded row kept the scale raw SQL wrote it with
+    // and the recomputed one does not, which is the trailing zero the format
+    // says it does not preserve.
+    expect(Number(amzn?.weight)).toBe(1241.6);
+    expect(amzn?.weight_commodity).toBe("cur:USD");
+
+    // Every group sums to zero per commodity, which the balance constraint
+    // enforced at COMMIT and which is the invariant the archive has to preserve.
+    const unbalanced = (await rawQuery(
+      `SELECT group_id FROM txs WHERE user_id = $1
+       GROUP BY group_id, weight_commodity HAVING SUM(weight) <> 0`,
+      [TEST_USER_ID],
+    )) as unknown[];
+    expect(unbalanced).toHaveLength(0);
+  });
+
+  test("refuses a file that is not a user archive", async ({
+    context,
+    page,
+  }) => {
+    await injectSession(context, sessionId);
+    await page.goto("/archive");
+
+    const systemArchive = path.join(
+      tmpdir(),
+      "system-archive-on-user-page.json",
+    );
     await writeFile(
       systemArchive,
       JSON.stringify({
-        envelope: { format_version: 1, exported_at: "2026-07-30T00:00:00Z", kind: "SYSTEM" },
+        envelope: {
+          format_version: 1,
+          exported_at: "2026-07-30T00:00:00Z",
+          kind: "SYSTEM",
+        },
       }),
     );
     await page.locator("[data-testid='choose-archive-file']").click();
-    await page.locator("input[aria-label='Choose archive file']").setInputFiles(systemArchive);
+    await page
+      .locator("input[aria-label='Choose archive file']")
+      .setInputFiles(systemArchive);
 
     // Which archive a file is is answered at parse time, so this never reaches
     // a job and the two archives cannot be crossed by accident.
     await expect(page.locator("[data-testid='archive-import']")).toContainText(
       "This is a system archive",
     );
-    await expect(page.locator("[data-testid='start-archive-import']")).toHaveCount(0);
+    await expect(
+      page.locator("[data-testid='start-archive-import']"),
+    ).toHaveCount(0);
   });
 });


### PR DESCRIPTION
Last of three for 0077. Stacked on #380, which is stacked on #379; review those first. Adds the Transactions row to the export menu, teaches the client assembler to accumulate windows, and pins the round trip end to end.

The e2e test exports a seeded corpus, checks the document, deletes every group, imports the file back, and then checks the database: six postings in three groups, no `IMBALANCE` routed on top, weights recomputed to the same values, and every group summing to zero per commodity. That last query is the invariant the archive exists to preserve.

## Two things worth reviewing

**The suite seeds its own fixture rather than `instruments.sql`.** That fixture's balancing leg carries the trade's own `BUYSTOCK` type against a currency instrument. Raw SQL bypasses validation so it stores, but ingestion rejects it -- `BUYSTOCK` implies `STOCK` and the instrument is `CASH` -- and a round trip has to be re-importable to prove anything. The new fixture's cash leg carries `CASHFLOW`, which implies `CASH`, as a converter's derived money leg does. I left `instruments.sql` alone: four other specs read it, and it is not wrong for what they ask of it.

Seeding through SQL rather than an upload also keeps this suite free of a cassette. An instrument carrying the identifier the export writes is found in the database on the way back in, so no plugin is called.

**A documentation defect fell out of writing the test.** Account types are the one vocabulary whose file spelling is not the column's: protojson writes `ACCOUNT_TYPE_EQUITY` where the column holds `EQUITY`, because `AccountType` cannot be unprefixed the way `AssetClass` was while `TxType` defines `INCOME` and `TRANSFER` in the same package scope. `docs/spec/archive-format.md` claimed every vocabulary matched its column; it now says which one does not, and why.

The spec also gains `share_count_basis` on the posting rather than the window, and a paragraph on what an export writes for a window -- one per broker, bounded by its own postings, sourced as `"<broker>:archive:export"`.

Two assertions I deliberately did not write: order within a group, which carries no meaning because the legs of a trade share a timestamp and nothing stored distinguishes them; and an exact string for a weight, since the seeded row keeps the scale raw SQL wrote it with and the format says trailing zeroes are not preserved.

0077 is closed with the four decisions and the two issues it opened.

`make test`, `make lint` and `make e2e-test` all pass -- 44 e2e tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)