### PR TITLE
Replace a period without destroying a straddling group (0094)

### DIFF
--- a/docs/adr/0039-replace-by-period-deletes-postings-not-groups.md
+++ b/docs/adr/0039-replace-by-period-deletes-postings-not-groups.md
@@ -1,0 +1,68 @@
+# Replace-by-period deletes postings, not groups
+
+Bulk upload is idempotent by replacement
+([0002](0002-transaction-ingestion-model.md)), and the replace originally deleted
+whole tx groups, selected by an `EXISTS` over the postings inside the window. That
+is wrong on a group whose postings straddle the boundary.
+
+A group's postings need not share a timestamp, and one grouping rule spans days
+deliberately: the Fidelity deposit-run pass keys on reference proximity rather than
+on the date bucket, because a run in the sample export settles across two days. One
+posting inside the window therefore destroyed the whole group, including legs
+outside it, and the upload that triggered the delete holds only the rows its own
+period covers. The legs outside were gone and nothing re-inserted them. The
+extension's 14-day lookback re-fetched them by accident, which is protection sized
+for a different problem and disappears when the lookback is lowered, when a user
+uploads a hand-picked file, or when a straddle exceeds it.
+
+**The replace deletes the postings inside the period.** A group left with nothing
+goes with them, which is every group that did not straddle, so the ordinary case is
+unchanged. A group left with something keeps it and gets a counterparty routed for
+what those postings no longer balance to. Balance is checked on the **stored**
+weight ([0029](0029-posting-weight-is-stored.md)), so the residual is
+`SUM(weight) GROUP BY weight_commodity` over the survivors and no weight rule is
+re-derived to compute it. `check_tx_group_balance()` is `DEFERRABLE INITIALLY
+DEFERRED`, so the delete and the routed insert commit together and the group is
+never observed unbalanced.
+
+## The routed leg is classified by the ordinary rule
+
+The counterparty takes the account type any residual would take -- `IMBALANCE`,
+`TRANSFER_CLEARING` or `SOURCE_ROUNDING`, chosen from the surviving legs' tx types
+and the tolerances in [0024](0024-group-balance-is-checked-on-weight.md) -- rather
+than always `IMBALANCE`. The one group shape that straddles today is the deposit
+run, which is transfer family; a plain `IMBALANCE` would hide the surviving half
+from the transfer matcher, which keys strictly on `TRANSFER_CLEARING`. Using one
+rule everywhere also means a group's residual does not depend on whether it was
+created whole or by a partial delete.
+
+That rule therefore has to be the same on both paths, and it now lives in one
+place, `server/residual`. Writing the transfer tx-type set and the tolerances into
+SQL instead would have made the whole operation expressible as statements, but it
+is the second copy [0029](0029-posting-weight-is-stored.md) rejected for the weight
+rules: a copy that has drifted checks the wrong rule while looking authoritative.
+The SQL aggregates stored weights, which is all the constraint trigger itself does,
+and Go classifies what comes back.
+
+The surviving group's own routed legs are re-derived rather than kept: they are
+deleted with the in-period postings and the whole remainder is routed fresh. A
+residual carried over would be a classification of a group that no longer exists in
+that shape, and a group cut twice would accumulate one residual per cut.
+
+## Consequences
+
+Two things a whole-group delete got for free now have to be done explicitly.
+`tx_groups.timestamp` is the timestamp of the first posting that named the group,
+and is derived rather than data, so a group whose first leg the delete took is
+re-dated to its earliest surviving posting. A transfer match is a link between two
+groups ([0037](0037-transfer-matches-are-links-not-postings.md)) that used to
+cascade with the group; a group that survives with a different residual has to lose
+its match, or the link outlives the evidence for it. Both are cheap, and the
+matcher runs after ingest and rebuilds what still holds.
+
+The result is stable under repetition rather than identical to what came before:
+re-importing a period leaves the out-of-period legs where they were and the
+in-period legs in a new group, each balanced by a routed residual. That is two
+groups where a converter once wrote one, and the imbalance report shows two typed
+residuals that net to nothing. Rejoining them is
+[0095](../issues/0095-match-imbalanced-groups-that-should-be-one.md).

--- a/docs/spec/postings.md
+++ b/docs/spec/postings.md
@@ -160,8 +160,10 @@ import and no manual psql session can leave an unbalanced group behind.
 
 The check is deferred to COMMIT because the legs of a group can be written in any
 order, and each leg on its own leaves the group unbalanced. A group deleted whole
-matches no rows and passes vacuously, which is what lets replace-by-period delete
-groups and let the cascade take their postings; deleting a single leg does not.
+matches no rows and passes vacuously. Deleting a single leg does not, which is why
+the partial delete below writes the counterparty that re-balances what is left in
+the same transaction: the two commit together and the group is never observed
+unbalanced.
 
 The exactness is what makes the check arguable-free. There is no tolerance in it,
 because every non-zero residual is routed at ingest -- including the sub-tolerance ones,
@@ -228,7 +230,8 @@ group is a journal. It keeps the broker, account, date and `tx_type` of the grou
 it balances, so the residual stays attributable to the account and the kind of
 event that produced it. Its commodity is carried by `instrument_id`, never encoded
 in a name. It is written into the group it balances, so replace-by-period takes it
-with the cascade.
+with the rest of the group -- and re-derives it, rather than keeping it, when the
+group only partly falls inside the period.
 
 ### Source rounding
 
@@ -274,9 +277,10 @@ running it often is cheap.
 A match is a link between the two tx groups -- both group ids, the commodity, how they were matched and
 when -- rather than a status on the posting or a third group closing both sides out.
 It records which group, and so which account, holds the other side, because that is
-what the membership test above consumes. The link is derived and disposable: it
-cascades when a re-upload replaces one side's groups, and the job rebuilds it. See
-adr/0037-transfer-matches-are-links-not-postings.md.
+what the membership test above consumes. The link is derived and disposable: a
+re-upload that replaces one side drops it -- with the group where the group goes,
+explicitly where the group survives with a different residual -- and the job
+rebuilds it. See adr/0037-transfer-matches-are-links-not-postings.md.
 
 A pair is found on evidence that identifies the occurrence, in this order:
 
@@ -319,13 +323,34 @@ group, so an appended posting is balanced like any other.
 
 ## Deletion
 
-The group is the unit of deletion. Deleting a group deletes its postings, so no code
-path can leave half an economic event behind.
+Deleting a group deletes its postings, so no code path can leave half an economic
+event behind by deleting the group it belongs to.
 
-Bulk upload replaces a period by deleting the groups whose postings fall inside it
-(see adr/0002-transaction-ingestion-model.md). Synthetic INITIALIZE postings are
-managed by the declaration machinery rather than by ingestion, so their groups are
-excluded from that delete and survive a replace (see fixed-point.md).
+Bulk upload replaces a period (see adr/0002-transaction-ingestion-model.md) by
+deleting **the postings** inside it, not the groups that hold them. A group's
+postings need not share a timestamp -- the Fidelity deposit-run pass groups on
+reference proximity rather than the date bucket, because a run in the sample export
+settles across two days -- so a group can straddle any boundary, and deleting it
+whole would take legs the upload that triggered the delete does not carry and
+nothing would re-insert. See
+adr/0039-replace-by-period-deletes-postings-not-groups.md.
+
+A group left with nothing is deleted with its postings, which is every group that
+did not straddle. A group left with something keeps it, is re-dated to its earliest
+surviving posting, and gets a counterparty routed for what those postings no longer
+balance to -- by the rule that classifies any other residual, so a group's residual
+does not depend on whether it was created whole or by a partial delete. Its routed
+counterparties are re-derived rather than kept, so a group carries one residual per
+commodity however many replaces have reached it.
+
+The result is stable under repetition rather than identical to what came before:
+re-importing a period leaves the out-of-period legs where they were and the
+in-period legs in a new group, each balanced by a routed residual. Two groups where
+a converter wrote one; rejoining them is a separate question.
+
+Synthetic INITIALIZE postings are managed by the declaration machinery rather than
+by ingestion, so they neither select a group for replacement nor get deleted from
+one, and survive a replace (see fixed-point.md).
 
 ## Where grouping is decided
 

--- a/server/db/postgres/balance_constraint_test.go
+++ b/server/db/postgres/balance_constraint_test.go
@@ -220,3 +220,19 @@ func TestTxGroupBalance_SplitRecomputeIsNotAffected(t *testing.T) {
 		t.Fatalf("recompute rejected by the balance constraint: %v", err)
 	}
 }
+
+// TestTxGroupBalance_PartialPeriodDeleteIsBalanced is what lets replace-by-period
+// delete part of a group at all. Deleting one leg of a balanced group is a
+// violation on its own; the routed counterparty that negates what is left is
+// written in the same transaction, and the constraint is deferred to COMMIT, so
+// the group is never observed unbalanced.
+func TestTxGroupBalance_PartialPeriodDeleteIsBalanced(t *testing.T) {
+	p := testDBTx(t)
+	userID, usd, _, day2 := straddlingRun(t, p, "sub|balance-straddle", typev1.TxType_JRNLFUND, "5000")
+
+	replaceDay(t, p, userID, usd, day2, nil, nil)
+
+	if err := drainBalanceChecks(t, p); err != nil {
+		t.Fatalf("partially deleted group rejected: %v", err)
+	}
+}

--- a/server/db/postgres/txs.go
+++ b/server/db/postgres/txs.go
@@ -2,12 +2,15 @@ package postgres
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
 	sq "github.com/Masterminds/squirrel"
 	"github.com/google/uuid"
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
 	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
 	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/residual"
+	"github.com/lib/pq"
 	"github.com/shopspring/decimal"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -95,27 +98,284 @@ func (p *Postgres) ReplaceTxsInPeriod(ctx context.Context, userID, broker, jobID
 		if err != nil {
 			return fmt.Errorf("period_before: %w", err)
 		}
-		// Delete whole groups and let the FK cascade take their postings, so that a
-		// replace can never leave half an economic event behind.
-		// Synthetic txs (e.g. INITIALIZE rows backing holding declarations) are
-		// managed by the declaration / recalc machinery, not by ingestion. Their
-		// groups never match here, so a bulk replace cannot collaterally delete them.
-		_, err = exec.ExecContext(ctx, `
-			DELETE FROM tx_groups g
-			WHERE g.user_id = $1
-			  AND EXISTS (
-			    SELECT 1 FROM txs t
-			    WHERE t.group_id = g.id
-			      AND t.broker = $2
-			      AND t.timestamp >= $3 AND t.timestamp < $4
-			      AND t.synthetic_purpose IS NULL
-			  )
-		`, userUUID, broker, fromT, beforeT)
-		if err != nil {
-			return fmt.Errorf("delete tx groups in period: %w", err)
+		if err := clearPeriod(ctx, exec, userUUID, broker, fromT, beforeT); err != nil {
+			return err
 		}
 		return insertPostings(ctx, exec, userUUID, broker, jobUUID, txs, instrumentIDs, weights, shareCountBasis, "")
 	})
+}
+
+// residualAccountTypes are the account types a routed counterparty takes.
+const residualAccountTypes = `'IMBALANCE', 'TRANSFER_CLEARING', 'SOURCE_ROUNDING'`
+
+// deletePeriodPostingsSQL removes the postings a replace covers, and the routed
+// counterparties of every group it touches. Those are re-derived rather than kept,
+// so a group ends with one residual per commodity classified against the legs it
+// now has, and a repeated replace lands on the same rows instead of stacking a
+// second residual on the first.
+//
+// It deletes postings rather than whole groups. A group's postings need not share
+// a timestamp -- the Fidelity deposit-run pass keys on reference proximity, and a
+// run in the sample export settles across two days -- so a whole-group delete
+// destroys legs outside the period, which the upload that triggered it does not
+// carry and nothing re-inserts.
+//
+// Synthetic txs (e.g. INITIALIZE rows backing holding declarations) are managed by
+// the declaration / recalc machinery, not by ingestion, so they neither select a
+// group nor get deleted from one.
+const deletePeriodPostingsSQL = `
+	WITH touched AS (
+		SELECT DISTINCT t.group_id
+		FROM txs t
+		WHERE t.user_id = $1
+		  AND t.broker = $2
+		  AND t.timestamp >= $3 AND t.timestamp < $4
+		  AND t.synthetic_purpose IS NULL
+	)
+	DELETE FROM txs t
+	USING touched
+	WHERE t.group_id = touched.group_id
+	  AND t.synthetic_purpose IS NULL
+	  AND ((t.broker = $2 AND t.timestamp >= $3 AND t.timestamp < $4)
+	       OR t.account_type IN (` + residualAccountTypes + `))
+	RETURNING t.group_id
+`
+
+// deleteEmptiedGroupsSQL removes the groups the delete emptied, which is every
+// group that did not straddle the period. The whole-group delete this replaces
+// left the same rows behind.
+const deleteEmptiedGroupsSQL = `
+	DELETE FROM tx_groups g
+	WHERE g.id = ANY($1)
+	  AND NOT EXISTS (SELECT 1 FROM txs t WHERE t.group_id = g.id)
+`
+
+// deleteTouchedMatchesSQL drops the transfer matches naming a touched group. A
+// match is a link between two groups rather than a posting, and it used to
+// cascade with the group a replace deleted; a group that survives with a
+// different residual needs it dropped explicitly, or the link outlives the
+// evidence for it. The matcher runs after ingest and rebuilds what still holds.
+// See docs/adr/0037-transfer-matches-are-links-not-postings.md.
+const deleteTouchedMatchesSQL = `
+	DELETE FROM transfer_matches m
+	WHERE m.from_group_id = ANY($1) OR m.to_group_id = ANY($1)
+`
+
+// repointGroupTimestampsSQL re-dates a group whose first leg the delete took.
+// tx_groups.timestamp is the timestamp of the first posting that named the group
+// and is derived rather than data, so it has to follow the legs that are left.
+const repointGroupTimestampsSQL = `
+	UPDATE tx_groups g
+	SET timestamp = s.first_timestamp
+	FROM (
+		SELECT group_id, MIN(timestamp) AS first_timestamp
+		FROM txs
+		WHERE group_id = ANY($1)
+		GROUP BY group_id
+	) s
+	WHERE g.id = s.group_id AND g.timestamp <> s.first_timestamp
+`
+
+// survivingResidualsSQL returns what each group the delete touched has left over,
+// with everything the counterparty that balances it is built from.
+//
+// The sum is over the stored weight per weight_commodity, which is exactly what
+// check_tx_group_balance() checks and what routeResiduals accumulates -- so no
+// weight rule is re-derived here and none is written in SQL. The account type the
+// residual takes is chosen in Go, by the rule the ingest balancer uses.
+//
+// first is the group's earliest surviving posting, matching the balancer taking
+// the group's first leg: the residual keeps the broker, account, date and tx type
+// of the group it balances, so it stays attributable. commodity is the earliest
+// surviving leg weighing in that commodity, which is where a residual in a
+// security takes its instrument and description from.
+const survivingResidualsSQL = `
+	SELECT r.group_id, r.weight_commodity, r.residual,
+	       types.tx_types,
+	       first.timestamp, first.tx_type, first.broker, first.account,
+	       first.trading_currency, first.settlement_currency,
+	       commodity.instrument_description, commodity.instrument_id
+	FROM (
+		SELECT group_id, weight_commodity, SUM(weight) AS residual
+		FROM txs
+		WHERE group_id = ANY($1)
+		GROUP BY group_id, weight_commodity
+		HAVING SUM(weight) <> 0
+	) r
+	JOIN LATERAL (
+		SELECT array_agg(DISTINCT t.tx_type) AS tx_types
+		FROM txs t WHERE t.group_id = r.group_id
+	) types ON true
+	JOIN LATERAL (
+		SELECT t.timestamp, t.tx_type, t.broker, t.account,
+		       t.trading_currency, t.settlement_currency
+		FROM txs t WHERE t.group_id = r.group_id
+		ORDER BY t.timestamp, t.id LIMIT 1
+	) first ON true
+	JOIN LATERAL (
+		SELECT t.instrument_description, t.instrument_id
+		FROM txs t
+		WHERE t.group_id = r.group_id AND t.weight_commodity = r.weight_commodity
+		ORDER BY t.timestamp, t.id LIMIT 1
+	) commodity ON true
+	ORDER BY r.group_id, r.weight_commodity
+`
+
+// currencyInstrumentSQL resolves the seeded instrument a money residual is
+// denominated in. It runs on the replace's own transaction rather than through
+// FindInstrumentByIdentifier so that the whole operation is one statement stream.
+const currencyInstrumentSQL = `
+	SELECT instrument_id FROM instrument_identifiers
+	WHERE identifier_type = 'CURRENCY' AND domain IS NULL AND value = $1
+`
+
+// survivingResidual is one commodity a partially deleted group no longer balances
+// in, and the group attributes the counterparty for it is built from.
+type survivingResidual struct {
+	groupID      uuid.UUID
+	commodity    string
+	amount       decimal.Decimal
+	txTypes      pq.StringArray
+	timestamp    time.Time
+	txType       string
+	broker       string
+	account      string
+	trading      *string
+	settlement   *string
+	description  string
+	instrumentID *uuid.UUID
+}
+
+// clearPeriod deletes the postings a replace covers and re-balances the groups it
+// left standing.
+//
+// A group that straddles the period keeps its postings outside it and gains a
+// routed counterparty for what those legs no longer balance to. The result is
+// stable under repetition rather than identical to what came before: re-importing
+// a period leaves the out-of-period legs where they were and the in-period legs in
+// a new group, each balanced by a routed residual.
+//
+// The delete and the routed insert commit together, and
+// check_tx_group_balance() is DEFERRABLE INITIALLY DEFERRED, so the group is never
+// observed unbalanced.
+func clearPeriod(ctx context.Context, exec queryable, userUUID uuid.UUID, broker string, fromT, beforeT time.Time) error {
+	rows, err := exec.QueryContext(ctx, deletePeriodPostingsSQL, userUUID, broker, fromT, beforeT)
+	if err != nil {
+		return fmt.Errorf("delete txs in period: %w", err)
+	}
+	seen := map[uuid.UUID]bool{}
+	var touched []uuid.UUID
+	for rows.Next() {
+		var id uuid.UUID
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return fmt.Errorf("delete txs in period: %w", err)
+		}
+		if !seen[id] {
+			seen[id] = true
+			touched = append(touched, id)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		rows.Close()
+		return fmt.Errorf("delete txs in period: %w", err)
+	}
+	rows.Close()
+	if len(touched) == 0 {
+		return nil
+	}
+
+	ids := pq.Array(touched)
+	if _, err := exec.ExecContext(ctx, deleteEmptiedGroupsSQL, ids); err != nil {
+		return fmt.Errorf("delete emptied tx groups: %w", err)
+	}
+	if _, err := exec.ExecContext(ctx, deleteTouchedMatchesSQL, ids); err != nil {
+		return fmt.Errorf("delete transfer matches: %w", err)
+	}
+	if _, err := exec.ExecContext(ctx, repointGroupTimestampsSQL, ids); err != nil {
+		return fmt.Errorf("repoint tx group timestamps: %w", err)
+	}
+	return routeSurvivors(ctx, exec, userUUID, ids)
+}
+
+// routeSurvivors writes the counterparty that balances each group the delete left
+// unbalanced, by the same rule the ingest balancer applies to an upload.
+func routeSurvivors(ctx context.Context, exec queryable, userUUID uuid.UUID, groupIDs interface{}) error {
+	rows, err := exec.QueryContext(ctx, survivingResidualsSQL, groupIDs)
+	if err != nil {
+		return fmt.Errorf("surviving residuals: %w", err)
+	}
+	defer rows.Close()
+	var residuals []survivingResidual
+	for rows.Next() {
+		var r survivingResidual
+		if err := rows.Scan(&r.groupID, &r.commodity, &r.amount, &r.txTypes,
+			&r.timestamp, &r.txType, &r.broker, &r.account,
+			&r.trading, &r.settlement, &r.description, &r.instrumentID); err != nil {
+			return fmt.Errorf("surviving residuals: %w", err)
+		}
+		residuals = append(residuals, r)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("surviving residuals: %w", err)
+	}
+
+	byCurrency := map[string]*uuid.UUID{}
+	for _, r := range residuals {
+		amount := r.amount.Neg()
+		txTypes := make([]typev1.TxType, 0, len(r.txTypes))
+		for _, t := range r.txTypes {
+			txTypes = append(txTypes, db.StrToTxType(t))
+		}
+		acctType, err := accountTypeToStr(residual.Type(r.commodity, amount, txTypes))
+		if err != nil {
+			return err
+		}
+
+		// A residual in a security carries the instrument and description of the
+		// legs it balances; one in money resolves the seeded currency instrument
+		// and takes the code as its description, matching how an ordinary cash row
+		// arrives so nothing downstream has to treat it specially.
+		desc, trading, settlement := r.description, r.trading, r.settlement
+		instID := r.instrumentID
+		if code, money := residual.CurrencyOf(r.commodity); money {
+			cached, ok := byCurrency[code]
+			if !ok {
+				var id uuid.UUID
+				switch err := exec.QueryRowContext(ctx, currencyInstrumentSQL, code).Scan(&id); {
+				case err == sql.ErrNoRows:
+					cached = nil
+				case err != nil:
+					return fmt.Errorf("resolve currency %s: %w", code, err)
+				default:
+					cached = &id
+				}
+				byCurrency[code] = cached
+			}
+			if cached == nil {
+				// Currencies are seeded, so this is a safety net rather than a live
+				// path. Naming the commodity is the only way the failure says
+				// anything useful: the alternative is the deferred constraint
+				// rejecting the whole replace at COMMIT.
+				return fmt.Errorf("no instrument for residual commodity %q", r.commodity)
+			}
+			instID = cached
+			desc, trading, settlement = code, &code, &code
+		}
+
+		// NULL share_count_basis leaves the insert trigger to seed it from the
+		// posting's own timestamp, and the split-adjusted pair is seeded the same
+		// way, exactly as for an uploaded posting.
+		args := []interface{}{
+			userUUID, r.broker, r.account, r.timestamp, desc, r.txType, amount,
+			trading, settlement, nil, instID, nil, acctType,
+			amount, r.commodity, nil, nil, r.groupID,
+		}
+		if _, err := exec.ExecContext(ctx, insertPostingInGroupSQL, args...); err != nil {
+			return fmt.Errorf("insert routed posting: %w", err)
+		}
+	}
+	return nil
 }
 
 // insertPostings writes each tx as a posting, creating one tx group per distinct

--- a/server/db/postgres/txs_test.go
+++ b/server/db/postgres/txs_test.go
@@ -1274,3 +1274,350 @@ func TestListTxsForExport_OrderedForGrouping(t *testing.T) {
 		}
 	}
 }
+
+// straddlingRun seeds one balanced group whose two legs sit on different days, and
+// returns the user, the USD instrument they weigh in, and the two days.
+//
+// This is the shape the Fidelity deposit-run pass produces: it keys on reference
+// proximity rather than the date bucket, because a run in the sample export
+// settles across two days. Any period boundary between the two legs therefore cuts
+// a group in half.
+func straddlingRun(t *testing.T, p *Postgres, sub string, txType typev1.TxType, qty string) (userID, usd string, day1, day2 time.Time) {
+	t.Helper()
+	ctx := context.Background()
+	userID, usd = balanceSeed(t, p, sub)
+	day1 = time.Date(2025, 9, 10, 15, 0, 0, 0, time.UTC)
+	day2 = day1.Add(24 * time.Hour)
+	amount := decimal.RequireFromString(qty)
+	txs := []*apiv1.Tx{
+		{Timestamp: timestamppb.New(day1), InstrumentDescription: "USD", Type: txType,
+			Quantity: amount.Neg().String(), Account: "A", GroupRef: "run"},
+		{Timestamp: timestamppb.New(day2), InstrumentDescription: "USD", Type: txType,
+			Quantity: amount.String(), Account: "A", GroupRef: "run"},
+	}
+	weights := []db.Weight{
+		{Amount: amount.Neg(), Commodity: "cur:USD"},
+		{Amount: amount, Commodity: "cur:USD"},
+	}
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "FIDELITY", "",
+		timestamppb.New(day1.Add(-time.Hour)), timestamppb.New(day2.Add(time.Hour)),
+		txs, []string{usd, usd}, weights, nil); err != nil {
+		t.Fatalf("seed straddling run: %v", err)
+	}
+	return userID, usd, day1, day2
+}
+
+// replaceDay replaces the calendar day starting at from with the given postings.
+func replaceDay(t *testing.T, p *Postgres, userID, usd string, from time.Time, txs []*apiv1.Tx, weights []db.Weight) {
+	t.Helper()
+	ids := make([]string, len(txs))
+	for i := range ids {
+		ids[i] = usd
+	}
+	if err := p.ReplaceTxsInPeriod(context.Background(), userID, "FIDELITY", "",
+		timestamppb.New(from), timestamppb.New(from.Add(24*time.Hour)), txs, ids, weights, nil); err != nil {
+		t.Fatalf("replace: %v", err)
+	}
+}
+
+// balancedUpload is one day's replacement batch as ingestion hands it over: an
+// event that already sums to zero, because whatever an upload leaves over is
+// routed above the db layer.
+func balancedUpload(at time.Time, qty string) []*apiv1.Tx {
+	return []*apiv1.Tx{
+		{Timestamp: timestamppb.New(at), InstrumentDescription: "USD", Type: typev1.TxType_JRNLFUND,
+			Quantity: qty, Account: "A", GroupRef: "new"},
+		{Timestamp: timestamppb.New(at), InstrumentDescription: "USD", Type: typev1.TxType_JRNLFUND,
+			Quantity: decimal.RequireFromString(qty).Neg().String(), Account: "B", GroupRef: "new"},
+	}
+}
+
+// balancedWeights are the weights of a balancedUpload.
+func balancedWeights(qty string) []db.Weight {
+	amount := decimal.RequireFromString(qty)
+	return []db.Weight{
+		{Amount: amount, Commodity: "cur:USD"},
+		{Amount: amount.Neg(), Commodity: "cur:USD"},
+	}
+}
+
+// routedPostings returns a user's routed counterparties, newest last, as
+// (account_type, quantity, weight_commodity).
+func routedPostings(t *testing.T, p *Postgres, userID string) [][3]string {
+	t.Helper()
+	rows, err := p.q.QueryContext(context.Background(), `
+		SELECT account_type, quantity::text, weight_commodity FROM txs
+		WHERE user_id = $1 AND account_type IN ('IMBALANCE', 'TRANSFER_CLEARING', 'SOURCE_ROUNDING')
+		ORDER BY timestamp, quantity
+	`, userID)
+	if err != nil {
+		t.Fatalf("routed postings: %v", err)
+	}
+	defer rows.Close()
+	var out [][3]string
+	for rows.Next() {
+		var r [3]string
+		if err := rows.Scan(&r[0], &r[1], &r[2]); err != nil {
+			t.Fatalf("routed postings: %v", err)
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+// assertBalanced fails when any of a user's groups has a commodity left over,
+// which is the invariant the deferred constraint enforces at COMMIT and which
+// testDBTx never reaches.
+func assertBalanced(t *testing.T, p *Postgres, userID string) {
+	t.Helper()
+	var unbalanced int
+	if err := p.q.QueryRowContext(context.Background(), `
+		SELECT count(*) FROM (
+			SELECT group_id FROM txs WHERE user_id = $1
+			GROUP BY group_id, weight_commodity HAVING SUM(weight) <> 0
+		) bad
+	`, userID).Scan(&unbalanced); err != nil {
+		t.Fatalf("check balance: %v", err)
+	}
+	if unbalanced != 0 {
+		t.Errorf("groups left unbalanced: want 0, got %d", unbalanced)
+	}
+}
+
+// TestReplaceTxsInPeriod_KeepsLegsOutsideThePeriod is the defect this path exists
+// for. An upload covering one day of a run that settled over two must not take the
+// legs it does not carry: it holds only the rows its own period covers, so nothing
+// would re-insert them.
+func TestReplaceTxsInPeriod_KeepsLegsOutsideThePeriod(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, usd, day1, day2 := straddlingRun(t, p, "sub|straddle-keep", typev1.TxType_JRNLFUND, "5000")
+
+	// The second day is re-uploaded with a different amount, as a corrected
+	// statement would carry it. The batch arrives balanced, because the caller
+	// routes what an upload leaves over before it reaches the db layer.
+	replaceDay(t, p, userID, usd, day2, balancedUpload(day2, "4000"), balancedWeights("4000"))
+
+	rows, _, err := p.ListTxs(ctx, userID, nil, "", nil, nil, false, 50, "")
+	if err != nil {
+		t.Fatalf("list txs: %v", err)
+	}
+	// The day-one leg, the counterparty routed for it, and the two legs of the
+	// re-uploaded day.
+	if len(rows) != 4 {
+		t.Fatalf("postings after replacing the second day: want 4, got %d", len(rows))
+	}
+	var kept bool
+	for _, r := range rows {
+		if r.GetTx().GetTimestamp().AsTime().Equal(day1) && r.GetTx().GetQuantity() == "-5000" {
+			kept = true
+		}
+	}
+	if !kept {
+		t.Error("the leg outside the replaced period was deleted")
+	}
+	// Two groups where the converter wrote one: the out-of-period leg keeps its
+	// group and the re-uploaded day lands in a new one. Rejoining them is 0095.
+	if got := countGroups(t, p, userID); got != 2 {
+		t.Errorf("tx_groups after replace: want 2, got %d", got)
+	}
+	assertBalanced(t, p, userID)
+}
+
+// TestReplaceTxsInPeriod_RoutesTheSurvivorsResidual pins the account type the
+// remainder is routed to. A deposit run is transfer family, and a plain IMBALANCE
+// would hide the surviving half from the transfer matcher, which keys strictly on
+// TRANSFER_CLEARING.
+func TestReplaceTxsInPeriod_RoutesTheSurvivorsResidual(t *testing.T) {
+	tests := []struct {
+		name   string
+		sub    string
+		txType typev1.TxType
+		qty    string
+		want   [3]string
+	}{
+		{
+			name:   "journal",
+			sub:    "sub|straddle-journal",
+			txType: typev1.TxType_JRNLFUND,
+			qty:    "5000",
+			want:   [3]string{"TRANSFER_CLEARING", "5000", "cur:USD"},
+		},
+		{
+			name:   "not a journal",
+			sub:    "sub|straddle-imbalance",
+			txType: typev1.TxType_CASHFLOW,
+			qty:    "5000",
+			want:   [3]string{"IMBALANCE", "5000", "cur:USD"},
+		},
+		{
+			// Sub-tolerance is rounding whatever the tx type says, so this beats
+			// the transfer classification rather than the other way round.
+			name:   "below the money tolerance",
+			sub:    "sub|straddle-rounding",
+			txType: typev1.TxType_JRNLFUND,
+			qty:    "0.002",
+			want:   [3]string{"SOURCE_ROUNDING", "0.002", "cur:USD"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p := testDBTx(t)
+			userID, usd, _, day2 := straddlingRun(t, p, tc.sub, tc.txType, tc.qty)
+			replaceDay(t, p, userID, usd, day2, nil, nil)
+
+			routed := routedPostings(t, p, userID)
+			if len(routed) != 1 {
+				t.Fatalf("routed postings: want 1, got %d (%v)", len(routed), routed)
+			}
+			if routed[0] != tc.want {
+				t.Errorf("routed posting: want %v, got %v", tc.want, routed[0])
+			}
+			assertBalanced(t, p, userID)
+		})
+	}
+}
+
+// TestReplaceTxsInPeriod_ResidualIsReDerivedNotStacked covers a group cut twice.
+// The second cut re-routes the whole remainder rather than adding a residual on
+// top of the first one, so a group keeps exactly one counterparty per commodity
+// however many replaces have reached it.
+func TestReplaceTxsInPeriod_ResidualIsReDerivedNotStacked(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, usd := balanceSeed(t, p, "sub|straddle-rederive")
+	day1 := time.Date(2025, 9, 10, 15, 0, 0, 0, time.UTC)
+	day2, day3 := day1.Add(24*time.Hour), day1.Add(48*time.Hour)
+	legs := []*apiv1.Tx{
+		{Timestamp: timestamppb.New(day1), InstrumentDescription: "USD", Type: typev1.TxType_JRNLFUND, Quantity: "-5000", Account: "A", GroupRef: "run"},
+		{Timestamp: timestamppb.New(day2), InstrumentDescription: "USD", Type: typev1.TxType_JRNLFUND, Quantity: "2000", Account: "A", GroupRef: "run"},
+		{Timestamp: timestamppb.New(day3), InstrumentDescription: "USD", Type: typev1.TxType_JRNLFUND, Quantity: "3000", Account: "A", GroupRef: "run"},
+	}
+	weights := []db.Weight{
+		{Amount: decimal.RequireFromString("-5000"), Commodity: "cur:USD"},
+		{Amount: decimal.RequireFromString("2000"), Commodity: "cur:USD"},
+		{Amount: decimal.RequireFromString("3000"), Commodity: "cur:USD"},
+	}
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "FIDELITY", "",
+		timestamppb.New(day1.Add(-time.Hour)), timestamppb.New(day3.Add(time.Hour)),
+		legs, []string{usd, usd, usd}, weights, nil); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// The middle day goes first, leaving the residual on the day-one leg.
+	replaceDay(t, p, userID, usd, day2, nil, nil)
+	// The first day goes next, which also takes the counterparty routed onto it.
+	replaceDay(t, p, userID, usd, day1, nil, nil)
+
+	routed := routedPostings(t, p, userID)
+	if len(routed) != 1 {
+		t.Fatalf("routed postings after two cuts: want 1, got %d (%v)", len(routed), routed)
+	}
+	// Only the day-three leg is left, so the counterparty negates it whole.
+	if want := ([3]string{"TRANSFER_CLEARING", "-3000", "cur:USD"}); routed[0] != want {
+		t.Errorf("routed posting: want %v, got %v", want, routed[0])
+	}
+	assertBalanced(t, p, userID)
+}
+
+// TestReplaceTxsInPeriod_IsIdempotent is the property replace-by-period exists
+// for: re-running the same upload lands on the same rows rather than doubling
+// them, and a straddling group must not weaken it.
+func TestReplaceTxsInPeriod_IsIdempotent(t *testing.T) {
+	p := testDBTx(t)
+	userID, usd, _, day2 := straddlingRun(t, p, "sub|straddle-idem", typev1.TxType_JRNLFUND, "5000")
+	replaceDay(t, p, userID, usd, day2, balancedUpload(day2, "4000"), balancedWeights("4000"))
+	first := postingSummary(t, p, userID)
+	replaceDay(t, p, userID, usd, day2, balancedUpload(day2, "4000"), balancedWeights("4000"))
+	second := postingSummary(t, p, userID)
+
+	if len(first) != len(second) {
+		t.Fatalf("postings after a repeated replace: want %d, got %d", len(first), len(second))
+	}
+	for i := range first {
+		if first[i] != second[i] {
+			t.Errorf("posting %d changed on a repeated replace: %v then %v", i, first[i], second[i])
+		}
+	}
+	assertBalanced(t, p, userID)
+}
+
+// postingSummary returns every posting as (timestamp, quantity, account_type),
+// ordered, for comparing two states of the same data.
+func postingSummary(t *testing.T, p *Postgres, userID string) [][3]string {
+	t.Helper()
+	rows, err := p.q.QueryContext(context.Background(), `
+		SELECT timestamp::text, quantity::text, account_type FROM txs
+		WHERE user_id = $1 ORDER BY timestamp, quantity, account_type
+	`, userID)
+	if err != nil {
+		t.Fatalf("posting summary: %v", err)
+	}
+	defer rows.Close()
+	var out [][3]string
+	for rows.Next() {
+		var r [3]string
+		if err := rows.Scan(&r[0], &r[1], &r[2]); err != nil {
+			t.Fatalf("posting summary: %v", err)
+		}
+		out = append(out, r)
+	}
+	return out
+}
+
+// TestReplaceTxsInPeriod_RedatesAPartiallyDeletedGroup covers tx_groups.timestamp,
+// which is the timestamp of the first posting that named the group. It is derived
+// rather than data, so it has to follow the legs that are left when the one it was
+// taken from is deleted.
+func TestReplaceTxsInPeriod_RedatesAPartiallyDeletedGroup(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, usd, day1, day2 := straddlingRun(t, p, "sub|straddle-redate", typev1.TxType_JRNLFUND, "5000")
+
+	// The first day goes, so the group has to re-date to the second.
+	replaceDay(t, p, userID, usd, day1, nil, nil)
+
+	var at time.Time
+	if err := p.q.QueryRowContext(ctx,
+		`SELECT timestamp FROM tx_groups WHERE user_id = $1`, userID).Scan(&at); err != nil {
+		t.Fatalf("group timestamp: %v", err)
+	}
+	if !at.Equal(day2) {
+		t.Errorf("group timestamp: want %v, got %v", day2, at)
+	}
+}
+
+// TestReplaceTxsInPeriod_DropsMatchesOnPartiallyDeletedGroups covers the link a
+// whole-group delete used to take with the cascade. A group that survives with a
+// different residual has to lose its match explicitly, or the link outlives the
+// evidence for it. The matcher runs after ingest and rebuilds what still holds.
+func TestReplaceTxsInPeriod_DropsMatchesOnPartiallyDeletedGroups(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, usd, _, day2 := straddlingRun(t, p, "sub|straddle-match", typev1.TxType_JRNLFUND, "5000")
+
+	var straddling string
+	if err := p.q.QueryRowContext(ctx,
+		`SELECT DISTINCT group_id FROM txs WHERE user_id = $1`, userID).Scan(&straddling); err != nil {
+		t.Fatalf("straddling group: %v", err)
+	}
+	other := newTxGroup(t, p, userID)
+	if _, err := p.q.ExecContext(ctx, `
+		INSERT INTO transfer_matches (user_id, from_group_id, to_group_id, instrument_id, method)
+		VALUES ($1::uuid, $2::uuid, $3::uuid, $4::uuid, 'REFERENCE')
+	`, userID, straddling, other, usd); err != nil {
+		t.Fatalf("seed match: %v", err)
+	}
+
+	replaceDay(t, p, userID, usd, day2, nil, nil)
+
+	var matches int
+	if err := p.q.QueryRowContext(ctx,
+		`SELECT count(*) FROM transfer_matches WHERE user_id = $1`, userID).Scan(&matches); err != nil {
+		t.Fatalf("count matches: %v", err)
+	}
+	if matches != 0 {
+		t.Errorf("transfer matches after a partial delete: want 0, got %d", matches)
+	}
+}

--- a/server/residual/residual.go
+++ b/server/residual/residual.go
@@ -1,0 +1,105 @@
+// Package residual classifies what a tx group has left over.
+//
+// A group balances when the stored weights sum to zero per commodity, and every
+// non-zero residual is routed to an explicit posting rather than rejected. Which
+// account type that posting takes is this package's whole subject: IMBALANCE for
+// a leg the source omitted, TRANSFER_CLEARING for the unmatched side of a
+// journal, and SOURCE_ROUNDING for a difference small enough to be the source
+// disagreeing with itself. See docs/adr/0024-group-balance-is-checked-on-weight.md.
+//
+// It is a package of its own because two paths route residuals and the rule has
+// to be the same on both. The ingest balancer weighs the postings of an upload;
+// the partial delete in replace-by-period sums the weights already stored. A
+// group's residual must not depend on which of the two produced it.
+package residual
+
+import (
+	"strings"
+
+	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
+	"github.com/shopspring/decimal"
+)
+
+// The commodity a weight is contributed in, prefixed by kind. The three are not
+// the same kind of thing, so a description that happened to read USD is not the
+// same commodity as the currency. See docs/adr/0029-posting-weight-is-stored.md.
+const (
+	CurrencyPrefix    = "cur:"
+	InstrumentPrefix  = "inst:"
+	DescriptionPrefix = "desc:"
+)
+
+// transferTypes are the journals whose other side is a different account. Their
+// residual is an unmatched transfer rather than a data-quality problem, so it is
+// routed to TRANSFER_CLEARING and holds the value in transit until the pair is
+// matched.
+var transferTypes = map[typev1.TxType]bool{
+	typev1.TxType_TRANSFER: true,
+	typev1.TxType_JRNLFUND: true,
+	typev1.TxType_JRNLSEC:  true,
+}
+
+// Tolerances below which a residual is the source disagreeing with itself rather
+// than a leg it left out. A trade of 37 shares at 12.3456 costs 456.7872 against a
+// broker cash row of -456.79: the 0.0028 is an artefact of the source being
+// written to 2dp, not a real discrepancy. Beancount infers half the last
+// significant digit for exactly this case, and half a cent is what it would infer
+// for 2dp money.
+//
+// Quantities are exact decimals now, so this is no longer absorbing arithmetic
+// error -- it is the disagreement between two figures the source rounded
+// differently, which exactness does not remove. Both beancount and ledger keep a
+// tolerance for the same reason. Inferring it from the scale of the contributing
+// amounts, rather than fixing it, is a change to how residuals get classified and
+// is deliberately not made here.
+var (
+	moneyTolerance     = decimal.RequireFromString("0.005")
+	commodityTolerance = decimal.New(1, -6)
+)
+
+// Tolerance returns the residual below which a difference in this commodity reads
+// as the source's own rounding rather than as a leg it omitted.
+func Tolerance(commodity string) decimal.Decimal {
+	if strings.HasPrefix(commodity, CurrencyPrefix) {
+		return moneyTolerance
+	}
+	return commodityTolerance
+}
+
+// Type returns the account type the residual of amount in commodity is routed to,
+// for a group whose postings have the given tx types.
+//
+// The tolerance decides the account type, not whether the residual is routed at
+// all: suppressing the small ones would leave the group summing to a small
+// non-zero value, which is exactly what the balance constraint rejects, and
+// dropping them into IMBALANCE alongside genuinely missing legs would throw away
+// the one thing already known about them. A sub-tolerance residual on a journal
+// is rounding too, so SOURCE_ROUNDING beats the transfer case rather than the
+// other way round.
+func Type(commodity string, amount decimal.Decimal, txTypes []typev1.TxType) typev1.AccountType {
+	if amount.Abs().LessThan(Tolerance(commodity)) {
+		return typev1.AccountType_ACCOUNT_TYPE_SOURCE_ROUNDING
+	}
+	for _, t := range txTypes {
+		if transferTypes[t] {
+			return typev1.AccountType_ACCOUNT_TYPE_TRANSFER_CLEARING
+		}
+	}
+	return typev1.AccountType_ACCOUNT_TYPE_IMBALANCE
+}
+
+// CurrencyOf returns the currency code a money commodity names, and whether it is
+// one. The routed posting for a money residual needs the code to resolve the
+// seeded currency instrument it is denominated in.
+func CurrencyOf(commodity string) (string, bool) {
+	code, ok := strings.CutPrefix(commodity, CurrencyPrefix)
+	return code, ok
+}
+
+// InstrumentOf returns the instrument id a security commodity names, and whether
+// it is one. A residual in a security carries the instrument of the legs it
+// balances rather than resolving one.
+func InstrumentOf(commodity string) (string, bool) {
+	id, ok := strings.CutPrefix(commodity, InstrumentPrefix)
+	return id, ok
+}

--- a/server/residual/residual_test.go
+++ b/server/residual/residual_test.go
@@ -1,0 +1,121 @@
+package residual
+
+import (
+	"testing"
+
+	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
+	"github.com/shopspring/decimal"
+)
+
+func TestType(t *testing.T) {
+	tests := []struct {
+		name      string
+		commodity string
+		amount    string
+		txTypes   []typev1.TxType
+		want      typev1.AccountType
+	}{
+		{
+			name:      "missing cash leg",
+			commodity: "cur:USD",
+			amount:    "-1855",
+			txTypes:   []typev1.TxType{typev1.TxType_BUYSTOCK},
+			want:      typev1.AccountType_ACCOUNT_TYPE_IMBALANCE,
+		},
+		{
+			name:      "one-sided journal",
+			commodity: "cur:USD",
+			amount:    "-500",
+			txTypes:   []typev1.TxType{typev1.TxType_JRNLFUND},
+			want:      typev1.AccountType_ACCOUNT_TYPE_TRANSFER_CLEARING,
+		},
+		{
+			name:      "one transfer leg in a mixed group",
+			commodity: "cur:USD",
+			amount:    "-500",
+			txTypes:   []typev1.TxType{typev1.TxType_INVEXPENSE, typev1.TxType_TRANSFER},
+			want:      typev1.AccountType_ACCOUNT_TYPE_TRANSFER_CLEARING,
+		},
+		{
+			name:      "sub-cent difference",
+			commodity: "cur:USD",
+			amount:    "0.0028",
+			txTypes:   []typev1.TxType{typev1.TxType_BUYSTOCK},
+			want:      typev1.AccountType_ACCOUNT_TYPE_SOURCE_ROUNDING,
+		},
+		{
+			// The tolerance is exclusive: half a cent is what a 2dp source can be
+			// out by, so a residual of exactly that is a leg rather than rounding.
+			name:      "exactly at the money tolerance",
+			commodity: "cur:USD",
+			amount:    "0.005",
+			txTypes:   []typev1.TxType{typev1.TxType_BUYSTOCK},
+			want:      typev1.AccountType_ACCOUNT_TYPE_IMBALANCE,
+		},
+		{
+			// Rounding beats the transfer classification rather than the other way
+			// round: a journal the source rounded is still rounding.
+			name:      "sub-cent difference on a journal",
+			commodity: "cur:USD",
+			amount:    "-0.001",
+			txTypes:   []typev1.TxType{typev1.TxType_JRNLSEC},
+			want:      typev1.AccountType_ACCOUNT_TYPE_SOURCE_ROUNDING,
+		},
+		{
+			name:      "shares the source left out",
+			commodity: "inst:11111111-1111-1111-1111-111111111111",
+			amount:    "10",
+			txTypes:   []typev1.TxType{typev1.TxType_BUYSTOCK},
+			want:      typev1.AccountType_ACCOUNT_TYPE_IMBALANCE,
+		},
+		{
+			// A security's tolerance is 1e-6, not half a cent, so a fraction of a
+			// share well below a cent is still a real quantity.
+			name:      "fraction of a share",
+			commodity: "inst:11111111-1111-1111-1111-111111111111",
+			amount:    "0.001",
+			txTypes:   []typev1.TxType{typev1.TxType_BUYSTOCK},
+			want:      typev1.AccountType_ACCOUNT_TYPE_IMBALANCE,
+		},
+		{
+			name:      "sub-tolerance quantity",
+			commodity: "inst:11111111-1111-1111-1111-111111111111",
+			amount:    "-0.0000001",
+			txTypes:   []typev1.TxType{typev1.TxType_JRNLSEC},
+			want:      typev1.AccountType_ACCOUNT_TYPE_SOURCE_ROUNDING,
+		},
+		{
+			// An unresolved commodity is weighed against itself, and takes the
+			// security tolerance because it is not money.
+			name:      "unresolved commodity",
+			commodity: "desc:MYSTERY HOLDING",
+			amount:    "0.001",
+			txTypes:   []typev1.TxType{typev1.TxType_CASHFLOW},
+			want:      typev1.AccountType_ACCOUNT_TYPE_IMBALANCE,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Type(tc.commodity, decimal.RequireFromString(tc.amount), tc.txTypes)
+			if got != tc.want {
+				t.Fatalf("Type(%q, %s) = %v, want %v", tc.commodity, tc.amount, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestCommodityAccessors(t *testing.T) {
+	if c, ok := CurrencyOf("cur:USD"); !ok || c != "USD" {
+		t.Fatalf("CurrencyOf(cur:USD) = %q, %v; want USD, true", c, ok)
+	}
+	if _, ok := CurrencyOf("inst:abc"); ok {
+		t.Fatal("CurrencyOf(inst:abc) reported money")
+	}
+	if id, ok := InstrumentOf("inst:abc"); !ok || id != "abc" {
+		t.Fatalf("InstrumentOf(inst:abc) = %q, %v; want abc, true", id, ok)
+	}
+	if _, ok := InstrumentOf("desc:inst:abc"); ok {
+		t.Fatal("InstrumentOf(desc:inst:abc) reported a security")
+	}
+}

--- a/server/service/ingestion/balance.go
+++ b/server/service/ingestion/balance.go
@@ -6,6 +6,7 @@ import (
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
 	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
 	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/residual"
 	"github.com/shopspring/decimal"
 	"google.golang.org/protobuf/proto"
 	"sort"
@@ -48,41 +49,6 @@ var exchangeTypes = map[typev1.TxType]bool{
 	typev1.TxType_REINVEST:   true,
 	typev1.TxType_CLOSUREOPT: true,
 }
-
-// transferTypes are the journals whose other side is a different account. Their
-// residual is an unmatched transfer rather than a data-quality problem, so it is
-// routed to TRANSFER_CLEARING and holds the value in transit until the pair is
-// matched.
-var transferTypes = map[typev1.TxType]bool{
-	typev1.TxType_TRANSFER: true,
-	typev1.TxType_JRNLFUND: true,
-	typev1.TxType_JRNLSEC:  true,
-}
-
-// Tolerances below which a residual is the source disagreeing with itself rather
-// than a leg it left out. A trade of 37 shares at 12.3456 costs 456.7872 against a
-// broker cash row of -456.79: the 0.0028 is an artefact of the source being
-// written to 2dp, not a real discrepancy. Beancount infers half the last
-// significant digit for exactly this case, and half a cent is what it would infer
-// for 2dp money.
-//
-// Quantities are exact decimals now, so this is no longer absorbing arithmetic
-// error -- it is the disagreement between two figures the source rounded
-// differently, which exactness does not remove. Both beancount and ledger keep a
-// tolerance for the same reason. Inferring it from the scale of the contributing
-// amounts, rather than fixing it, is a change to how residuals get classified and
-// is deliberately not made here.
-//
-// The tolerance decides the account type a residual is routed to, not whether it
-// is routed at all. Suppressing the small ones would leave the group summing to a
-// small non-zero value, which is exactly what the balance constraint rejects; and
-// dropping them into IMBALANCE alongside genuinely missing legs would throw away
-// the one thing already known about them. See
-// docs/adr/0024-group-balance-is-checked-on-weight.md.
-var (
-	moneyTolerance     = decimal.RequireFromString("0.005")
-	commodityTolerance = decimal.New(1, -6)
-)
 
 // balanceInstrument is what balancing needs to know about a posting's commodity.
 // Currencies are instruments, so telling money from a security is a property of
@@ -131,21 +97,12 @@ type commodity struct {
 func (c commodity) key() string {
 	switch {
 	case c.currency != "":
-		return "cur:" + c.currency
+		return residual.CurrencyPrefix + c.currency
 	case c.instrumentID != "":
-		return "inst:" + c.instrumentID
+		return residual.InstrumentPrefix + c.instrumentID
 	default:
-		return "desc:" + c.description
+		return residual.DescriptionPrefix + c.description
 	}
-}
-
-// tolerance returns the residual below which a difference in this commodity reads
-// as the source's own rounding rather than as a leg it omitted.
-func (c commodity) tolerance() decimal.Decimal {
-	if c.currency != "" {
-		return moneyTolerance
-	}
-	return commodityTolerance
 }
 
 // routedPosting is a counterparty the server writes to make a group balance.
@@ -295,10 +252,9 @@ func groupPostings(txs []*apiv1.Tx) ([]string, map[string][]int) {
 // routeResiduals returns the counterparty postings that make every group balance.
 // Only a group that already sums to exactly zero produces none. A group can produce
 // more than one when its residual spans commodities, as beancount's residual
-// inventory and ledger's Imbalance:<CUR> both can. The account type says which kind
-// of residual it is: IMBALANCE for a leg the source omitted, TRANSFER_CLEARING for
-// the unmatched side of a journal, and SOURCE_ROUNDING for a difference small
-// enough to be the source's own rounding.
+// inventory and ledger's Imbalance:<CUR> both can. Which account type each takes is
+// residual.Type's, shared with the partial delete in replace-by-period so that a
+// group's residual does not depend on which path produced it.
 //
 // It assigns a synthetic group_ref to any posting that has none, so that a routed
 // counterparty is stored in the same group as the posting it balances.
@@ -320,12 +276,10 @@ func routeResiduals(txs []*apiv1.Tx, instrumentIDs []string, instruments map[str
 		// the leg it balances rather than invented.
 		descs := map[string]string{}
 		var keys []string
-		transfer := false
+		var txTypes []typev1.TxType
 		for _, i := range idxs {
 			t := txs[i]
-			if transferTypes[t.GetType()] {
-				transfer = true
-			}
+			txTypes = append(txTypes, t.GetType())
 			amount, c, ok := weighPosting(t, instrumentIDs[i], instruments[instrumentIDs[i]])
 			if !ok {
 				continue
@@ -343,26 +297,13 @@ func routeResiduals(txs []*apiv1.Tx, instrumentIDs []string, instruments map[str
 		// the map iteration gave.
 		sort.Strings(keys)
 		first := txs[idxs[0]]
-		residual := typev1.AccountType_ACCOUNT_TYPE_IMBALANCE
-		if transfer {
-			residual = typev1.AccountType_ACCOUNT_TYPE_TRANSFER_CLEARING
-		}
 		for _, k := range keys {
 			c := commodities[k]
 			if sums[k].IsZero() {
 				continue
 			}
-			// Below tolerance the residual is the source disagreeing with itself
-			// rather than a leg the source left out, and saying so is worth more
-			// than leaving it unposted: it keeps the group summing to exactly zero
-			// while classifying the difference as what it is. A sub-tolerance
-			// residual on a journal is rounding too, so this beats the transfer
-			// case rather than the other way round.
-			accountType := residual
-			if sums[k].Abs().LessThan(c.tolerance()) {
-				accountType = typev1.AccountType_ACCOUNT_TYPE_SOURCE_ROUNDING
-			}
-			out = append(out, routedFor(first, ref, c, descs[k], sums[k].Neg(), accountType))
+			amount := sums[k].Neg()
+			out = append(out, routedFor(first, ref, c, descs[k], amount, residual.Type(k, amount, txTypes)))
 		}
 	}
 	return out


### PR DESCRIPTION
First of two PRs for [0094](docs/issues/0094-replace-period-without-destroying-straddling-group.md). This one is the defect fix; the period-scoped export follows.

## The defect

`ReplaceTxsInPeriod` deleted whole tx groups, selected by an `EXISTS` over the postings inside the window. A group's postings need not share a timestamp -- the Fidelity deposit-run pass keys on reference proximity rather than the date bucket, because a run in the sample export settles across two days -- so one posting inside the window destroyed legs outside it. The upload that triggered the delete holds only the rows its own period covers, so nothing re-inserts them. The extension's 14-day lookback re-fetches them by accident today; that disappears when the lookback is lowered, when a user uploads a hand-picked file, or when a straddle exceeds it.

This affects broker statement uploads and archive imports alike -- both go through `ingestBatch`.

## The change

The replace deletes the postings inside the period. A group left with nothing goes with them, which is every group that did not straddle, so the ordinary case is unchanged. A group left with something keeps it, is re-dated to its earliest surviving posting, and gets a counterparty routed for what those postings no longer balance to. The delete and the routed insert commit together and `check_tx_group_balance()` is deferred, so the group is never observed unbalanced.

The residual is `SUM(weight) GROUP BY weight_commodity` over the survivors -- the same aggregation the constraint trigger performs, so no weight rule is re-derived and none is written in SQL. The account type it takes is chosen in Go.

## `server/residual`

The classification rule -- SOURCE_ROUNDING below tolerance, else TRANSFER_CLEARING for a journal, else IMBALANCE -- moves out of `balance.go` into a leaf package both paths import. A group's residual must not depend on whether it was created whole or by a partial delete, and that matters most for the deposit run: it is transfer family, and a plain `IMBALANCE` would hide the surviving half from the transfer matcher, which keys strictly on `TRANSFER_CLEARING`. `routeResiduals` behaves exactly as before and its tests still pin it.

## Explicit where the cascade used to be implicit

- `tx_groups.timestamp` is the timestamp of the first posting that named the group. It is derived, so a group whose first leg the delete took is re-dated.
- A transfer match is a link between two groups that used to cascade with the group. A group surviving with a different residual now loses its match explicitly, for the matcher to rebuild after ingest.

## Docs

New `adr/0039-replace-by-period-deletes-postings-not-groups.md`, and `docs/spec/postings.md`'s deletion section, which described the whole-group delete.

## Tests

`make db-test` covers: legs outside the period surviving; the routed type per group shape (journal / not / sub-tolerance); a group cut twice getting one residual rather than a stack; idempotence of a repeated replace; the group re-dating; the match being dropped. `balance_constraint_test.go` proves the partial delete plus re-route is balanced at the point the constraint fires. `server/residual` has a table over the rule, including the exactly-at-tolerance and rounding-beats-transfer cases.

`make check`, `make server-test` and `make db-test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)