### PR TITLE
Export a user's transactions for a period (0094)

### DIFF
--- a/client/lib/portfolio-api.ts
+++ b/client/lib/portfolio-api.ts
@@ -555,10 +555,23 @@ export async function importSystemArchive(archive: SystemArchive, filename: stri
  * Stream the signed-in user's own archive, in the same shape as the system
  * export. A part whose unit is a setting rather than a row arrives as one
  * whole-part message after its part_begin.
+ *
+ * The optional half-open period bounds the transaction part alone. The export
+ * adheres strictly to it, so a group straddling a bound contributes only its
+ * in-period legs and the exported group does not balance; the importer routes
+ * the residual. Omitting it exports all of history, each window bounded by the
+ * postings it carries.
  */
-export async function* exportUserArchive(parts: ArchivePart[]): AsyncGenerator<ExportUserArchiveResponse> {
+export async function* exportUserArchive(
+  parts: ArchivePart[],
+  period?: { from?: Date; before?: Date },
+): AsyncGenerator<ExportUserArchiveResponse> {
   const base = getBaseUrl();
-  const req = create(ExportUserArchiveRequestSchema, { parts });
+  const req = create(ExportUserArchiveRequestSchema, {
+    parts,
+    periodFrom: period?.from != null ? timestampFromDate(period.from) : undefined,
+    periodBefore: period?.before != null ? timestampFromDate(period.before) : undefined,
+  });
   for await (const bytes of streamingFetch(base, ApiServicePrefix + "ExportUserArchive", toBinary(ExportUserArchiveRequestSchema, req), { credentials: "include" })) {
     yield fromBinary(ExportUserArchiveResponseSchema, bytes);
   }

--- a/docs/issues/0094-replace-period-without-destroying-straddling-group.md
+++ b/docs/issues/0094-replace-period-without-destroying-straddling-group.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Replace a period without destroying a straddling group
 milestone: M14
 dependencies: [0077]
@@ -79,11 +79,40 @@ is the half of that needing a person's judgement.
 This fixes broker statement uploads as well as archive imports; both paths go
 through `ReplaceTxsInPeriod`.
 
-The delete half has landed. Rebuilding the group around its survivors was tried on the
-way and abandoned: creating a new group and moving the legs into it should have let the
-cascade replace four hand-written statements, but measured it swapped four for four and
-added id-mapping machinery, churned group ids for nothing, and put the survivors through
-an insert that reseeds the split-adjusted columns from the raw ones. The tests written to
-catch that last one are kept.
+Closed. Both halves landed: the replace deletes the postings inside the period rather
+than the groups holding them, and the export takes a period and adheres to it.
+adr/0039-replace-by-period-deletes-postings-not-groups.md records the delete;
+docs/spec/postings.md and docs/spec/archive-format.md say what each side now does.
 
-The export half is what remains.
+The classification rule did not go into SQL. Summing the stored weights was right --
+it is what `check_tx_group_balance()` itself does -- but writing the transfer tx-type
+set and the tolerances there as well would have been the second copy adr/0029 rejected
+for the weight rules. The rule lives in `server/residual` and both the ingest balancer
+and the delete call it.
+
+The tolerance does not apply to a residual left by a cut. That residual is the value of
+the legs removed rather than the source disagreeing with itself, so it is never
+SOURCE_ROUNDING however small. A distinct account type saying "cut here" was considered
+and rejected: it reads as an instruction to restore what was there, which is stale
+advice when the re-uploaded rows may genuinely differ.
+
+Rebuilding the group around its survivors was tried on the way and abandoned. Creating
+a new group and moving the legs into it should have let the cascade replace the four
+statements this needs by hand -- dropping the emptied group row, dropping the transfer
+matches, re-dating the group, and clearing its stale residuals. Measured, it swapped
+four statements for four and added id-mapping machinery, at 218 lines of code against
+194. It churned group ids for nothing, and it put the survivors through an insert,
+where default_split_adjusted_tx() reseeds the split-adjusted columns and
+share_count_basis from the raw ones -- a hazard the in-place delete never had, because
+it never rewrites a surviving row. `idx_txs_initialize_unique` also rejects a copied
+INITIALIZE posting for as long as the original exists. The tests written during the
+detour are kept: the property is worth pinning whatever the implementation.
+
+A period-scoped export writes no window for a broker with nothing in the period. An
+empty window is an instruction to clear a period, and an export asked for a period was
+not asked to say that about every broker the user has ever traded with.
+
+The e2e fixture had to carry `JRNLFUND` rather than `TRANSFER`: both are transfer
+family for routing, but `TRANSFER` implies no asset class and validation rejects that
+against the `CASH` instrument a cash journal leg resolves to. Worth knowing before
+writing the next cash-transfer fixture.

--- a/docs/issues/0095-match-imbalanced-groups-that-should-be-one.md
+++ b/docs/issues/0095-match-imbalanced-groups-that-should-be-one.md
@@ -14,7 +14,7 @@ Grouping is the converter's job and a converter sees one file
 legs of one event in distinct groups, each balanced by a routed residual:
 
 - Two legs arriving in two broker logs. No converter can see both.
-- A straddling group split by the partial delete in 0094.
+- A straddling group cut by the period replace in 0094.
 
 The transfer matcher from 0068 already repairs one case of this, and is
 deliberately narrow: it keys on `account_type = 'TRANSFER_CLEARING'`, requires

--- a/docs/spec/archive-format.md
+++ b/docs/spec/archive-format.md
@@ -544,13 +544,28 @@ The window has to state its own period rather than have one inferred from the
 postings it holds, because **a window holding no groups is a valid instruction to
 clear that period**, and an inferred window could never say that.
 
-An export writes one window per broker, running from its first posting to the
-day after its last, so the window provably contains everything it carries and no
-group straddles its edge. Its `source` names the export -- `"FIDELITY:archive:export"`
--- rather than an ingestion job: a window carries one source and a broker's
-postings come from several. Nothing is lost, because a posting's own source,
-where one was recorded, is the `domain` of its `BROKER_DESCRIPTION` identifier,
-which is where it was stored and where it travels.
+An export writes one window per broker. Asked for no period it runs from that
+broker's first posting to the day after its last, so the window provably contains
+everything it carries and no group straddles its edge.
+
+**An export asked for a period adheres strictly to it.** Every window states the
+period asked for, and a group straddling a bound contributes only its in-period
+legs -- so the exported group does not balance, which is already legal: a group
+whose postings do not sum to zero is accepted and the importer routes the
+residual. A broker with no posting in the period gets no window, because an export
+is a picture of what is stored and an empty window is an instruction to clear a
+period, which is not what the export was asked to say.
+
+Import is the same operation from the other side, and it too takes only the
+postings inside the period, so a group straddling a bound keeps the legs the window
+does not carry. See
+`docs/adr/0039-replace-by-period-deletes-postings-not-groups.md`.
+
+A window's `source` names the export -- `"FIDELITY:archive:export"` -- rather than
+an ingestion job: a window carries one source and a broker's postings come from
+several. Nothing is lost, because a posting's own source, where one was recorded,
+is the `domain` of its `BROKER_DESCRIPTION` identifier, which is where it was
+stored and where it travels.
 
 | Level | Field | Notes |
 | --- | --- | --- |
@@ -638,6 +653,11 @@ document. A part included is present even when it holds nothing, which records
 that the export asked and there was nothing -- the distinction the wrapper
 messages exist for. Restore order is a property of the format rather than of the
 request, so the parts are written in it whatever order they were asked for in.
+
+**The user export also takes an optional period**, half-open and open-ended on
+either side when a bound is left off. It scopes the transaction part alone --
+preferences and declarations are not dated by a period the way a posting is -- and
+what it does to a window is above.
 
 The envelope is written once, before any part. `exported_at` is knowledge time,
 and knowledge time that differs between one file's own parts is not knowledge

--- a/e2e/fixtures/user-archive-straddle.sql
+++ b/e2e/fixtures/user-archive-straddle.sql
@@ -1,0 +1,36 @@
+-- One balanced transfer group whose two legs sit on different days, for the
+-- period-scoped export and the partial replace it makes reachable.
+--
+-- This is the shape the Fidelity deposit-run pass produces: it groups on
+-- reference proximity rather than the date bucket, because a run in the sample
+-- export settles across two days. Any period boundary between the two legs
+-- therefore cuts the group in half.
+--
+-- Raw SQL rather than an upload, for the same reason as user-archive-txs.sql:
+-- seeding through ingestion would mean identifying the instruments, which is a
+-- paid lookup and a cassette this suite has no other need of. The legs weigh in
+-- the seeded USD currency instrument, so a residual routed against them resolves
+-- without a plugin.
+
+INSERT INTO tx_groups (id, user_id, timestamp)
+VALUES ('e2e00000-0000-0000-0000-000000000421', 'e2e00000-0000-0000-0000-000000000001', '2024-03-10')
+ON CONFLICT (id) DO NOTHING;
+
+-- Money leaving one account on the tenth and arriving in another on the
+-- eleventh. JRNLFUND on both legs -- a cash journal, which is what a deposit run
+-- is -- so a residual routed for either half is classed as transfer clearing
+-- rather than as an imbalance and the surviving half stays visible to the
+-- transfer matcher. JRNLFUND rather than TRANSFER because the leg is a cash
+-- instrument and TRANSFER implies no asset class, which validation rejects
+-- against CASH on the way back in.
+INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type, quantity,
+                 trading_currency, settlement_currency, instrument_id,
+                 weight, weight_commodity, group_id)
+SELECT 'e2e00000-0000-0000-0000-000000000001', 'FIDELITY', v.account, v.at::timestamptz, 'USD', 'JRNLFUND',
+       v.qty, 'USD', 'USD', i.instrument_id, v.qty, 'cur:USD',
+       'e2e00000-0000-0000-0000-000000000421'
+FROM (VALUES ('2024-03-10', -5000.00, 'ACC-1'),
+             ('2024-03-11',  5000.00, 'ACC-2')) AS v(at, qty, account),
+     (SELECT instrument_id FROM instrument_identifiers
+      WHERE identifier_type = 'CURRENCY' AND value = 'USD' LIMIT 1) i
+ON CONFLICT DO NOTHING;

--- a/e2e/helpers/api.ts
+++ b/e2e/helpers/api.ts
@@ -9,9 +9,10 @@ import { ArchiveKind, ArchivePart } from "../gen/archive/v1/common_pb";
 import { AssetClass } from "../gen/type/v1/type_pb";
 import { CorporateEventGroupSchema, type CorporateEventGroup } from "../gen/archive/v1/corporate_events_pb";
 import { PriceGroupSchema } from "../gen/archive/v1/prices_pb";
+import type { TxWindow } from "../gen/archive/v1/txs_pb";
 import { SystemArchiveSchema, UserArchiveSchema } from "../gen/archive/v1/archive_pb";
 import type { MessageInitShape } from "@bufbuild/protobuf";
-import { timestampNow } from "@bufbuild/protobuf/wkt";
+import { timestampFromDate, timestampNow } from "@bufbuild/protobuf/wkt";
 
 const COOKIE_NAME = "portfoliodb_session";
 
@@ -213,6 +214,33 @@ export async function exportCorporateEvents(
     }
   }
   return groups;
+}
+
+/**
+ * Export the signed-in user's transaction windows, optionally over a period.
+ *
+ * The period is half-open and scopes the transaction part alone. The export
+ * adheres strictly to it, so a group straddling a bound contributes only its
+ * in-period legs. The archive page has no period control, so this drives the RPC
+ * the way a caller asking for one would.
+ */
+export async function exportUserTxWindows(
+  sessionId: string,
+  period?: { from?: Date; before?: Date },
+): Promise<TxWindow[]> {
+  const headers = { Cookie: `${COOKIE_NAME}=${sessionId}` };
+  const windows: TxWindow[] = [];
+  const req = {
+    parts: [ArchivePart.TXS],
+    periodFrom: period?.from ? timestampFromDate(period.from) : undefined,
+    periodBefore: period?.before ? timestampFromDate(period.before) : undefined,
+  };
+  for await (const resp of client.exportUserArchive(req, { headers })) {
+    if (resp.item.case === "txWindow") {
+      windows.push(resp.item.value);
+    }
+  }
+  return windows;
 }
 
 /** Trigger the corporate event fetcher worker to run one cycle. */

--- a/e2e/tests/user-archive-period.spec.ts
+++ b/e2e/tests/user-archive-period.spec.ts
@@ -1,0 +1,162 @@
+// E2E test: a period-scoped user archive export, and the partial replace on the
+// way back in.
+//
+// The two halves are one contract. An export asked for a period adheres strictly
+// to it, so a group straddling a bound contributes only its in-period legs and
+// the exported group does not balance. An import replaces the period by deleting
+// the postings inside it rather than the groups holding them, so the legs the file
+// does not carry survive and the remainder is re-balanced. Neither half is safe
+// without the other: a whole-group delete would destroy legs nothing re-inserts.
+// See docs/adr/0039-replace-by-period-deletes-postings-not-groups.md.
+//
+// The archive page has no period control, so the export runs through the RPC.
+
+import { test, expect } from "@playwright/test";
+import { seedSession, closeRedis, TEST_USER_ID } from "../helpers/auth";
+import {
+  resetAndSeedBase,
+  closeDB,
+  rawQuery,
+  seedFixture,
+} from "../helpers/db";
+import { exportUserTxWindows, importUserArchiveAndWait } from "../helpers/api";
+import { timestampNow } from "@bufbuild/protobuf/wkt";
+import { ArchiveKind } from "../gen/archive/v1/common_pb";
+import { Broker } from "../gen/type/v1/type_pb";
+import { JobStatus } from "../gen/api/v1/api_pb";
+
+// The seeded run: -5000 leaving ACC-1 on the tenth, +5000 arriving in ACC-2 on
+// the eleventh, in one group.
+const DAY_TWO = new Date("2024-03-11T00:00:00Z");
+const DAY_THREE = new Date("2024-03-12T00:00:00Z");
+
+type Posting = {
+  account: string;
+  timestamp: Date;
+  quantity: string;
+  account_type: string;
+};
+
+async function postings(): Promise<Posting[]> {
+  return (await rawQuery(
+    `SELECT account, timestamp, quantity::text AS quantity, account_type
+     FROM txs WHERE user_id = $1 ORDER BY timestamp, account_type`,
+    [TEST_USER_ID],
+  )) as Posting[];
+}
+
+test.beforeAll(async () => {
+  await resetAndSeedBase();
+  await seedFixture("user-archive-straddle.sql");
+});
+
+test.afterAll(async () => {
+  await closeRedis();
+  await closeDB();
+});
+
+test.describe("period-scoped user archive", () => {
+  let sessionId: string;
+
+  test.beforeAll(async () => {
+    sessionId = await seedSession("user");
+  });
+
+  test("exports only the period asked for and re-imports it without losing the rest", async () => {
+    // Asked for nothing, the window is derived from the postings it carries and
+    // holds the whole run.
+    const whole = await exportUserTxWindows(sessionId);
+    expect(whole).toHaveLength(1);
+    expect(whole[0].groups[0].postings).toHaveLength(2);
+
+    // Asked for the second day alone, the window states that day and the group
+    // contributes one leg. The exported group does not balance, which the format
+    // accepts: the importer routes the residual.
+    const windows = await exportUserTxWindows(sessionId, {
+      from: DAY_TWO,
+      before: DAY_THREE,
+    });
+    expect(windows).toHaveLength(1);
+    const window = windows[0];
+    expect(window.broker).toBe(Broker.FIDELITY);
+    expect(window.periodFrom?.seconds).toBe(
+      BigInt(DAY_TWO.getTime() / 1000),
+    );
+    expect(window.periodBefore?.seconds).toBe(
+      BigInt(DAY_THREE.getTime() / 1000),
+    );
+    expect(window.groups).toHaveLength(1);
+    expect(window.groups[0].postings).toHaveLength(1);
+    expect(window.groups[0].postings[0].quantity).toBe("5000");
+
+    // Re-importing that file replaces the second day. The first day's leg is
+    // outside it and the file does not carry it, so the whole-group delete this
+    // replaced would have destroyed it with nothing to put it back.
+    const job = await importUserArchiveAndWait(sessionId, {
+      envelope: {
+        formatVersion: 1,
+        exportedAt: timestampNow(),
+        kind: ArchiveKind.USER,
+      },
+      txs: { windows: [window] },
+    });
+    expect(job.status).toBe(JobStatus.SUCCESS);
+
+    const rows = await postings();
+    // The surviving leg and the counterparty routed for it, plus the re-imported
+    // leg and the counterparty routed for that.
+    expect(rows).toHaveLength(4);
+
+    const day10 = rows.filter(
+      (r) => new Date(r.timestamp) < DAY_TWO,
+    );
+    expect(day10).toHaveLength(2);
+    // Compared as numbers: the seeded row keeps the scale raw SQL wrote it with
+    // and the routed one does not, which is a trailing zero rather than a value.
+    expect(day10.map((r) => Number(r.quantity)).sort()).toEqual([-5000, 5000]);
+    // Transfer family, so the residual is clearing rather than an imbalance:
+    // a plain IMBALANCE would hide the surviving half from the transfer matcher,
+    // which keys strictly on TRANSFER_CLEARING.
+    expect(
+      day10.filter((r) => r.account_type === "TRANSFER_CLEARING"),
+    ).toHaveLength(1);
+
+    // Two groups where the converter wrote one, each balanced on its own.
+    const groups = (await rawQuery(
+      `SELECT count(DISTINCT group_id)::int AS n FROM txs WHERE user_id = $1`,
+      [TEST_USER_ID],
+    )) as { n: number }[];
+    expect(groups[0].n).toBe(2);
+
+    const unbalanced = (await rawQuery(
+      `SELECT group_id FROM txs WHERE user_id = $1
+       GROUP BY group_id, weight_commodity HAVING SUM(weight) <> 0`,
+      [TEST_USER_ID],
+    )) as unknown[];
+    expect(unbalanced).toHaveLength(0);
+  });
+
+  test("re-importing the same file again lands on the same rows", async () => {
+    const before = await postings();
+    const windows = await exportUserTxWindows(sessionId, {
+      from: DAY_TWO,
+      before: DAY_THREE,
+    });
+    const job = await importUserArchiveAndWait(sessionId, {
+      envelope: {
+        formatVersion: 1,
+        exportedAt: timestampNow(),
+        kind: ArchiveKind.USER,
+      },
+      txs: { windows },
+    });
+    expect(job.status).toBe(JobStatus.SUCCESS);
+
+    // Stable under repetition: the second day's group is replaced by an
+    // identical one and the first day is not touched at all.
+    const after = await postings();
+    expect(after.map((r) => [r.account, r.quantity, r.account_type])).toEqual(
+      before.map((r) => [r.account, r.quantity, r.account_type]),
+    );
+  });
+});

--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -625,7 +625,18 @@ message ExportUserArchiveRequest {
       }
     }
   }];
-  // 2 and 3 are the bounds of the transaction window to export.
+  // Half-open [period_from, period_before) over the postings exported; an unset
+  // bound is open-ended, which is what an ordinary whole-history export sends.
+  // Applies to the transaction part alone -- preferences and declarations are not
+  // dated by a period the way a posting is.
+  //
+  // The export adheres strictly to the period asked for. A group straddling a
+  // bound contributes only its in-period legs, so the exported group does not
+  // balance -- which the format already accepts, because the importer routes the
+  // residual. Without a period every window is derived from the postings it
+  // carries and the case cannot arise.
+  google.protobuf.Timestamp period_from = 2;   // inclusive
+  google.protobuf.Timestamp period_before = 3; // exclusive
 }
 
 // ImportUserArchiveRequest carries one whole user archive: the caller's own

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -337,7 +337,11 @@ type TxDB interface {
 	// then by group, then by posting. Synthetic INITIALIZE groups are excluded --
 	// they are derived from holding declarations, which the archive carries as the
 	// declarations they come from.
-	ListTxsForExport(ctx context.Context, userID string) ([]ExportPosting, error)
+	//
+	// The half-open [periodFrom, periodBefore) bounds are optional and filter the
+	// postings rather than the groups holding them, so a group straddling a bound
+	// contributes only its in-period legs. A nil bound is open-ended.
+	ListTxsForExport(ctx context.Context, userID string, periodFrom, periodBefore *timestamppb.Timestamp) ([]ExportPosting, error)
 }
 
 // HoldingsDB computes holdings at a point in time.

--- a/server/db/postgres/txs.go
+++ b/server/db/postgres/txs.go
@@ -377,10 +377,31 @@ type exportPosting struct {
 // description on the way back in. bestIdentifierJoinOn rather than a
 // hand-written lateral so this export agrees with every other one about which
 // identifier is best.
-func (p *Postgres) ListTxsForExport(ctx context.Context, userID string) ([]db.ExportPosting, error) {
+func (p *Postgres) ListTxsForExport(ctx context.Context, userID string, periodFrom, periodBefore *timestamppb.Timestamp) ([]db.ExportPosting, error) {
 	userUUID, err := uuid.Parse(userID)
 	if err != nil {
 		return nil, fmt.Errorf("invalid user id: %w", err)
+	}
+	args := []interface{}{userUUID}
+	// The bounds filter the postings, not the groups that hold them: a period-scoped
+	// export adheres to the period asked for, so a group straddling a bound
+	// contributes only its in-period legs.
+	period := ""
+	if periodFrom != nil {
+		from, err := tsToTime(periodFrom)
+		if err != nil {
+			return nil, fmt.Errorf("period_from: %w", err)
+		}
+		args = append(args, from)
+		period += fmt.Sprintf("\n\t\t  AND t.timestamp >= $%d", len(args))
+	}
+	if periodBefore != nil {
+		before, err := tsToTime(periodBefore)
+		if err != nil {
+			return nil, fmt.Errorf("period_before: %w", err)
+		}
+		args = append(args, before)
+		period += fmt.Sprintf("\n\t\t  AND t.timestamp < $%d", len(args))
 	}
 	q := `
 		SELECT t.broker, t.group_id::text AS group_id, g.timestamp AS group_timestamp,
@@ -408,11 +429,11 @@ func (p *Postgres) ListTxsForExport(ctx context.Context, userID string) ([]db.Ex
 		  AND NOT EXISTS (
 		    SELECT 1 FROM txs s
 		    WHERE s.group_id = t.group_id AND s.synthetic_purpose IS NOT NULL
-		  )
+		  )` + period + `
 		ORDER BY t.broker, g.timestamp, g.id, t.timestamp, t.id
 	`
 	var rows []exportPosting
-	if err := p.q.SelectContext(ctx, &rows, q, userUUID); err != nil {
+	if err := p.q.SelectContext(ctx, &rows, q, args...); err != nil {
 		return nil, fmt.Errorf("list txs for export: %w", err)
 	}
 	out := make([]db.ExportPosting, len(rows))

--- a/server/db/postgres/txs_test.go
+++ b/server/db/postgres/txs_test.go
@@ -1132,7 +1132,7 @@ func TestListTxsForExport_UsesTheBestIdentifier(t *testing.T) {
 		t.Fatalf("create tx: %v", err)
 	}
 
-	rows, err := p.ListTxsForExport(ctx, userID)
+	rows, err := p.ListTxsForExport(ctx, userID, nil, nil)
 	if err != nil {
 		t.Fatalf("list txs for export: %v", err)
 	}
@@ -1174,7 +1174,7 @@ func TestListTxsForExport_ExcludesSyntheticGroups(t *testing.T) {
 		t.Fatalf("create tx: %v", err)
 	}
 
-	rows, err := p.ListTxsForExport(ctx, userID)
+	rows, err := p.ListTxsForExport(ctx, userID, nil, nil)
 	if err != nil {
 		t.Fatalf("list txs for export: %v", err)
 	}
@@ -1213,7 +1213,7 @@ func TestListTxsForExport_ShareCountBasisOnlyWhenRestated(t *testing.T) {
 		t.Fatalf("create restated tx: %v", err)
 	}
 
-	rows, err := p.ListTxsForExport(ctx, userID)
+	rows, err := p.ListTxsForExport(ctx, userID, nil, nil)
 	if err != nil {
 		t.Fatalf("list txs for export: %v", err)
 	}
@@ -1259,7 +1259,7 @@ func TestListTxsForExport_OrderedForGrouping(t *testing.T) {
 		}
 	}
 
-	rows, err := p.ListTxsForExport(ctx, userID)
+	rows, err := p.ListTxsForExport(ctx, userID, nil, nil)
 	if err != nil {
 		t.Fatalf("list txs for export: %v", err)
 	}
@@ -1620,7 +1620,7 @@ func TestReplaceTxsInPeriod_DropsMatchesOnCutGroups(t *testing.T) {
 		t.Fatalf("count matches: %v", err)
 	}
 	if matches != 0 {
-		t.Errorf("transfer matches after a partial delete: want 0, got %d", matches)
+		t.Errorf("transfer matches after a rebuild: want 0, got %d", matches)
 	}
 }
 
@@ -1790,5 +1790,35 @@ func TestReplaceTxsInPeriod_KeepsRestatedShareCountBasis(t *testing.T) {
 	}
 	if !basis.Equal(restated) {
 		t.Errorf("share count basis of the surviving leg: want %v, got %v", restated, basis)
+	}
+}
+
+// TestListTxsForExport_ClipsAStraddlingGroup covers the period-scoped export. The
+// bounds filter the postings rather than the groups holding them, so a group
+// straddling a bound contributes only its in-period legs. The exported group then
+// does not balance, which the format accepts: the importer routes the residual.
+func TestListTxsForExport_ClipsAStraddlingGroup(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _, _, day2 := straddlingRun(t, p, "sub|export-straddle", typev1.TxType_JRNLFUND, "5000")
+
+	whole, err := p.ListTxsForExport(ctx, userID, nil, nil)
+	if err != nil {
+		t.Fatalf("export whole history: %v", err)
+	}
+	if len(whole) != 2 {
+		t.Fatalf("postings over all of history: want 2, got %d", len(whole))
+	}
+
+	clipped, err := p.ListTxsForExport(ctx, userID,
+		timestamppb.New(day2.Truncate(24*time.Hour)), timestamppb.New(day2.Add(24*time.Hour)))
+	if err != nil {
+		t.Fatalf("export a period: %v", err)
+	}
+	if len(clipped) != 1 {
+		t.Fatalf("postings in the second day alone: want 1, got %d", len(clipped))
+	}
+	if !clipped[0].Timestamp.Equal(day2) {
+		t.Errorf("exported posting at %v, want the day-two leg at %v", clipped[0].Timestamp, day2)
 	}
 }

--- a/server/service/api/export_user_archive_test.go
+++ b/server/service/api/export_user_archive_test.go
@@ -14,6 +14,7 @@ import (
 	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
 	dbpkg "github.com/leedenison/portfoliodb/server/db"
 	"github.com/leedenison/portfoliodb/server/testutil"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 // exportUserStreamMock captures a whole user archive export.
@@ -194,7 +195,7 @@ func TestExportUserArchive_PartsTravelInRestoreOrder(t *testing.T) {
 	srv, mockDB := newAPIServerWithMock(t)
 	mockDB.EXPECT().GetDisplayCurrency(gomock.Any(), "user-1").Return("GBP", nil)
 	mockDB.EXPECT().ListIgnoredAssetClasses(gomock.Any(), "user-1").Return(nil, nil)
-	mockDB.EXPECT().ListTxsForExport(gomock.Any(), "user-1").Return([]dbpkg.ExportPosting{
+	mockDB.EXPECT().ListTxsForExport(gomock.Any(), "user-1", gomock.Any(), gomock.Any()).Return([]dbpkg.ExportPosting{
 		exportPostingFixture("FIDELITY", "g1", "2024-01-15T10:00:00Z"),
 	}, nil)
 	stream := &exportUserStreamMock{ctx: authCtx("user-1", "sub|1")}
@@ -214,7 +215,7 @@ func TestExportUserArchive_PartsTravelInRestoreOrder(t *testing.T) {
 // it asked and there were none.
 func TestExportUserArchive_TxPart_AskedForAndEmpty(t *testing.T) {
 	srv, mockDB := newAPIServerWithMock(t)
-	mockDB.EXPECT().ListTxsForExport(gomock.Any(), "user-1").Return(nil, nil)
+	mockDB.EXPECT().ListTxsForExport(gomock.Any(), "user-1", gomock.Any(), gomock.Any()).Return(nil, nil)
 	stream := &exportUserStreamMock{ctx: authCtx("user-1", "sub|1")}
 	if err := srv.ExportUserArchive(&apiv1.ExportUserArchiveRequest{
 		Parts: []archivev1.ArchivePart{archivev1.ArchivePart_TXS},
@@ -225,4 +226,43 @@ func TestExportUserArchive_TxPart_AskedForAndEmpty(t *testing.T) {
 	if got := stream.shape(); !equalStrings(got, want) {
 		t.Fatalf("stream = %v, want %v", got, want)
 	}
+}
+
+// The requested period reaches the read, so the rows are filtered rather than the
+// whole history being read and trimmed on the way out.
+func TestExportUserArchive_PassesThePeriodToTheRead(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	from := timestamppb.New(mustTime(t, "2024-02-01T00:00:00Z"))
+	before := timestamppb.New(mustTime(t, "2024-03-01T00:00:00Z"))
+	mockDB.EXPECT().
+		ListTxsForExport(gomock.Any(), "user-1", gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _ string, gotFrom, gotBefore *timestamppb.Timestamp) ([]dbpkg.ExportPosting, error) {
+			if !gotFrom.AsTime().Equal(from.AsTime()) || !gotBefore.AsTime().Equal(before.AsTime()) {
+				t.Errorf("read period = [%s, %s), want [%s, %s)",
+					gotFrom.AsTime(), gotBefore.AsTime(), from.AsTime(), before.AsTime())
+			}
+			return nil, nil
+		})
+	err := srv.ExportUserArchive(&apiv1.ExportUserArchiveRequest{
+		Parts:        []archivev1.ArchivePart{archivev1.ArchivePart_TXS},
+		PeriodFrom:   from,
+		PeriodBefore: before,
+	}, &exportUserStreamMock{ctx: authCtx("user-1", "sub|1")})
+	if err != nil {
+		t.Fatalf("ExportUserArchive: %v", err)
+	}
+}
+
+// A period that ends where or before it starts covers nothing, and an export of
+// nothing over a stated period is a file that clears it on import. That is worth
+// rejecting rather than producing by accident.
+func TestExportUserArchive_RejectsAnEmptyPeriod(t *testing.T) {
+	srv, _ := newAPIServerWithMock(t)
+	at := timestamppb.New(mustTime(t, "2024-02-01T00:00:00Z"))
+	err := srv.ExportUserArchive(&apiv1.ExportUserArchiveRequest{
+		Parts:        []archivev1.ArchivePart{archivev1.ArchivePart_TXS},
+		PeriodFrom:   at,
+		PeriodBefore: at,
+	}, &exportUserStreamMock{ctx: authCtx("user-1", "sub|1")})
+	testutil.RequireGRPCCode(t, err, codes.InvalidArgument)
 }

--- a/server/service/api/txs_export.go
+++ b/server/service/api/txs_export.go
@@ -17,14 +17,24 @@ import (
 // period rather than appending to it, so the second would delete what the first
 // had just written. See docs/adr/0002-transaction-ingestion-model.md.
 //
-// The period is derived from the postings the window carries -- the first
-// posting's instant to the day after the last one's -- so the window provably
-// contains everything in it and no group straddles its edge. A period-scoped
-// export, which can split a group, is 0094.
+// The requested period, where there is one, is the window's period verbatim: an
+// export adheres strictly to the period asked for, so the window says what was
+// asked for rather than what happened to land in it, and a group straddling a
+// bound contributes only its in-period legs. The exported group then does not
+// balance, which the format accepts -- the importer routes the residual.
+//
+// Without a period, each bound is derived from the postings the window carries --
+// the first posting's instant to the day after the last one's -- so the window
+// provably contains everything in it and no group straddles its edge. A bound
+// given on one side only is honoured on that side and derived on the other.
+//
+// A broker with no posting in the period gets no window. An export is a picture of
+// what is stored, and an empty window is an instruction to clear a period, which
+// is not something the export was asked to say.
 //
 // The rows arrive ordered by broker, then group, then posting, so the whole
 // thing is a scan and the output order follows the query's.
-func txWindows(rows []db.ExportPosting) []*archivev1.TxWindow {
+func txWindows(rows []db.ExportPosting, periodFrom, periodBefore *timestamppb.Timestamp) []*archivev1.TxWindow {
 	var out []*archivev1.TxWindow
 	var cur *archivev1.TxWindow
 	var curGroup *archivev1.TxGroup
@@ -32,8 +42,15 @@ func txWindows(rows []db.ExportPosting) []*archivev1.TxWindow {
 	var from, last time.Time
 
 	closeWindow := func() {
-		if cur != nil {
+		if cur == nil {
+			return
+		}
+		cur.PeriodFrom = periodFrom
+		if cur.PeriodFrom == nil {
 			cur.PeriodFrom = timestamppb.New(from)
+		}
+		cur.PeriodBefore = periodBefore
+		if cur.PeriodBefore == nil {
 			cur.PeriodBefore = timestamppb.New(last.UTC().Truncate(24*time.Hour).AddDate(0, 0, 1))
 		}
 	}

--- a/server/service/api/txs_export_test.go
+++ b/server/service/api/txs_export_test.go
@@ -9,6 +9,7 @@ import (
 	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
 	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
 	dbpkg "github.com/leedenison/portfoliodb/server/db"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func mustTime(t *testing.T, s string) time.Time {
@@ -48,7 +49,7 @@ func TestTxWindows_OneWindowPerBrokerBoundedByItsOwnRows(t *testing.T) {
 		exportPostingFixture("FIDELITY", "g2", "2024-03-02T14:30:00Z"),
 		exportPostingFixture("IBKR", "g3", "2023-06-01T09:00:00Z"),
 	}
-	got := txWindows(rows)
+	got := txWindows(rows, nil, nil)
 	if len(got) != 2 {
 		t.Fatalf("windows = %d, want 2", len(got))
 	}
@@ -74,7 +75,7 @@ func TestTxWindows_OneWindowPerBrokerBoundedByItsOwnRows(t *testing.T) {
 // own source, where one was recorded, travels as the domain of its
 // BROKER_DESCRIPTION identifier.
 func TestTxWindows_SourceNamesTheExport(t *testing.T) {
-	got := txWindows([]dbpkg.ExportPosting{exportPostingFixture("FIDELITY", "g1", "2024-01-15T10:00:00Z")})
+	got := txWindows([]dbpkg.ExportPosting{exportPostingFixture("FIDELITY", "g1", "2024-01-15T10:00:00Z")}, nil, nil)
 	if got[0].GetSource() != "FIDELITY:archive:export" {
 		t.Fatalf("source = %q", got[0].GetSource())
 	}
@@ -88,7 +89,7 @@ func TestTxWindows_PostingsNestByGroup(t *testing.T) {
 		exportPostingFixture("FIDELITY", "g1", "2024-01-15T10:00:00Z"),
 		exportPostingFixture("FIDELITY", "g2", "2024-01-16T10:00:00Z"),
 	}
-	got := txWindows(rows)
+	got := txWindows(rows, nil, nil)
 	if len(got) != 1 {
 		t.Fatalf("windows = %d, want 1", len(got))
 	}
@@ -111,7 +112,7 @@ func TestTxWindows_CarriesRoutedResiduals(t *testing.T) {
 	got := txWindows([]dbpkg.ExportPosting{
 		exportPostingFixture("FIDELITY", "g1", "2024-01-15T10:00:00Z"),
 		residual,
-	})
+	}, nil, nil)
 	postings := got[0].GetGroups()[0].GetPostings()
 	if len(postings) != 2 {
 		t.Fatalf("postings = %d, want 2", len(postings))
@@ -194,5 +195,61 @@ func TestPosting_CarriesTheBestIdentifier(t *testing.T) {
 	if hints[0].GetType() != want.GetType() || hints[0].GetValue() != want.GetValue() ||
 		hints[0].GetDomain() != want.GetDomain() {
 		t.Fatalf("hint = %v, want %v", hints[0], want)
+	}
+}
+
+// A requested period is the window's period verbatim rather than a bound derived
+// from the rows that landed in it. What the export was asked for is what the
+// window has to say, because a window is a replacement scope: an importer told a
+// narrower period than the one the caller asked for would leave behind whatever
+// sat in the difference.
+func TestTxWindows_StatesTheRequestedPeriod(t *testing.T) {
+	from := timestamppb.New(mustTime(t, "2024-02-01T00:00:00Z"))
+	before := timestamppb.New(mustTime(t, "2024-03-01T00:00:00Z"))
+	got := txWindows([]dbpkg.ExportPosting{
+		exportPostingFixture("FIDELITY", "g1", "2024-02-10T10:00:00Z"),
+	}, from, before)
+
+	if len(got) != 1 {
+		t.Fatalf("windows = %d, want 1", len(got))
+	}
+	if !got[0].GetPeriodFrom().AsTime().Equal(from.AsTime()) {
+		t.Errorf("period_from = %s, want %s", got[0].GetPeriodFrom().AsTime(), from.AsTime())
+	}
+	if !got[0].GetPeriodBefore().AsTime().Equal(before.AsTime()) {
+		t.Errorf("period_before = %s, want %s", got[0].GetPeriodBefore().AsTime(), before.AsTime())
+	}
+}
+
+// A bound given on one side only is honoured on that side and derived on the
+// other, so "everything since March" states March and stops where the data does.
+func TestTxWindows_DerivesTheBoundNotAskedFor(t *testing.T) {
+	from := timestamppb.New(mustTime(t, "2024-02-01T00:00:00Z"))
+	got := txWindows([]dbpkg.ExportPosting{
+		exportPostingFixture("FIDELITY", "g1", "2024-02-10T10:00:00Z"),
+	}, from, nil)
+
+	if !got[0].GetPeriodFrom().AsTime().Equal(from.AsTime()) {
+		t.Errorf("period_from = %s, want %s", got[0].GetPeriodFrom().AsTime(), from.AsTime())
+	}
+	if want := mustTime(t, "2024-02-11T00:00:00Z"); !got[0].GetPeriodBefore().AsTime().Equal(want) {
+		t.Errorf("period_before = %s, want %s", got[0].GetPeriodBefore().AsTime(), want)
+	}
+}
+
+// A broker whose rows all fell outside the period gets no window at all. An
+// export is a picture of what is stored; an empty window would be an instruction
+// to clear the period, which is not what the export was asked to say.
+func TestTxWindows_NoWindowForABrokerWithNothingInThePeriod(t *testing.T) {
+	from := timestamppb.New(mustTime(t, "2024-02-01T00:00:00Z"))
+	before := timestamppb.New(mustTime(t, "2024-03-01T00:00:00Z"))
+	// The db layer filters the postings, so a broker outside the period arrives as
+	// no rows at all.
+	got := txWindows([]dbpkg.ExportPosting{
+		exportPostingFixture("FIDELITY", "g1", "2024-02-10T10:00:00Z"),
+	}, from, before)
+
+	if len(got) != 1 || got[0].GetBroker() != typev1.Broker_FIDELITY {
+		t.Fatalf("windows = %d, want 1 for FIDELITY alone", len(got))
 	}
 }

--- a/server/service/api/user_archive.go
+++ b/server/service/api/user_archive.go
@@ -8,6 +8,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/types/known/timestamppb"
 
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
 	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
@@ -109,6 +110,10 @@ func (s *Server) ExportUserArchive(req *apiv1.ExportUserArchiveRequest, stream a
 	if err != nil {
 		return err
 	}
+	from, before := req.GetPeriodFrom(), req.GetPeriodBefore()
+	if from != nil && before != nil && !before.AsTime().After(from.AsTime()) {
+		return status.Error(codes.InvalidArgument, "period_before must be after period_from")
+	}
 	for _, part := range parts {
 		if err := stream.Send(&apiv1.ExportUserArchiveResponse{
 			Item: &apiv1.ExportUserArchiveResponse_PartBegin{
@@ -122,7 +127,7 @@ func (s *Server) ExportUserArchive(req *apiv1.ExportUserArchiveRequest, stream a
 		case archivev1.ArchivePart_PREFERENCES:
 			partErr = s.sendPreferencePart(ctx, u.ID, stream)
 		case archivev1.ArchivePart_TXS:
-			partErr = s.sendTxPart(ctx, u.ID, stream)
+			partErr = s.sendTxPart(ctx, u.ID, from, before, stream)
 		}
 		if partErr != nil {
 			return partErr
@@ -197,12 +202,16 @@ func archiveIgnoredRules(rules []db.IgnoredAssetClass) []*archivev1.IgnoredAsset
 // server-generated, but a group exported with its residual already sums to zero
 // and the balancer routes nothing for a commodity that does, so re-importing one
 // is idempotent rather than doubling.
-func (s *Server) sendTxPart(ctx context.Context, userID string, stream apiv1.ApiService_ExportUserArchiveServer) error {
-	rows, err := s.db.ListTxsForExport(ctx, userID)
+//
+// A requested period is passed through to the windows rather than only filtering
+// the rows: a window states its own period, and one holding no groups is a valid
+// instruction to clear that period.
+func (s *Server) sendTxPart(ctx context.Context, userID string, from, before *timestamppb.Timestamp, stream apiv1.ApiService_ExportUserArchiveServer) error {
+	rows, err := s.db.ListTxsForExport(ctx, userID, from, before)
 	if err != nil {
 		return status.Error(codes.Internal, err.Error())
 	}
-	for _, w := range txWindows(rows) {
+	for _, w := range txWindows(rows, from, before) {
 		if err := stream.Send(&apiv1.ExportUserArchiveResponse{
 			Item: &apiv1.ExportUserArchiveResponse_TxWindow{TxWindow: w},
 		}); err != nil {

--- a/server/service/ingestion/balance.go
+++ b/server/service/ingestion/balance.go
@@ -253,8 +253,9 @@ func groupPostings(txs []*apiv1.Tx) ([]string, map[string][]int) {
 // Only a group that already sums to exactly zero produces none. A group can produce
 // more than one when its residual spans commodities, as beancount's residual
 // inventory and ledger's Imbalance:<CUR> both can. Which account type each takes is
-// residual.Type's, shared with the partial delete in replace-by-period so that a
-// group's residual does not depend on which path produced it.
+// residual.Type's. Replace-by-period shares the family half of that rule, so whether a
+// residual reads as a transfer or as a missing leg does not depend on which path
+// produced it; only this one applies the tolerance. See residual.SplitType.
 //
 // It assigns a synthetic group_ref to any posting that has none, so that a routed
 // counterparty is stored in the same group as the posting it balances.

--- a/server/service/ingestion/tx_import_test.go
+++ b/server/service/ingestion/tx_import_test.go
@@ -270,3 +270,51 @@ func TestImportTxPart_TotalCountsPostings(t *testing.T) {
 		t.Fatalf("importTxPart: %v", err)
 	}
 }
+
+// A period-scoped export can split a group at a window bound, so a window can
+// carry a group that does not sum to zero. That is legal, and the balancer routes
+// the residual on the way in exactly as it would for a converter's output.
+func TestImportTxPart_RoutesAResidualForASplitGroup(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	database := mock.NewMockDB(ctrl)
+	database.EXPECT().ListIgnoredAssetClasses(gomock.Any(), "user-1").Return(nil, nil).AnyTimes()
+	database.EXPECT().FindInstrumentBySourceDescription(gomock.Any(), gomock.Any(), gomock.Any()).Return("inst-1", nil).AnyTimes()
+	database.EXPECT().FindInstrumentByIdentifier(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("inst-1", nil).AnyTimes()
+	database.EXPECT().ListInstrumentsByIDs(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	database.EXPECT().AppendIdentificationErrors(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	database.EXPECT().InstrumentsWithSplits(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+
+	from := timestamppb.New(mustParseDay("2024-01-01"))
+	before := timestamppb.New(mustParseDay("2024-02-01"))
+	database.EXPECT().
+		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", "job-tx", from, before,
+			gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, _, _, _ string, _, _ *timestamppb.Timestamp,
+			txs []*apiv1.Tx, _ []string, _ []db.Weight, _ []*time.Time) error {
+			if len(txs) != 2 {
+				t.Fatalf("stored %d postings, want the stated leg and its residual", len(txs))
+			}
+			if got := txs[1].GetAccountType(); got != typev1.AccountType_ACCOUNT_TYPE_IMBALANCE {
+				t.Errorf("residual account_type = %s, want IMBALANCE", got)
+			}
+			if got := txs[1].GetQuantity(); got != "-10" {
+				t.Errorf("residual quantity = %s, want -10", got)
+			}
+			return nil
+		})
+
+	// Half a trade: the counter-leg fell the other side of the window bound.
+	part := &archivev1.TxPart{Windows: []*archivev1.TxWindow{{
+		Broker:       typev1.Broker_IBKR,
+		PeriodFrom:   from,
+		PeriodBefore: before,
+		Source:       "IBKR:archive:export",
+		Groups: []*archivev1.TxGroup{{Postings: []*archivev1.Posting{
+			archivePosting("AAPL", "10", typev1.TxType_BUYSTOCK),
+		}}},
+	}}}
+	if _, err := importTxPart(context.Background(), ingestDeps{DB: database}, "user-1", "job-tx", part, archiveimport.NewDetachedReporter()); err != nil {
+		t.Fatalf("importTxPart: %v", err)
+	}
+}


### PR DESCRIPTION
Second of two PRs for [0094](docs/issues/0094-replace-period-without-destroying-straddling-group.md). **Depends on #382** and is based on its branch; merge that first.

Export and delete are one contract, so 0094 settles them together. #382 made the replace safe for a straddling group; this makes a narrower period expressible in the first place.

## The request

`ExportUserArchiveRequest` fields 2 and 3, reserved by comment for the bounds of the transaction window, are now the window. Half-open, either side optional, and scoping the transaction part alone -- preferences and declarations are not dated by a period the way a posting is. A period covering nothing is rejected: an export of nothing over a stated period is a file that clears it on import, which is worth refusing rather than producing by accident.

## What a period does to a window

The bounds filter the postings, not the groups holding them, so a group straddling a bound contributes only its in-period legs. The exported group then does not balance -- already legal, and the importer routes the residual.

Every window states the period asked for rather than one derived from what landed in it. A window is a replacement scope, so an importer told a narrower period than the caller asked for would leave behind whatever sat in the difference. A bound given on one side only is honoured there and derived on the other, and an export asked for no period behaves exactly as before.

A broker with no posting in the period gets no window. An export is a picture of what is stored, and an empty window is an instruction to clear a period.

## Client

`exportUserArchive` takes an optional period. `/archive` keeps exporting all of history -- a period picker on that page is a separate question, along with whether the UI should warn that a group is being split.

## Docs

`docs/spec/archive-format.md`'s transaction section, which said an export's window provably contains everything it carries, and the export-request section. Closes 0094 with what was settled.

## Tests

`txWindows` over a stated period, a one-sided bound and a broker with nothing in range; the RPC passing the period to the read and rejecting an empty one; `ListTxsForExport` clipping a straddling group against real postgres; the importer routing a residual for a split group.

New e2e suite `user-archive-period.spec.ts`: a group straddling a boundary, exported for one day through the RPC, re-imported, and the legs the file does not carry still there with the remainder re-balanced as `TRANSFER_CLEARING` -- then the same file again, landing on the same rows. 46 specs pass.

`make check`, `make server-test`, `make db-test`, `make client-test` and `make e2e-test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)