### PR TITLE
Move transaction grouping to the server (M15)

### DIFF
--- a/docs/adr/0021-converters-own-transaction-grouping.md
+++ b/docs/adr/0021-converters-own-transaction-grouping.md
@@ -1,4 +1,19 @@
+---
+status: partly superseded by ADR-0041
+---
+
 # Converters own transaction grouping; the server never derives a leg
+
+Partly superseded by [0041](0041-server-owns-transaction-grouping.md), which moves the
+grouping decision to the server: a converter sees one file and cannot group across
+uploads, and the premise recorded at the foot of this ADR -- that the broker's reference
+numbers are gone by the time data reaches the standard format -- has not held since they
+were stored on the posting.
+
+What survives is everything below about ledger content. The server still does not invent
+a leg, does not derive a cash side from `quantity * unit_price`, and does not fold a fee
+into a cash amount; fees remain postings with `type=INVEXPENSE`. Grouping decides which
+postings belong together, not what postings exist.
 
 An upload is a list of postings, and the broker-specific converter decides which of
 them are legs of one economic event. The server persists what it is given: it does

--- a/docs/adr/0037-transfer-matches-are-links-not-postings.md
+++ b/docs/adr/0037-transfer-matches-are-links-not-postings.md
@@ -33,6 +33,25 @@ deleting its clearing leg: that would leave its group unbalanced. Only a whole g
 deleted passes vacuously. The invariant that makes ingestion trustworthy is the same
 one that rules out every representation except a link beside the ledger.
 
+## A link rather than a merge, and that part is about transfers only
+
+The argument above rules out a status column and a third group for any residual. The
+choice of a *link* over a *merge* is narrower than that, and turns on something only
+transfers have: the link records which account holds the other side, because the
+membership test in [0022](0022-typed-per-account-cash-flow-boundary.md) asks whether
+both accounts are members before it nets a pair or values what is in transit. Merging
+two transfer groups would erase the account boundary money-weighted return depends on,
+which is the whole reason the pairing exists.
+
+An `IMBALANCE` residual carries no such boundary. Both halves of a split trade sit in
+one account, and the residual is an artefact of the split rather than an economic fact,
+so the right repair there is a merge: reassign `group_id` and delete both residuals.
+The unreachability argument above does not forbid it -- that argument is about clearing
+one side of a pair by mutating its leg. `check_tx_group_balance()` is `DEFERRABLE
+INITIALLY DEFERRED`, so a merge performed in one transaction is evaluated at COMMIT,
+where the merged group balances. See
+[0095](../issues/0095-match-imbalanced-groups-that-should-be-one.md).
+
 ## Keyed per (group, commodity), and directed
 
 Balancing emits one residual per commodity, so an unpaired `JRNLSEC` group can have a
@@ -54,7 +73,19 @@ has to know a re-upload happened. The link is never authoritative and is always 
 to rebuild, which is what licenses a heuristic to write one at all.
 
 The matcher only ever inserts. It never updates and never deletes, so a `MANUAL`
-match survives every rebuild.
+match survives every rebuild the matcher performs.
+
+It does not survive a regroup. Under
+[0041](0041-server-owns-transaction-grouping.md) the partition is recomputed and group
+ids churn, so a link keyed on them breaks whether or not the matcher touched it. For a
+heuristic match that costs nothing -- it is cache, and the next cycle rebuilds it from
+the same evidence. A `MANUAL` match cannot be rebuilt from evidence, which is precisely
+what made it manual. A person's judgement therefore has to be recorded as an *input* to
+grouping and matching and replayed on every run, keyed on something that outlives the
+groups it currently names. What that key is remains open, because a posting has no
+natural key ([0002](0002-transaction-ingestion-model.md)). See
+[0095](../issues/0095-match-imbalanced-groups-that-should-be-one.md) and
+[0091](../issues/0091-manual-transfer-match.md).
 
 ## Ambiguity is left unmatched
 
@@ -97,6 +128,11 @@ converter still has them." That premise no longer holds: the reference is stored
 the posting. And the pairing it enables spans uploads, statements and accounts, which
 is a scope no single converter has. Where the evidence is within one file the
 converter still does the pairing; this is the residue it cannot see.
+
+That last sentence has since been overtaken:
+[0041](0041-server-owns-transaction-grouping.md) moves the grouping decision to the
+server outright, for the same reason set out here and generalised. This section stands
+as the first case of it rather than as an exception to 0021.
 
 ## Consequences
 

--- a/docs/adr/0040-delete-window-widens-only-to-dataset-coverage.md
+++ b/docs/adr/0040-delete-window-widens-only-to-dataset-coverage.md
@@ -1,0 +1,44 @@
+# A delete window widens only as far as the replacing dataset covers it
+
+Bulk upload is idempotent by replacement ([0002](0002-transaction-ingestion-model.md)):
+a period is deleted and the uploaded set is written in its place. A tx group can
+straddle the period boundary, so the delete cuts an economic event in half. The
+obvious repair is to widen the window until it holds whole groups, so that nothing is
+ever cut.
+
+**Widening is legal only where the replacing dataset covers the widened range.**
+Where it does not, the replace cuts the group and the grouping pass
+([0041](0041-server-owns-transaction-grouping.md)) rejoins it afterwards.
+
+The rule matters because the delete and the data that replaces it are decided at
+different times. An archive is a snapshot: a period exported at time X, in which one
+transaction sat in an imbalanced group, is re-imported at time Y, by which point a
+balancing leg has been appended and has joined that group. Widening the delete to the
+group's extent as it stands at Y destroys the appended leg, which the archive was
+never in a position to carry. Cutting preserves it, at the cost of a residual on each
+side that the grouping pass then clears.
+
+A broker statement has no choice at all: it covers the period it covers, and there is
+nothing outside it to widen into.
+
+## The one case that could widen, and why it does not
+
+The extension picks its own window and only then fetches
+(`extension/src/background/sync.ts`), so it could snap its lower bound back to a
+boundary that cuts no stored group and fetch the wider range -- the one place where
+widening is both legal and free of the time-skew problem above. It is not built,
+because it would be a second mechanism for a problem the grouping pass already solves
+everywhere else, and because it would still need a fallback for the range a broker
+will no longer serve.
+
+## Consequences
+
+Every replace path cuts groups the same way and relies on one repair, which
+concentrates correctness in the grouping pass rather than spreading it across the
+callers. Until that pass exists, cut groups stay cut: a fragment and a routed
+residual on each side. That is worse than a whole group and better than the silent
+loss of the legs outside the window, which is what deleting whole groups did.
+
+An export therefore adheres strictly to the period it was asked for, contributing only
+the in-period legs of a straddling group, and the exported group does not balance. The
+format already allows that and the importer already routes the residual.

--- a/docs/adr/0041-server-owns-transaction-grouping.md
+++ b/docs/adr/0041-server-owns-transaction-grouping.md
@@ -1,0 +1,58 @@
+# The server owns transaction grouping
+
+[0021](0021-converters-own-transaction-grouping.md) put grouping in the broker-specific
+converter, on the grounds that only the converter knows how a broker reports the legs
+of an event, and that the broker's own reference numbers were discarded before the data
+reached the standard format. The second half of that premise no longer holds -- 0021
+records as much: the references are stored on the posting.
+
+**The server decides which postings are legs of one event.** The converter's job is to
+synthesise its broker's data into the standard evidence shape
+([0042](0042-grouping-evidence-in-the-standard-format.md)); the server derives the
+partition from that evidence over the whole of a user's data rather than over one
+upload.
+
+Three things argue for it. A converter sees one file, so any evidence that links rows
+across uploads is invisible to it, and several ordinary paths leave the legs of one
+event in separate groups: two legs arriving in two broker logs, and a group cut by a
+period replace ([0040](0040-delete-window-widens-only-to-dataset-coverage.md)). The
+server therefore has to be able to group whatever the converters do, and two
+implementations with different reach is worse than one. And broker idiosyncrasy is an
+argument about *translation*, not about *decision*: what a converter uniquely knows is
+how its broker encodes the evidence, not what should be done with it once encoded.
+
+## Considered: leaving the partition with the converter and giving the server only a merge
+
+Cross-upload grouping is always a merge. Each upload's converter has already
+partitioned its own rows, so what the server lacks is never the ability to split a
+converter's group, only the ability to join two that separate converter runs could not
+see together. A merge engine would therefore have satisfied every capability argument
+above, and would have needed far less evidence -- correlation, amount, type, date --
+than a partition does.
+
+It was rejected because it leaves two rule sets in place permanently. Grouping quality
+would keep improving one converter at a time, in TypeScript, tested per broker, with
+the server able only to repair what those rules produced. One engine means one place to
+improve, one place to test, and every rule available to every broker.
+
+## Consequences
+
+`group_ref` retires, and grouping becomes derived state rather than an input. The
+archive currently carries transactions "and their grouping" as irreplaceable data,
+which has to be re-examined against
+[0032](0032-archive-preserves-inputs-not-derived-state.md) and
+[0035](0035-archive-nests-by-aggregate-root.md) once that is true.
+
+Group ids churn whenever the partition is recomputed. A machine-derived transfer match
+is cache and the matcher rebuilds it ([0037](0037-transfer-matches-are-links-not-postings.md)),
+but a match or a grouping a person asserted by hand cannot be keyed on something that
+evaporates. Human assertions have to become inputs to the grouping pass, replayed on
+every run, which needs the postings they name to be identifiable -- an open design
+question, and the one place [0002](0002-transaction-ingestion-model.md)'s "no natural
+key" bites.
+
+Moving the decision does not make it broker-agnostic. The engine has to express what
+the converters express today: ordered passes that claim rows so a later pass cannot
+take them, bucketing by account and date, amount equality within a tolerance, a
+consideration cross-check, and directional distance between references. Expect
+broker-specific passes on the server, not their disappearance.

--- a/docs/adr/0042-grouping-evidence-in-the-standard-format.md
+++ b/docs/adr/0042-grouping-evidence-in-the-standard-format.md
@@ -1,0 +1,49 @@
+# Grouping evidence in the standard format
+
+[0041](0041-server-owns-transaction-grouping.md) makes the server the thing that
+decides which postings are legs of one event, which means the evidence a converter
+reads out of its broker's file has to survive into the standard format in a shape the
+server can reason about without knowing the broker.
+
+**A posting carries a repeated correlation element and a role.** A correlation is a
+`kind` from a shared vocabulary ([0038](0038-controlled-vocabularies-are-shared.md)), a
+`namespace` that scopes what it is comparable with, a `token` that two postings match
+on for equality, and an **optional `ordinal`**: the identifier's position in a
+monotonic sequence, which is what lets the engine ask how far apart two references are
+rather than only whether they are equal.
+
+The ordinal is explicit because proximity is load-bearing and cannot be recovered from
+the token. The Fidelity deposit run is held together by references being *near* each
+other, not equal, so an equality key alone cannot express it. The converter parses its
+broker's identifier into an integer within a declared namespace and the engine compares
+the difference.
+
+Inferring the distance from the identifier strings instead -- an edit distance, or any
+similar measure -- was rejected. It does not correlate with issuance proximity:
+`1000000` and `0999999` are adjacent references four edits apart, while `1000001` and
+`2000001` are one edit apart and a million references apart. It would group unrelated
+rows and miss related ones, differently for every broker, and it would do so silently.
+
+Where a source's identifiers are genuinely opaque -- an OFX `FITID` is the case in hand
+-- the converter emits the correlation with no ordinal, and proximity is simply
+unavailable for that broker. That is honest, and preferable to manufacturing an
+ordering the source does not have.
+
+`role` is separate from `TxType` because the type is too coarse to drive the rules.
+Fidelity's `Cash In Lump Sum`, `Cash In` and `Transfer Into Account` are all
+journal-family and play different parts in a deposit run; the type cannot tell them
+apart and the grouping rules turn on the difference.
+
+## Considered: a field per broker
+
+Carrying each source's grouping fields verbatim was rejected. The format becomes the
+union of every broker's evidence, growing a nullable field per source, until no
+consumer can rely on any of it. Abstracting the *shape* of the evidence rather than the
+fields keeps the format small and puts the translation where the broker knowledge
+already is.
+
+## Relationship to broker_ref
+
+`broker_ref` is the equality half of this, already carried and already stored, and
+`counterparty_account` is a pointer of the same kind. Whether they fold into
+correlation or stay alongside it is settled when the field lands, not here.

--- a/docs/issues/0091-manual-transfer-match.md
+++ b/docs/issues/0091-manual-transfer-match.md
@@ -32,3 +32,12 @@ survives every rebuild. What is missing is the API and the UI.
   re-propose it. Something has to stop that: either a deletion is recorded so the pair
   is not re-proposed, or a deletion is only offered together with a replacement match.
   Settle which when this is picked up.
+
+## Staleness
+
+A hand-made match can stop making sense without anyone touching it: a later upload can
+change the residual of a group it names, or remove the clearing leg it was made
+against. 0095 carries the question of what happens then -- survive, drop, or flag for
+review -- and it needs an answer here too, because this is where the match is created.
+Related but separate is that a regroup churns group ids, so the anchor a manual match
+is keyed on has to outlive the groups it names; that is settled in 0097.

--- a/docs/issues/0095-match-imbalanced-groups-that-should-be-one.md
+++ b/docs/issues/0095-match-imbalanced-groups-that-should-be-one.md
@@ -1,7 +1,7 @@
 ---
 status: open
 title: Match imbalanced groups that should be one
-dependencies: [0068]
+dependencies: [0068, 0097]
 ---
 
 Repair, after the fact, postings that belong to one economic event but were
@@ -52,6 +52,31 @@ the merged group balances.
 
 Amend 0037 to say it is scoped to transfers and why, rather than leaving it
 reading as a rule about matching in general.
+
+## Relationship to 0097
+
+0097 derives groups on the server from stored evidence, over the whole dataset rather
+than one upload. That takes most of the first bullet above with it: two legs in two
+broker logs, and a group cut by a period replace, are both cases the engine joins
+without anyone being asked. What is left here is the half 0097 cannot do -- the pair
+whose evidence does not identify the occurrence, where the answer is a person's
+judgement rather than a rule.
+
+## A manual match whose target stops making sense
+
+Distinct from the id churn adr/0037-transfer-matches-are-links-not-postings.md now records, and not fixed by anchoring a match to
+something durable. A later upload can leave the group a manual match names in a state
+where the match no longer means anything, with the same id throughout: the group's
+residual changes commodity or sign, or it loses the clearing leg the match was made
+against, because the re-uploaded rows genuinely differ from the ones the person looked
+at.
+
+So a match can be anchored perfectly and still be stale. Settle what happens: whether
+it survives on the assumption the judgement still holds, is dropped as unsupported, or
+is kept and flagged for review. The last is probably right -- a person's answer is
+expensive to obtain and discarding it silently is worse than showing it with a caveat
+-- but the condition that triggers the flag has to be stated, and it is not simply "the
+group is imbalanced", because an unmatched transfer is imbalanced by construction.
 
 ## Relationship to 0091
 

--- a/docs/issues/0096-grouping-evidence-in-the-standard-format.md
+++ b/docs/issues/0096-grouping-evidence-in-the-standard-format.md
@@ -1,0 +1,46 @@
+---
+status: open
+title: Carry grouping evidence in the standard format
+milestone: M15
+dependencies: [0092]
+---
+
+Give a posting a broker-neutral description of why it might belong with another
+posting, and make each converter synthesise its broker's data into it.
+
+## Motivation
+
+adr/0041-server-owns-transaction-grouping.md moves the grouping decision to the
+server. The server cannot make it on what the standard format carries today: the
+converter's answer arrives as `group_ref`, which is opaque, upload-scoped and not
+stored, and the evidence behind it never leaves the converter at all.
+
+## Design
+
+The shape is settled in adr/0042-grouping-evidence-in-the-standard-format.md: a
+repeated correlation on `Tx` carrying `kind`, `namespace`, `token` and an optional
+`ordinal`, plus a `role` that says what part the row plays where `TxType` is too
+coarse to. `kind` and `role` are controlled vocabularies and belong in
+`proto/type/v1/type.proto` with the rest (0092, adr/0038-controlled-vocabularies-are-shared.md).
+
+The ordinal is the part that needs care. It is a monotonic integer within its
+namespace, so `abs(a - b)` is a count of references and comparable across uploads --
+not a rank within one file, which would not be. A converter whose broker issues opaque
+identifiers emits no ordinal.
+
+Per converter:
+
+- **Fidelity CSV and the extension's Fidelity JSON** already parse `referenceId` as a
+  number and use its distance when grouping. That becomes the ordinal.
+- **OFX** has `FITID` on every transaction and no ordering, so it emits an equality
+  token only.
+
+`broker_ref` and `counterparty_account` are stored already and overlap this: the
+first is the equality half, the second a pointer of the same kind. Decide here whether
+they fold into correlation or stay alongside it.
+
+## Scope
+
+The evidence has to be stored on `txs` and to travel in the user archive, or a rebuild
+from an archive would have nothing to group on. Converters populate it while still
+emitting `group_ref`; nothing reads it until 0097.

--- a/docs/issues/0097-server-side-transaction-grouping.md
+++ b/docs/issues/0097-server-side-transaction-grouping.md
@@ -1,0 +1,50 @@
+---
+status: open
+title: Derive transaction groups on the server
+milestone: M15
+dependencies: [0096]
+---
+
+Build the pass that decides which postings are legs of one economic event, from
+stored evidence, over the whole of a user's data.
+
+## Motivation
+
+adr/0041-server-owns-transaction-grouping.md sets out why. In short: a converter sees
+one file, so it cannot join legs that arrive in separate uploads, and it cannot repair
+a group that a period replace cut
+(adr/0040-delete-window-widens-only-to-dataset-coverage.md). The server has to be able
+to group regardless, and one engine is better than two rule sets with different reach.
+
+## Design
+
+The engine has to express what `assignFidelityGroups` expresses today, so it is a rules
+engine rather than a lookup:
+
+- ordered passes, where an earlier pass claims a row so a later one cannot take it
+- bucketing by account and date for some passes and not others
+- amount equality within a tolerance, and a consideration cross-check from independent
+  fields
+- directional distance between correlation ordinals, with a span bound
+
+It runs post-ingest, on the signalling the transfer matcher already uses: an admin RPC
+for a cadence and a trigger when an import commits (adr/0037-transfer-matches-are-links-not-postings.md).
+
+**Blast radius.** A partition over the entire dataset per upload is not wanted. Group
+the neighbourhood of the changed postings and widen until it is stable. Unlike an
+upload window this can be widened freely, because it reads stored data and fetches
+nothing.
+
+**Validation.** The converters are the oracle. Their rules are pinned against the
+sample exports with exact counts -- sells 91/91, buys 78/78, deposit runs 21/21 -- so
+the engine can run in shadow over stored postings and be required to reproduce
+`group_ref` exactly before anything depends on it. Do this before 0098 flips the
+switch.
+
+## Open
+
+A regroup churns group ids, so a human assertion -- a hand-made transfer match, and
+later a hand-made grouping -- cannot be keyed on them. Human judgement has to become an
+input replayed on every run, anchored on something durable, and a posting has no
+natural key (adr/0002-transaction-ingestion-model.md). Settle this here rather than in 0091 or 0095, both of which
+depend on the answer.

--- a/docs/issues/0098-retire-converter-side-grouping.md
+++ b/docs/issues/0098-retire-converter-side-grouping.md
@@ -1,0 +1,26 @@
+---
+status: open
+title: Retire converter-side grouping
+milestone: M15
+dependencies: [0097]
+---
+
+Make the server's partition authoritative, stop converters asserting one, and remove
+`group_ref`.
+
+## Design
+
+Flip in one step once 0097's shadow run reproduces the converters exactly. The
+grouping passes come out of `client/lib/csv/converters/` and the extension's brokers,
+leaving them to emit rows and evidence; `Tx.group_ref` and its plumbing go.
+
+## Consequences
+
+Grouping stops being an input and becomes derived state, so the user archive should no
+longer carry it: it currently lists transactions "and their grouping" as irreplaceable
+data. Re-examine against adr/0032-archive-preserves-inputs-not-derived-state.md and
+adr/0035-archive-nests-by-aggregate-root.md, and confirm that an archive carrying
+evidence alone regroups to the same partition on import.
+
+Fragments left by period replaces before this lands are repaired by the same run, since
+the engine works over stored postings rather than over an upload.

--- a/docs/issues/milestones.md
+++ b/docs/issues/milestones.md
@@ -14,6 +14,7 @@
 - **M12** - Move transactions to grouped double-entry postings with exact decimal amounts and an enforced balance constraint.
 - **M13** - Automated broker transaction import via a browser extension.
 - **M14** - Complete the archive: system and user archives carry everything a rebuild needs, and the transaction CSV is retired.
+- **M15** - The server owns transaction grouping: converters emit evidence and the server derives groups across the whole dataset rather than within one upload.
 
 ## Unscheduled
 

--- a/docs/spec/postings.md
+++ b/docs/spec/postings.md
@@ -334,6 +334,10 @@ server persists what it is given and never infers a missing leg, pairs rows, or 
 a fee into a cash amount. Fees are expressed as postings with `type=INVEXPENSE`, not
 as a column on the upload. See adr/0021-converters-own-transaction-grouping.md.
 
+The decision to move grouping to the server, so that it can join legs a converter
+never sees together, is recorded in adr/0041-server-owns-transaction-grouping.md. This
+section describes what happens until it lands.
+
 Routing a residual is not an exception to that. A residual is arithmetic on the legs
 supplied -- what they leave over -- and it is typed as a residual rather than posted
 as the cash or the fee the server cannot know it to be. A derived cash leg would be


### PR DESCRIPTION
Docs only. Records the decisions taken while reviewing PR 382 and opens the work they imply. No behaviour changes.

## The invariant the review turned on

`adr/0040` -- **a delete window may only be widened as far as the replacing dataset covers it.** Boundary snapping was the tempting alternative: widen the window until it holds whole groups so nothing is cut. It fails on the round trip, because an archive is a snapshot and the database moves on. A period exported at X, in which a transaction sat in an imbalanced group, is re-imported at Y by which point a balancing leg has been appended and joined that group; widening the delete to the group's extent at Y destroys the appended leg the archive never knew about. A broker statement cannot widen at all. So every replace path cuts, and one repair puts it back.

## What that repair is

`adr/0041` -- **the server owns grouping.** A converter sees one file, so evidence linking rows across uploads is invisible to it, and the server must be able to group regardless. Two rule sets with different reach is worse than one.

It records the alternative honestly: cross-upload grouping is always a merge, since each converter has already partitioned its own rows, so a merge-only engine would have discharged every capability argument on far less evidence. One engine was chosen so grouping quality improves in one place rather than one converter at a time.

`adr/0042` -- the evidence shape. Correlation carrying `kind`, `namespace`, `token` and an **optional monotonic `ordinal`**, plus a `role` where `TxType` is too coarse. The ordinal is explicit because proximity is load-bearing for the Fidelity deposit run and cannot be recovered from an identifier string: an edit distance does not track issuance proximity (`1000000`/`0999999` are adjacent but four edits apart; `1000001`/`2000001` are one edit apart and a million apart), and it would fail silently and differently per broker.

## Amendments

- `adr/0021` marked partly superseded. What survives is that the server invents no ledger content -- no derived cash leg, fees stay postings. Grouping decides which postings belong together, not what postings exist.
- `adr/0037` gains the scope 0095 asked for: link-rather-than-merge is specific to transfers, because only a transfer link carries the account boundary MWR depends on. It also gains the consequence that a `MANUAL` match does not survive a regroup -- group ids churn, and a person's judgement cannot be rebuilt from evidence, so it has to become an input replayed on each run.

## Issues

- **0096** grouping evidence in the standard format (deps 0092)
- **0097** derive transaction groups on the server (deps 0096) -- carries the blast-radius question, the shadow-validation harness, and the durable-anchor question 0091 and 0095 both wait on
- **0098** retire converter-side grouping (deps 0097)

0095 and 0091 gain the staleness question raised in review: a manual match can stop making sense without its group id changing, because a re-upload can alter the residual it was made against. Distinct from id churn and not fixed by anchoring.

## Scope notes

`docs/spec/postings.md` gets a pointer to 0041 only. The spec states what the system does, so the behavioural rewrite lands with 0098; the Deletion section rewrite lands with the period-replace redo.

M15 sizing is deliberately open. `assignFidelityGroups` is three ordered passes with claiming semantics, row-type keying, an amount epsilon, a consideration cross-check and directional reference distance -- the engine has to express all of it, and 0097 says to size that before fixing scope.

## Next

PR 382 gets closed and redone as delete-and-rebuild on a branch off main. PR 383 must be retargeted before 382's branch is deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)