### PR TITLE
Move the upload wire to the archive schema (0084)

### DIFF
--- a/client/app/components/upload-modal.tsx
+++ b/client/app/components/upload-modal.tsx
@@ -94,19 +94,20 @@ function UploadModalBody({
   }, []);
 
   const handleUpload = useCallback(async () => {
-    if (!parseResult || parseResult.errors.length > 0 || parseResult.txs.length === 0) return;
+    if (!parseResult || parseResult.errors.length > 0 || parseResult.postings.length === 0) return;
     setSubmitError(null);
     try {
       const sourcePrefix = getSourcePrefix(broker);
       const source = `${sourcePrefix}:web:${formatId}`;
       const res = await upsertTxs({
-        broker,
-        source,
-        periodFrom: timestampFromDate(parseResult.periodFrom),
-        periodBefore: timestampFromDate(parseResult.periodBefore),
-        txs: parseResult.txs,
+        window: {
+          broker,
+          source,
+          periodFrom: timestampFromDate(parseResult.periodFrom),
+          periodBefore: timestampFromDate(parseResult.periodBefore),
+          postings: parseResult.postings,
+        },
         filename: file?.name,
-        shareCountBasis: parseResult.shareCountBasis,
       });
       onJobStarted(res.jobId);
     } catch (e) {
@@ -137,7 +138,7 @@ function UploadModalBody({
   const canUpload =
     parseResult &&
     parseResult.errors.length === 0 &&
-    parseResult.txs.length > 0 &&
+    parseResult.postings.length > 0 &&
     optionsValid &&
     !jobId;
 
@@ -333,7 +334,7 @@ function UploadModalBody({
                 ) : (
                   <>
                     <div data-testid="upload-parse-preview" className="text-sm text-text-primary">
-                      {parseResult.txs.length} transaction(s), from{" "}
+                      {parseResult.postings.length} posting(s), from{" "}
                       {parseResult.periodFrom.toLocaleDateString()} to{" "}
                       {lastCoveredDay(parseResult.periodBefore).toLocaleDateString()}.
                     </div>

--- a/client/lib/csv/converters/fidelity-csv.test.ts
+++ b/client/lib/csv/converters/fidelity-csv.test.ts
@@ -12,20 +12,20 @@ describe("convertFidelityToStandard", () => {
     const result = convertFidelityToStandard("Order date,Transaction type,Investments\n", {});
     expect(result.errors.length).toBeGreaterThan(0);
     expect(result.errors.some((e) => e.message.includes("Currency"))).toBe(true);
-    expect(result.txs.length).toBe(0);
+    expect(result.postings.length).toBe(0);
   });
 
   it("returns error when file is empty", () => {
     const result = convertFidelityToStandard("", { currency: "GBP" });
     expect(result.errors.length).toBeGreaterThan(0);
-    expect(result.txs.length).toBe(0);
+    expect(result.postings.length).toBe(0);
   });
 
   it("returns error when Fidelity header not found", () => {
     const result = convertFidelityToStandard("foo,bar\n1,2", { currency: "GBP" });
     expect(result.errors.length).toBeGreaterThan(0);
     expect(result.errors.some((e) => e.message.includes("Order date"))).toBe(true);
-    expect(result.txs.length).toBe(0);
+    expect(result.postings.length).toBe(0);
   });
 
   it("parses a single Sell row and uses Completion date", () => {
@@ -35,13 +35,13 @@ describe("convertFidelityToStandard", () => {
     ].join("\n");
     const result = convertFidelityToStandard(csv, { currency: "GBP" });
     expect(result.errors).toEqual([]);
-    expect(result.txs.length).toBe(1);
-    expect(result.txs[0]!.instrumentDescription).toContain("INVESCO");
-    expect(result.txs[0]!.quantity).toBe("-70");
-    expect(result.txs[0]!.type).toBe(10); // SELLSTOCK
-    expect(result.txs[0]!.settlementCurrency).toBe("GBP");
-    expect(result.txs[0]!.tradingCurrency).toBe(""); // Sell is not Cash type
-    expect(result.txs[0]!.account).toBe("AG10000001");
+    expect(result.postings.length).toBe(1);
+    expect(result.postings[0]!.instrumentDescription).toContain("INVESCO");
+    expect(result.postings[0]!.quantity).toBe("-70");
+    expect(result.postings[0]!.type).toBe(10); // SELLSTOCK
+    expect(result.postings[0]!.settlementCurrency).toBe("GBP");
+    expect(result.postings[0]!.tradingCurrency).toBeUndefined(); // Sell is not Cash type
+    expect(result.postings[0]!.account).toBe("AG10000001");
     expect(result.periodFrom.getFullYear()).toBe(2026);
     expect(result.periodFrom.getMonth()).toBe(0); // Jan
     expect(result.periodFrom.getDate()).toBe(23);
@@ -54,7 +54,7 @@ describe("convertFidelityToStandard", () => {
     ].join("\n");
     const result = convertFidelityToStandard(csv, { currency: "GBP" });
     expect(result.errors).toEqual([]);
-    expect(result.txs.length).toBe(1);
+    expect(result.postings.length).toBe(1);
     expect(result.periodFrom.getFullYear()).toBe(2026);
     expect(result.periodFrom.getMonth()).toBe(0); // Jan
     expect(result.periodFrom.getDate()).toBe(21);
@@ -81,10 +81,10 @@ describe("convertFidelityToStandard", () => {
     const result = convertFidelityToStandard(csv, { currency: "USD" });
     expect(result.errors).toEqual([]);
     // The cash row plus the income it came from.
-    expect(result.txs.length).toBe(2);
-    expect(result.txs[0]!.type).toBe(11); // INCOME
-    expect(result.txs[0]!.quantity).toBe("3.27");
-    expect(result.txs[0]!.settlementCurrency).toBe("USD");
+    expect(result.postings.length).toBe(2);
+    expect(result.postings[0]!.type).toBe(11); // INCOME
+    expect(result.postings[0]!.quantity).toBe("3.27");
+    expect(result.postings[0]!.settlementCurrency).toBe("USD");
   });
 
   // The exported map is the set of types the converter accepts. Consumers that
@@ -100,7 +100,7 @@ describe("convertFidelityToStandard", () => {
     expect(result.errors).toEqual([]);
     // Counter-legs are appended for the one-sided rows, so count the postings
     // that came from a source row: those are the ones a type maps to.
-    const source = result.txs.filter((tx) => tx.accountType === AccountType.UNSPECIFIED);
+    const source = result.postings.filter((tx) => tx.accountType === AccountType.UNSPECIFIED);
     expect(source.length).toBe(types.length);
     expect(new Set(source.map((tx) => tx.type))).toEqual(
       new Set(Object.values(FIDELITY_TYPE_TO_OFX))
@@ -113,7 +113,7 @@ describe("convertFidelityToStandard", () => {
       "20 Oct 2025,22 Oct 2025,Corporate Action Reinvestment,ISHARES II PLC INRG,SIPP,1,7.16",
     ].join("\n");
     const result = convertFidelityToStandard(csv, { currency: "GBP" });
-    expect(result.txs).toEqual([]);
+    expect(result.postings).toEqual([]);
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0]!.field).toBe("type");
     expect(result.errors[0]!.message).toContain("Corporate Action Reinvestment");
@@ -157,7 +157,7 @@ describe("convertFidelityToStandard", () => {
       it(tc.name, () => {
         const result = convertFidelityToStandard([FULL_HEADER, tc.row].join("\n"), { currency: "GBP" });
         expect(result.errors).toEqual([]);
-        expect(result.txs[0]!.quantity).toBe(tc.want);
+        expect(result.postings[0]!.quantity).toBe(tc.want);
       });
     }
 
@@ -168,7 +168,7 @@ describe("convertFidelityToStandard", () => {
       const result = convertFidelityToStandard(csv, { currency: "GBP" });
       // Summed in decimal so the assertion holds for any pair rather than for
       // ones whose float64 sum happens to land on zero.
-      const total = result.txs.reduce((sum, tx) => sum.plus(tx.quantity), new Big(0));
+      const total = result.postings.reduce((sum, tx) => sum.plus(tx.quantity), new Big(0));
       expect(total.eq(0)).toBe(true);
     });
   });
@@ -185,8 +185,8 @@ describe("convertFidelityToStandard", () => {
       ].join("\n");
       const result = convertFidelityToStandard(csv, { currency: "GBP" });
       expect(result.errors).toEqual([]);
-      expect(result.txs).toHaveLength(1);
-      expect(result.txs[0]!.quantity).toBe("-100");
+      expect(result.postings).toHaveLength(1);
+      expect(result.postings[0]!.quantity).toBe("-100");
     }
   );
 
@@ -197,7 +197,7 @@ describe("convertFidelityToStandard", () => {
     ].join("\n");
     const result = convertFidelityToStandard(csv, { currency: "GBP" });
     // Quantity is a share count here, not money, so Amount must not replace it.
-    expect(result.txs[0]!.quantity).toBe("-70");
+    expect(result.postings[0]!.quantity).toBe("-70");
   });
 
   it("falls back to Quantity when the export has no Amount column", () => {
@@ -206,7 +206,7 @@ describe("convertFidelityToStandard", () => {
       "15 Jul 2026,21 Jul 2026,Cash Interest,Cash,AS10000001,1.26,1",
     ].join("\n");
     const result = convertFidelityToStandard(csv, { currency: "GBP" });
-    expect(result.txs[0]!.quantity).toBe("1.26");
+    expect(result.postings[0]!.quantity).toBe("1.26");
   });
 
   // Fidelity reports money leaving an account as a sale of the account's cash.
@@ -230,18 +230,18 @@ describe("convertFidelityToStandard", () => {
     it("is a cash movement, not a security trade", () => {
       const result = convert([SELL]);
       expect(result.errors).toEqual([]);
-      expect(result.txs).toHaveLength(1);
-      expect(result.txs[0]!.type).toBe(TxType.CASHFLOW);
+      expect(result.postings).toHaveLength(1);
+      expect(result.postings[0]!.type).toBe(TxType.CASHFLOW);
       // The signed Amount, not the unsigned share count the row also carries.
-      expect(result.txs[0]!.quantity).toBe("-401");
-      expect(result.txs[0]!.tradingCurrency).toBe("GBP");
+      expect(result.postings[0]!.quantity).toBe("-401");
+      expect(result.postings[0]!.tradingCurrency).toBe("GBP");
     });
 
     it("groups with its cash in, and the pair weighs nothing", () => {
       const result = convert([SELL, CASH_IN]);
-      expect(result.txs[0]!.groupRef).toBe("608442561");
-      expect(result.txs[1]!.groupRef).toBe("608442561");
-      expectGroupsBalance(result.txs);
+      expect(result.postings[0]!.groupRef).toBe("608442561");
+      expect(result.postings[1]!.groupRef).toBe("608442561");
+      expectGroupsBalance(result.postings);
     });
 
     it("leaves the transfer beside it as the money that moved", () => {
@@ -251,17 +251,17 @@ describe("convertFidelityToStandard", () => {
       // management account records against it.
       const result = convert([TRANSFER, SELL, CASH_IN]);
       expect(result.errors).toEqual([]);
-      const total = result.txs.reduce((sum, tx) => sum.plus(tx.quantity), new Big(0));
+      const total = result.postings.reduce((sum, tx) => sum.plus(tx.quantity), new Big(0));
       expect(total.eq(-401)).toBe(true);
-      expect(result.txs.some((tx) => tx.type === TxType.SELLSTOCK)).toBe(false);
+      expect(result.postings.some((tx) => tx.type === TxType.SELLSTOCK)).toBe(false);
     });
 
     it("still reads a security sale as one", () => {
       const result = convert([
         '2022-02-08,10 Feb 2022,Sell,"WISE PLC, CLS A ORD GBP0.01 (WISE)",SIPP - Pension Savings Account,AP10000001,,-7266.49,1242,5.85,441416452,Completed,LON,WISE,STOCK,Sell',
       ]);
-      expect(result.txs[0]!.type).toBe(TxType.SELLSTOCK);
-      expect(result.txs[0]!.quantity).toBe("-1242");
+      expect(result.postings[0]!.type).toBe(TxType.SELLSTOCK);
+      expect(result.postings[0]!.quantity).toBe("-1242");
     });
 
     it("does not let a sale of cash claim a security sale's cash in", () => {
@@ -274,10 +274,10 @@ describe("convertFidelityToStandard", () => {
         "2024-04-10,10 Apr 2024,Cash In From Sell,Cash,Investment Account,AG10000001,,19502.15,19502.15,1,791691785,Completed,,GBP,CASH,Cash",
       ]);
 
-      expect(result.txs[0]!.groupRef).toBe("795832439");
-      expect(result.txs[1]!.groupRef).toBe("795832439");
-      expect(result.txs[2]!.groupRef).toBe("791691783");
-      expect(result.txs[3]!.groupRef).toBe("791691783");
+      expect(result.postings[0]!.groupRef).toBe("795832439");
+      expect(result.postings[1]!.groupRef).toBe("795832439");
+      expect(result.postings[2]!.groupRef).toBe("791691783");
+      expect(result.postings[3]!.groupRef).toBe("791691783");
     });
 
     // The map-completeness test above feeds security rows through a header with
@@ -289,8 +289,8 @@ describe("convertFidelityToStandard", () => {
         "8 Feb 2022,10 Feb 2022,Sell,ISHARES II PLC INRG,AG10000001,100,7.16",
       ].join("\n");
       const result = convertFidelityToStandard(csv, { currency: "GBP" });
-      expect(result.txs[0]!.type).toBe(TxType.CASHFLOW);
-      expect(result.txs[1]!.type).toBe(TxType.SELLSTOCK);
+      expect(result.postings[0]!.type).toBe(TxType.CASHFLOW);
+      expect(result.postings[1]!.type).toBe(TxType.SELLSTOCK);
     });
   });
 
@@ -301,11 +301,11 @@ describe("convertFidelityToStandard", () => {
     ].join("\n");
     const result = convertFidelityToStandard(csv, { currency: "GBP" });
     expect(result.errors).toEqual([]);
-    expect(result.txs.length).toBe(1);
-    expect(result.txs[0]!.type).toBe(5); // BUYSTOCK
-    expect(result.txs[0]!.quantity).toBe("12783");
-    expect(result.txs[0]!.settlementCurrency).toBe("GBP");
-    expect(result.txs[0]!.tradingCurrency).toBe(""); // Buy is not Cash type
+    expect(result.postings.length).toBe(1);
+    expect(result.postings[0]!.type).toBe(5); // BUYSTOCK
+    expect(result.postings[0]!.quantity).toBe("12783");
+    expect(result.postings[0]!.settlementCurrency).toBe("GBP");
+    expect(result.postings[0]!.tradingCurrency).toBeUndefined(); // Buy is not Cash type
   });
 });
 
@@ -333,9 +333,9 @@ describe("transaction grouping", () => {
       row("Cash In From Sell", "Cash", "AG1", "7266.49", "7266.49", "1", "441416454"),
     ]);
 
-    expect(result.txs).toHaveLength(2);
-    expect(result.txs[0].groupRef).toBe("441416452");
-    expect(result.txs[1].groupRef).toBe("441416452");
+    expect(result.postings).toHaveLength(2);
+    expect(result.postings[0].groupRef).toBe("441416452");
+    expect(result.postings[1].groupRef).toBe("441416452");
   });
 
   it("pairs a buy with the cash out despite the fee gap", () => {
@@ -346,8 +346,8 @@ describe("transaction grouping", () => {
       row("Buy", "INVESCO EQQQ (EQQQ)", "AG1", "7390.19", "28", "263.58", "441416515"),
     ]);
 
-    expect(result.txs[0].groupRef).toBe("441416515");
-    expect(result.txs[1].groupRef).toBe("441416515");
+    expect(result.postings[0].groupRef).toBe("441416515");
+    expect(result.postings[1].groupRef).toBe("441416515");
   });
 
   it("keeps a separately reported charge out of the trade's group", () => {
@@ -360,8 +360,8 @@ describe("transaction grouping", () => {
     // It has a group of its own -- it needs one to hold its expense leg -- but
     // Fidelity dates it on the order date while the trade settles later, so
     // folding it into the trade would misdate it.
-    expect(result.txs[2].groupRef).not.toBe("");
-    expect(result.txs[2].groupRef).not.toBe(result.txs[0].groupRef);
+    expect(result.postings[2].groupRef).toBeTruthy();
+    expect(result.postings[2].groupRef).not.toBe(result.postings[0].groupRef);
   });
 
   it("does not cross-pair two sells settling the same day in one account", () => {
@@ -374,10 +374,10 @@ describe("transaction grouping", () => {
 
     // Amount, not proximity, decides: the 100.00 cash belongs to the 100.00 sell
     // even though a different cash row sits closer in the file.
-    expect(result.txs[0].groupRef).toBe("1001");
-    expect(result.txs[3].groupRef).toBe("1001");
-    expect(result.txs[1].groupRef).toBe("1003");
-    expect(result.txs[2].groupRef).toBe("1003");
+    expect(result.postings[0].groupRef).toBe("1001");
+    expect(result.postings[3].groupRef).toBe("1001");
+    expect(result.postings[1].groupRef).toBe("1003");
+    expect(result.postings[2].groupRef).toBe("1003");
   });
 
   it("does not let one buy strand another by claiming its cash row", () => {
@@ -390,10 +390,10 @@ describe("transaction grouping", () => {
       row("Buy", "INVESCO EQQQ (EQQQ)", "AP1", "36954.22", "120", "307.95", "697042346"),
     ]);
 
-    expect(result.txs[1].groupRef).toBe("697042343");
-    expect(result.txs[0].groupRef).toBe("697042343");
-    expect(result.txs[3].groupRef).toBe("697042346");
-    expect(result.txs[2].groupRef).toBe("697042346");
+    expect(result.postings[1].groupRef).toBe("697042343");
+    expect(result.postings[0].groupRef).toBe("697042343");
+    expect(result.postings[3].groupRef).toBe("697042346");
+    expect(result.postings[2].groupRef).toBe("697042346");
   });
 
   it("does not pair a sell across accounts or settlement dates", () => {
@@ -403,8 +403,8 @@ describe("transaction grouping", () => {
       row("Cash In From Sell", "Cash", "AG1", "100.00", "100", "1", "1003", "11 Feb 2022"),
     ]);
 
-    for (const tx of result.txs) {
-      expect(tx.groupRef).toBe("");
+    for (const tx of result.postings) {
+      expect(tx.groupRef).toBeUndefined();
     }
   });
 
@@ -417,8 +417,8 @@ describe("transaction grouping", () => {
       row("Cash Out For Buy", "Cash", "AG1", "-100.00", "100", "1", "1003", "11 Feb 2022"),
     ]);
 
-    for (const tx of result.txs) {
-      expect(tx.groupRef).toBe("");
+    for (const tx of result.postings) {
+      expect(tx.groupRef).toBeUndefined();
     }
   });
 
@@ -433,10 +433,10 @@ describe("transaction grouping", () => {
       row("Buy", "INVESCO EQQQ (EQQQ)", "AP1", "8007.50", "20", "400", "2004"),
     ]);
 
-    expect(result.txs[1].groupRef).toBe("2002");
-    expect(result.txs[2].groupRef).toBe("2002");
-    expect(result.txs[3].groupRef).toBe("2004");
-    expect(result.txs[0].groupRef).toBe("2004");
+    expect(result.postings[1].groupRef).toBe("2002");
+    expect(result.postings[2].groupRef).toBe("2002");
+    expect(result.postings[3].groupRef).toBe("2004");
+    expect(result.postings[0].groupRef).toBe("2004");
   });
 
   it("tolerates the rounding in a quoted unit price", () => {
@@ -447,8 +447,8 @@ describe("transaction grouping", () => {
       row("Cash In From Sell", "Cash", "AG1", "20514.62", "20514.62", "1", "3003"),
     ]);
 
-    expect(result.txs[0].groupRef).toBe("3001");
-    expect(result.txs[1].groupRef).toBe("3001");
+    expect(result.postings[0].groupRef).toBe("3001");
+    expect(result.postings[1].groupRef).toBe("3001");
   });
 
   it("pairs on the totals alone when no unit price is quoted", () => {
@@ -457,8 +457,8 @@ describe("transaction grouping", () => {
       row("Cash In From Sell", "Cash", "AG1", "7266.49", "7266.49", "1", "4002"),
     ]);
 
-    expect(result.txs[0].groupRef).toBe("4001");
-    expect(result.txs[1].groupRef).toBe("4001");
+    expect(result.postings[0].groupRef).toBe("4001");
+    expect(result.postings[1].groupRef).toBe("4001");
   });
 
   it("leaves a cash row with no trade ungrouped rather than failing", () => {
@@ -467,8 +467,8 @@ describe("transaction grouping", () => {
     ]);
 
     expect(result.errors).toHaveLength(0);
-    expect(result.txs).toHaveLength(1);
-    expect(result.txs[0].groupRef).toBe("");
+    expect(result.postings).toHaveLength(1);
+    expect(result.postings[0].groupRef).toBeUndefined();
   });
 });
 
@@ -500,16 +500,16 @@ describe("deposits into a product account", () => {
     const result = convert([LUMP_SUM, SPEND, DEPARTURE, ARRIVAL]);
 
     expect(result.errors).toEqual([]);
-    expect(result.txs.map((tx) => tx.groupRef)).toEqual([
+    expect(result.postings.map((tx) => tx.groupRef)).toEqual([
       "971613428",
       "971613428",
-      "",
+      undefined,
       "971613428",
     ]);
     // What each account is left with: the arrival and the departure it answers,
     // equal and opposite, which is the pair 0068 has to match. Ungrouped the ISA
     // offered two identical credits and an unexplained debit instead.
-    expect(residuals(result.txs)).toEqual({
+    expect(residuals(result.postings)).toEqual({
       "971613428": { GBP: "20000" },
       "#2": { GBP: "-20000" },
     });
@@ -521,7 +521,7 @@ describe("deposits into a product account", () => {
     // a trade's cash leg is.
     const result = convert([LUMP_SUM, SPEND, ARRIVAL]);
 
-    expect(result.txs.map((tx) => tx.type)).toEqual([
+    expect(result.postings.map((tx) => tx.type)).toEqual([
       TxType.JRNLFUND,
       TxType.CASHFLOW,
       TxType.JRNLFUND,
@@ -535,9 +535,9 @@ describe("deposits into a product account", () => {
       "2024-05-30,2024-05-30,Cash In Lump Sum,Cash,Cash Management Account,AW10000001,,19999,19999,1,822942572,Completed,,GBP,CASH,Cash",
     ]);
 
-    expect(result.txs).toHaveLength(1);
-    expect(result.txs[0]!.groupRef).toBe("");
-    expect(result.txs[0]!.type).toBe(TxType.JRNLFUND);
+    expect(result.postings).toHaveLength(1);
+    expect(result.postings[0]!.groupRef).toBeUndefined();
+    expect(result.postings[0]!.type).toBe(TxType.JRNLFUND);
   });
 
   it("groups a run whose rows settled on different days", () => {
@@ -550,7 +550,7 @@ describe("deposits into a product account", () => {
       "2022-11-14,14 Nov 2022,Cash In,Cash,Investment Account,AG10000002,,19996,19996,1,559604933,Completed,,GBP,CASH,Cash",
     ]);
 
-    expect(result.txs.map((tx) => tx.groupRef)).toEqual([
+    expect(result.postings.map((tx) => tx.groupRef)).toEqual([
       "559604931",
       "559604931",
       "559604931",
@@ -567,9 +567,9 @@ describe("deposits into a product account", () => {
       "2022-11-14,14 Nov 2022,Cash In,Cash,Investment Account,AG10000002,,19995,19995,1,559677712,Completed,,GBP,CASH,Cash",
     ]);
 
-    expect(result.txs.map((tx) => tx.groupRef)).toEqual([
+    expect(result.postings.map((tx) => tx.groupRef)).toEqual([
       "559677710",
-      "",
+      undefined,
       "559677710",
       "559677710",
     ]);
@@ -586,7 +586,7 @@ describe("deposits into a product account", () => {
       '2025-04-15,2025-04-17,Buy,"VANECK UCITS ETFS PLC, SEMICONDUCTOR UCITS ETF A GBP ACC (SMGB)",Investment ISA,AS10000001,,19976.7,769,25.97,971613494,Completed,LON,SMGB,ETF,Buy',
     ]);
 
-    expect(result.txs.map((tx) => tx.groupRef)).toEqual([
+    expect(result.postings.map((tx) => tx.groupRef)).toEqual([
       "971613428",
       "971613428",
       "971613428",
@@ -616,11 +616,11 @@ describe("trades the broker names for their reason", () => {
     expect(result.errors).toEqual([]);
     // A plain purchase: the dividend has already posted as its own Cash Dividend
     // row, so typing this REINVEST would count the income twice.
-    expect(result.txs[0]!.type).toBe(TxType.BUYSTOCK);
-    expect(result.txs[0]!.quantity).toBe("17");
-    expect(result.txs[1]!.type).toBe(TxType.CASHFLOW);
-    expect(result.txs[0]!.groupRef).toBe("442184379");
-    expect(result.txs[1]!.groupRef).toBe("442184379");
+    expect(result.postings[0]!.type).toBe(TxType.BUYSTOCK);
+    expect(result.postings[0]!.quantity).toBe("17");
+    expect(result.postings[1]!.type).toBe(TxType.CASHFLOW);
+    expect(result.postings[0]!.groupRef).toBe("442184379");
+    expect(result.postings[1]!.groupRef).toBe("442184379");
   });
 
   it("pairs a rebate reinvestment with its cash out", () => {
@@ -630,14 +630,14 @@ describe("trades the broker names for their reason", () => {
     ]);
 
     expect(result.errors).toEqual([]);
-    expect(result.txs[1]!.type).toBe(TxType.BUYSTOCK);
-    expect(result.txs[0]!.groupRef).toBe("452602204");
-    expect(result.txs[1]!.groupRef).toBe("452602204");
+    expect(result.postings[1]!.type).toBe(TxType.BUYSTOCK);
+    expect(result.postings[0]!.groupRef).toBe("452602204");
+    expect(result.postings[1]!.groupRef).toBe("452602204");
     // The group does not weigh zero, and cannot: 9.24 units at the printed price
     // of 0.85 is 7.854 against a cash out of 7.81. The price is rounded to the
     // penny and the units are not, so the 0.044 is the source disagreeing with
     // itself. The imbalance report is where that belongs.
-    expect(residuals(result.txs)).toEqual({ "452602204": { GBP: "0.044" } });
+    expect(residuals(result.postings)).toEqual({ "452602204": { GBP: "0.044" } });
   });
 
   it("derives the income a reinvestment consumed, since no row reports it", () => {
@@ -648,16 +648,16 @@ describe("trades the broker names for their reason", () => {
     ]);
 
     expect(result.errors).toEqual([]);
-    expect(result.txs).toHaveLength(2);
-    expect(result.txs[0]!.type).toBe(TxType.REINVEST);
-    expect(result.txs[0]!.quantity).toBe("21.09");
-    expect(result.txs[1]!.accountType).toBe(AccountType.INCOME);
+    expect(result.postings).toHaveLength(2);
+    expect(result.postings[0]!.type).toBe(TxType.REINVEST);
+    expect(result.postings[0]!.quantity).toBe("21.09");
+    expect(result.postings[1]!.accountType).toBe(AccountType.INCOME);
     // The posting's own weight, not the 31.65 the broker printed: taking that
     // would leave the group short by the rounding in the quoted price.
-    expect(result.txs[1]!.quantity).toBe("-31.635");
-    expect(result.txs[1]!.instrumentDescription).toBe("GBP");
-    expect(result.txs[1]!.groupRef).toBe(result.txs[0]!.groupRef);
-    expectGroupsBalance(result.txs);
+    expect(result.postings[1]!.quantity).toBe("-31.635");
+    expect(result.postings[1]!.instrumentDescription).toBe("GBP");
+    expect(result.postings[1]!.groupRef).toBe(result.postings[0]!.groupRef);
+    expectGroupsBalance(result.postings);
   });
 
   it("settles a switch through the rows the broker used for it", () => {
@@ -671,13 +671,13 @@ describe("trades the broker names for their reason", () => {
     expect(result.errors).toEqual([]);
     // The buy side names cash as the asset, so it is a movement of money rather
     // than a purchase of a security called Cash, and it nets against its cash out.
-    expect(result.txs[2]!.type).toBe(TxType.CASHFLOW);
-    expect(result.txs[0]!.groupRef).toBe("661638575");
-    expect(result.txs[2]!.groupRef).toBe("661638575");
+    expect(result.postings[2]!.type).toBe(TxType.CASHFLOW);
+    expect(result.postings[0]!.groupRef).toBe("661638575");
+    expect(result.postings[2]!.groupRef).toBe("661638575");
     // The sale side is a real disposal, and its proceeds arrive as a Cash In.
-    expect(result.txs[1]!.type).toBe(TxType.SELLSTOCK);
-    expect(result.txs[1]!.groupRef).toBe("661638570");
-    expect(result.txs[3]!.groupRef).toBe("661638570");
+    expect(result.postings[1]!.type).toBe(TxType.SELLSTOCK);
+    expect(result.postings[1]!.groupRef).toBe("661638570");
+    expect(result.postings[3]!.groupRef).toBe("661638570");
   });
 
   it("retypes a Cash In that turned out to be a sale's proceeds", () => {
@@ -687,14 +687,14 @@ describe("trades the broker names for their reason", () => {
       "2023-06-28,04 Jul 2023,Sell For Switch,M&G European Index Tracker,SIPP - Pension Savings Account,AP10000002,,-12091.15,12147.03,1,661638570,Completed,LON,M&G European Index Tracker,FUND,Sell",
       "2023-06-28,04 Jul 2023,Cash In,Cash,SIPP - Pension Savings Account,AP10000002,,12091.15,12091.15,1,661638574,Completed,,GBP,CASH,Cash",
     ]);
-    expect(paired.txs[1]!.type).toBe(TxType.CASHFLOW);
-    expect(paired.txs[1]!.tradingCurrency).toBe("GBP");
+    expect(paired.postings[1]!.type).toBe(TxType.CASHFLOW);
+    expect(paired.postings[1]!.tradingCurrency).toBe("GBP");
 
     const alone = convert([
       "2023-06-28,04 Jul 2023,Cash In,Cash,SIPP - Pension Savings Account,AP10000002,,12091.15,12091.15,1,661638574,Completed,,GBP,CASH,Cash",
     ]);
-    expect(alone.txs[0]!.type).toBe(TxType.JRNLFUND);
-    expect(alone.txs[0]!.groupRef).toBe("");
+    expect(alone.postings[0]!.type).toBe(TxType.JRNLFUND);
+    expect(alone.postings[0]!.groupRef).toBeUndefined();
   });
 
   it("skips a cancelled transaction and its cancelled cash row", () => {
@@ -706,8 +706,8 @@ describe("trades the broker names for their reason", () => {
 
     expect(result.errors).toEqual([]);
     // The fee and its expense leg; nothing from the trade that never happened.
-    expect(result.txs).toHaveLength(2);
-    expect(result.txs[0]!.type).toBe(TxType.INVEXPENSE);
+    expect(result.postings).toHaveLength(2);
+    expect(result.postings[0]!.type).toBe(TxType.INVEXPENSE);
   });
 });
 
@@ -725,12 +725,12 @@ describe("what a posting resolves to", () => {
       "2022-01-11,11 Jan 2022,Service Fee,Cash,Cash Management Account,AW10000001,,-3.24,3.24,1,428845305,Completed,,GBP,CASH,Cash",
     ]);
 
-    expect(result.txs[0]!.instrumentDescription).toBe("GBP");
-    expect(result.txs[0]!.identifierHints.map((h) => [h.type, h.value])).toEqual([
+    expect(result.postings[0]!.instrumentDescription).toBe("GBP");
+    expect(result.postings[0]!.identifierHints.map((h) => [h.type, h.value])).toEqual([
       [IdentifierType.CURRENCY, "GBP"],
     ]);
     // Including the expense leg it balances against, which was already money.
-    expect(result.txs[1]!.instrumentDescription).toBe("GBP");
+    expect(result.postings[1]!.instrumentDescription).toBe("GBP");
   });
 
   it("describes a dividend by the currency it paid, not the payer", () => {
@@ -741,8 +741,8 @@ describe("what a posting resolves to", () => {
       '2022-02-11,11 Feb 2022,Cash Dividend,Cash,Investment ISA,AS10000002,"BAILLIE GIFFORD EUROPEAN GROWTH TST, ORD GBP0.025 (BGEU)",22.67,22.67,1,442183607,Completed,,GBP,CASH,Cash',
     ]);
 
-    expect(result.txs[0]!.instrumentDescription).toBe("GBP");
-    expect(result.txs[0]!.type).toBe(TxType.INCOME);
+    expect(result.postings[0]!.instrumentDescription).toBe("GBP");
+    expect(result.postings[0]!.type).toBe(TxType.INCOME);
   });
 
   it("keeps a security's own description and offers its ticker", () => {
@@ -750,8 +750,8 @@ describe("what a posting resolves to", () => {
       '2022-02-08,10 Feb 2022,Sell,"WISE PLC, CLS A ORD GBP0.01 (WISE)",SIPP - Pension Savings Account,AP10000001,,-7266.49,1242,5.85,441416452,Completed,LON,WISE,STOCK,Sell',
     ]);
 
-    expect(result.txs[0]!.instrumentDescription).toContain("WISE PLC");
-    expect(result.txs[0]!.identifierHints.map((h) => [h.type, h.value, h.domain])).toEqual([
+    expect(result.postings[0]!.instrumentDescription).toContain("WISE PLC");
+    expect(result.postings[0]!.identifierHints.map((h) => [h.type, h.value, h.domain])).toEqual([
       [IdentifierType.MIC_TICKER, "WISE", "XLON"],
     ]);
   });
@@ -764,8 +764,8 @@ describe("what a posting resolves to", () => {
       "2022-03-24,06 Apr 2022,Reinvestment From Income,Baillie Gifford Responsible Global Equity Income B Inc,Investment ISA,AS10000002,,31.65,21.09,1.5,460143202,Completed,LON,Baillie Gifford Responsible Global Equity Income B Inc,FUND,Buy",
     ]);
 
-    expect(result.txs[0]!.identifierHints).toEqual([]);
-    expect(result.txs[0]!.instrumentDescription).toContain("Baillie Gifford");
+    expect(result.postings[0]!.identifierHints).toEqual([]);
+    expect(result.postings[0]!.instrumentDescription).toContain("Baillie Gifford");
   });
 
   it("names the exchange a ticker belongs to, where it knows the MIC", () => {
@@ -776,9 +776,9 @@ describe("what a posting resolves to", () => {
       '2024-06-03,05 Jun 2024,Buy,"SAFRAN SA, ORD EUR0.20 (SAF)",Investment Account,AG10000001,,5000,25,200,1000000002,Completed,XXX,SAF,STOCK,Buy',
     ]);
 
-    expect(result.txs[0]!.identifierHints[0]!.domain).toBe("XETR");
-    expect(result.txs[1]!.identifierHints[0]!.value).toBe("SAF");
-    expect(result.txs[1]!.identifierHints[0]!.domain).toBe("");
+    expect(result.postings[0]!.identifierHints[0]!.domain).toBe("XETR");
+    expect(result.postings[1]!.identifierHints[0]!.value).toBe("SAF");
+    expect(result.postings[1]!.identifierHints[0]!.domain).toBe("");
   });
 });
 
@@ -803,21 +803,21 @@ describe("counter-legs", () => {
   it("names the account a charge went to", () => {
     const result = convert([row("Dealing Fee", "Cash", "AG1", "-10", "10", "1", "441416483")]);
 
-    expect(result.txs).toHaveLength(2);
-    expect(result.txs[1].type).toBe(TxType.INVEXPENSE);
-    expect(result.txs[1].accountType).toBe(AccountType.EXPENSE);
-    expect(result.txs[1].quantity).toBe("10");
-    expect(result.txs[1].groupRef).toBe(result.txs[0].groupRef);
-    expectGroupsBalance(result.txs);
+    expect(result.postings).toHaveLength(2);
+    expect(result.postings[1].type).toBe(TxType.INVEXPENSE);
+    expect(result.postings[1].accountType).toBe(AccountType.EXPENSE);
+    expect(result.postings[1].quantity).toBe("10");
+    expect(result.postings[1].groupRef).toBe(result.postings[0].groupRef);
+    expectGroupsBalance(result.postings);
   });
 
   it("names the account a dividend came from", () => {
     const result = convert([row("Cash Dividend", "Cash", "AG1", "23.40", "23.40", "1", "441416484")]);
 
-    expect(result.txs).toHaveLength(2);
-    expect(result.txs[1].accountType).toBe(AccountType.INCOME);
-    expect(result.txs[1].quantity).toBe("-23.4");
-    expectGroupsBalance(result.txs);
+    expect(result.postings).toHaveLength(2);
+    expect(result.postings[1].accountType).toBe(AccountType.INCOME);
+    expect(result.postings[1].quantity).toBe("-23.4");
+    expectGroupsBalance(result.postings);
   });
 
   it("leaves a trade and its cash leg alone -- the source supplied both", () => {
@@ -826,8 +826,8 @@ describe("counter-legs", () => {
       row("Cash In From Sell", "Cash", "AG1", "7265.70", "7265.70", "1", "441416454"),
     ]);
 
-    expect(result.txs).toHaveLength(2);
-    expectGroupsBalance(result.txs);
+    expect(result.postings).toHaveLength(2);
+    expectGroupsBalance(result.postings);
   });
 
   it("balances a trade, its cash leg and the charge reported beside it", () => {
@@ -837,15 +837,15 @@ describe("counter-legs", () => {
       row("Dealing Fee", "Cash", "AG1", "-10", "10", "1", "441416483", "8 Feb 2022"),
     ]);
 
-    expect(result.txs).toHaveLength(4);
-    expectGroupsBalance(result.txs);
+    expect(result.postings).toHaveLength(4);
+    expectGroupsBalance(result.postings);
   });
 
   it("does not invent a leg for a journal, whose other side is another account", () => {
     const result = convert([row("Cash In", "Cash", "AG1", "5000", "5000", "1", "441416485")]);
 
-    expect(result.txs).toHaveLength(1);
-    expect(result.txs[0].type).toBe(TxType.JRNLFUND);
+    expect(result.postings).toHaveLength(1);
+    expect(result.postings[0].type).toBe(TxType.JRNLFUND);
   });
 });
 
@@ -863,11 +863,11 @@ describe("trade cash legs", () => {
       "8 Feb 2022,10 Feb 2022,Cash In From Sell,Cash,Investment Account,AG1,,7265.70,7265.70,1,441416454,Completed",
     ]);
 
-    expect(result.txs[0].type).toBe(TxType.CASHFLOW);
-    expect(result.txs[0].quantity).toBe("-401");
-    expect(result.txs[0].tradingCurrency).toBe("GBP");
-    expect(result.txs[1].type).toBe(TxType.CASHFLOW);
-    expect(result.txs[1].quantity).toBe("7265.7");
+    expect(result.postings[0].type).toBe(TxType.CASHFLOW);
+    expect(result.postings[0].quantity).toBe("-401");
+    expect(result.postings[0].tradingCurrency).toBe("GBP");
+    expect(result.postings[1].type).toBe(TxType.CASHFLOW);
+    expect(result.postings[1].quantity).toBe("7265.7");
   });
 });
 
@@ -886,9 +886,9 @@ describe("source references", () => {
       "2022-05-06,2022-05-06,Cash In Ring-fenced For Fees,Cash,Cash Management Account,AW1,,2.19,2.19,1,481052152,Completed",
     ]);
 
-    expect(result.txs).toHaveLength(2);
-    expect(result.txs[0].brokerRef).toBe("481052149");
-    expect(result.txs[1].brokerRef).toBe("481052152");
+    expect(result.postings).toHaveLength(2);
+    expect(result.postings[0].brokerRef).toBe("481052149");
+    expect(result.postings[1].brokerRef).toBe("481052152");
   });
 
   // The export's "Source investment" column holds an asset name rather than an
@@ -899,7 +899,7 @@ describe("source references", () => {
       "8 Feb 2022,10 Feb 2022,Sell,\"WISE PLC (WISE)\",Investment Account,AG1,Cash,-7266.49,1242,5.85,441416452,Completed",
     ]);
 
-    expect(result.txs[0].counterpartyAccount).toBe("");
+    expect(result.postings[0].counterpartyAccount).toBeUndefined();
   });
 
   it("leaves a posting the source gave no reference for unreferenced", () => {
@@ -907,7 +907,7 @@ describe("source references", () => {
       "8 Feb 2022,10 Feb 2022,Cash Interest,Cash,Investment Account,AG1,,1.18,1.18,1,,Completed",
     ]);
 
-    expect(result.txs[0].brokerRef).toBe("");
+    expect(result.postings[0].brokerRef).toBeUndefined();
   });
 
   // A dividend's income leg is the converter's invention: the source wrote one
@@ -918,11 +918,11 @@ describe("source references", () => {
       "8 Feb 2022,10 Feb 2022,Cash Dividend,Cash,Investment Account,AG1,,23.40,23.40,1,441416483,Completed",
     ]);
 
-    expect(result.txs).toHaveLength(2);
-    expect(result.txs[0].brokerRef).toBe("441416483");
-    expect(result.txs[1].accountType).toBe(AccountType.INCOME);
-    expect(result.txs[1].brokerRef).toBe("");
+    expect(result.postings).toHaveLength(2);
+    expect(result.postings[0].brokerRef).toBe("441416483");
+    expect(result.postings[1].accountType).toBe(AccountType.INCOME);
+    expect(result.postings[1].brokerRef).toBeUndefined();
     // Both legs still belong to one event.
-    expect(result.txs[1].groupRef).toBe(result.txs[0].groupRef);
+    expect(result.postings[1].groupRef).toBe(result.postings[0].groupRef);
   });
 });

--- a/client/lib/csv/converters/fidelity-csv.ts
+++ b/client/lib/csv/converters/fidelity-csv.ts
@@ -9,10 +9,11 @@
 import { create } from "@bufbuild/protobuf";
 import { timestampFromDate } from "@bufbuild/protobuf/wkt";
 import { startOfNextDay } from "@/lib/dates";
-import type { Tx } from "@/gen/api/v1/api_pb";
-import { InstrumentIdentifierSchema, TxSchema } from "@/gen/api/v1/api_pb";
+import type { Posting } from "@/gen/archive/v1/txs_pb";
+import { PostingSchema } from "@/gen/archive/v1/txs_pb";
+import { InstrumentRefSchema } from "@/gen/archive/v1/common_pb";
 import { IdentifierType, TxType } from "@/gen/type/v1/type_pb";
-import type { StandardParseResult, ParseError } from "@/lib/csv/standard";
+import type { StandardParseResult, ParseError } from "@/lib/csv/parse-result";
 import { parseCSVLine } from "@/lib/csv/standard";
 import { counterLegs, currencyHint } from "@/lib/csv/postings";
 import { Big, parseDecimal } from "@/lib/decimal";
@@ -459,12 +460,12 @@ export function assignFidelityGroups(legs: FidelityLeg[]): FidelityGroups {
  * JRNLFUND it would make the trade group read as a transfer, so the group's
  * residual would be routed to TRANSFER_CLEARING rather than IMBALANCE.
  */
-export function asTradeCashLeg(tx: Tx, currency: string): void {
-  if (tx.type !== TxType.JRNLFUND) return;
-  tx.type = TxType.CASHFLOW;
+export function asTradeCashLeg(p: Posting, currency: string): void {
+  if (p.type !== TxType.JRNLFUND) return;
+  p.type = TxType.CASHFLOW;
   // isCashTxType covers CASHFLOW but not JRNLFUND, so the currency the row was
   // denied as a journal is owed to it as a cash leg.
-  if (currency) tx.tradingCurrency = currency;
+  if (currency) p.tradingCurrency = currency;
 }
 
 export function convertFidelityToStandard(
@@ -475,7 +476,7 @@ export function convertFidelityToStandard(
   const currency = (options?.currency as string) ?? "";
   if (!currency) {
     return {
-      txs: [],
+      postings: [],
       periodFrom: new Date(0),
       periodBefore: new Date(0),
       errors: [{ rowIndex: 0, field: "options", message: "Currency is required" }],
@@ -485,7 +486,7 @@ export function convertFidelityToStandard(
   const lines = csvText.split(/\r?\n/).map((l) => l.trim()).filter((l) => l.length > 0);
   if (lines.length === 0) {
     return {
-      txs: [],
+      postings: [],
       periodFrom: new Date(0),
       periodBefore: new Date(0),
       errors: [{ rowIndex: 0, field: "file", message: "File is empty" }],
@@ -505,7 +506,7 @@ export function convertFidelityToStandard(
   }
   if (headerRowIndex < 0) {
     return {
-      txs: [],
+      postings: [],
       periodFrom: new Date(0),
       periodBefore: new Date(0),
       errors: [{ rowIndex: 0, field: "file", message: "Could not find Fidelity data header (Order date)" }],
@@ -537,14 +538,14 @@ export function convertFidelityToStandard(
 
   if (orderDateCol < 0 || txTypeCol < 0 || investmentsCol < 0) {
     return {
-      txs: [],
+      postings: [],
       periodFrom: new Date(0),
       periodBefore: new Date(0),
       errors: [{ rowIndex: headerRowIndex + 1, field: "header", message: "Missing required Fidelity columns" }],
     };
   }
 
-  const txs: Tx[] = [];
+  const postings: Posting[] = [];
   const legs: FidelityLeg[] = [];
   let minTime = Infinity;
   let maxTime = -Infinity;
@@ -621,10 +622,9 @@ export function convertFidelityToStandard(
         : []
       : symbol && exchange && listed
         ? [
-            create(InstrumentIdentifierSchema, {
+            create(InstrumentRefSchema, {
               type: IdentifierType.MIC_TICKER,
               value: symbol,
-              canonical: false,
               ...(MIC_BY_EXCHANGE[exchange] ? { domain: MIC_BY_EXCHANGE[exchange] } : {}),
             }),
           ]
@@ -660,8 +660,8 @@ export function convertFidelityToStandard(
     // asset name, not an account, so this file names no counterparty anywhere.
     // Only the JSON the extension reads does.
     const brokerRef = refCol >= 0 ? get(refCol) : "";
-    txs.push(
-      create(TxSchema, {
+    postings.push(
+      create(PostingSchema, {
         timestamp: timestampFromDate(date),
         instrumentDescription,
         type: ofxType,
@@ -679,19 +679,19 @@ export function convertFidelityToStandard(
 
   const groups = assignFidelityGroups(legs);
   groups.refs.forEach((ref, i) => {
-    if (ref) txs[i].groupRef = ref;
+    if (ref) postings[i].groupRef = ref;
   });
   groups.cashLegs.forEach((paired, i) => {
-    if (paired) asTradeCashLeg(txs[i], currency);
+    if (paired) asTradeCashLeg(postings[i], currency);
   });
   // After the refs are stamped, since that loop is index-parallel with legs.
   // Fidelity nets nothing into a trade total, so no fee is derived here: its
   // charges arrive as their own rows and only need the account they went to.
-  txs.push(...counterLegs(txs));
+  postings.push(...counterLegs(postings));
 
   const periodFrom = minTime === Infinity ? new Date(0) : new Date(minTime);
   const periodBefore =
     maxTime === -Infinity ? new Date(0) : startOfNextDay(new Date(maxTime));
 
-  return { txs, periodFrom, periodBefore, errors };
+  return { postings, periodFrom, periodBefore, errors };
 }

--- a/client/lib/csv/converters/ibkr-ofx.test.ts
+++ b/client/lib/csv/converters/ibkr-ofx.test.ts
@@ -60,7 +60,7 @@ describe("convertIbkrOfx", () => {
     const result = convertIbkrOfx(buildOfx(OPT_BUY, OPT_SEC_LIST));
     expect(result.errors).toEqual([]);
 
-    const security = result.txs.find((t) => t.type === TxType.BUYOPT)!;
+    const security = result.postings.find((t) => t.type === TxType.BUYOPT)!;
     expect(security.identifierHints).toHaveLength(1);
     expect(security.identifierHints[0]!.type).toBe(IdentifierType.OCC);
     expect(security.identifierHints[0]!.value).toBe("P RHM  20250919 560 M");
@@ -70,23 +70,23 @@ describe("convertIbkrOfx", () => {
     // The assertion that matters: expectGroupsBalance mirrors weightOf in
     // balance.go, so a group that balances here is one the server will not route
     // to IMBALANCE. Without the 100x it is out by 15927.56 EUR.
-    expectGroupsBalance(convertIbkrOfx(buildOfx(OPT_BUY, OPT_SEC_LIST)).txs);
+    expectGroupsBalance(convertIbkrOfx(buildOfx(OPT_BUY, OPT_SEC_LIST)).postings);
   });
 
   it("splits the commission out of the option's netted total", () => {
     const result = convertIbkrOfx(buildOfx(OPT_BUY, OPT_SEC_LIST));
 
-    const cash = result.txs.find((t) => t.type === TxType.CASHFLOW)!;
+    const cash = result.postings.find((t) => t.type === TxType.CASHFLOW)!;
     expect(cash.quantity).toBe("-16088.4468");
 
-    const fees = result.txs.filter((t) => t.type === TxType.INVEXPENSE);
+    const fees = result.postings.filter((t) => t.type === TxType.INVEXPENSE);
     expect(fees).toHaveLength(2);
     expect(fees.find((t) => t.accountType === AccountType.USER)!.quantity).toBe("-7.420248");
     expect(fees.find((t) => t.accountType === AccountType.EXPENSE)!.quantity).toBe("7.420248");
   });
 
   it("leaves an option with no SECLIST entry unhinted rather than guessing", () => {
-    const security = convertIbkrOfx(buildOfx(OPT_BUY, "")).txs.find(
+    const security = convertIbkrOfx(buildOfx(OPT_BUY, "")).postings.find(
       (t) => t.type === TxType.BUYOPT,
     )!;
     expect(security.identifierHints).toHaveLength(0);

--- a/client/lib/csv/converters/ibkr-ofx.ts
+++ b/client/lib/csv/converters/ibkr-ofx.ts
@@ -4,9 +4,9 @@
  */
 
 import { create } from "@bufbuild/protobuf";
-import { InstrumentIdentifierSchema } from "@/gen/api/v1/api_pb";
+import { InstrumentRefSchema } from "@/gen/archive/v1/common_pb";
 import { Broker, IdentifierType } from "@/gen/type/v1/type_pb";
-import type { StandardParseResult } from "@/lib/csv/standard";
+import type { StandardParseResult } from "@/lib/csv/parse-result";
 import { parseOfxStatement } from "@/lib/ofx/parser";
 import { register } from "./registry";
 
@@ -17,19 +17,18 @@ export function convertIbkrOfx(text: string): StandardParseResult {
   // carries the OCC-format TICKER for these contracts. Add OCC hints
   // for any transaction whose SECID has no standard identifier hints
   // but can be resolved via SECLIST.
-  for (const tx of result.txs) {
-    const hasStandardHint = tx.identifierHints.length > 0;
+  for (const posting of result.postings) {
+    const hasStandardHint = posting.identifierHints.length > 0;
     if (hasStandardHint) continue;
 
     // Look up the instrument description in the SECLIST by matching
     // on secName (which is what we set as instrumentDescription).
     for (const [, sec] of result.secList) {
-      if (sec.secName === tx.instrumentDescription && sec.uniqueIdType === "CONID" && sec.ticker) {
-        tx.identifierHints.push(
-          create(InstrumentIdentifierSchema, {
+      if (sec.secName === posting.instrumentDescription && sec.uniqueIdType === "CONID" && sec.ticker) {
+        posting.identifierHints.push(
+          create(InstrumentRefSchema, {
             type: IdentifierType.OCC,
             value: sec.ticker,
-            canonical: false,
           }),
         );
         break;

--- a/client/lib/csv/converters/registry.ts
+++ b/client/lib/csv/converters/registry.ts
@@ -5,7 +5,7 @@
 
 import type { ComponentType } from "react";
 import type { Broker } from "@/gen/type/v1/type_pb";
-import type { StandardParseResult } from "@/lib/csv/standard";
+import type { StandardParseResult } from "@/lib/csv/parse-result";
 
 export interface ConverterOptionsProps {
   onOptionsChange: (opts: Record<string, unknown>) => void;

--- a/client/lib/csv/group-balance.test-utils.ts
+++ b/client/lib/csv/group-balance.test-utils.ts
@@ -13,7 +13,7 @@
  */
 
 import { expect } from "vitest";
-import type { Tx } from "@/gen/api/v1/api_pb";
+import type { Posting } from "@/gen/archive/v1/txs_pb";
 import { Big } from "@/lib/decimal";
 import { IdentifierType, TxType } from "@/gen/type/v1/type_pb";
 
@@ -59,14 +59,14 @@ const TOLERANCE = new Big("0.005");
 const OPTION_CONTRACT_SIZE = new Big(100);
 
 /** What one unit of quantity delivers: 100 for an option contract, else 1. */
-function contractSize(tx: Tx): Big {
+function contractSize(tx: Posting): Big {
   const isOption = tx.identifierHints.some((h) => h.type === IdentifierType.OCC);
   return isOption ? OPTION_CONTRACT_SIZE : new Big(1);
 }
 
 /** What a posting contributes to its group's balance, and in what commodity. */
-export function weigh(tx: Tx): { amount: Big; commodity: string } {
-  const settle = (tx.settlementCurrency || tx.tradingCurrency).toUpperCase();
+export function weigh(tx: Posting): { amount: Big; commodity: string } {
+  const settle = (tx.settlementCurrency || tx.tradingCurrency || "").toUpperCase();
   const qty = new Big(tx.quantity);
   if (EXCHANGE_TYPES.has(tx.type)) {
     // With no price there is nothing to convert at, so the residual stays in the
@@ -85,7 +85,7 @@ export function weigh(tx: Tx): { amount: Big; commodity: string } {
  *
  * A posting with no group_ref is its own group, as the server treats it.
  */
-export function residuals(txs: Tx[]): Record<string, Record<string, string>> {
+export function residuals(txs: Posting[]): Record<string, Record<string, string>> {
   const sums: Record<string, Record<string, Big>> = {};
   txs.forEach((tx, i) => {
     const ref = tx.groupRef || `#${i}`;
@@ -104,6 +104,6 @@ export function residuals(txs: Tx[]): Record<string, Record<string, string>> {
 }
 
 /** Asserts every group in the batch balances. */
-export function expectGroupsBalance(txs: Tx[]): void {
+export function expectGroupsBalance(txs: Posting[]): void {
   expect(residuals(txs)).toEqual({});
 }

--- a/client/lib/csv/parse-result.ts
+++ b/client/lib/csv/parse-result.ts
@@ -1,0 +1,27 @@
+/**
+ * What a converter returns: the contents of one archive transaction window.
+ *
+ * A converter reads a broker's own file and produces archive postings, which is
+ * the one format PortfolioDB defines for transactions in either direction. The
+ * broker and the source are the caller's -- they come from which converter was
+ * chosen, not from the file -- so what the converter states is the postings and
+ * the period they cover. See docs/spec/archive-format.md.
+ *
+ * Kept free of React so the import extension can use it.
+ */
+
+import type { Posting } from "@/gen/archive/v1/txs_pb";
+
+export interface ParseError {
+  rowIndex: number;
+  field: string;
+  message: string;
+}
+
+export interface StandardParseResult {
+  postings: Posting[];
+  periodFrom: Date;
+  /** Exclusive: local midnight after the last transaction's day. */
+  periodBefore: Date;
+  errors: ParseError[];
+}

--- a/client/lib/csv/postings.test.ts
+++ b/client/lib/csv/postings.test.ts
@@ -2,15 +2,15 @@ import { describe, it, expect } from "vitest";
 import { create } from "@bufbuild/protobuf";
 import type { MessageInitShape } from "@bufbuild/protobuf";
 import { timestampFromDate } from "@bufbuild/protobuf/wkt";
-import type { Tx } from "@/gen/api/v1/api_pb";
-import { TxSchema } from "@/gen/api/v1/api_pb";
+import type { Posting } from "@/gen/archive/v1/txs_pb";
+import { PostingSchema } from "@/gen/archive/v1/txs_pb";
 import { AccountType, IdentifierType, TxType } from "@/gen/type/v1/type_pb";
 import { counterLeg, counterLegs, feeLeg, refPrefix, reinvestLeg, FEE_EPSILON } from "./postings";
 import { Big } from "@/lib/decimal";
 import { expectGroupsBalance } from "./group-balance.test-utils";
 
-const tx = (fields: MessageInitShape<typeof TxSchema>): Tx =>
-  create(TxSchema, {
+const tx = (fields: MessageInitShape<typeof PostingSchema>): Posting =>
+  create(PostingSchema, {
     timestamp: timestampFromDate(new Date(2026, 1, 1)),
     instrumentDescription: "GBP",
     quantity: "0",

--- a/client/lib/csv/postings.ts
+++ b/client/lib/csv/postings.ts
@@ -13,8 +13,9 @@
 import { clone, create } from "@bufbuild/protobuf";
 import { Big } from "@/lib/decimal";
 import { TimestampSchema } from "@bufbuild/protobuf/wkt";
-import type { Tx } from "@/gen/api/v1/api_pb";
-import { InstrumentIdentifierSchema, TxSchema } from "@/gen/api/v1/api_pb";
+import type { Posting } from "@/gen/archive/v1/txs_pb";
+import { PostingSchema } from "@/gen/archive/v1/txs_pb";
+import { InstrumentRefSchema } from "@/gen/archive/v1/common_pb";
 import { AccountType, IdentifierType, TxType } from "@/gen/type/v1/type_pb";
 
 /**
@@ -46,21 +47,21 @@ export const FEE_EPSILON = new Big("0.005");
  * from or went to. Returns undefined when the type has no other side to name, or
  * when the posting is itself a counter-leg.
  */
-export function counterLeg(tx: Tx): Tx | undefined {
-  const accountType = COUNTER_TYPE.get(tx.type);
+export function counterLeg(p: Posting): Posting | undefined {
+  const accountType = COUNTER_TYPE.get(p.type);
   if (accountType === undefined) return undefined;
-  if (tx.accountType !== AccountType.USER && tx.accountType !== AccountType.UNSPECIFIED) {
+  if (p.accountType !== AccountType.USER && p.accountType !== AccountType.UNSPECIFIED) {
     return undefined;
   }
-  const leg = clone(TxSchema, tx);
-  leg.quantity = new Big(tx.quantity).times(-1).toString();
+  const leg = clone(PostingSchema, p);
+  leg.quantity = new Big(p.quantity).times(-1).toString();
   leg.accountType = accountType;
   // A derived leg names no source row, because the source wrote none for it. The
   // clone above would otherwise hand it the reference of the posting it mirrors,
   // making an invention indistinguishable from a transcription. moneyLeg builds
   // from scratch and needs no such reset. See docs/spec/postings.md.
-  leg.brokerRef = "";
-  leg.counterpartyAccount = "";
+  leg.brokerRef = undefined;
+  leg.counterpartyAccount = undefined;
   return leg;
 }
 
@@ -69,10 +70,9 @@ export function counterLeg(tx: Tx): Tx | undefined {
  * after its description.
  */
 export function currencyHint(currency: string) {
-  return create(InstrumentIdentifierSchema, {
+  return create(InstrumentRefSchema, {
     type: IdentifierType.CURRENCY,
     value: currency,
-    canonical: false,
   });
 }
 
@@ -82,9 +82,9 @@ export function currencyHint(currency: string) {
  * The instrument description is the currency code, matching how an ordinary cash
  * row arrives, so nothing downstream has to treat a derived posting specially.
  */
-function moneyLeg(from: Tx, type: TxType, accountType: AccountType, quantity: Big): Tx {
+function moneyLeg(from: Posting, type: TxType, accountType: AccountType, quantity: Big): Posting {
   const currency = from.settlementCurrency || from.tradingCurrency;
-  return create(TxSchema, {
+  return create(PostingSchema, {
     ...(from.timestamp ? { timestamp: clone(TimestampSchema, from.timestamp) } : {}),
     instrumentDescription: currency,
     type,
@@ -111,7 +111,7 @@ function moneyLeg(from: Tx, type: TxType, accountType: AccountType, quantity: Bi
  * counterLeg, so a derived fee and a separately reported one end up identical.
  * Returns undefined below FEE_EPSILON.
  */
-export function feeLeg(from: Tx, fee: Big | undefined): Tx | undefined {
+export function feeLeg(from: Posting, fee: Big | undefined): Posting | undefined {
   if (fee === undefined || fee.abs().lt(FEE_EPSILON)) return undefined;
   return moneyLeg(from, TxType.INVEXPENSE, AccountType.USER, fee.abs().times(-1));
 }
@@ -130,7 +130,7 @@ export function feeLeg(from: Tx, fee: Big | undefined): Tx | undefined {
  * quoted price, and taking the broker's would leave the group short by a residual
  * of our choosing rather than one the source has.
  */
-export function reinvestLeg(from: Tx): Tx | undefined {
+export function reinvestLeg(from: Posting): Posting | undefined {
   if (from.type !== TxType.REINVEST) return undefined;
   const value = new Big(from.quantity).times(from.unitPrice || "0");
   if (value.abs().lt(FEE_EPSILON)) return undefined;
@@ -142,10 +142,10 @@ export function reinvestLeg(from: Tx): Tx | undefined {
  * synthesised ref cannot collide with a broker's own. Mirrors groupPostings in
  * server/service/ingestion/balance.go.
  */
-export function refPrefix(txs: Tx[]): string {
+export function refPrefix(postings: Posting[]): string {
   let prefix = "p";
-  for (const tx of txs) {
-    while (tx.groupRef.startsWith(prefix)) prefix += "_";
+  for (const p of postings) {
+    while (p.groupRef?.startsWith(prefix)) prefix += "_";
   }
   return prefix;
 }
@@ -155,17 +155,17 @@ export function refPrefix(txs: Tx[]): string {
  * to append. Postings that had no group_ref are given one in place, since a leg
  * only balances the posting it mirrors if the two share a group.
  */
-export function counterLegs(txs: Tx[]): Tx[] {
-  const prefix = refPrefix(txs);
-  const legs: Tx[] = [];
-  txs.forEach((tx, i) => {
+export function counterLegs(postings: Posting[]): Posting[] {
+  const prefix = refPrefix(postings);
+  const legs: Posting[] = [];
+  postings.forEach((p, i) => {
     // A reinvestment's other side is money it never held, so it is built rather
     // than mirrored; everything else that has one is a sign flip.
-    const leg = reinvestLeg(tx) ?? counterLeg(tx);
+    const leg = reinvestLeg(p) ?? counterLeg(p);
     if (!leg) return;
-    if (!tx.groupRef) {
-      tx.groupRef = `${prefix}${i}`;
-      leg.groupRef = tx.groupRef;
+    if (!p.groupRef) {
+      p.groupRef = `${prefix}${i}`;
+      leg.groupRef = p.groupRef;
     }
     legs.push(leg);
   });

--- a/client/lib/csv/standard.test.ts
+++ b/client/lib/csv/standard.test.ts
@@ -11,17 +11,17 @@ describe("parseStandardCSV", () => {
     const result = parseStandardCSV(csv);
 
     expect(result.errors).toHaveLength(0);
-    expect(result.txs).toHaveLength(2);
-    expect(result.txs[0].instrumentDescription).toBe("AAPL - Apple Inc.");
-    expect(result.txs[0].type).toBe(TxType.BUYSTOCK);
-    expect(result.txs[0].quantity).toBe("10");
-    expect(result.txs[0].tradingCurrency).toBe("USD");
-    expect(result.txs[0].settlementCurrency).toBe("USD");
-    expect(result.txs[0].unitPrice).toBe("185.5");
+    expect(result.postings).toHaveLength(2);
+    expect(result.postings[0].instrumentDescription).toBe("AAPL - Apple Inc.");
+    expect(result.postings[0].type).toBe(TxType.BUYSTOCK);
+    expect(result.postings[0].quantity).toBe("10");
+    expect(result.postings[0].tradingCurrency).toBe("USD");
+    expect(result.postings[0].settlementCurrency).toBe("USD");
+    expect(result.postings[0].unitPrice).toBe("185.5");
 
-    expect(result.txs[1].instrumentDescription).toBe("MSFT - Microsoft");
-    expect(result.txs[1].type).toBe(TxType.SELLSTOCK);
-    expect(result.txs[1].quantity).toBe("-5");
+    expect(result.postings[1].instrumentDescription).toBe("MSFT - Microsoft");
+    expect(result.postings[1].type).toBe(TxType.SELLSTOCK);
+    expect(result.postings[1].quantity).toBe("-5");
 
     expect(result.periodFrom.getTime()).toBe(new Date("2024-01-10").getTime());
     // Exclusive: midnight after the last row's day, so the last row is inside.
@@ -39,8 +39,8 @@ describe("parseStandardCSV", () => {
     const result = parseStandardCSV(csv);
 
     expect(result.errors).toHaveLength(0);
-    expect(result.txs).toHaveLength(1);
-    expect(result.txs[0].timestamp).toBeDefined();
+    expect(result.postings).toHaveLength(1);
+    expect(result.postings[0].timestamp).toBeDefined();
   });
 
   it("accepts case-insensitive headers", () => {
@@ -50,14 +50,14 @@ describe("parseStandardCSV", () => {
     const result = parseStandardCSV(csv);
 
     expect(result.errors).toHaveLength(0);
-    expect(result.txs).toHaveLength(1);
-    expect(result.txs[0].instrumentDescription).toBe("FOO");
+    expect(result.postings).toHaveLength(1);
+    expect(result.postings[0].instrumentDescription).toBe("FOO");
   });
 
   it("returns error for empty file", () => {
     const result = parseStandardCSV("");
 
-    expect(result.txs).toHaveLength(0);
+    expect(result.postings).toHaveLength(0);
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0].field).toBe("file");
     expect(result.errors[0].message).toContain("empty");
@@ -69,7 +69,7 @@ describe("parseStandardCSV", () => {
 
     const result = parseStandardCSV(csv);
 
-    expect(result.txs).toHaveLength(0);
+    expect(result.postings).toHaveLength(0);
     expect(result.errors.some((e) => e.field === "header" && e.message.includes("type"))).toBe(true);
     expect(result.errors.some((e) => e.field === "header" && e.message.includes("quantity"))).toBe(true);
   });
@@ -80,7 +80,7 @@ not-a-date,AAPL,BUYSTOCK,10`;
 
     const result = parseStandardCSV(csv);
 
-    expect(result.txs).toHaveLength(0);
+    expect(result.postings).toHaveLength(0);
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0].field).toBe("date");
     expect(result.errors[0].message).toContain("Invalid");
@@ -92,7 +92,7 @@ not-a-date,AAPL,BUYSTOCK,10`;
 
     const result = parseStandardCSV(csv);
 
-    expect(result.txs).toHaveLength(0);
+    expect(result.postings).toHaveLength(0);
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0].field).toBe("type");
     expect(result.errors[0].message).toContain("Unknown");
@@ -104,7 +104,7 @@ not-a-date,AAPL,BUYSTOCK,10`;
 
     const result = parseStandardCSV(csv);
 
-    expect(result.txs).toHaveLength(0);
+    expect(result.postings).toHaveLength(0);
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0].field).toBe("quantity");
     expect(result.errors[0].message).toContain("number");
@@ -116,7 +116,7 @@ not-a-date,AAPL,BUYSTOCK,10`;
 
     const result = parseStandardCSV(csv);
 
-    expect(result.txs).toHaveLength(0);
+    expect(result.postings).toHaveLength(0);
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0].field).toBe("instrument_description");
   });
@@ -128,8 +128,8 @@ not-a-date,AAPL,BUYSTOCK,10`;
     const result = parseStandardCSV(csv);
 
     expect(result.errors).toHaveLength(0);
-    expect(result.txs).toHaveLength(1);
-    expect(result.txs[0].instrumentDescription).toBe("Apple, Inc. - AAPL");
+    expect(result.postings).toHaveLength(1);
+    expect(result.postings[0].instrumentDescription).toBe("Apple, Inc. - AAPL");
   });
 
   it("allows optional trading_currency, settlement_currency and unit_price to be omitted", () => {
@@ -139,12 +139,12 @@ not-a-date,AAPL,BUYSTOCK,10`;
     const result = parseStandardCSV(csv);
 
     expect(result.errors).toHaveLength(0);
-    expect(result.txs).toHaveLength(1);
-    expect(result.txs[0].quantity).toBe("10");
-    expect(result.txs[0].instrumentDescription).toBe("AAPL");
+    expect(result.postings).toHaveLength(1);
+    expect(result.postings[0].quantity).toBe("10");
+    expect(result.postings[0].instrumentDescription).toBe("AAPL");
     // Optional fields may be unset or proto default ("" or 0)
-    expect([undefined, ""]).toContain(result.txs[0].settlementCurrency);
-    expect([undefined, ""]).toContain(result.txs[0].tradingCurrency);
+    expect([undefined, ""]).toContain(result.postings[0].settlementCurrency);
+    expect([undefined, ""]).toContain(result.postings[0].tradingCurrency);
   });
 
   it("returns error for invalid unit_price when present", () => {
@@ -153,7 +153,7 @@ not-a-date,AAPL,BUYSTOCK,10`;
 
     const result = parseStandardCSV(csv);
 
-    expect(result.txs).toHaveLength(0);
+    expect(result.postings).toHaveLength(0);
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0].field).toBe("unit_price");
   });
@@ -166,9 +166,9 @@ not-a-date,FOO,BUYSTOCK,5
 
     const result = parseStandardCSV(csv);
 
-    expect(result.txs).toHaveLength(2);
-    expect(result.txs[0].instrumentDescription).toBe("AAPL");
-    expect(result.txs[1].instrumentDescription).toBe("MSFT");
+    expect(result.postings).toHaveLength(2);
+    expect(result.postings[0].instrumentDescription).toBe("AAPL");
+    expect(result.postings[1].instrumentDescription).toBe("MSFT");
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0].rowIndex).toBe(3);
     expect(result.errors[0].field).toBe("date");
@@ -184,10 +184,10 @@ not-a-date,FOO,BUYSTOCK,5
     const result = parseStandardCSV(csv);
 
     expect(result.errors).toHaveLength(0);
-    expect(result.txs).toHaveLength(1);
-    expect(result.txs[0].account).toBe("ACC-123");
-    expect(result.txs[0].tradingCurrency).toBe("EUR");
-    expect(result.txs[0].settlementCurrency).toBe("GBP");
+    expect(result.postings).toHaveLength(1);
+    expect(result.postings[0].account).toBe("ACC-123");
+    expect(result.postings[0].tradingCurrency).toBe("EUR");
+    expect(result.postings[0].settlementCurrency).toBe("GBP");
   });
 
   it("parses symbol_type + symbol as identifier hint", () => {
@@ -197,10 +197,10 @@ not-a-date,FOO,BUYSTOCK,5
     const result = parseStandardCSV(csv);
 
     expect(result.errors).toHaveLength(0);
-    expect(result.txs).toHaveLength(1);
-    expect(result.txs[0].identifierHints).toHaveLength(1);
-    expect(result.txs[0].identifierHints).toContainEqual(
-      expect.objectContaining({ type: IdentifierType.MIC_TICKER, value: "AAPL", canonical: false })
+    expect(result.postings).toHaveLength(1);
+    expect(result.postings[0].identifierHints).toHaveLength(1);
+    expect(result.postings[0].identifierHints).toContainEqual(
+      expect.objectContaining({ type: IdentifierType.MIC_TICKER, value: "AAPL" })
     );
   });
 
@@ -211,10 +211,10 @@ not-a-date,FOO,BUYSTOCK,5
     const result = parseStandardCSV(csv);
 
     expect(result.errors).toHaveLength(0);
-    expect(result.txs).toHaveLength(1);
-    expect(result.txs[0].identifierHints).toHaveLength(1);
-    expect(result.txs[0].identifierHints).toContainEqual(
-      expect.objectContaining({ type: IdentifierType.MIC_TICKER, value: "AAPL", domain: "XNAS", canonical: false })
+    expect(result.postings).toHaveLength(1);
+    expect(result.postings[0].identifierHints).toHaveLength(1);
+    expect(result.postings[0].identifierHints).toContainEqual(
+      expect.objectContaining({ type: IdentifierType.MIC_TICKER, value: "AAPL", domain: "XNAS" })
     );
   });
 
@@ -225,10 +225,10 @@ not-a-date,FOO,BUYSTOCK,5
     const result = parseStandardCSV(csv);
 
     expect(result.errors).toHaveLength(0);
-    expect(result.txs).toHaveLength(1);
-    expect(result.txs[0].identifierHints).toHaveLength(1);
-    expect(result.txs[0].identifierHints).toContainEqual(
-      expect.objectContaining({ type: IdentifierType.OPENFIGI_TICKER, value: "AAPL", domain: "US", canonical: false })
+    expect(result.postings).toHaveLength(1);
+    expect(result.postings[0].identifierHints).toHaveLength(1);
+    expect(result.postings[0].identifierHints).toContainEqual(
+      expect.objectContaining({ type: IdentifierType.OPENFIGI_TICKER, value: "AAPL", domain: "US" })
     );
   });
 
@@ -239,10 +239,10 @@ not-a-date,FOO,BUYSTOCK,5
     const result = parseStandardCSV(csv);
 
     expect(result.errors).toHaveLength(0);
-    expect(result.txs).toHaveLength(1);
-    expect(result.txs[0].identifierHints).toHaveLength(1);
-    expect(result.txs[0].identifierHints).toContainEqual(
-      expect.objectContaining({ type: IdentifierType.ISIN, value: "US0378331005", canonical: false })
+    expect(result.postings).toHaveLength(1);
+    expect(result.postings[0].identifierHints).toHaveLength(1);
+    expect(result.postings[0].identifierHints).toContainEqual(
+      expect.objectContaining({ type: IdentifierType.ISIN, value: "US0378331005" })
     );
   });
 
@@ -253,10 +253,10 @@ not-a-date,FOO,BUYSTOCK,5
     const result = parseStandardCSV(csv);
 
     expect(result.errors).toHaveLength(0);
-    expect(result.txs).toHaveLength(1);
-    expect(result.txs[0].identifierHints).toHaveLength(1);
-    expect(result.txs[0].identifierHints).toContainEqual(
-      expect.objectContaining({ type: IdentifierType.OCC, value: "AAPL  240119C00185000", canonical: false })
+    expect(result.postings).toHaveLength(1);
+    expect(result.postings[0].identifierHints).toHaveLength(1);
+    expect(result.postings[0].identifierHints).toContainEqual(
+      expect.objectContaining({ type: IdentifierType.OCC, value: "AAPL  240119C00185000" })
     );
   });
 
@@ -266,7 +266,7 @@ not-a-date,FOO,BUYSTOCK,5
 
     const result = parseStandardCSV(csv);
 
-    expect(result.txs).toHaveLength(0);
+    expect(result.postings).toHaveLength(0);
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0].field).toBe("symbol_type");
     expect(result.errors[0].message).toContain("Unknown");
@@ -278,7 +278,7 @@ not-a-date,FOO,BUYSTOCK,5
 
     const result = parseStandardCSV(csv);
 
-    expect(result.txs).toHaveLength(0);
+    expect(result.postings).toHaveLength(0);
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0].field).toBe("exchange_type");
     expect(result.errors[0].message).toContain("Unknown");
@@ -290,7 +290,7 @@ not-a-date,FOO,BUYSTOCK,5
 
     const result = parseStandardCSV(csv);
 
-    expect(result.txs).toHaveLength(0);
+    expect(result.postings).toHaveLength(0);
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0].field).toBe("symbol");
   });
@@ -301,7 +301,7 @@ not-a-date,FOO,BUYSTOCK,5
 
     const result = parseStandardCSV(csv);
 
-    expect(result.txs).toHaveLength(0);
+    expect(result.postings).toHaveLength(0);
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0].field).toBe("exchange");
   });
@@ -313,8 +313,8 @@ not-a-date,FOO,BUYSTOCK,5
     const result = parseStandardCSV(csv);
 
     expect(result.errors).toHaveLength(0);
-    expect(result.txs).toHaveLength(1);
-    expect(result.txs[0].identifierHints).toHaveLength(0);
+    expect(result.postings).toHaveLength(1);
+    expect(result.postings[0].identifierHints).toHaveLength(0);
   });
 
   it("produces no hint when symbol_type and symbol are both empty", () => {
@@ -324,8 +324,8 @@ not-a-date,FOO,BUYSTOCK,5
     const result = parseStandardCSV(csv);
 
     expect(result.errors).toHaveLength(0);
-    expect(result.txs).toHaveLength(1);
-    expect(result.txs[0].identifierHints).toHaveLength(0);
+    expect(result.postings).toHaveLength(1);
+    expect(result.postings[0].identifierHints).toHaveLength(0);
   });
 
 describe("share count basis", () => {
@@ -336,15 +336,17 @@ describe("share count basis", () => {
     const result = parseStandardCSV(rows);
 
     expect(result.errors).toHaveLength(0);
-    expect(result.shareCountBasis).toBeUndefined();
+    expect(result.postings[0].shareCountBasis).toBeUndefined();
   });
 
-  it("reads the basis from a comment line", () => {
+  // The comment declares one basis for the whole file; the archive states it per
+  // posting, so every posting carries the declared value.
+  it("reads the basis from a comment line onto every posting", () => {
     const result = parseStandardCSV(`# share_count_basis=2026-07-29\n${rows}`);
 
     expect(result.errors).toHaveLength(0);
-    expect(result.txs).toHaveLength(1);
-    expect(result.shareCountBasis).toBe("2026-07-29");
+    expect(result.postings).toHaveLength(1);
+    expect(result.postings[0].shareCountBasis).toBe("2026-07-29");
   });
 
   it("rejects a basis that is not a plain date", () => {
@@ -358,7 +360,7 @@ describe("share count basis", () => {
     const result = parseStandardCSV(`# exported from somewhere\n${rows}`);
 
     expect(result.errors).toHaveLength(0);
-    expect(result.txs).toHaveLength(1);
+    expect(result.postings).toHaveLength(1);
   });
 });
 });
@@ -373,11 +375,11 @@ describe("group_ref", () => {
     const result = parseStandardCSV(csv);
 
     expect(result.errors).toHaveLength(0);
-    expect(result.txs).toHaveLength(3);
-    expect(result.txs[0].groupRef).toBe("441416452");
-    expect(result.txs[1].groupRef).toBe("441416452");
+    expect(result.postings).toHaveLength(3);
+    expect(result.postings[0].groupRef).toBe("441416452");
+    expect(result.postings[1].groupRef).toBe("441416452");
     // A separately-reported charge is its own event, so it names no group.
-    expect(result.txs[2].groupRef).toBe("");
+    expect(result.postings[2].groupRef).toBeUndefined();
   });
 
   it("defaults to empty when the column is absent", () => {
@@ -387,7 +389,7 @@ describe("group_ref", () => {
     const result = parseStandardCSV(csv);
 
     expect(result.errors).toHaveLength(0);
-    expect(result.txs[0].groupRef).toBe("");
+    expect(result.postings[0].groupRef).toBeUndefined();
   });
 });
 
@@ -400,12 +402,12 @@ describe("source references", () => {
     const result = parseStandardCSV(csv);
 
     expect(result.errors).toHaveLength(0);
-    expect(result.txs).toHaveLength(2);
-    expect(result.txs[0].brokerRef).toBe("971613411");
+    expect(result.postings).toHaveLength(2);
+    expect(result.postings[0].brokerRef).toBe("971613411");
     // Only the receiving side names the counterparty; the departure does not.
-    expect(result.txs[0].counterpartyAccount).toBe("");
-    expect(result.txs[1].brokerRef).toBe("971613414");
-    expect(result.txs[1].counterpartyAccount).toBe("AG10000001");
+    expect(result.postings[0].counterpartyAccount).toBeUndefined();
+    expect(result.postings[1].brokerRef).toBe("971613414");
+    expect(result.postings[1].counterpartyAccount).toBe("AG10000001");
   });
 
   it("is opaque: a reference that is not a number survives verbatim", () => {
@@ -415,7 +417,7 @@ describe("source references", () => {
     const result = parseStandardCSV(csv);
 
     expect(result.errors).toHaveLength(0);
-    expect(result.txs[0].brokerRef).toBe("20240301U1234567");
+    expect(result.postings[0].brokerRef).toBe("20240301U1234567");
   });
 
   it("defaults to empty when the columns are absent", () => {
@@ -425,8 +427,8 @@ describe("source references", () => {
     const result = parseStandardCSV(csv);
 
     expect(result.errors).toHaveLength(0);
-    expect(result.txs[0].brokerRef).toBe("");
-    expect(result.txs[0].counterpartyAccount).toBe("");
+    expect(result.postings[0].brokerRef).toBeUndefined();
+    expect(result.postings[0].counterpartyAccount).toBeUndefined();
   });
 });
 
@@ -439,12 +441,12 @@ describe("account_type", () => {
     const result = parseStandardCSV(csv);
 
     expect(result.errors).toHaveLength(0);
-    expect(result.txs).toHaveLength(2);
+    expect(result.postings).toHaveLength(2);
     // The cash arriving in the account is an ordinary posting; the income it came
     // from is the other side of the same event.
-    expect(result.txs[0].accountType).toBe(AccountType.USER);
-    expect(result.txs[1].accountType).toBe(AccountType.INCOME);
-    expect(result.txs[1].groupRef).toBe("div-8842");
+    expect(result.postings[0].accountType).toBe(AccountType.USER);
+    expect(result.postings[1].accountType).toBe(AccountType.INCOME);
+    expect(result.postings[1].groupRef).toBe("div-8842");
   });
 
   it("is case-insensitive and accepts the whole vocabulary", () => {
@@ -457,7 +459,7 @@ describe("account_type", () => {
     const result = parseStandardCSV(csv);
 
     expect(result.errors).toHaveLength(0);
-    expect(result.txs.map((t) => t.accountType)).toEqual([
+    expect(result.postings.map((t) => t.accountType)).toEqual([
       AccountType.EQUITY,
       AccountType.EXPENSE,
       AccountType.IMBALANCE,
@@ -472,7 +474,7 @@ describe("account_type", () => {
     const result = parseStandardCSV(csv);
 
     expect(result.errors).toHaveLength(0);
-    expect(result.txs[0].accountType).toBe(AccountType.USER);
+    expect(result.postings[0].accountType).toBe(AccountType.USER);
   });
 
   it("rejects an unknown value rather than falling back to USER", () => {
@@ -481,7 +483,7 @@ describe("account_type", () => {
 
     const result = parseStandardCSV(csv);
 
-    expect(result.txs).toHaveLength(0);
+    expect(result.postings).toHaveLength(0);
     expect(result.errors).toHaveLength(1);
     expect(result.errors[0].field).toBe("account_type");
   });
@@ -492,7 +494,7 @@ describe("account_type", () => {
 
     const result = parseStandardCSV(csv);
 
-    expect(result.txs).toHaveLength(0);
+    expect(result.postings).toHaveLength(0);
     expect(result.errors[0].field).toBe("account_type");
   });
 });
@@ -508,7 +510,7 @@ describe("unit_price", () => {
     const result = parseStandardCSV(csv);
 
     expect(result.errors).toHaveLength(0);
-    expect(result.txs[0].unitPrice).toBe("0");
-    expect(result.txs[1].unitPrice).toBeUndefined();
+    expect(result.postings[0].unitPrice).toBe("0");
+    expect(result.postings[1].unitPrice).toBeUndefined();
   });
 });

--- a/client/lib/csv/standard.ts
+++ b/client/lib/csv/standard.ts
@@ -8,43 +8,14 @@ import { create } from "@bufbuild/protobuf";
 import { timestampFromDate } from "@bufbuild/protobuf/wkt";
 import { startOfNextDay } from "@/lib/dates";
 import { parseDecimal } from "@/lib/decimal";
-import type { Tx } from "@/gen/api/v1/api_pb";
-import { InstrumentIdentifierSchema, TxSchema } from "@/gen/api/v1/api_pb";
+import type { Posting } from "@/gen/archive/v1/txs_pb";
+import { PostingSchema } from "@/gen/archive/v1/txs_pb";
+import { InstrumentRefSchema } from "@/gen/archive/v1/common_pb";
+import type { ParseError, StandardParseResult } from "@/lib/csv/parse-result";
 import { AccountType, IdentifierType, TxType } from "@/gen/type/v1/type_pb";
-
-export interface ParseError {
-  rowIndex: number;
-  field: string;
-  message: string;
-}
 
 /** Comment line carrying the share count basis, e.g. "# share_count_basis=2026-07-29". */
 const SHARE_COUNT_BASIS_PREFIX = "# share_count_basis=";
-
-export interface StandardParseResult {
-  txs: Tx[];
-  periodFrom: Date;
-  /** Exclusive: local midnight after the last transaction's day. */
-  periodBefore: Date;
-  errors: ParseError[];
-  /**
-   * The share count the quantities and unit prices are denominated in, as
-   * "YYYY-MM-DD".
-   *
-   * Omit for an as-traded source: each row reflects the splits that happened
-   * before its own transaction date and nothing after it, which is what
-   * brokers normally supply and what the server assumes. Set it only when the
-   * source has post-adjusted historical rows for splits that happened *after*
-   * the transaction -- then this is the date those quantities are current as
-   * of, and the server will not apply those splits a second time.
-   *
-   * The converter declares the convention rather than undoing the arithmetic:
-   * reversing it here would need the split table, which lives server-side, and
-   * would store numbers the broker never printed. See
-   * docs/spec/bitemporality.md.
-   */
-  shareCountBasis?: string;
-}
 
 const TX_TYPE_BY_NAME = new Map<string, TxType>(
   (Object.entries(TxType) as [string, number][]).filter(([, v]) => typeof v === "number").map(([k, v]) => [k, v as TxType])
@@ -103,7 +74,7 @@ export function parseCSVLine(line: string): string[] {
 }
 
 /**
- * Parse standard-format CSV text into Tx array and period.
+ * Parse standard-format CSV text into archive postings and a period.
  * Header names are case-insensitive. Required: date (or timestamp), instrument_description, type, quantity.
  * Optional: trading_currency, settlement_currency, unit_price, account, symbol_type, symbol, exchange_type,
  * exchange, group_ref, account_type, broker_ref, counterparty_account.
@@ -129,7 +100,7 @@ export function parseStandardCSV(csvText: string): StandardParseResult {
     lines.push(line);
   }
   if (lines.length === 0) {
-    return { txs: [], periodFrom: new Date(0), periodBefore: new Date(0), errors: [{ rowIndex: 0, field: "file", message: "File is empty or has no header" }] };
+    return { postings: [], periodFrom: new Date(0), periodBefore: new Date(0), errors: [{ rowIndex: 0, field: "file", message: "File is empty or has no header" }] };
   }
 
   const headerRow = parseCSVLine(lines[0]);
@@ -163,9 +134,9 @@ export function parseStandardCSV(csvText: string): StandardParseResult {
   if (descCol < 0) errors.push({ rowIndex: 0, field: "header", message: "Missing required column: instrument_description" });
   if (typeCol < 0) errors.push({ rowIndex: 0, field: "header", message: "Missing required column: type" });
   if (qtyCol < 0) errors.push({ rowIndex: 0, field: "header", message: "Missing required column: quantity" });
-  if (errors.length > 0) return { txs: [], periodFrom: new Date(0), periodBefore: new Date(0), errors };
+  if (errors.length > 0) return { postings: [], periodFrom: new Date(0), periodBefore: new Date(0), errors };
 
-  const txs: Tx[] = [];
+  const postings: Posting[] = [];
   let minTime = Infinity;
   let maxTime = -Infinity;
 
@@ -263,8 +234,8 @@ export function parseStandardCSV(csvText: string): StandardParseResult {
     if (ts < minTime) minTime = ts;
     if (ts > maxTime) maxTime = ts;
 
-    txs.push(
-      create(TxSchema, {
+    postings.push(
+      create(PostingSchema, {
         timestamp: timestampFromDate(date),
         instrumentDescription,
         type: txType,
@@ -277,10 +248,14 @@ export function parseStandardCSV(csvText: string): StandardParseResult {
         ...(tradingCurrency ? { tradingCurrency } : {}),
         ...(settlementCurrency ? { settlementCurrency } : {}),
         ...(unitPrice !== undefined ? { unitPrice } : {}),
+        // The comment line declares one basis for the whole file, so every
+        // posting carries it. The archive states it per posting, because a file
+        // can restate some rows and not others.
+        ...(shareCountBasis ? { shareCountBasis } : {}),
         ...(identifierHints.length > 0
           ? {
               identifierHints: identifierHints.map((h) =>
-                create(InstrumentIdentifierSchema, { type: h.type, value: h.value, canonical: false, ...(h.domain ? { domain: h.domain } : {}) })
+                create(InstrumentRefSchema, { type: h.type, value: h.value, ...(h.domain ? { domain: h.domain } : {}) })
               ),
             }
           : {}),
@@ -292,5 +267,5 @@ export function parseStandardCSV(csvText: string): StandardParseResult {
   const periodBefore =
     maxTime === -Infinity ? new Date(0) : startOfNextDay(new Date(maxTime));
 
-  return { txs, periodFrom, periodBefore, errors, shareCountBasis };
+  return { postings, periodFrom, periodBefore, errors };
 }

--- a/client/lib/ingestion-api.test.ts
+++ b/client/lib/ingestion-api.test.ts
@@ -1,7 +1,7 @@
 import { create, fromBinary, toBinary } from "@bufbuild/protobuf";
 import { timestampFromDate } from "@bufbuild/protobuf/wkt";
 import { Broker } from "@/gen/type/v1/type_pb";
-import { TxSchema } from "@/gen/api/v1/api_pb";
+import { PostingSchema } from "@/gen/archive/v1/txs_pb";
 import {
   UpsertTxsResponseSchema,
   UpsertTxsRequestSchema,
@@ -34,7 +34,7 @@ describe("ingestion-api", () => {
         )
       );
 
-      const tx = create(TxSchema, {
+      const posting = create(PostingSchema, {
         timestamp: timestampFromDate(new Date("2024-01-15")),
         instrumentDescription: "AAPL",
         type: 5, // BUYSTOCK
@@ -43,11 +43,13 @@ describe("ingestion-api", () => {
       });
 
       const result = await upsertTxs({
-        broker: Broker.IBKR,
-        source: "IBKR:web:standard",
-        periodFrom: timestampFromDate(new Date("2024-01-01")),
-        periodBefore: timestampFromDate(new Date("2024-02-01")),
-        txs: [tx],
+        window: {
+          broker: Broker.IBKR,
+          source: "IBKR:web:standard",
+          periodFrom: timestampFromDate(new Date("2024-01-01")),
+          periodBefore: timestampFromDate(new Date("2024-02-01")),
+          postings: [posting],
+        },
       });
 
       expect(result.jobId).toBe("job-abc");
@@ -61,12 +63,12 @@ describe("ingestion-api", () => {
       const reqBytes = mockUnaryFetch.mock.calls[0]?.[2];
       expect(reqBytes).toBeDefined();
       const decoded = fromBinary(UpsertTxsRequestSchema, reqBytes!);
-      expect(decoded.broker).toBe(Broker.IBKR);
-      expect(decoded.source).toBe("IBKR:web:standard");
-      expect(decoded.txs).toHaveLength(1);
-      expect(decoded.txs[0].instrumentDescription).toBe("AAPL");
-      expect(decoded.txs[0].quantity).toBe("10");
-      expect(decoded.txs[0].account).toBe("");
+      expect(decoded.window?.broker).toBe(Broker.IBKR);
+      expect(decoded.window?.source).toBe("IBKR:web:standard");
+      expect(decoded.window?.postings).toHaveLength(1);
+      expect(decoded.window?.postings[0].instrumentDescription).toBe("AAPL");
+      expect(decoded.window?.postings[0].quantity).toBe("10");
+      expect(decoded.window?.postings[0].account).toBe("");
     });
   });
 });

--- a/client/lib/ingestion-api.ts
+++ b/client/lib/ingestion-api.ts
@@ -3,13 +3,12 @@
  */
 
 import { create, fromBinary, toBinary } from "@bufbuild/protobuf";
-import type { Timestamp } from "@bufbuild/protobuf/wkt";
+import type { MessageInitShape } from "@bufbuild/protobuf";
 import {
   UpsertTxsResponseSchema,
   UpsertTxsRequestSchema,
 } from "@/gen/ingestion/v1/ingestion_pb";
-import type { Tx } from "@/gen/api/v1/api_pb";
-import type { Broker } from "@/gen/type/v1/type_pb";
+import type { TxWindowSchema } from "@/gen/archive/v1/txs_pb";
 import type { UpsertTxsResponse } from "@/gen/ingestion/v1/ingestion_pb";
 import { unaryFetch } from "./grpc-web";
 
@@ -22,31 +21,20 @@ function getBaseUrl(): string {
 
 /** Parameters for bulk transaction upload. */
 export interface UpsertTxsParams {
-  broker: Broker;
-  source: string;
-  periodFrom?: Timestamp;
-  /** Exclusive: the first instant NOT replaced. */
-  periodBefore?: Timestamp;
-  txs: Tx[];
-  filename?: string;
   /**
-   * The share count the uploaded quantities and unit prices are denominated
-   * in, as "YYYY-MM-DD". Omit for an as-traded source, which is every CSV
-   * export the client handles. See docs/spec/bitemporality.md.
+   * The replacement scope and the postings inside it, in the archive schema.
+   * The window states its own broker, source and half-open period, so an upload
+   * describes itself. See docs/spec/archive-format.md.
    */
-  shareCountBasis?: string;
+  window: MessageInitShape<typeof TxWindowSchema>;
+  filename?: string;
 }
 
 export async function upsertTxs(params: UpsertTxsParams): Promise<UpsertTxsResponse> {
   const base = getBaseUrl();
   const req = create(UpsertTxsRequestSchema, {
-    broker: params.broker,
-    source: params.source,
-    periodFrom: params.periodFrom,
-    periodBefore: params.periodBefore,
-    txs: params.txs,
+    window: params.window,
     filename: params.filename ?? "",
-    shareCountBasis: params.shareCountBasis ?? "",
   });
   const resBytes = await unaryFetch(
     base,

--- a/client/lib/ofx/parser.test.ts
+++ b/client/lib/ofx/parser.test.ts
@@ -134,7 +134,7 @@ describe("parseOfxStatement", () => {
   it("returns error for non-OFX content", () => {
     const result = parseOfxStatement("just some text");
     expect(result.errors.length).toBeGreaterThan(0);
-    expect(result.txs.length).toBe(0);
+    expect(result.postings.length).toBe(0);
   });
 
   it("parses a single BUYSTOCK with CUSIP identifier", () => {
@@ -144,9 +144,9 @@ describe("parseOfxStatement", () => {
     });
     const result = parseOfxStatement(ofx);
     expect(result.errors).toEqual([]);
-    expect(result.txs.length).toBe(2); // security tx + cashflow
+    expect(result.postings.length).toBe(2); // security tx + cashflow
 
-    const tx = result.txs[0]!;
+    const tx = result.postings[0]!;
     expect(tx.type).toBe(TxType.BUYSTOCK);
     expect(tx.quantity).toBe("20");
     expect(tx.unitPrice).toBe("156.55");
@@ -157,7 +157,7 @@ describe("parseOfxStatement", () => {
     expect(tx.identifierHints[0]!.type).toBe(IdentifierType.CUSIP);
     expect(tx.identifierHints[0]!.value).toBe("023135106");
 
-    const cf = result.txs[1]!;
+    const cf = result.postings[1]!;
     expect(cf.type).toBe(TxType.CASHFLOW);
     expect(cf.quantity).toBe("-3131");
     expect(cf.unitPrice).toBe("1");
@@ -174,16 +174,16 @@ describe("parseOfxStatement", () => {
     });
     const result = parseOfxStatement(ofx);
     expect(result.errors).toEqual([]);
-    expect(result.txs.length).toBe(2); // security tx + cashflow
+    expect(result.postings.length).toBe(2); // security tx + cashflow
 
-    const tx = result.txs[0]!;
+    const tx = result.postings[0]!;
     expect(tx.type).toBe(TxType.SELLSTOCK);
     expect(tx.quantity).toBe("-1230");
     expect(tx.instrumentDescription).toBe("SGLN ISHARES PHYSICAL GOLD ETC");
     expect(tx.identifierHints[0]!.type).toBe(IdentifierType.ISIN);
     expect(tx.identifierHints[0]!.value).toBe("IE00B4ND3602");
 
-    const cf = result.txs[1]!;
+    const cf = result.postings[1]!;
     expect(cf.type).toBe(TxType.CASHFLOW);
     expect(cf.quantity).toBe("85939");
     expect(cf.unitPrice).toBe("1");
@@ -195,7 +195,7 @@ describe("parseOfxStatement", () => {
     const result = parseOfxStatement(ofx);
     expect(result.errors).toEqual([]);
     // 2 security txs + 2 cashflow txs = 4
-    const buys = result.txs.filter((t) => t.type === TxType.BUYSTOCK);
+    const buys = result.postings.filter((t) => t.type === TxType.BUYSTOCK);
     expect(buys.length).toBe(2);
     expect(buys[0]!.quantity).toBe("10");
     expect(buys[1]!.quantity).toBe("20");
@@ -207,9 +207,9 @@ describe("parseOfxStatement", () => {
     const result = parseOfxStatement(ofx);
     expect(result.errors).toEqual([]);
     // 2 security txs + 2 cashflow txs = 4
-    expect(result.txs.some((t) => t.type === TxType.BUYSTOCK)).toBe(true);
-    expect(result.txs.some((t) => t.type === TxType.SELLSTOCK)).toBe(true);
-    expect(result.txs.filter((t) => t.type === TxType.CASHFLOW).length).toBe(2);
+    expect(result.postings.some((t) => t.type === TxType.BUYSTOCK)).toBe(true);
+    expect(result.postings.some((t) => t.type === TxType.SELLSTOCK)).toBe(true);
+    expect(result.postings.filter((t) => t.type === TxType.CASHFLOW).length).toBe(2);
   });
 
   it("parses INCOME with TOTAL as quantity and price=1", () => {
@@ -228,9 +228,9 @@ describe("parseOfxStatement", () => {
     const result = parseOfxStatement(ofx);
     expect(result.errors).toEqual([]);
     // The cash row plus the income it came from.
-    expect(result.txs.length).toBe(2);
+    expect(result.postings.length).toBe(2);
 
-    const tx = result.txs[0]!;
+    const tx = result.postings[0]!;
     expect(tx.type).toBe(TxType.INCOME);
     expect(tx.quantity).toBe("137.08");
     expect(tx.unitPrice).toBe("1");
@@ -259,9 +259,9 @@ describe("parseOfxStatement", () => {
     });
     const result = parseOfxStatement(ofx);
     expect(result.errors).toEqual([]);
-    expect(result.txs.length).toBe(2); // security tx + cashflow
+    expect(result.postings.length).toBe(2); // security tx + cashflow
 
-    const tx = result.txs[0]!;
+    const tx = result.postings[0]!;
     expect(tx.type).toBe(TxType.BUYOPT);
     expect(tx.quantity).toBe("3");
     expect(tx.instrumentDescription).toContain("BRKB");
@@ -269,7 +269,7 @@ describe("parseOfxStatement", () => {
     // Broker-specific converters (e.g. IBKR) add OCC hints via post-processing.
     expect(tx.identifierHints.length).toBe(0);
 
-    const cf = result.txs[1]!;
+    const cf = result.postings[1]!;
     expect(cf.type).toBe(TxType.CASHFLOW);
     expect(cf.quantity).toBe("-4239");
   });
@@ -299,7 +299,7 @@ describe("parseOfxStatement", () => {
     const ofx = buildOfx({ curdef: "EUR", transactions: tx });
     const result = parseOfxStatement(ofx);
     expect(result.errors).toEqual([]);
-    const buy = result.txs.find((t) => t.type === TxType.BUYSTOCK)!;
+    const buy = result.postings.find((t) => t.type === TxType.BUYSTOCK)!;
     expect(buy.tradingCurrency).toBe("EUR");
   });
 
@@ -307,7 +307,7 @@ describe("parseOfxStatement", () => {
     const ofx = buildOfx({ transactions: buyStockTx() });
     const result = parseOfxStatement(ofx);
     expect(result.errors).toEqual([]);
-    expect(result.txs[0]!.instrumentDescription).toBe("023135106");
+    expect(result.postings[0]!.instrumentDescription).toBe("023135106");
   });
 
   it("returns error when no currency is available", () => {
@@ -341,7 +341,7 @@ VERSION:102
   </INVSTMTMSGSRSV1>
 </OFX>`;
     const result = parseOfxStatement(ofx);
-    expect(result.txs.length).toBe(0);
+    expect(result.postings.length).toBe(0);
     expect(result.errors.length).toBe(1);
     expect(result.errors[0]!.field).toBe("CURRENCY");
   });
@@ -368,7 +368,7 @@ VERSION:102
       transactions: buyStockTx(),
     });
     const result = parseOfxStatement(ofx);
-    const lastTx = result.txs[result.txs.length - 1]!.timestamp!;
+    const lastTx = result.postings[result.postings.length - 1]!.timestamp!;
     expect(result.periodBefore.getTime()).toBeGreaterThan(
       Number(lastTx.seconds) * 1000
     );
@@ -413,7 +413,7 @@ describe("groups and charges", () => {
 
   it("groups a trade with its cash leg on the broker's own reference", () => {
     const result = parse(GBP_BUY);
-    const refs = new Set(result.txs.map((t) => t.groupRef));
+    const refs = new Set(result.postings.map((t) => t.groupRef));
     expect(refs).toEqual(new Set(["20251015U10000018371888432"]));
   });
 
@@ -422,19 +422,19 @@ describe("groups and charges", () => {
   // is that record -- the cash and fee legs are derived from TOTAL and COMMISSION.
   it("keeps the FITID as the transcribed leg's source reference", () => {
     const result = parse(GBP_BUY);
-    const refs = result.txs.map((t) => t.brokerRef);
-    expect(refs.filter((r) => r !== "")).toEqual(["20251015U10000018371888432"]);
+    const refs = result.postings.map((t) => t.brokerRef);
+    expect(refs.filter((r) => r !== undefined)).toEqual(["20251015U10000018371888432"]);
   });
 
   it("splits the commission out of the netted total", () => {
     const result = parse(GBP_BUY);
 
-    const cash = result.txs.find((t) => t.type === TxType.CASHFLOW)!;
+    const cash = result.postings.find((t) => t.type === TxType.CASHFLOW)!;
     // toBe, not toBeCloseTo: the split is a decimal subtraction, so the result
     // is the exact value narrowed once rather than an accumulation of error.
     expect(cash.quantity).toBe("-23080.68");
 
-    const fees = result.txs.filter((t) => t.type === TxType.INVEXPENSE);
+    const fees = result.postings.filter((t) => t.type === TxType.INVEXPENSE);
     expect(fees).toHaveLength(2);
     expect(fees.find((t) => t.accountType === AccountType.USER)!.quantity).toBe("-11.54034");
     expect(fees.find((t) => t.accountType === AccountType.EXPENSE)!.quantity).toBe("11.54034");
@@ -444,20 +444,20 @@ describe("groups and charges", () => {
     const result = parse(GBP_BUY);
     // Summed in decimal so the assertion holds for any fixture rather than for
     // ones whose float64 sum happens to land. This one's does.
-    const cash = result.txs
+    const cash = result.postings
       .filter((t) => t.accountType !== AccountType.EXPENSE && t.type !== TxType.BUYSTOCK)
       .reduce((sum, t) => sum.plus(t.quantity), new Big(0));
     expect(cash.toString()).toBe("-23092.22034");
   });
 
   it("balances a buy and a sell, including one not in the account's currency", () => {
-    expectGroupsBalance(parse(GBP_BUY + EUR_SELL).txs);
+    expectGroupsBalance(parse(GBP_BUY + EUR_SELL).postings);
   });
 
   it("derives the fee in the currency the trade was quoted in, not the account's", () => {
     // CURDEF is GBP and CURRATE is the rate back to it. UNITPRICE, COMMISSION
     // and TOTAL are all EUR, so nothing needs converting before the split.
-    const fee = parse(EUR_SELL).txs.find(
+    const fee = parse(EUR_SELL).postings.find(
       (t) => t.type === TxType.INVEXPENSE && t.accountType === AccountType.USER
     )!;
     expect(fee.settlementCurrency).toBe("EUR");
@@ -467,16 +467,16 @@ describe("groups and charges", () => {
 
   it("emits no charge postings for a commission-free trade", () => {
     const result = parse(buyStockTx());
-    expect(result.txs.filter((t) => t.type === TxType.INVEXPENSE)).toHaveLength(0);
-    expect(result.txs).toHaveLength(2);
+    expect(result.postings.filter((t) => t.type === TxType.INVEXPENSE)).toHaveLength(0);
+    expect(result.postings).toHaveLength(2);
   });
 
   it("groups a trade whose source gave no reference", () => {
     const result = parse(GBP_BUY.replace("<FITID>20251015U10000018371888432", "<FITID>"));
-    const refs = new Set(result.txs.map((t) => t.groupRef));
+    const refs = new Set(result.postings.map((t) => t.groupRef));
     expect(refs.size).toBe(1);
-    expect([...refs][0]).not.toBe("");
-    expectGroupsBalance(result.txs);
+    expect([...refs][0]).toBeTruthy();
+    expectGroupsBalance(result.postings);
   });
 
   it("names the account a dividend came from", () => {
@@ -490,10 +490,10 @@ describe("groups and charges", () => {
     </INCOME>`;
     const result = parse(income);
 
-    expect(result.txs).toHaveLength(2);
-    expect(result.txs[1]!.accountType).toBe(AccountType.INCOME);
-    expect(result.txs[1]!.quantity).toBe("-137.08");
-    expect(result.txs[1]!.groupRef).toBe("div1");
-    expectGroupsBalance(result.txs);
+    expect(result.postings).toHaveLength(2);
+    expect(result.postings[1]!.accountType).toBe(AccountType.INCOME);
+    expect(result.postings[1]!.quantity).toBe("-137.08");
+    expect(result.postings[1]!.groupRef).toBe("div1");
+    expectGroupsBalance(result.postings);
   });
 });

--- a/client/lib/ofx/parser.ts
+++ b/client/lib/ofx/parser.ts
@@ -9,10 +9,11 @@
 import { create } from "@bufbuild/protobuf";
 import { timestampDate, timestampFromDate } from "@bufbuild/protobuf/wkt";
 import { startOfNextDay } from "@/lib/dates";
-import type { Tx } from "@/gen/api/v1/api_pb";
-import { InstrumentIdentifierSchema, TxSchema } from "@/gen/api/v1/api_pb";
+import type { Posting } from "@/gen/archive/v1/txs_pb";
+import { PostingSchema } from "@/gen/archive/v1/txs_pb";
+import { InstrumentRefSchema } from "@/gen/archive/v1/common_pb";
 import { IdentifierType, TxType } from "@/gen/type/v1/type_pb";
-import type { StandardParseResult, ParseError } from "@/lib/csv/standard";
+import type { StandardParseResult, ParseError } from "@/lib/csv/parse-result";
 import { counterLegs, feeLeg, refPrefix } from "@/lib/csv/postings";
 import { Big, parseDecimal } from "@/lib/decimal";
 import { parseOfxSgml } from "./sgml";
@@ -201,7 +202,7 @@ export function parseOfxStatement(text: string): OfxParseResult {
   );
   if (!stmtRs) {
     return {
-      txs: [],
+      postings: [],
       periodFrom: new Date(0),
       periodBefore: new Date(0),
       errors: [{ rowIndex: 0, field: "file", message: "No investment statement found in OFX file" }],
@@ -216,7 +217,7 @@ export function parseOfxStatement(text: string): OfxParseResult {
   const tranList = one(stmtRs.INVTRANLIST);
   if (!tranList) {
     return {
-      txs: [],
+      postings: [],
       periodFrom: new Date(0),
       periodBefore: new Date(0),
       errors: [{ rowIndex: 0, field: "file", message: "No transaction list found in OFX file" }],
@@ -232,12 +233,12 @@ export function parseOfxStatement(text: string): OfxParseResult {
   const periodFrom = parseOfxDate(str(tranList, "DTSTART")) ?? new Date(0);
   const dtEnd = parseOfxDate(str(tranList, "DTEND")) ?? new Date(0);
 
-  const txs: Tx[] = [];
+  const postings: Posting[] = [];
   // Legs of transactions the source gave no FITID for, so they can be given a
   // synthesised group once every real ref is known. FITID is mandatory in OFX,
   // but without a group a trade and its cash leg would land as two groups and
   // neither would balance -- too quiet a failure to leave to the source.
-  const unreferenced: Tx[][] = [];
+  const unreferenced: Posting[][] = [];
   let txIndex = 0;
 
   for (const [tag, def] of Object.entries(TX_TYPES)) {
@@ -311,15 +312,14 @@ export function parseOfxStatement(text: string): OfxParseResult {
 
       const ts = timestampFromDate(date);
       const hintProtos = identifierHints.map((h) =>
-        create(InstrumentIdentifierSchema, {
+        create(InstrumentRefSchema, {
           type: h.type,
           value: h.value,
-          canonical: false,
         }),
       );
 
-      const legs: Tx[] = [];
-      const security = create(TxSchema, {
+      const legs: Posting[] = [];
+      const security = create(PostingSchema, {
         timestamp: ts,
         instrumentDescription: description,
         type: def.txType,
@@ -356,14 +356,13 @@ export function parseOfxStatement(text: string): OfxParseResult {
 
         if (total !== undefined && !total.eq(ZERO)) {
           const cashHints = [
-            create(InstrumentIdentifierSchema, {
+            create(InstrumentRefSchema, {
               type: IdentifierType.CURRENCY,
               value: tradingCurrency,
-              canonical: false,
             }),
           ];
           legs.push(
-            create(TxSchema, {
+            create(PostingSchema, {
               timestamp: ts,
               instrumentDescription: description,
               type: TxType.CASHFLOW,
@@ -385,13 +384,13 @@ export function parseOfxStatement(text: string): OfxParseResult {
         if (fee) legs.push(fee);
       }
 
-      txs.push(...legs);
+      postings.push(...legs);
       if (!fitId) unreferenced.push(legs);
     }
   }
 
   if (unreferenced.length > 0) {
-    const prefix = refPrefix(txs);
+    const prefix = refPrefix(postings);
     unreferenced.forEach((legs, i) => {
       for (const leg of legs) leg.groupRef = `${prefix}${i}`;
     });
@@ -399,15 +398,15 @@ export function parseOfxStatement(text: string): OfxParseResult {
 
   // The income a dividend came from and the expense a commission went to. After
   // the loop so a derived fee gets its counter-leg too.
-  txs.push(...counterLegs(txs));
+  postings.push(...counterLegs(postings));
 
-  txs.sort((a, b) =>
+  postings.sort((a, b) =>
     Number(a.timestamp?.seconds ?? 0) - Number(b.timestamp?.seconds ?? 0),
   );
 
-  const lastTx = txs[txs.length - 1]?.timestamp;
-  const afterLastTx = lastTx ? startOfNextDay(timestampDate(lastTx)) : new Date(0);
-  const periodBefore = afterLastTx > dtEnd ? afterLastTx : dtEnd;
+  const last = postings[postings.length - 1]?.timestamp;
+  const afterLast = last ? startOfNextDay(timestampDate(last)) : new Date(0);
+  const periodBefore = afterLast > dtEnd ? afterLast : dtEnd;
 
-  return { txs, periodFrom, periodBefore, errors, secList };
+  return { postings, periodFrom, periodBefore, errors, secList };
 }

--- a/docs/spec/broker-import-extension.md
+++ b/docs/spec/broker-import-extension.md
@@ -59,16 +59,17 @@ The window bounds are then materialised as local midnights in the runtime's own 
 
 ## Upload
 
-`UpsertTxs` is called with:
+`UpsertTxs` carries an archive transaction window -- the same message an archive
+document carries, so an upload describes itself. See
+[archive-format.md](archive-format.md).
 
 | Field | Value |
 | ----- | ----- |
-| `broker` | The target broker enum. |
-| `source` | The same source string the web UI produces for this broker and format, e.g. `Fidelity:web:fidelity-csv`. |
-| `period_from`, `period_before` | The **requested** window from step 3 -- not the minimum and maximum of the parsed rows. |
-| `txs` | The converted transactions. |
-| `filename` | A synthetic name identifying the run, e.g. `fidelity-ext-2026-07-27.csv`. |
-| `share_count_basis` | Whatever the converter declared; empty for an as-traded broker (see Share count below). |
+| `window.broker` | The target broker enum. |
+| `window.source` | The same source string the web UI produces for this broker and format, e.g. `Fidelity:web:fidelity-csv`. |
+| `window.period_from`, `window.period_before` | The **requested** window from step 3 -- not the minimum and maximum of the parsed rows. |
+| `window.postings` | The converted postings. |
+| `filename` | A synthetic name identifying the run, e.g. `fidelity-ext-2026-07-27.json`. |
 
 Two of these need care.
 
@@ -80,7 +81,7 @@ Two of these need care.
 
 The extension reads the broker's live web UI, which is the one import path where a broker could present historical rows restated into post-split terms.
 
-The default is as-traded: quantities and unit prices are denominated in the share count current on the row's own transaction date, and no broker found so far violates that. A converter for a broker that does restate sets `shareCountBasis` on its parse result, and the extension forwards it. The declaration sits on the converter rather than the recipe or the run because it is a property of how the broker reports, and because the converter is shared with the web upload path -- so both routes get it from one place. See [bitemporality.md](bitemporality.md#share-count-basis).
+The default is as-traded: quantities and unit prices are denominated in the share count current on the row's own transaction date, and no broker found so far violates that. A converter for a broker that does restate sets `share_count_basis` on the postings it emits, which is where the archive states it -- a file can restate some rows and not others. The declaration sits on the converter rather than the recipe or the run because it is a property of how the broker reports, and because the converter is shared with the web upload path -- so both routes get it from one place. See [bitemporality.md](bitemporality.md#share-count-basis).
 
 ### Account scope
 

--- a/e2e/helpers/upload.ts
+++ b/e2e/helpers/upload.ts
@@ -12,7 +12,7 @@ export async function uploadCSVAndWait(
   page: Page,
   browser: Browser,
   fixtureName: string,
-  opts?: { expectedTxCount?: number }
+  opts?: { expectedPostingCount?: number }
 ): Promise<void> {
   await page.goto("/uploads");
   await expect(
@@ -38,10 +38,10 @@ export async function uploadCSVAndWait(
     page.locator("[data-testid='upload-parse-preview']")
   ).toBeVisible();
 
-  if (opts?.expectedTxCount != null) {
+  if (opts?.expectedPostingCount != null) {
     await expect(
       page.locator("[data-testid='upload-parse-preview']")
-    ).toContainText(`${opts.expectedTxCount} transaction(s)`);
+    ).toContainText(`${opts.expectedPostingCount} posting(s)`);
   }
 
   // Submit.

--- a/e2e/tests/error-recovery-reupload.spec.ts
+++ b/e2e/tests/error-recovery-reupload.spec.ts
@@ -35,7 +35,7 @@ test.describe("error recovery via corrected re-upload", () => {
 
     // First upload: AAPL (resolvable) + XYZFAKE (unresolvable).
     await uploadCSVAndWait(page, browser, "mixed-identification.csv", {
-      expectedTxCount: 2,
+      expectedPostingCount: 2,
     });
 
     // Verify holdings show both (AAPL resolved, XYZFAKE as description).
@@ -66,7 +66,7 @@ test.describe("error recovery via corrected re-upload", () => {
     // Corrected re-upload: AAPL + MSFT (with ISIN) for same period.
     // This replaces the previous upload via idempotent bulk semantics.
     await uploadCSVAndWait(page, browser, "identification-corrected.csv", {
-      expectedTxCount: 2,
+      expectedPostingCount: 2,
     });
 
     // Verify holdings now show AAPL + MSFT (both resolved). XYZFAKE gone.

--- a/e2e/tests/failed-identification.spec.ts
+++ b/e2e/tests/failed-identification.spec.ts
@@ -35,7 +35,7 @@ test.describe("failed instrument identification", () => {
 
     // Upload CSV with one resolvable (AAPL) and one unresolvable (XYZFAKE).
     await uploadCSVAndWait(page, browser, "mixed-identification.csv", {
-      expectedTxCount: 2,
+      expectedPostingCount: 2,
     });
 
     // Both instruments should appear in holdings.

--- a/e2e/tests/fetch-blocks.spec.ts
+++ b/e2e/tests/fetch-blocks.spec.ts
@@ -67,7 +67,7 @@ test.describe("fetch block full flow", () => {
     ).toBeVisible();
     await expect(
       page.locator("[data-testid='upload-parse-preview']")
-    ).toContainText("3 transaction(s)");
+    ).toContainText("3 posting(s)");
 
     // Upload and wait for ingestion to complete.
     await page.locator("[data-testid='btn-upload-submit']").click();

--- a/e2e/tests/idempotent-reupload.spec.ts
+++ b/e2e/tests/idempotent-reupload.spec.ts
@@ -35,7 +35,7 @@ test.describe("idempotent bulk re-upload", () => {
 
     // First upload: AAPL 10, MSFT 5, GOOGL 20.
     await uploadCSVAndWait(page, browser, "standard-3-stocks.csv", {
-      expectedTxCount: 3,
+      expectedPostingCount: 3,
     });
 
     // Verify initial holdings.
@@ -53,7 +53,7 @@ test.describe("idempotent bulk re-upload", () => {
 
     // Second upload: exact same CSV. Should replace, not append.
     await uploadCSVAndWait(page, browser, "standard-3-stocks.csv", {
-      expectedTxCount: 3,
+      expectedPostingCount: 3,
     });
 
     // Verify holdings are identical (not doubled).
@@ -77,7 +77,7 @@ test.describe("idempotent bulk re-upload", () => {
 
     // Third upload: AAPL 15, MSFT 5, AMZN 8 (GOOGL removed).
     await uploadCSVAndWait(page, browser, "reupload-modified.csv", {
-      expectedTxCount: 3,
+      expectedPostingCount: 3,
     });
 
     // Verify holdings reflect the replacement.

--- a/e2e/tests/ingestion-flow.spec.ts
+++ b/e2e/tests/ingestion-flow.spec.ts
@@ -61,7 +61,7 @@ test.describe("CSV ingestion flow", () => {
     ).toBeVisible();
     await expect(
       page.locator("[data-testid='upload-parse-preview']")
-    ).toContainText("3 transaction(s)");
+    ).toContainText("3 posting(s)");
 
     // Click Upload.
     await page.locator("[data-testid='btn-upload-submit']").click();

--- a/e2e/tests/mixed-tx-types.spec.ts
+++ b/e2e/tests/mixed-tx-types.spec.ts
@@ -35,7 +35,7 @@ test.describe("mixed transaction types", () => {
 
     // Upload CSV with BUY 100, BUY 50, SELL -30, SPLIT 2 (all AAPL).
     await uploadCSVAndWait(page, browser, "mixed-tx-types.csv", {
-      expectedTxCount: 4,
+      expectedPostingCount: 4,
     });
 
     // Navigate to holdings and verify the aggregated result.

--- a/e2e/tests/price-import-merge.spec.ts
+++ b/e2e/tests/price-import-merge.spec.ts
@@ -112,7 +112,7 @@ test.describe("price-first instrument merge", () => {
     // instrument via ResolveByHintsDBOnly. The instrument is reused
     // without calling identifier plugins.
     await uploadCSVAndWait(page, browser, "single-aapl-stock.csv", {
-      expectedTxCount: 1,
+      expectedPostingCount: 1,
     });
 
     // Step 4: Verify the transaction was attached to the SAME instrument.

--- a/e2e/tests/stock-split.spec.ts
+++ b/e2e/tests/stock-split.spec.ts
@@ -46,7 +46,7 @@ test.describe("stock split: tx uploaded before split", () => {
     // Upload all txs in one CSV to avoid ReplaceTxsInPeriod conflicts
     // between overlapping date ranges on different instruments.
     await uploadCSVAndWait(page, browser, "split-txs.csv", {
-      expectedTxCount: 3,
+      expectedPostingCount: 3,
     });
 
     // Before the split: Adj Qty should show em-dash for all AAPL stock txs.
@@ -177,7 +177,7 @@ test.describe("stock split: split uploaded before tx", () => {
 
     // Upload all txs in one CSV.
     await uploadCSVAndWait(page, browser, "split-txs.csv", {
-      expectedTxCount: 3,
+      expectedPostingCount: 3,
     });
 
     // Trigger the fetcher to record coverage and process option splits.

--- a/e2e/tests/tx-update-price-fetch.spec.ts
+++ b/e2e/tests/tx-update-price-fetch.spec.ts
@@ -39,7 +39,7 @@ test.describe("no redundant price fetch after transaction update", () => {
     // Upload initial transaction: buy 10 INTC ~6 months ago.
     // This triggers identification and price fetch for the held period.
     await uploadCSVAndWait(page, browser, "tx-update-initial.csv", {
-      expectedTxCount: 1,
+      expectedPostingCount: 1,
     });
 
     // Verify the holding appears.
@@ -59,7 +59,7 @@ test.describe("no redundant price fetch after transaction update", () => {
     // The holding period is unchanged (still ~6 months ago to today),
     // just with a larger position from ~3 months ago onwards.
     await uploadCSVAndWait(page, browser, "tx-update-additional.csv", {
-      expectedTxCount: 1,
+      expectedPostingCount: 1,
     });
 
     // Wait for the price fetcher cycle triggered by the new transaction.

--- a/extension/src/background/dry-run.ts
+++ b/extension/src/background/dry-run.ts
@@ -41,13 +41,13 @@ export async function dryRun(req: DryRunRequest): Promise<DryRunResult> {
     }
 
     return {
-      ok: parsed.txs.length > 0,
+      ok: parsed.postings.length > 0,
       requested,
       ...(rowCount !== undefined ? { rowCount } : {}),
-      txCount: parsed.txs.length,
+      txCount: parsed.postings.length,
       droppedCount: parsed.errors.length,
       droppedTypes: droppedTypes(parsed.errors),
-      ...(parsed.txs.length === 0
+      ...(parsed.postings.length === 0
         ? {
             error: parsed.errors[0]?.message ?? "the export contained no transactions",
             preview: captured.body.slice(0, 300),

--- a/extension/src/background/sync.test.ts
+++ b/extension/src/background/sync.test.ts
@@ -80,30 +80,37 @@ describe("sync", () => {
     const { entry } = await run();
 
     expect(entry.status).toBe("success");
-    const req = upsertTxs.mock.calls[0]![2] as { periodFrom: { seconds: bigint }; periodBefore: { seconds: bigint } };
+    const req = upsertTxs.mock.calls[0]![2] as {
+      window: { periodFrom: { seconds: bigint }; periodBefore: { seconds: bigint } };
+    };
     // Window is 14 days before the last known transaction (20 Jul) up to the
     // start of today (27 Jul) -- wider than the single 21 Jul row that came
     // back, which is what lets the replace delete anything the broker
     // cancelled.
-    expect(Number(req.periodFrom.seconds)).toBe(Math.floor(new Date(2026, 6, 6).getTime() / 1000));
-    expect(Number(req.periodBefore.seconds)).toBe(
+    expect(Number(req.window.periodFrom.seconds)).toBe(Math.floor(new Date(2026, 6, 6).getTime() / 1000));
+    expect(Number(req.window.periodBefore.seconds)).toBe(
       Math.floor(new Date(2026, 6, 27).getTime() / 1000)
     );
   });
 
   it("sends the source string the web client already uses", async () => {
     await run();
-    const req = upsertTxs.mock.calls[0]![2] as { source: string };
-    expect(req.source).toBe("Fidelity:web:fidelity-csv");
+    const req = upsertTxs.mock.calls[0]![2] as { window: { source: string } };
+    expect(req.window.source).toBe("Fidelity:web:fidelity-csv");
   });
 
   it("leaves the share count undeclared when the converter does not declare one", async () => {
     await run();
-    const req = upsertTxs.mock.calls[0]![2] as { shareCountBasis: string };
+    const req = upsertTxs.mock.calls[0]![2] as {
+      window: { postings: { shareCountBasis?: string }[] };
+    };
     // Declaring a basis on an as-traded export would tell the server the
     // quantities are already post-split, and historical rows spanning a split
-    // would be left unadjusted.
-    expect(req.shareCountBasis).toBe("");
+    // would be left unadjusted. The archive states it per posting, so an
+    // as-traded export states it nowhere.
+    for (const p of req.window.postings) {
+      expect(p.shareCountBasis).toBeUndefined();
+    }
   });
 
   it("asks only for the most recent transaction of that broker", async () => {
@@ -194,8 +201,8 @@ describe("sync", () => {
 
     await run();
 
-    const req = upsertTxs.mock.calls[0]![2] as { periodFrom: { seconds: bigint } };
-    expect(Number(req.periodFrom.seconds)).toBe(Math.floor(new Date(2025, 0, 6).getTime() / 1000));
+    const req = upsertTxs.mock.calls[0]![2] as { window: { periodFrom: { seconds: bigint } } };
+    expect(Number(req.window.periodFrom.seconds)).toBe(Math.floor(new Date(2025, 0, 6).getTime() / 1000));
   });
 
   it("stops before fetching when there is no session", async () => {

--- a/extension/src/background/sync.ts
+++ b/extension/src/background/sync.ts
@@ -133,13 +133,13 @@ export async function sync(opts: SyncOptions): Promise<SyncResult> {
   const counted: RunLogEntry = {
     ...withWindow,
     rowCount: rowCount(payload),
-    txCount: parsed.txs.length,
+    txCount: parsed.postings.length,
     droppedCount: parsed.errors.length,
     ...(parsed.errors.length > 0 ? { droppedRows: parsed.errors } : {}),
     ...(dropped.length > 0 ? { droppedTypes: dropped } : {}),
   };
 
-  if (parsed.txs.length === 0) {
+  if (parsed.postings.length === 0) {
     // Refusing rather than uploading nothing: the server marks a bulk upload with
     // no storable rows successful without performing the replace, so an empty
     // upload would report success while deleting nothing.
@@ -154,18 +154,16 @@ export async function sync(opts: SyncOptions): Promise<SyncResult> {
   let jobId: string;
   try {
     const res = await upsertTxs(config.portfoliodbOrigin, sessionId, {
-      broker: opts.broker,
-      source: sourceFor(recipe),
-      // The window that was requested, not the range of the rows that came back:
-      // that is what lets the replace delete transactions the broker cancelled.
-      periodFrom: timestampFromDate(win.from),
-      periodBefore: timestampFromDate(win.before),
-      txs: parsed.txs,
+      window: {
+        broker: opts.broker,
+        source: sourceFor(recipe),
+        // The window that was requested, not the range of the rows that came back:
+        // that is what lets the replace delete transactions the broker cancelled.
+        periodFrom: timestampFromDate(win.from),
+        periodBefore: timestampFromDate(win.before),
+        postings: parsed.postings,
+      },
       filename: `${recipe.id}-${formatDate(lastDay, "yyyy-MM-dd")}.json`,
-      // Declared by the converter, which knows its broker's convention. Empty
-      // for an as-traded export, which is denominated per row and is what the
-      // server assumes by default.
-      shareCountBasis: parsed.shareCountBasis ?? "",
     });
     jobId = res.jobId;
   } catch (e) {

--- a/extension/src/brokers/fidelity-json.test.ts
+++ b/extension/src/brokers/fidelity-json.test.ts
@@ -67,13 +67,13 @@ describe("convertFidelityJson", () => {
   it("maps a purchase to its share count with both identifiers", () => {
     const result = convertFidelityJson(json(BUY));
     expect(result.errors).toEqual([]);
-    const tx = result.txs[0]!;
+    const tx = result.postings[0]!;
     expect(tx.type).toBe(TxType.BUYSTOCK);
     expect(tx.quantity).toBe("913");
     expect(tx.unitPrice).toBe("79.848724");
     expect(tx.settlementCurrency).toBe("GBP");
     // Not a cash transaction, so no trading currency is asserted.
-    expect(tx.tradingCurrency).toBe("");
+    expect(tx.tradingCurrency).toBeUndefined();
     expect(tx.identifierHints.map((h) => [h.type, h.value])).toEqual([
       [IdentifierType.ISIN, "IE00B3XXRP09"],
       [IdentifierType.SEDOL, "B7NLLS3"],
@@ -84,22 +84,22 @@ describe("convertFidelityJson", () => {
     // A zero price is a price -- an option expiring worthless. Only a row that
     // reports none at all leaves unitPrice unset.
     const priced = convertFidelityJson(json({ ...BUY, pricePerUnit: 0 }));
-    expect(priced.txs[0]!.unitPrice).toBe("0");
+    expect(priced.postings[0]!.unitPrice).toBe("0");
 
     const { pricePerUnit: _omitted, ...unpriced } = BUY;
-    expect(convertFidelityJson(json(unpriced)).txs[0]!.unitPrice).toBeUndefined();
+    expect(convertFidelityJson(json(unpriced)).postings[0]!.unitPrice).toBeUndefined();
   });
 
   it("negates a disposal", () => {
     const result = convertFidelityJson(
       json({ ...BUY, transactionType: "Sell", debitCreditIndicator: "DEBIT" })
     );
-    expect(result.txs[0]!.quantity).toBe("-913");
+    expect(result.postings[0]!.quantity).toBe("-913");
   });
 
   it("takes a cash movement's value from valuation, signed by the indicator", () => {
     const result = convertFidelityJson(json(SERVICE_FEE));
-    const tx = result.txs[0]!;
+    const tx = result.postings[0]!;
     expect(tx.quantity).toBe("-5.2");
     expect(tx.type).toBe(TxType.INVEXPENSE);
     // Cash transactions carry the currency on both sides.
@@ -111,7 +111,7 @@ describe("convertFidelityJson", () => {
     const result = convertFidelityJson(
       json({ ...SERVICE_FEE, transactionType: "Tax On Interest", units: 0, valuation: 0.2 })
     );
-    expect(result.txs[0]!.quantity).toBe("-0.2");
+    expect(result.postings[0]!.quantity).toBe("-0.2");
   });
 
   it("nets a matched transfer pair to zero", () => {
@@ -125,7 +125,7 @@ describe("convertFidelityJson", () => {
     const back = { ...out, transactionType: "Cash In Ring-fenced For Fees", debitCreditIndicator: "CREDIT" };
     const result = convertFidelityJson(json(out, back));
     // Summed as decimals: the postings carry decimal strings now.
-    const total = result.txs.reduce((sum, tx) => sum.plus(tx.quantity), new Big(0));
+    const total = result.postings.reduce((sum, tx) => sum.plus(tx.quantity), new Big(0));
     expect(total.eq(0)).toBe(true);
   });
 
@@ -134,8 +134,8 @@ describe("convertFidelityJson", () => {
     // type cannot be used to decide whether a row names a real security. Nothing
     // is passed on that would resolve to a fictional instrument.
     const result = convertFidelityJson(json(SERVICE_FEE));
-    expect(result.txs[0]!.instrumentDescription).toBe("GBP");
-    expect(result.txs[0]!.identifierHints.map((h) => [h.type, h.value])).toEqual([
+    expect(result.postings[0]!.instrumentDescription).toBe("GBP");
+    expect(result.postings[0]!.identifierHints.map((h) => [h.type, h.value])).toEqual([
       [IdentifierType.CURRENCY, "GBP"],
     ]);
   });
@@ -146,12 +146,12 @@ describe("convertFidelityJson", () => {
     const result = convertFidelityJson(
       json({ ...SERVICE_FEE, transactionType: "Cash Dividend", assetName: "Relationship Cash Source", isin: "AA00K0000000", debitCreditIndicator: "CREDIT" })
     );
-    expect(result.txs[0]!.instrumentDescription).toBe("GBP");
+    expect(result.postings[0]!.instrumentDescription).toBe("GBP");
   });
 
   it("falls back to the order date when a transaction has not settled", () => {
     const result = convertFidelityJson(json({ ...SERVICE_FEE, settlementDate: null }));
-    const ts = result.txs[0]!.timestamp!;
+    const ts = result.postings[0]!.timestamp!;
     // dealDate is 03/07/2026, built as local midnight.
     expect(Number(ts.seconds)).toBe(Math.floor(new Date(2026, 6, 3).getTime() / 1000));
   });
@@ -161,14 +161,14 @@ describe("convertFidelityJson", () => {
       json({ ...BUY, status: "Cancelled", units: 0, valuation: 0 }, SERVICE_FEE)
     );
     // The service fee and its expense leg; nothing from the cancelled buy.
-    expect(result.txs).toHaveLength(2);
-    expect(result.txs[0]!.type).toBe(TxType.INVEXPENSE);
+    expect(result.postings).toHaveLength(2);
+    expect(result.postings[0]!.type).toBe(TxType.INVEXPENSE);
     expect(result.errors).toEqual([]);
   });
 
   it("reports an unrecognised transaction type by name", () => {
     const result = convertFidelityJson(json({ ...SERVICE_FEE, transactionType: "Corporate Action" }));
-    expect(result.txs).toEqual([]);
+    expect(result.postings).toEqual([]);
     expect(result.errors[0]!.message).toContain("Corporate Action");
     expect(result.errors[0]!.rowIndex).toBe(1);
   });
@@ -226,7 +226,7 @@ describe("convertFidelityJson cash-asset rows", () => {
   it("is a cash movement, not a security trade", () => {
     const result = convertFidelityJson(json(BUY_CASH));
     expect(result.errors).toEqual([]);
-    const tx = result.txs[0]!;
+    const tx = result.postings[0]!;
     expect(tx.type).toBe(TxType.CASHFLOW);
     expect(tx.quantity).toBe("12772.83");
     expect(tx.tradingCurrency).toBe("GBP");
@@ -239,9 +239,9 @@ describe("convertFidelityJson cash-asset rows", () => {
 
   it("groups a purchase of cash with the cash out beside it", () => {
     const result = convertFidelityJson(json(CASH_OUT, BUY_CASH));
-    expect(result.txs[0]!.groupRef).toBe("1166853279");
-    expect(result.txs[1]!.groupRef).toBe("1166853279");
-    expectGroupsBalance(result.txs);
+    expect(result.postings[0]!.groupRef).toBe("1166853279");
+    expect(result.postings[1]!.groupRef).toBe("1166853279");
+    expectGroupsBalance(result.postings);
   });
 
   it("leaves the transfer beside it as the money that arrived", () => {
@@ -250,9 +250,9 @@ describe("convertFidelityJson cash-asset rows", () => {
     // zero, so the account must end that much up rather than level.
     const result = convertFidelityJson(json(CASH_OUT, ARRIVAL, BUY_CASH));
     expect(result.errors).toEqual([]);
-    const total = result.txs.reduce((sum, tx) => sum.plus(tx.quantity), new Big(0));
+    const total = result.postings.reduce((sum, tx) => sum.plus(tx.quantity), new Big(0));
     expect(total.eq(12772.83)).toBe(true);
-    expect(result.txs.some((tx) => tx.type === TxType.BUYSTOCK)).toBe(false);
+    expect(result.postings.some((tx) => tx.type === TxType.BUYSTOCK)).toBe(false);
   });
 
   it("reads a sale of cash the same way", () => {
@@ -278,16 +278,16 @@ describe("convertFidelityJson cash-asset rows", () => {
     });
 
     const result = convertFidelityJson(json(sell, cashIn));
-    expect(result.txs[0]!.type).toBe(TxType.CASHFLOW);
-    expect(result.txs[0]!.quantity).toBe("-20000");
-    expect(result.txs[0]!.groupRef).toBe("971613412");
-    expect(result.txs[1]!.groupRef).toBe("971613412");
-    expectGroupsBalance(result.txs);
+    expect(result.postings[0]!.type).toBe(TxType.CASHFLOW);
+    expect(result.postings[0]!.quantity).toBe("-20000");
+    expect(result.postings[0]!.groupRef).toBe("971613412");
+    expect(result.postings[1]!.groupRef).toBe("971613412");
+    expectGroupsBalance(result.postings);
   });
 
   it("still reads a purchase carrying a real identifier as a security trade", () => {
     const result = convertFidelityJson(json(BUY));
-    expect(result.txs[0]!.type).toBe(TxType.BUYSTOCK);
+    expect(result.postings[0]!.type).toBe(TxType.BUYSTOCK);
   });
 
   it("retypes a Cash In that paired with a sale, keeping the row's own currency", () => {
@@ -312,10 +312,10 @@ describe("convertFidelityJson cash-asset rows", () => {
     });
 
     const result = convertFidelityJson(json(sale, proceeds));
-    expect(result.txs[0]!.type).toBe(TxType.SELLSTOCK);
-    expect(result.txs[1]!.type).toBe(TxType.CASHFLOW);
-    expect(result.txs[1]!.tradingCurrency).toBe("GBP");
-    expect(result.txs[1]!.groupRef).toBe("661638570");
+    expect(result.postings[0]!.type).toBe(TxType.SELLSTOCK);
+    expect(result.postings[1]!.type).toBe(TxType.CASHFLOW);
+    expect(result.postings[1]!.tradingCurrency).toBe("GBP");
+    expect(result.postings[1]!.groupRef).toBe("661638570");
   });
 });
 
@@ -352,9 +352,9 @@ describe("convertFidelityJson grouping", () => {
       )
     );
 
-    expect(result.txs).toHaveLength(2);
-    expect(result.txs[0]!.groupRef).toBe("441416452");
-    expect(result.txs[1]!.groupRef).toBe("441416452");
+    expect(result.postings).toHaveLength(2);
+    expect(result.postings[0]!.groupRef).toBe("441416452");
+    expect(result.postings[1]!.groupRef).toBe("441416452");
   });
 
   it("pairs a buy with the cash out despite the fee gap", () => {
@@ -380,8 +380,8 @@ describe("convertFidelityJson grouping", () => {
       )
     );
 
-    expect(result.txs[0]!.groupRef).toBe("441416515");
-    expect(result.txs[1]!.groupRef).toBe("441416515");
+    expect(result.postings[0]!.groupRef).toBe("441416515");
+    expect(result.postings[1]!.groupRef).toBe("441416515");
   });
 
   it("keeps a separately reported charge out of any trade's group", () => {
@@ -399,10 +399,10 @@ describe("convertFidelityJson grouping", () => {
     );
 
     // A group of its own, holding the charge and the expense it went to.
-    expect(result.txs).toHaveLength(2);
-    expect(result.txs[0]!.groupRef).not.toBe("");
-    expect(result.txs[1]!.groupRef).toBe(result.txs[0]!.groupRef);
-    expect(result.txs[1]!.accountType).toBe(AccountType.EXPENSE);
+    expect(result.postings).toHaveLength(2);
+    expect(result.postings[0]!.groupRef).toBeTruthy();
+    expect(result.postings[1]!.groupRef).toBe(result.postings[0]!.groupRef);
+    expect(result.postings[1]!.accountType).toBe(AccountType.EXPENSE);
   });
 
   it("groups the run a deposit into a product account is reported through", () => {
@@ -442,14 +442,14 @@ describe("convertFidelityJson grouping", () => {
     );
 
     expect(result.errors).toEqual([]);
-    expect(result.txs.map((tx) => tx.groupRef)).toEqual([
+    expect(result.postings.map((tx) => tx.groupRef)).toEqual([
       "971613428",
       "971613428",
       "971613428",
     ]);
     // The journals stay journals, which is what routes the group's residual to
     // TRANSFER_CLEARING rather than IMBALANCE.
-    expect(result.txs.map((tx) => tx.type)).toEqual([
+    expect(result.postings.map((tx) => tx.type)).toEqual([
       TxType.JRNLFUND,
       TxType.CASHFLOW,
       TxType.JRNLFUND,
@@ -476,8 +476,8 @@ describe("convertFidelityJson grouping", () => {
       )
     );
 
-    for (const tx of result.txs) {
-      expect(tx.groupRef).toBe("");
+    for (const tx of result.postings) {
+      expect(tx.groupRef).toBeUndefined();
     }
   });
 });
@@ -508,8 +508,8 @@ describe("source references", () => {
     );
 
     expect(result.errors).toEqual([]);
-    expect(result.txs[0]!.brokerRef).toBe("971613414");
-    expect(result.txs[0]!.counterpartyAccount).toBe("AG10000001");
+    expect(result.postings[0]!.brokerRef).toBe("971613414");
+    expect(result.postings[0]!.counterpartyAccount).toBe("AG10000001");
   });
 
   it("leaves the counterparty empty where the source names none", () => {
@@ -524,8 +524,8 @@ describe("source references", () => {
       })
     );
 
-    expect(result.txs[0]!.brokerRef).toBe("971613430");
-    expect(result.txs[0]!.counterpartyAccount).toBe("");
+    expect(result.postings[0]!.brokerRef).toBe("971613430");
+    expect(result.postings[0]!.counterpartyAccount).toBeUndefined();
   });
 
   // Fidelity puts the product account a fee was charged for in the same field it
@@ -547,12 +547,12 @@ describe("source references", () => {
       })
     );
 
-    const fee = result.txs[0]!;
+    const fee = result.postings[0]!;
     expect(fee.type).toBe(TxType.INVEXPENSE);
     expect(fee.counterpartyAccount).toBe("AP10000001");
     // The derived expense leg is the converter's own, so it names no source row.
-    const expense = result.txs.find((tx) => tx.accountType === AccountType.EXPENSE)!;
-    expect(expense.brokerRef).toBe("");
-    expect(expense.counterpartyAccount).toBe("");
+    const expense = result.postings.find((tx) => tx.accountType === AccountType.EXPENSE)!;
+    expect(expense.brokerRef).toBeUndefined();
+    expect(expense.counterpartyAccount).toBeUndefined();
   });
 });

--- a/extension/src/brokers/fidelity-json.ts
+++ b/extension/src/brokers/fidelity-json.ts
@@ -13,8 +13,9 @@
 import { create } from "@bufbuild/protobuf";
 import { timestampFromDate } from "@bufbuild/protobuf/wkt";
 import { startOfNextDay } from "../lib/dates";
-import type { Tx } from "@/gen/api/v1/api_pb";
-import { InstrumentIdentifierSchema, TxSchema } from "@/gen/api/v1/api_pb";
+import type { Posting } from "@/gen/archive/v1/txs_pb";
+import { PostingSchema } from "@/gen/archive/v1/txs_pb";
+import { InstrumentRefSchema } from "@/gen/archive/v1/common_pb";
 import { IdentifierType } from "@/gen/type/v1/type_pb";
 import type { FidelityLeg } from "@/lib/csv/converters/fidelity-csv";
 import {
@@ -25,7 +26,7 @@ import {
   isCashTxType,
   typeForAsset,
 } from "@/lib/csv/converters/fidelity-csv";
-import type { ParseError, StandardParseResult } from "@/lib/csv/standard";
+import type { ParseError, StandardParseResult } from "@/lib/csv/parse-result";
 import { counterLegs, currencyHint } from "@/lib/csv/postings";
 import { Big, decimalFromNumber } from "@/lib/decimal";
 import { parseSlashDate } from "../lib/dates";
@@ -94,7 +95,7 @@ export function isValidIsin(value: string): boolean {
 
 function fail(message: string): StandardParseResult {
   return {
-    txs: [],
+    postings: [],
     periodFrom: new Date(0),
     periodBefore: new Date(0),
     errors: [{ rowIndex: 0, field: "file", message }],
@@ -117,7 +118,7 @@ export function convertFidelityJson(
   }
 
   const errors: ParseError[] = [];
-  const txs: Tx[] = [];
+  const postings: Posting[] = [];
   const legs: FidelityLeg[] = [];
   let minTime = Infinity;
   let maxTime = -Infinity;
@@ -175,17 +176,15 @@ export function convertFidelityJson(
         : []
       : isValidIsin(isin)
         ? [
-            create(InstrumentIdentifierSchema, {
+            create(InstrumentRefSchema, {
               type: IdentifierType.ISIN,
               value: isin,
-              canonical: false,
             }),
             ...(sedol
               ? [
-                  create(InstrumentIdentifierSchema, {
+                  create(InstrumentRefSchema, {
                     type: IdentifierType.SEDOL,
                     value: sedol,
-                    canonical: false,
                   }),
                 ]
               : []),
@@ -213,8 +212,8 @@ export function convertFidelityJson(
       ref: parseInt(row.referenceId ?? "", 10),
       cashAsset,
     });
-    txs.push(
-      create(TxSchema, {
+    postings.push(
+      create(PostingSchema, {
         timestamp: timestampFromDate(date),
         // A cash posting is described by its currency, which is what resolves it
         // to the currency instrument rather than to a holding named after the
@@ -244,16 +243,16 @@ export function convertFidelityJson(
 
   const groups = assignFidelityGroups(legs);
   groups.refs.forEach((ref, i) => {
-    if (ref) txs[i].groupRef = ref;
+    if (ref) postings[i].groupRef = ref;
   });
   groups.cashLegs.forEach((paired, i) => {
-    if (paired) asTradeCashLeg(txs[i], txs[i].settlementCurrency);
+    if (paired) asTradeCashLeg(postings[i], postings[i].settlementCurrency ?? "");
   });
   // After the refs are stamped, since that loop is index-parallel with legs.
-  txs.push(...counterLegs(txs));
+  postings.push(...counterLegs(postings));
 
   return {
-    txs,
+    postings,
     periodFrom: minTime === Infinity ? new Date(0) : new Date(minTime),
     periodBefore:
       maxTime === -Infinity ? new Date(0) : startOfNextDay(new Date(maxTime)),

--- a/extension/src/brokers/types.ts
+++ b/extension/src/brokers/types.ts
@@ -13,7 +13,7 @@
  */
 
 import type { Broker } from "@/gen/type/v1/type_pb";
-import type { StandardParseResult } from "@/lib/csv/standard";
+import type { StandardParseResult } from "@/lib/csv/parse-result";
 
 /**
  * A request to replay against the broker, with {{from}} and {{to}} substituted.

--- a/extension/src/client-imports.test.ts
+++ b/extension/src/client-imports.test.ts
@@ -23,8 +23,8 @@ describe("client module imports", () => {
     const result = parseStandardCSV(csv);
 
     expect(result.errors).toEqual([]);
-    expect(result.txs).toHaveLength(1);
-    expect(result.txs[0]!.type).toBe(TxType.BUYSTOCK);
-    expect(result.txs[0]!.quantity).toBe("10");
+    expect(result.postings).toHaveLength(1);
+    expect(result.postings[0]!.type).toBe(TxType.BUYSTOCK);
+    expect(result.postings[0]!.quantity).toBe("10");
   });
 });

--- a/extension/src/lib/api.test.ts
+++ b/extension/src/lib/api.test.ts
@@ -68,29 +68,31 @@ describe("api", () => {
     const before = new Date("2026-07-27T00:00:00Z");
 
     const res = await upsertTxs(ORIGIN, SESSION, {
-      broker: Broker.FIDELITY,
-      source: "Fidelity:web:fidelity-csv",
-      periodFrom: timestampFromDate(from),
-      periodBefore: timestampFromDate(before),
+      window: {
+        broker: Broker.FIDELITY,
+        source: "Fidelity:web:fidelity-csv",
+        periodFrom: timestampFromDate(from),
+        periodBefore: timestampFromDate(before),
+        postings: [
+          {
+            timestamp: timestampFromDate(new Date("2026-07-10T00:00:00Z")),
+            instrumentDescription: "ISHARES II PLC INRG",
+            type: TxType.BUYSTOCK,
+            quantity: "10",
+          },
+        ],
+      },
       filename: "fidelity-ext-2026-07-27.csv",
-      txs: [
-        {
-          timestamp: timestampFromDate(new Date("2026-07-10T00:00:00Z")),
-          instrumentDescription: "ISHARES II PLC INRG",
-          type: TxType.BUYSTOCK,
-          quantity: "10",
-        },
-      ],
     });
 
     expect(res.jobId).toBe("job-1");
     const req = fromBinary(UpsertTxsRequestSchema, sentRequest(spy));
     // The period is the window that was requested, not the range of the rows:
     // that is what makes the replace delete transactions the broker cancelled.
-    expect(req.periodFrom?.seconds).toBe(BigInt(Math.floor(from.getTime() / 1000)));
-    expect(req.periodBefore?.seconds).toBe(BigInt(Math.floor(before.getTime() / 1000)));
-    expect(req.source).toBe("Fidelity:web:fidelity-csv");
-    expect(req.txs).toHaveLength(1);
+    expect(req.window?.periodFrom?.seconds).toBe(BigInt(Math.floor(from.getTime() / 1000)));
+    expect(req.window?.periodBefore?.seconds).toBe(BigInt(Math.floor(before.getTime() / 1000)));
+    expect(req.window?.source).toBe("Fidelity:web:fidelity-csv");
+    expect(req.window?.postings).toHaveLength(1);
   });
 
   it("propagates a gRPC error status from the response headers", async () => {

--- a/extension/src/lib/dropped.ts
+++ b/extension/src/lib/dropped.ts
@@ -8,7 +8,7 @@
  * precisely enough to extend the converter's map.
  */
 
-import type { ParseError } from "@/lib/csv/standard";
+import type { ParseError } from "@/lib/csv/parse-result";
 
 /**
  * Distinct broker transaction types the converter did not recognise.

--- a/extension/src/lib/run-log.ts
+++ b/extension/src/lib/run-log.ts
@@ -6,7 +6,7 @@
  * dropped rows names the broker transaction types it did not recognise.
  */
 
-import type { ParseError } from "@/lib/csv/standard";
+import type { ParseError } from "@/lib/csv/parse-result";
 
 const STORAGE_KEY = "runLog";
 const MAX_ENTRIES = 20;

--- a/proto/ingestion/v1/ingestion.proto
+++ b/proto/ingestion/v1/ingestion.proto
@@ -3,8 +3,7 @@ syntax = "proto3";
 package portfoliodb.ingestion.v1;
 
 import "buf/validate/validate.proto";
-import "google/protobuf/timestamp.proto";
-import "api/v1/api.proto";
+import "archive/v1/txs.proto";
 import "type/v1/type.proto";
 
 option go_package = "github.com/leedenison/portfoliodb/proto/ingestion/v1;ingestionv1";
@@ -12,55 +11,43 @@ option go_package = "github.com/leedenison/portfoliodb/proto/ingestion/v1;ingest
 // IngestionService provides gRPC endpoints for uploading transaction data
 // (bulk and single).
 service IngestionService {
-  // UpsertTxs replaces all transactions for the given broker in the given
-  // period with the supplied list. Processed asynchronously; returns a job_id
-  // for status and validation errors via the front-end API.
+  // UpsertTxs replaces all transactions for the window's broker over the
+  // window's period with the postings it carries. Processed asynchronously;
+  // returns a job_id for status and validation errors via the front-end API.
   rpc UpsertTxs(UpsertTxsRequest) returns (UpsertTxsResponse);
-  // CreateTx appends one transaction. No natural key; not idempotent (duplicate
+  // CreateTx appends one posting. No natural key; not idempotent (duplicate
   // submissions create duplicate rows). Source required for instrument resolution. Processed
   // asynchronously; returns a job_id for status.
   rpc CreateTx(CreateTxRequest) returns (CreateTxResponse);
 }
 
-// UpsertTxsRequest replaces all transactions for the given broker in the
-// given period with the supplied list. User from auth.
+// UpsertTxsRequest replaces all transactions for the window's broker over the
+// window's period with the postings it carries. User from auth.
+//
+// The payload is an archive transaction window rather than a list plus a set of
+// request fields. A window already states its broker, its source, the half-open
+// period it replaces and the postings inside it, so an upload describes itself
+// and the two ways transactions arrive -- a broker file and an archive document
+// -- meet above the ingestion pipeline instead of each assembling their own
+// call. See docs/spec/archive-format.md.
 message UpsertTxsRequest {
-  // Broker. All transactions in this request are for this broker.
-  portfoliodb.type.v1.Broker broker = 1 [(buf.validate.field).enum = {defined_only: true, not_in: [0]}];
-  // Source (opaque; e.g. "<broker>:<client>:<source>"). Required. Used for instrument resolution.
-  string source = 2 [(buf.validate.field).string.min_len = 1];
-  // Half-open [period_from, period_before) period of transactions covered. Only
-  // transactions in this range for this broker are replaced; others are
-  // unchanged.
-  google.protobuf.Timestamp period_from   = 3 [(buf.validate.field).required = true]; // inclusive
-  google.protobuf.Timestamp period_before = 4 [(buf.validate.field).required = true]; // exclusive
-  // Transactions to store. Replaces any existing tx in
-  // [period_from, period_before) for this user and broker. Each tx carries its
-  // own account.
-  repeated portfoliodb.api.v1.Tx txs = 5;
-  // Original filename of the uploaded CSV file.
-  string filename = 6;
-  // The share count the quantities and unit prices in this upload are
-  // denominated in, as "YYYY-MM-DD". Optional; when empty each row falls back
-  // to its own transaction date, the as-traded assumption. Set it only for a
-  // source that restates historical rows into current share terms, such as a
-  // broker web UI that shows post-split quantities on pre-split trades.
-  // See docs/spec/bitemporality.md.
-  string share_count_basis = 7;
+  portfoliodb.archive.v1.TxWindow window = 1 [(buf.validate.field).required = true];
+  // Original filename of the uploaded file.
+  string filename = 2;
 }
 
-// CreateTxRequest appends one transaction.
+// CreateTxRequest appends one posting. There is no window because there is no
+// period: an append replaces nothing, which is the one thing the bulk path does
+// that this one does not.
 message CreateTxRequest {
-  // Broker for this transaction.
+  // Broker for this posting.
   portfoliodb.type.v1.Broker broker = 1 [(buf.validate.field).enum = {defined_only: true, not_in: [0]}];
   // Source (opaque; e.g. "<broker>:<client>:<source>"). Required. Used for instrument resolution.
   string source = 2 [(buf.validate.field).string.min_len = 1];
-  // The transaction (must include account).
-  portfoliodb.api.v1.Tx tx = 3 [(buf.validate.field).required = true];
-  // The share count the quantity and unit price are denominated in, as
-  // "YYYY-MM-DD". Optional; when empty the row falls back to its own
-  // transaction date, the as-traded assumption. See UpsertTxsRequest.
-  string share_count_basis = 4;
+  // The posting (must include account). Its share_count_basis says what share
+  // count the quantity and unit price are denominated in; absent is the
+  // posting's own date, the as-traded assumption.
+  portfoliodb.archive.v1.Posting posting = 3 [(buf.validate.field).required = true];
 }
 
 // UpsertTxsResponse identifies the async job the upload became. Job status and
@@ -71,7 +58,7 @@ message UpsertTxsResponse {
   string job_id = 1;
 }
 
-// CreateTxResponse identifies the async job the transaction became.
+// CreateTxResponse identifies the async job the posting became.
 message CreateTxResponse {
   // Identifier for the async ingestion job. Use with front-end API to poll
   // status and retrieve validation errors.

--- a/server/service/ingestion/server.go
+++ b/server/service/ingestion/server.go
@@ -3,7 +3,7 @@ package ingestion
 import (
 	"context"
 	"fmt"
-	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
 	ingestionv1 "github.com/leedenison/portfoliodb/proto/ingestion/v1"
 	"github.com/leedenison/portfoliodb/server/auth"
 	"github.com/leedenison/portfoliodb/server/db"
@@ -30,13 +30,14 @@ func (s *Server) UpsertTxs(ctx context.Context, req *ingestionv1.UpsertTxsReques
 	if authErr != nil {
 		return nil, authErr
 	}
-	if err := ValidateBroker(req.Broker); err != nil {
+	w := req.GetWindow()
+	if err := ValidateBroker(w.GetBroker()); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Message)
 	}
-	if err := ValidateSource(req.GetSource()); err != nil {
+	if err := ValidateSource(w.GetSource()); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Message)
 	}
-	periodErrs := ValidateBulkRequest(req.PeriodFrom, req.PeriodBefore)
+	periodErrs := ValidateBulkRequest(w.GetPeriodFrom(), w.GetPeriodBefore())
 	if len(periodErrs) > 0 {
 		return nil, status.Error(codes.InvalidArgument, periodErrs[0].Message)
 	}
@@ -44,15 +45,15 @@ func (s *Server) UpsertTxs(ctx context.Context, req *ingestionv1.UpsertTxsReques
 	if err != nil {
 		return nil, status.Error(codes.Internal, fmt.Sprintf("serialize request: %v", err))
 	}
-	brokerStr := db.BrokerToStr(req.Broker)
+	brokerStr := db.BrokerToStr(w.GetBroker())
 	jobID, err := s.db.CreateJob(ctx, db.CreateJobParams{
 		UserID:       u.ID,
 		JobType:      "tx",
 		Broker:       brokerStr,
-		Source:       req.GetSource(),
+		Source:       w.GetSource(),
 		Filename:     req.GetFilename(),
-		PeriodFrom:   req.PeriodFrom,
-		PeriodBefore: req.PeriodBefore,
+		PeriodFrom:   w.GetPeriodFrom(),
+		PeriodBefore: w.GetPeriodBefore(),
 		Payload:      payload,
 	})
 	if err != nil {
@@ -78,16 +79,18 @@ func (s *Server) CreateTx(ctx context.Context, req *ingestionv1.CreateTxRequest)
 	if err := ValidateSource(req.GetSource()); err != nil {
 		return nil, status.Error(codes.InvalidArgument, err.Message)
 	}
-	if req.Tx == nil {
-		return nil, status.Error(codes.InvalidArgument, "tx required")
+	if req.Posting == nil {
+		return nil, status.Error(codes.InvalidArgument, "posting required")
 	}
-	// Wrap single tx in UpsertTxsRequest for uniform payload format.
+	// One payload shape for both paths: a window with no period, which is what
+	// makes this an append rather than a replacement.
 	brokerStr := db.BrokerToStr(req.Broker)
 	wrapped := &ingestionv1.UpsertTxsRequest{
-		Broker:          req.Broker,
-		Source:          req.GetSource(),
-		Txs:             []*apiv1.Tx{req.Tx},
-		ShareCountBasis: req.GetShareCountBasis(),
+		Window: &archivev1.TxWindow{
+			Broker:   req.Broker,
+			Source:   req.GetSource(),
+			Postings: []*archivev1.Posting{req.GetPosting()},
+		},
 	}
 	payload, err := proto.Marshal(wrapped)
 	if err != nil {

--- a/server/service/ingestion/server_test.go
+++ b/server/service/ingestion/server_test.go
@@ -2,7 +2,7 @@ package ingestion
 
 import (
 	"context"
-	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
 	ingestionv1 "github.com/leedenison/portfoliodb/proto/ingestion/v1"
 	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
 	"github.com/leedenison/portfoliodb/server/auth"
@@ -37,27 +37,35 @@ func TestUpsertTxs(t *testing.T) {
 		wantCode codes.Code
 	}{
 		{"Unauthenticated", context.Background(), &ingestionv1.UpsertTxsRequest{
-			Broker:       typev1.Broker_IBKR,
-			Source:       "IBKR:test:statement",
-			PeriodFrom:   now,
-			PeriodBefore: now,
+			Window: &archivev1.TxWindow{
+				Broker:       typev1.Broker_IBKR,
+				Source:       "IBKR:test:statement",
+				PeriodFrom:   now,
+				PeriodBefore: now,
+			},
 		}, codes.Unauthenticated},
 		{"InvalidArgument_broker", authCtx("user-1"), &ingestionv1.UpsertTxsRequest{
-			Broker:       typev1.Broker_BROKER_UNSPECIFIED,
-			Source:       "IBKR:test:statement",
-			PeriodFrom:   now,
-			PeriodBefore: now,
+			Window: &archivev1.TxWindow{
+				Broker:       typev1.Broker_BROKER_UNSPECIFIED,
+				Source:       "IBKR:test:statement",
+				PeriodFrom:   now,
+				PeriodBefore: now,
+			},
 		}, codes.InvalidArgument},
 		{"InvalidArgument_source", authCtx("user-1"), &ingestionv1.UpsertTxsRequest{
-			Broker:       typev1.Broker_IBKR,
-			Source:       "",
-			PeriodFrom:   now,
-			PeriodBefore: now,
+			Window: &archivev1.TxWindow{
+				Broker:       typev1.Broker_IBKR,
+				Source:       "",
+				PeriodFrom:   now,
+				PeriodBefore: now,
+			},
 		}, codes.InvalidArgument},
 		{"InvalidArgument_period", authCtx("user-1"), &ingestionv1.UpsertTxsRequest{
-			Broker:       typev1.Broker_IBKR,
-			Source:       "IBKR:test:statement",
-			PeriodBefore: now,
+			Window: &archivev1.TxWindow{
+				Broker:       typev1.Broker_IBKR,
+				Source:       "IBKR:test:statement",
+				PeriodBefore: now,
+			},
 		}, codes.InvalidArgument},
 	}
 	for _, tc := range tests {
@@ -90,11 +98,12 @@ func TestUpsertTxs_Success(t *testing.T) {
 		})
 	ctx := authCtx("user-1")
 	resp, err := srv.UpsertTxs(ctx, &ingestionv1.UpsertTxsRequest{
-		Broker:       typev1.Broker_IBKR,
-		Source:       "IBKR:test:statement",
-		PeriodFrom:   periodFrom,
-		PeriodBefore: periodBefore,
-		Txs:          []*apiv1.Tx{},
+		Window: &archivev1.TxWindow{
+			Broker:       typev1.Broker_IBKR,
+			Source:       "IBKR:test:statement",
+			PeriodFrom:   periodFrom,
+			PeriodBefore: periodBefore,
+		},
 	})
 	if err != nil {
 		t.Fatalf("UpsertTxs: %v", err)

--- a/server/service/ingestion/worker.go
+++ b/server/service/ingestion/worker.go
@@ -187,30 +187,19 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 		return false, ""
 	}
 
-	txs := req.GetTxs()
-	if txs == nil {
-		txs = []*apiv1.Tx{}
-	}
 	// A tx job has no part rows, so its reporter is the unscoped kind: it writes
 	// progress and problems against the job itself.
 	rep := archiveimport.NewPartReporter(database, j.JobID, archivev1.ArchivePart_ARCHIVE_PART_UNSPECIFIED)
 
-	// The upload declares one basis for every row it carries, so the per-row
-	// slice the store takes is that value repeated. A file that restates only
-	// some of its rows is the archive's shape, not the CSV's.
-	var basis []*time.Time
-	if b := req.GetShareCountBasis(); b != "" {
-		parsed, err := time.Parse("2006-01-02", b)
-		if err != nil {
-			rep.Errf(-1, "share_count_basis", fmt.Sprintf("invalid date %q: want YYYY-MM-DD", b))
-			rep.Flush(ctx)
-			finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
-			return false, ""
-		}
-		basis = make([]*time.Time, len(txs))
-		for i := range basis {
-			basis[i] = &parsed
-		}
+	// The payload is an archive window, so a broker upload and an archive
+	// document are read by the same code above the ingestion pipeline.
+	w := req.GetWindow()
+	txs, basis, rowIdx, err := windowTxs(w, 0, rep)
+	if err != nil {
+		rep.Flush(ctx)
+		log.Printf("ingestion job %s: %v", j.JobID, err)
+		finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
+		return false, ""
 	}
 
 	res, err := ingestBatch(ctx, ingestDeps{
@@ -220,16 +209,17 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 		Counter:      counter,
 	}, ingestParams{
 		UserID:          userID,
-		Broker:          db.BrokerToStr(req.Broker),
-		Source:          req.GetSource(),
+		Broker:          db.BrokerToStr(w.GetBroker()),
+		Source:          w.GetSource(),
 		JobID:           j.JobID,
 		Txs:             txs,
 		ShareCountBasis: basis,
+		RowIndices:      rowIdx,
 		// Both bounds present makes this a replacement rather than an append.
-		// CreateTx wraps its one tx in the same request with no period, which is
+		// CreateTx wraps its one posting in a window with no period, which is
 		// where the two paths diverge.
-		PeriodFrom:   req.PeriodFrom,
-		PeriodBefore: req.PeriodBefore,
+		PeriodFrom:   w.GetPeriodFrom(),
+		PeriodBefore: w.GetPeriodBefore(),
 	}, rep)
 	// Flushed before the job is marked terminal on both paths: the problems
 	// gathered before a failure are what explain it.

--- a/server/service/ingestion/worker_test.go
+++ b/server/service/ingestion/worker_test.go
@@ -47,15 +47,17 @@ func TestProcessBulk_AppendsIdentificationErrorsWhenBrokerDescriptionOnly(t *tes
 	ctx := context.Background()
 	from := timestamppb.Now()
 	before := timestamppb.Now()
-	txs := []*apiv1.Tx{
+	postings := []*archivev1.Posting{
 		{Timestamp: from, InstrumentDescription: "UNKNOWN", Type: typev1.TxType_BUYSTOCK, Quantity: "1", Account: ""},
 	}
 	payload := marshalPayload(t, &ingestionv1.UpsertTxsRequest{
-		Broker:       typev1.Broker_IBKR,
-		Source:       "IBKR:test:statement",
-		PeriodFrom:   from,
-		PeriodBefore: before,
-		Txs:          txs,
+		Window: &archivev1.TxWindow{
+			Broker:       typev1.Broker_IBKR,
+			Source:       "IBKR:test:statement",
+			PeriodFrom:   from,
+			PeriodBefore: before,
+			Postings:     postings,
+		},
 	})
 	j := &JobRequest{JobID: "job-1", JobType: "tx"}
 
@@ -121,16 +123,18 @@ func TestProcessBulk_BatchCache_ResolvesSameDescriptionOnce(t *testing.T) {
 	ctx := context.Background()
 	from := timestamppb.Now()
 	before := timestamppb.Now()
-	txs := []*apiv1.Tx{
+	postings := []*archivev1.Posting{
 		{Timestamp: timestamppb.New(from.AsTime().Add(-1)), InstrumentDescription: "CACHED", Type: typev1.TxType_BUYSTOCK, Quantity: "1", Account: ""},
 		{Timestamp: timestamppb.New(from.AsTime().Add(1)), InstrumentDescription: "CACHED", Type: typev1.TxType_BUYSTOCK, Quantity: "2", Account: ""},
 	}
 	payload := marshalPayload(t, &ingestionv1.UpsertTxsRequest{
-		Broker:       typev1.Broker_IBKR,
-		Source:       "IBKR:test:statement",
-		PeriodFrom:   from,
-		PeriodBefore: before,
-		Txs:          txs,
+		Window: &archivev1.TxWindow{
+			Broker:       typev1.Broker_IBKR,
+			Source:       "IBKR:test:statement",
+			PeriodFrom:   from,
+			PeriodBefore: before,
+			Postings:     postings,
+		},
 	})
 	j := &JobRequest{JobID: "job-2", JobType: "tx"}
 
@@ -183,16 +187,18 @@ func TestProcessBulk_DropsTxTypeSplitTransactions(t *testing.T) {
 	ctx := context.Background()
 	from := timestamppb.Now()
 	before := timestamppb.Now()
-	txs := []*apiv1.Tx{
-		{Timestamp: from, InstrumentDescription: "AAPL", Type: typev1.TxType_BUYSTOCK, Quantity: "10", Account: "", GroupRef: "ref-1"},
-		{Timestamp: from, InstrumentDescription: "SPLIT", Type: typev1.TxType_SPLIT, Quantity: "1", Account: "", GroupRef: "ref-1"},
+	postings := []*archivev1.Posting{
+		{Timestamp: from, InstrumentDescription: "AAPL", Type: typev1.TxType_BUYSTOCK, Quantity: "10", Account: "", GroupRef: proto.String("ref-1")},
+		{Timestamp: from, InstrumentDescription: "SPLIT", Type: typev1.TxType_SPLIT, Quantity: "1", Account: "", GroupRef: proto.String("ref-1")},
 	}
 	payload := marshalPayload(t, &ingestionv1.UpsertTxsRequest{
-		Broker:       typev1.Broker_IBKR,
-		Source:       "IBKR:test:statement",
-		PeriodFrom:   from,
-		PeriodBefore: before,
-		Txs:          txs,
+		Window: &archivev1.TxWindow{
+			Broker:       typev1.Broker_IBKR,
+			Source:       "IBKR:test:statement",
+			PeriodFrom:   from,
+			PeriodBefore: before,
+			Postings:     postings,
+		},
 	})
 	j := &JobRequest{JobID: "job-split", JobType: "tx"}
 
@@ -285,16 +291,18 @@ func TestProcessBulk_BuystockIncomeSameDescriptionFails(t *testing.T) {
 	ctx := context.Background()
 	from := timestamppb.Now()
 	before := timestamppb.Now()
-	txs := []*apiv1.Tx{
+	postings := []*archivev1.Posting{
 		{Timestamp: from, InstrumentDescription: "MICROSOFT INC", Type: typev1.TxType_BUYSTOCK, Quantity: "10", Account: ""},
 		{Timestamp: from, InstrumentDescription: "MICROSOFT INC", Type: typev1.TxType_INCOME, Quantity: "0", Account: ""},
 	}
 	payload := marshalPayload(t, &ingestionv1.UpsertTxsRequest{
-		Broker:       typev1.Broker_IBKR,
-		Source:       "IBKR:test:statement",
-		PeriodFrom:   from,
-		PeriodBefore: before,
-		Txs:          txs,
+		Window: &archivev1.TxWindow{
+			Broker:       typev1.Broker_IBKR,
+			Source:       "IBKR:test:statement",
+			PeriodFrom:   from,
+			PeriodBefore: before,
+			Postings:     postings,
+		},
 	})
 	j := &JobRequest{JobID: "job-contradict", JobType: "tx"}
 
@@ -354,15 +362,17 @@ func TestProcessBulk_StockEtfEquivalence(t *testing.T) {
 	ctx := context.Background()
 	from := timestamppb.Now()
 	before := timestamppb.Now()
-	txs := []*apiv1.Tx{
+	postings := []*archivev1.Posting{
 		{Timestamp: from, InstrumentDescription: "SPY", Type: typev1.TxType_BUYSTOCK, Quantity: "10", Account: ""},
 	}
 	payload := marshalPayload(t, &ingestionv1.UpsertTxsRequest{
-		Broker:       typev1.Broker_IBKR,
-		Source:       "IBKR:test:statement",
-		PeriodFrom:   from,
-		PeriodBefore: before,
-		Txs:          txs,
+		Window: &archivev1.TxWindow{
+			Broker:       typev1.Broker_IBKR,
+			Source:       "IBKR:test:statement",
+			PeriodFrom:   from,
+			PeriodBefore: before,
+			Postings:     postings,
+		},
 	})
 	j := &JobRequest{JobID: "job-etf", JobType: "tx"}
 
@@ -415,15 +425,17 @@ func TestProcessBulk_StockMutualFundNotEquivalent(t *testing.T) {
 	ctx := context.Background()
 	from := timestamppb.Now()
 	before := timestamppb.Now()
-	txs := []*apiv1.Tx{
+	postings := []*archivev1.Posting{
 		{Timestamp: from, InstrumentDescription: "VFIAX", Type: typev1.TxType_BUYSTOCK, Quantity: "10", Account: ""},
 	}
 	payload := marshalPayload(t, &ingestionv1.UpsertTxsRequest{
-		Broker:       typev1.Broker_IBKR,
-		Source:       "IBKR:test:statement",
-		PeriodFrom:   from,
-		PeriodBefore: before,
-		Txs:          txs,
+		Window: &archivev1.TxWindow{
+			Broker:       typev1.Broker_IBKR,
+			Source:       "IBKR:test:statement",
+			PeriodFrom:   from,
+			PeriodBefore: before,
+			Postings:     postings,
+		},
 	})
 	j := &JobRequest{JobID: "job-mf", JobType: "tx"}
 
@@ -474,15 +486,17 @@ func TestProcessBulk_TransferToCashRejected(t *testing.T) {
 	ctx := context.Background()
 	from := timestamppb.Now()
 	before := timestamppb.Now()
-	txs := []*apiv1.Tx{
+	postings := []*archivev1.Posting{
 		{Timestamp: from, InstrumentDescription: "USD CASH", Type: typev1.TxType_TRANSFER, Quantity: "10", Account: ""},
 	}
 	payload := marshalPayload(t, &ingestionv1.UpsertTxsRequest{
-		Broker:       typev1.Broker_IBKR,
-		Source:       "IBKR:test:statement",
-		PeriodFrom:   from,
-		PeriodBefore: before,
-		Txs:          txs,
+		Window: &archivev1.TxWindow{
+			Broker:       typev1.Broker_IBKR,
+			Source:       "IBKR:test:statement",
+			PeriodFrom:   from,
+			PeriodBefore: before,
+			Postings:     postings,
+		},
 	})
 	j := &JobRequest{JobID: "job-transfer-cash", JobType: "tx"}
 
@@ -528,15 +542,17 @@ func TestProcessBulk_TransferToStockAllowed(t *testing.T) {
 	ctx := context.Background()
 	from := timestamppb.Now()
 	before := timestamppb.Now()
-	txs := []*apiv1.Tx{
+	postings := []*archivev1.Posting{
 		{Timestamp: from, InstrumentDescription: "MSFT", Type: typev1.TxType_TRANSFER, Quantity: "10", Account: ""},
 	}
 	payload := marshalPayload(t, &ingestionv1.UpsertTxsRequest{
-		Broker:       typev1.Broker_IBKR,
-		Source:       "IBKR:test:statement",
-		PeriodFrom:   from,
-		PeriodBefore: before,
-		Txs:          txs,
+		Window: &archivev1.TxWindow{
+			Broker:       typev1.Broker_IBKR,
+			Source:       "IBKR:test:statement",
+			PeriodFrom:   from,
+			PeriodBefore: before,
+			Postings:     postings,
+		},
 	})
 	j := &JobRequest{JobID: "job-transfer-stock", JobType: "tx"}
 
@@ -585,9 +601,11 @@ func TestProcessSingle_DropsTxTypeSplitTransaction(t *testing.T) {
 
 	ctx := context.Background()
 	payload := marshalPayload(t, &ingestionv1.UpsertTxsRequest{
-		Broker: typev1.Broker_IBKR,
-		Source: "IBKR:test:statement",
-		Txs:    []*apiv1.Tx{{Timestamp: timestamppb.Now(), InstrumentDescription: "SPLIT", Type: typev1.TxType_SPLIT, Quantity: "1", Account: ""}},
+		Window: &archivev1.TxWindow{
+			Broker:   typev1.Broker_IBKR,
+			Source:   "IBKR:test:statement",
+			Postings: []*archivev1.Posting{{Timestamp: timestamppb.Now(), InstrumentDescription: "SPLIT", Type: typev1.TxType_SPLIT, Quantity: "1", Account: ""}},
+		},
 	})
 	j := &JobRequest{JobID: "job-single-split", JobType: "tx"}
 


### PR DESCRIPTION
Depends on #387, which flattens the transaction part this reuses. Based on that branch; retarget as the stack merges.

`UpsertTxsRequest` collapses into an archive `TxWindow` plus a filename. A window already states its broker, its source, the half-open period it replaces and the postings inside it, so an upload describes itself, and the two ways transactions arrive -- a broker file and an archive document -- meet at `windowTxs` rather than each assembling their own `ingestBatch` call. `CreateTx` takes a `Posting` and wraps it in a window with no period, which is the one thing that distinguishes an append from a replacement.

Converters return archive postings. The field set is the one they already filled, so the change is the message type and what optional means in it: an absent unit price, broker ref or group ref is `undefined` rather than the empty string, which is the distinction the archive draws and the CSV could not. `StandardParseResult` moves to `lib/csv/parse-result.ts`, where it does not depend on the CSV parser that is about to go.

`share_count_basis` moves from the upload to the posting, the correction 0077 made to the archive window for the same reason: a file-wide value can only say "one date for everything". The CSV's comment line still declares one basis for the file, and `standard.ts` now stamps it on every posting it emits.

The upload preview counts postings rather than transactions, which is what it was counting: a converter's output includes the legs it derives.

The standard CSV file itself is untouched here -- `standard.ts` still parses it, and retiring it is the next step.

## Verification

- `make check` and `make test` green.
- Full e2e suite green (46 passed), which is the real exercise: every CSV fixture goes through the converter, the new wire and the ingestion path.
- The converter suites pin group counts against the sample exports and none moved -- converter grouping is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)