### PR TITLE
Narrow the residual posting index and audit the index set (0101)

### DIFF
--- a/docs/issues/0101-narrow-the-residual-posting-index.md
+++ b/docs/issues/0101-narrow-the-residual-posting-index.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Narrow the residual posting index and audit the index set
 ---
 
@@ -41,3 +41,38 @@ and prove nothing either way.
 The audit should look for the same shape elsewhere: a column that no query filters
 or groups on, sitting in front of the columns that would otherwise have matched a
 query's prefix.
+
+Closed. `idx_txs_residual_postings` is now `(timestamp) WHERE account_type IN
+(...)`: the partial predicate isolates the residual minority, `timestamp` is the
+only column the report actually filters on, grouping cannot be index-ordered
+because two keys come from the joined `instruments` table, and a covering shape
+would need `split_adjusted_quantity` and `group_id` -- more bytes than the heap
+fetch it would save.
+
+The audit found two further indexes worth touching in the same PR, both a
+one-line SQL change in the same file:
+
+- `idx_instrument_identifiers_lookup (identifier_type, COALESCE(domain,''), value)`
+  had the anti-pattern outright: no query filters on `domain` and no query
+  filters on the full triple. The domain-aware paths are already served by the
+  partial unique indexes at `(identifier_type, value) WHERE domain IS NULL` and
+  `(identifier_type, domain, value) WHERE domain IS NOT NULL`, and every
+  reachable consumer (FX pair, ticker, ISIN) filters `(identifier_type, value)`.
+  Narrowed to `(identifier_type, value)`.
+
+- `idx_prov_instr_ident_lookup (provider, identifier_type, value)` was a related
+  but different shape: no query in the codebase filters by that prefix at all.
+  Both reads on the table lead with `instrument_id` and are served by the two
+  partial unique indexes. Dropped; the comment describing it as a reverse
+  lookup describes a lookup nothing performs.
+
+Nothing else surfaced. `idx_txs_user_broker_time` uses its middle `broker` as a
+real filter and grouping key; `idx_tx_groups_user_time` wastes a trailing
+`timestamp` but is at the trailing edge, not blocking a prefix, and is too
+small to be worth touching here. The remaining indexes are single-column or
+partial-unique whose column order is dictated by the uniqueness they enforce.
+
+Confirming an actual planner improvement was out of scope: it needs a seeded
+dataset with a realistic residual-to-`USER` ratio, and `EXPLAIN` against the
+integration-test database proves nothing either way. The correctness of the
+change rides on `make test`.

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -331,7 +331,11 @@ CREATE UNIQUE INDEX idx_instrument_identifiers_inst_unique_non_null_domain ON in
 -- Global uniqueness: (identifier_type, domain, value) unique across the table.
 CREATE UNIQUE INDEX idx_instrument_identifiers_unique_null_domain ON instrument_identifiers (identifier_type, value) WHERE domain IS NULL;
 CREATE UNIQUE INDEX idx_instrument_identifiers_unique_non_null_domain ON instrument_identifiers (identifier_type, domain, value) WHERE domain IS NOT NULL;
-CREATE INDEX idx_instrument_identifiers_lookup ON instrument_identifiers (identifier_type, COALESCE(domain, ''), value);
+-- Domain-agnostic lookup by (identifier_type, value). The domain-aware paths are
+-- served by the two partial unique indexes above, so this one is deliberately narrow:
+-- an intermediate COALESCE(domain,'') column would block the prefix match on value
+-- for the queries that actually reach this index (FX pair, ticker, ISIN lookups).
+CREATE INDEX idx_instrument_identifiers_lookup ON instrument_identifiers (identifier_type, value);
 
 -- Trigger: recompute instruments.name and instruments.exchange whenever identifiers
 -- or the instrument itself change. Fires AFTER so that all rows are visible.
@@ -395,11 +399,11 @@ CREATE TABLE provider_instrument_identifiers (
   value           TEXT NOT NULL
 );
 
--- Per-instrument per-provider uniqueness.
+-- Per-instrument per-provider uniqueness. Both read paths -- loadProviderIdentifiers
+-- and FindProviderIdentifiers -- lead with instrument_id and are served by these
+-- indexes, so no separate lookup index is needed.
 CREATE UNIQUE INDEX idx_prov_instr_ident_unique_null_domain ON provider_instrument_identifiers (instrument_id, provider, identifier_type, value) WHERE domain IS NULL;
 CREATE UNIQUE INDEX idx_prov_instr_ident_unique_non_null_domain ON provider_instrument_identifiers (instrument_id, provider, identifier_type, domain, value) WHERE domain IS NOT NULL;
--- Reverse lookup by provider + identifier.
-CREATE INDEX idx_prov_instr_ident_lookup ON provider_instrument_identifiers (provider, identifier_type, value);
 
 -- Plugin config: which plugins are enabled, precedence (unique per category), plugin-specific config.
 -- category: 'identifier', 'description', 'price'.
@@ -467,9 +471,11 @@ CREATE INDEX idx_txs_instrument_id ON txs (instrument_id);
 -- routed to balance a group its source data left one-sided -- are a small minority of
 -- txs, and the report that aggregates them reads every one across all users. A partial
 -- index over just those rows answers it without carrying the USER postings that
--- dominate the table. Column order follows the report's GROUP BY.
+-- dominate the table. The key is timestamp because the report filters on a time window
+-- and nothing else on the residual subset; grouping cannot be index-ordered anyway,
+-- because two GROUP BY keys come from the joined instruments table.
 CREATE INDEX idx_txs_residual_postings
-  ON txs (account_type, user_id, broker, account, instrument_id, tx_type)
+  ON txs (timestamp)
   WHERE account_type IN ('IMBALANCE', 'TRANSFER_CLEARING', 'SOURCE_ROUNDING');
 
 -- At most one INITIALIZE posting per holding per account type. account_type is part of


### PR DESCRIPTION
## Summary

Closes #101 (issue 0101).

- Narrows `idx_txs_residual_postings` from a six-column composite whose middle `user_id` broke every prefix, to `(timestamp) WHERE account_type IN (...)`. The report is cross-user, filters on a timestamp window on the residual subset, cannot use index-ordered grouping (two `GROUP BY` keys come from a joined table), and would need a `NUMERIC(38,12)` and a UUID to become covering -- more bytes than the heap fetch it would save.
- Narrows `idx_instrument_identifiers_lookup` from `(identifier_type, COALESCE(domain,''), value)` to `(identifier_type, value)`. The domain-aware paths are already served by two partial unique indexes; the intermediate `COALESCE(domain,'')` blocked the prefix match on `value` for every domain-agnostic consumer (FX pair, ticker, ISIN).
- Drops `idx_prov_instr_ident_lookup (provider, identifier_type, value)`. No query in the codebase filters by that prefix. Both reads on `provider_instrument_identifiers` lead with `instrument_id` and are served by the two partial unique indexes.

Nothing else surfaced by the audit warranted a change: `idx_txs_user_broker_time` uses its middle `broker` as a real filter and grouping key; `idx_tx_groups_user_time` wastes a trailing `timestamp` but is at the trailing edge, not blocking a prefix. Full findings in the closed issue file.

Confirming an actual planner improvement was out of scope for this PR: it needs a seeded dataset with a realistic residual-to-`USER` ratio, and `EXPLAIN` against the integration-test database sequential-scans a small table and proves nothing either way. **Please do not ask for `EXPLAIN` output in review.**

## Test plan

- [x] `make test` -- full suite. The relevant integration tests exercise the affected queries end-to-end and pass on the new index shapes:
  - `residual_balances_test.go` -- `TestListResidualBalances_*`, `TestCountResidualBalances_*`
  - the instrument-identifier resolution tests under `instruments_test.go`
  - the FX-pair paths under `price_cache_test.go` and `valuation_test.go`
  - `TestSplitsByUnderlyingTicker` in `corporate_events_test.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)