### PR TITLE
Synthesise each broker's evidence into a correlation (0096)

### DIFF
--- a/client/lib/csv/converters/fidelity-csv.test.ts
+++ b/client/lib/csv/converters/fidelity-csv.test.ts
@@ -1,6 +1,6 @@
 import { Big } from "@/lib/decimal";
 import { describe, it, expect } from "vitest";
-import { AccountType, IdentifierType, TxType } from "@/gen/type/v1/type_pb";
+import { AccountType, IdentifierType, Match, Scope, TxType } from "@/gen/type/v1/type_pb";
 import { convertFidelityToStandard, FIDELITY_TYPE_TO_OFX } from "./fidelity-csv";
 import { expectGroupsBalance, residuals } from "@/lib/csv/group-balance.test-utils";
 
@@ -924,5 +924,71 @@ describe("source references", () => {
     expect(result.postings[1].brokerRef).toBeUndefined();
     // Both legs still belong to one event.
     expect(result.postings[1].groupRef).toBe(result.postings[0].groupRef);
+  });
+});
+
+// What the source said about why a row might belong with another one. A Fidelity
+// reference number is honestly comparable both ways -- two rows of one event are
+// numbered near each other, and one row is named by exactly one reference -- so
+// the correlation declares both and carries the number in a field of its own.
+describe("correlations", () => {
+  const HEAD =
+    "Order date,Completion date,Transaction type,Investments,Product Wrapper,Account Number,Source investment,Amount,Quantity,Price per unit,Reference Number,Status";
+  const convert = (rows: string[]) =>
+    convertFidelityToStandard([HEAD, ...rows].join("\n"), { currency: "GBP" });
+
+  it("states what a reference number is comparable by", () => {
+    const result = convert([
+      "2022-05-06,2022-05-06,Transfer To Cash Management Account For Fees,Cash,SIPP,AP1,,-2.19,2.19,1,481052149,Completed",
+    ]);
+
+    expect(result.postings[0].correlations).toHaveLength(1);
+    const c = result.postings[0].correlations[0]!;
+    expect(c.label).toBe("");
+    expect(c.token).toBe("481052149");
+    expect(c.ordinal).toBe(481052149n);
+    expect(c.scope).toBe(Scope.FILE);
+    expect(c.match).toEqual([Match.EXACT, Match.ORDINAL]);
+    // The span the deposit rule is measured against travels with the evidence,
+    // because how densely Fidelity issues references is a fact about its
+    // numbering rather than a grouping policy.
+    expect(c.ordinalSpan).toBe(8n);
+  });
+
+  // Nothing in the sample exports writes one, but the field is opaque and a
+  // reference in some other shape has to keep its equality half rather than
+  // become NaN.
+  it("keeps equality alone for a reference that carries no number", () => {
+    const result = convert([
+      "8 Feb 2022,10 Feb 2022,Cash Interest,Cash,Investment Account,AG1,,1.18,1.18,1,REF/2022/A,Completed",
+    ]);
+
+    const c = result.postings[0].correlations[0]!;
+    expect(c.token).toBe("REF/2022/A");
+    expect(c.ordinal).toBeUndefined();
+    expect(c.ordinalSpan).toBeUndefined();
+    expect(c.match).toEqual([Match.EXACT]);
+  });
+
+  it("correlates nothing for a row the source gave no reference for", () => {
+    const result = convert([
+      "8 Feb 2022,10 Feb 2022,Cash Interest,Cash,Investment Account,AG1,,1.18,1.18,1,,Completed",
+    ]);
+
+    expect(result.postings[0].correlations).toEqual([]);
+  });
+
+  // A derived leg transcribes nothing, so it correlates with nothing. Copying
+  // the correlation of the posting it mirrors would state that the source
+  // correlated a row it never wrote.
+  it("does not give a derived counter-leg a correlation", () => {
+    const result = convert([
+      "8 Feb 2022,10 Feb 2022,Cash Dividend,Cash,Investment Account,AG1,,23.40,23.40,1,441416483,Completed",
+    ]);
+
+    expect(result.postings).toHaveLength(2);
+    expect(result.postings[0].correlations).toHaveLength(1);
+    expect(result.postings[1].accountType).toBe(AccountType.INCOME);
+    expect(result.postings[1].correlations).toEqual([]);
   });
 });

--- a/client/lib/csv/converters/fidelity-csv.ts
+++ b/client/lib/csv/converters/fidelity-csv.ts
@@ -9,10 +9,10 @@
 import { create } from "@bufbuild/protobuf";
 import { timestampFromDate } from "@bufbuild/protobuf/wkt";
 import { startOfNextDay } from "@/lib/dates";
-import type { Posting } from "@/gen/archive/v1/txs_pb";
-import { PostingSchema } from "@/gen/archive/v1/txs_pb";
+import type { Correlation, Posting } from "@/gen/archive/v1/txs_pb";
+import { CorrelationSchema, PostingSchema } from "@/gen/archive/v1/txs_pb";
 import { InstrumentRefSchema } from "@/gen/archive/v1/common_pb";
-import { IdentifierType, TxType } from "@/gen/type/v1/type_pb";
+import { IdentifierType, Match, Scope, TxType } from "@/gen/type/v1/type_pb";
 import type { StandardParseResult, ParseError } from "@/lib/csv/parse-result";
 import { parseCSVLine } from "@/lib/csv/line";
 import { counterLegs, currencyHint } from "@/lib/csv/postings";
@@ -273,6 +273,69 @@ const DEPOSIT_ROWS = ["Cash Out For Buy", "Cash In"];
  * coincidence rather than a discriminator.
  */
 const DEPOSIT_REF_SPAN = 8;
+
+/**
+ * The label the counterparty pointer is correlated under.
+ *
+ * Distinct from the reference series, which uses the empty label, so an account
+ * name is never compared against a reference number. The pointer declares
+ * MATCH_ACCOUNT alone: its token names the account of some other posting rather
+ * than a token that posting carries, so equality against another token could
+ * never fire.
+ */
+const COUNTERPARTY_LABEL = "counterparty";
+
+/**
+ * The correlation a Fidelity reference number supplies, or undefined for a row
+ * the source gave no reference for.
+ *
+ * The cell verbatim as the token and the number it carries as the ordinal, which
+ * is what MATCH_ORDINAL means: the ordinal field is populated and comparable,
+ * never "parse the token as a number". A reference the source wrote in some shape
+ * this converter did not expect keeps its equality half rather than becoming NaN.
+ *
+ * Scoped to the file. DEPOSIT_REF_SPAN travels with it because how densely a
+ * broker issues references is a fact about its numbering rather than a grouping
+ * policy, and a server-side constant would be wrong for every broker but one.
+ *
+ * Shared with the extension's JSON converter, so the two cannot disagree about
+ * what a Fidelity reference is comparable by.
+ */
+export function fidelityRefCorrelation(ref: string): Correlation | undefined {
+  if (!ref) return undefined;
+  const ordinal = parseInt(ref, 10);
+  if (!Number.isFinite(ordinal)) {
+    return create(CorrelationSchema, {
+      token: ref,
+      scope: Scope.FILE,
+      match: [Match.EXACT],
+    });
+  }
+  return create(CorrelationSchema, {
+    token: ref,
+    ordinal: BigInt(ordinal),
+    ordinalSpan: BigInt(DEPOSIT_REF_SPAN),
+    scope: Scope.FILE,
+    match: [Match.EXACT, Match.ORDINAL],
+  });
+}
+
+/**
+ * The correlation the account Fidelity names as the other side of a row
+ * supplies.
+ *
+ * Scoped to the broker rather than to the file: an account label means nothing
+ * outside the broker that issued it, and the two sides of one transfer routinely
+ * arrive in different exports.
+ */
+export function fidelityCounterpartyCorrelation(account: string): Correlation {
+  return create(CorrelationSchema, {
+    label: COUNTERPARTY_LABEL,
+    token: account,
+    scope: Scope.BROKER,
+    match: [Match.ACCOUNT],
+  });
+}
 
 /**
  * The broker type of the cash row a trade settles through, or "" for a row that
@@ -654,12 +717,15 @@ export function convertFidelityToStandard(
     });
     // The cell, not the parsed number the leg carries: broker_ref is opaque and a
     // reference the source wrote in some other shape should survive rather than
-    // become NaN. Nothing here parses it -- that is the matcher's problem.
+    // become NaN. The correlation beside it carries the number, in a field of its
+    // own, because knowing how to take a number out of this broker's references
+    // is exactly what a converter uniquely knows.
     //
     // No counterpartyAccount. The export's "Source investment" column holds an
     // asset name, not an account, so this file names no counterparty anywhere.
     // Only the JSON the extension reads does.
     const brokerRef = refCol >= 0 ? get(refCol) : "";
+    const correlation = fidelityRefCorrelation(brokerRef);
     postings.push(
       create(PostingSchema, {
         timestamp: timestampFromDate(date),
@@ -672,6 +738,7 @@ export function convertFidelityToStandard(
         // Presence, not truthiness: a reported price of zero is a price.
         ...(unitPriceDec !== undefined ? { unitPrice: unitPriceDec.toString() } : {}),
         ...(brokerRef ? { brokerRef } : {}),
+        ...(correlation ? { correlations: [correlation] } : {}),
         ...(identifierHints.length > 0 ? { identifierHints } : {}),
       })
     );

--- a/client/lib/csv/postings.ts
+++ b/client/lib/csv/postings.ts
@@ -58,10 +58,13 @@ export function counterLeg(p: Posting): Posting | undefined {
   leg.accountType = accountType;
   // A derived leg names no source row, because the source wrote none for it. The
   // clone above would otherwise hand it the reference of the posting it mirrors,
-  // making an invention indistinguishable from a transcription. moneyLeg builds
-  // from scratch and needs no such reset. See docs/spec/postings.md.
+  // making an invention indistinguishable from a transcription. The correlations
+  // go for the same reason, and go harder: a copied one would state that the
+  // source correlated a row it never wrote. moneyLeg builds from scratch and
+  // needs no such reset. See docs/spec/postings.md.
   leg.brokerRef = undefined;
   leg.counterpartyAccount = undefined;
+  leg.correlations = [];
   return leg;
 }
 

--- a/client/lib/ofx/parser.test.ts
+++ b/client/lib/ofx/parser.test.ts
@@ -1,7 +1,7 @@
 import { Big } from "@/lib/decimal";
 import { describe, it, expect } from "vitest";
 import { parseOfxStatement, parseOfxDate } from "./parser";
-import { AccountType, TxType, IdentifierType } from "@/gen/type/v1/type_pb";
+import { AccountType, IdentifierType, Match, Scope, TxType } from "@/gen/type/v1/type_pb";
 import { expectGroupsBalance } from "@/lib/csv/group-balance.test-utils";
 
 describe("parseOfxDate", () => {
@@ -477,6 +477,29 @@ describe("groups and charges", () => {
     expect(refs.size).toBe(1);
     expect([...refs][0]).toBeTruthy();
     expectGroupsBalance(result.postings);
+  });
+
+  // The FITID is unique within the account rather than within the institution,
+  // which is the uniqueness the OFX spec gives it, and it is opaque: the string
+  // plainly carries a number but nothing here knows where it starts, so equality
+  // is all it honestly offers.
+  it("states what the FITID is comparable by, on the transcribed leg alone", () => {
+    const result = parse(GBP_BUY);
+    const correlated = result.postings.filter((t) => t.correlations.length > 0);
+    expect(correlated).toHaveLength(1);
+    const c = correlated[0]!.correlations[0]!;
+    expect(c.token).toBe("20251015U10000018371888432");
+    expect(c.scope).toBe(Scope.ACCOUNT);
+    expect(c.match).toEqual([Match.EXACT]);
+    expect(c.ordinal).toBeUndefined();
+  });
+
+  // The parser synthesises a group for legs the source gave no FITID for, so the
+  // group is inferred rather than transcribed. Emitting a correlation for it
+  // would state that the source said something it did not.
+  it("correlates nothing for a trade whose group it synthesised", () => {
+    const result = parse(GBP_BUY.replace("<FITID>20251015U10000018371888432", "<FITID>"));
+    expect(result.postings.every((t) => t.correlations.length === 0)).toBe(true);
   });
 
   it("names the account a dividend came from", () => {

--- a/client/lib/ofx/parser.ts
+++ b/client/lib/ofx/parser.ts
@@ -10,9 +10,9 @@ import { create } from "@bufbuild/protobuf";
 import { timestampDate, timestampFromDate } from "@bufbuild/protobuf/wkt";
 import { startOfNextDay } from "@/lib/dates";
 import type { Posting } from "@/gen/archive/v1/txs_pb";
-import { PostingSchema } from "@/gen/archive/v1/txs_pb";
+import { CorrelationSchema, PostingSchema } from "@/gen/archive/v1/txs_pb";
 import { InstrumentRefSchema } from "@/gen/archive/v1/common_pb";
-import { IdentifierType, TxType } from "@/gen/type/v1/type_pb";
+import { IdentifierType, Match, Scope, TxType } from "@/gen/type/v1/type_pb";
 import type { StandardParseResult, ParseError } from "@/lib/csv/parse-result";
 import { counterLegs, feeLeg, refPrefix } from "@/lib/csv/postings";
 import { Big, parseDecimal } from "@/lib/decimal";
@@ -164,6 +164,22 @@ function buildIdentifierHints(
   }
 
   return hints;
+}
+
+/**
+ * What a FITID is comparable by.
+ *
+ * Account-scoped, because that is the uniqueness the OFX spec gives it: reading
+ * it file-wide would compare two accounts' identifier sequences, which are
+ * unrelated. Equality alone, since the string is opaque to anything but the
+ * institution that issued it.
+ */
+function fitIdCorrelation(fitId: string) {
+  return create(CorrelationSchema, {
+    token: fitId,
+    scope: Scope.ACCOUNT,
+    match: [Match.EXACT],
+  });
 }
 
 // ── Transaction type mapping ─────────────────────────────────────────
@@ -328,11 +344,19 @@ export function parseOfxStatement(text: string): OfxParseResult {
         tradingCurrency,
         settlementCurrency: tradingCurrency,
         groupRef: fitId,
-        // The same id in both fields, saying two different things: which postings
-        // are one event, and which statement record this one was transcribed from.
-        // Only this leg carries the reference -- the cash and fee legs below are
-        // derived from TOTAL and COMMISSION rather than from rows of their own.
-        ...(fitId ? { brokerRef: fitId } : {}),
+        // The same id in three places, saying three different things: which
+        // postings are one event, which statement record this one was
+        // transcribed from, and what it is comparable with. Only this leg
+        // carries the reference and the correlation -- the cash and fee legs
+        // below are derived from TOTAL and COMMISSION rather than from rows of
+        // their own, so they transcribe nothing.
+        //
+        // Scoped to the account rather than to the file: the OFX spec makes a
+        // FITID unique within the account, not within the institution. Equality
+        // alone, because a FITID is opaque -- 20251015U10000018371888432 plainly
+        // carries a number, but nothing here knows where it starts, and an
+        // ordering invented from the string would group unrelated rows silently.
+        ...(fitId ? { brokerRef: fitId, correlations: [fitIdCorrelation(fitId)] } : {}),
         ...(unitPrice !== undefined ? { unitPrice } : {}),
         ...(hintProtos.length > 0 ? { identifierHints: hintProtos } : {}),
       });

--- a/extension/src/brokers/fidelity-json.test.ts
+++ b/extension/src/brokers/fidelity-json.test.ts
@@ -5,7 +5,7 @@
 
 import { Big } from "@/lib/decimal";
 import { describe, expect, it } from "vitest";
-import { AccountType, IdentifierType, TxType } from "@/gen/type/v1/type_pb";
+import { AccountType, IdentifierType, Match, Scope, TxType } from "@/gen/type/v1/type_pb";
 import { convertFidelityJson, isValidIsin } from "./fidelity-json";
 import { expectGroupsBalance } from "@/lib/csv/group-balance.test-utils";
 
@@ -554,5 +554,92 @@ describe("source references", () => {
     const expense = result.postings.find((tx) => tx.accountType === AccountType.EXPENSE)!;
     expect(expense.brokerRef).toBeUndefined();
     expect(expense.counterpartyAccount).toBeUndefined();
+  });
+});
+
+// The JSON carries both series the format can express, and they are kept apart:
+// a reference number is compared against another reference number, while the
+// counterparty names an account and is compared against one.
+describe("correlations", () => {
+  const base = {
+    accountNumber: "AW10000001",
+    assetName: "Cash",
+    isin: "AA00K0000000",
+    currency: "GBP",
+    status: "Completed",
+    pricePerUnit: 1,
+    dealDate: "15/04/2025",
+    settlementDate: "15/04/2025",
+  };
+
+  it("states both series where the source supplies both", () => {
+    const result = convertFidelityJson(
+      json({
+        ...base,
+        transactionType: "Transfer Into Account",
+        debitCreditIndicator: "CREDIT",
+        units: 20000,
+        valuation: 20000,
+        referenceId: "971613414",
+        sourceOrTargetAccount: "AG10000001",
+      })
+    );
+
+    const got = result.postings[0]!.correlations;
+    expect(got).toHaveLength(2);
+    // Identical to what the CSV converter states for the same reference: the two
+    // readings of one export share the builder, so they cannot disagree.
+    expect(got[0]!.label).toBe("");
+    expect(got[0]!.token).toBe("971613414");
+    expect(got[0]!.ordinal).toBe(971613414n);
+    expect(got[0]!.scope).toBe(Scope.FILE);
+    expect(got[0]!.match).toEqual([Match.EXACT, Match.ORDINAL]);
+    // The pointer is broker-scoped, because an account label means nothing
+    // outside the broker that issued it and the two sides of one transfer
+    // routinely arrive in different exports.
+    expect(got[1]!.label).toBe("counterparty");
+    expect(got[1]!.token).toBe("AG10000001");
+    expect(got[1]!.scope).toBe(Scope.BROKER);
+    expect(got[1]!.match).toEqual([Match.ACCOUNT]);
+    expect(got[1]!.ordinal).toBeUndefined();
+  });
+
+  it("states only the reference where the source names no other side", () => {
+    const result = convertFidelityJson(
+      json({
+        ...base,
+        transactionType: "Transfer Out From Cash Management Account",
+        debitCreditIndicator: "DEBIT",
+        units: 20000,
+        valuation: 20000,
+        referenceId: "971613430",
+      })
+    );
+
+    const got = result.postings[0]!.correlations;
+    expect(got).toHaveLength(1);
+    expect(got[0]!.token).toBe("971613430");
+  });
+
+  // A derived leg transcribes nothing, so it correlates with nothing -- and the
+  // fee's attribution in particular must not be copied onto the expense leg,
+  // where it would name a counterparty the source never gave that row.
+  it("does not give a derived counter-leg a correlation", () => {
+    const result = convertFidelityJson(
+      json({
+        ...base,
+        assetName: "Relationship Cash Source",
+        transactionType: "Service Fee",
+        debitCreditIndicator: "DEBIT",
+        units: 5.13,
+        valuation: 5.13,
+        referenceId: "1177083111",
+        sourceOrTargetAccount: "AP10000001",
+      })
+    );
+
+    expect(result.postings[0]!.correlations).toHaveLength(2);
+    const expense = result.postings.find((tx) => tx.accountType === AccountType.EXPENSE)!;
+    expect(expense.correlations).toEqual([]);
   });
 });

--- a/extension/src/brokers/fidelity-json.ts
+++ b/extension/src/brokers/fidelity-json.ts
@@ -13,7 +13,7 @@
 import { create } from "@bufbuild/protobuf";
 import { timestampFromDate } from "@bufbuild/protobuf/wkt";
 import { startOfNextDay } from "../lib/dates";
-import type { Posting } from "@/gen/archive/v1/txs_pb";
+import type { Correlation, Posting } from "@/gen/archive/v1/txs_pb";
 import { PostingSchema } from "@/gen/archive/v1/txs_pb";
 import { InstrumentRefSchema } from "@/gen/archive/v1/common_pb";
 import { IdentifierType } from "@/gen/type/v1/type_pb";
@@ -21,6 +21,8 @@ import type { FidelityLeg } from "@/lib/csv/converters/fidelity-csv";
 import {
   assignFidelityGroups,
   asTradeCashLeg,
+  fidelityCounterpartyCorrelation,
+  fidelityRefCorrelation,
   FIDELITY_TYPE_TO_OFX,
   isCashMovement,
   isCashTxType,
@@ -195,6 +197,18 @@ export function convertFidelityJson(
     if (ts < minTime) minTime = ts;
     if (ts > maxTime) maxTime = ts;
 
+    // Two series, and they are kept apart: a reference number is comparable
+    // against another reference number, while the counterparty names an account
+    // and is compared against one. The builders are the CSV converter's, so the
+    // two readings of a Fidelity export cannot disagree about what its
+    // identifiers are comparable by.
+    const correlations: Correlation[] = [];
+    const refCorrelation = fidelityRefCorrelation(row.referenceId ?? "");
+    if (refCorrelation) correlations.push(refCorrelation);
+    if (row.sourceOrTargetAccount) {
+      correlations.push(fidelityCounterpartyCorrelation(row.sourceOrTargetAccount));
+    }
+
     // units, not the sign-corrected quantity: cash rows report their money as units,
     // which would make the check compare a total against itself.
     legs.push({
@@ -236,6 +250,7 @@ export function convertFidelityJson(
         // becoming NaN.
         ...(row.referenceId ? { brokerRef: row.referenceId } : {}),
         ...(row.sourceOrTargetAccount ? { counterpartyAccount: row.sourceOrTargetAccount } : {}),
+        ...(correlations.length > 0 ? { correlations } : {}),
         ...(identifierHints.length > 0 ? { identifierHints } : {}),
       })
     );


### PR DESCRIPTION
Second of three for [0096](https://github.com/leedenison/portfoliodb/blob/main/docs/issues/0096-correlation-evidence-in-the-standard-format.md). **Depends on #393**, which lands the field; this one has the converters populate it. Nothing reads a correlation yet and `group_ref` still states the partition.

## Per converter

**Fidelity, both readings.** A reference number is honestly comparable both ways -- two rows of one event are numbered near each other, and a row is named by exactly one reference -- so its correlation declares `MATCH_EXACT` and `MATCH_ORDINAL`, with the number in `ordinal` rather than parsed out of the token downstream. `DEPOSIT_REF_SPAN` travels as `ordinal_span`. A reference in a shape the converter did not expect keeps its equality half rather than becoming NaN.

The builder lives in `fidelity-csv.ts` and the extension imports it, as it already imports `FIDELITY_TYPE_TO_OFX` and `assignFidelityGroups`, so the two readings of one export cannot disagree about what a Fidelity reference is comparable by.

**The extension's JSON** names a counterparty account as well. That is a second series and stays one, under its own label: its token names *another posting's* account rather than a token that posting carries, so it declares `MATCH_ACCOUNT` alone.

**OFX.** The `FITID` is account-scoped, which is the uniqueness the spec gives it rather than the file-wide reading, and opaque -- `20251015U10000018371888432` plainly carries a number but nothing here knows where it starts, so equality is all it honestly offers. It goes on the security leg alone, where `broker_ref` goes, and not at all on a trade whose group the parser synthesised: that group is inferred rather than transcribed.

## Notes

`counterLeg` clears the correlations it would otherwise clone, for the reason it already clears `broker_ref` and harder -- a copied correlation would state that the source correlated a row it never wrote.

No converter asserts a grouping through a shared exact-match token, which keeps 0097's shadow validation against `group_ref` meaningful: the engine will have to reproduce the partition from proximity and structure rather than from being handed it.

`make check` and `make test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
