### PR TITLE
Rekey the ignore rules on the instrument's asset class (0100)

### DIFF
--- a/server/archiveimport/preferences.go
+++ b/server/archiveimport/preferences.go
@@ -61,7 +61,7 @@ func PreferencePart(ctx context.Context, database db.DB, userID string, part *ar
 			// An empty set is applied rather than skipped: it clears the user's
 			// rules, and telling that apart from a file that does not state them
 			// is what the wrapper message exists for.
-			if err := database.SetIgnoredAssetClasses(ctx, userID, rules, db.AssetClassToTxTypesMap(rules)); err != nil {
+			if err := database.SetIgnoredAssetClasses(ctx, userID, rules); err != nil {
 				return out, fmt.Errorf("set ignored asset classes: %w", err)
 			}
 			out.Applied++

--- a/server/archiveimport/preferences_test.go
+++ b/server/archiveimport/preferences_test.go
@@ -36,8 +36,7 @@ func TestPreferencePart_AppliesBothSettings(t *testing.T) {
 	database.EXPECT().SetDisplayCurrency(gomock.Any(), "user-1", "GBP").Return(nil)
 	database.EXPECT().
 		SetIgnoredAssetClasses(gomock.Any(), "user-1",
-			[]db.IgnoredAssetClass{{Broker: "IBKR", Account: "U123", AssetClass: "OPTION"}},
-			gomock.Any()).
+			[]db.IgnoredAssetClass{{Broker: "IBKR", Account: "U123", AssetClass: "OPTION"}}).
 		Return(nil)
 
 	res := applyPreferences(t, database, rep, &archivev1.PreferencePart{
@@ -66,7 +65,7 @@ func TestPreferencePart_CurrencyOnly(t *testing.T) {
 
 func TestPreferencePart_RulesOnly(t *testing.T) {
 	database, rep := newPartTest(t)
-	database.EXPECT().SetIgnoredAssetClasses(gomock.Any(), "user-1", gomock.Any(), gomock.Any()).Return(nil)
+	database.EXPECT().SetIgnoredAssetClasses(gomock.Any(), "user-1", gomock.Any()).Return(nil)
 
 	res := applyPreferences(t, database, rep, &archivev1.PreferencePart{
 		IgnoredAssetClasses: ignored(rule(typev1.Broker_FIDELITY, "", typev1.AssetClass_STOCK)),
@@ -81,7 +80,7 @@ func TestPreferencePart_RulesOnly(t *testing.T) {
 func TestPreferencePart_EmptyRulesClearsThem(t *testing.T) {
 	database, rep := newPartTest(t)
 	database.EXPECT().
-		SetIgnoredAssetClasses(gomock.Any(), "user-1", []db.IgnoredAssetClass{}, gomock.Any()).
+		SetIgnoredAssetClasses(gomock.Any(), "user-1", []db.IgnoredAssetClass{}).
 		Return(nil)
 
 	res := applyPreferences(t, database, rep, &archivev1.PreferencePart{IgnoredAssetClasses: ignored()})
@@ -107,7 +106,7 @@ func TestPreferencePart_NeitherSettingWritesNothing(t *testing.T) {
 // row index of -1 because there is no row to point at.
 func TestPreferencePart_BadCurrencyRejectedAloneAndRulesStillLand(t *testing.T) {
 	database, rep := newPartTest(t)
-	database.EXPECT().SetIgnoredAssetClasses(gomock.Any(), "user-1", gomock.Any(), gomock.Any()).Return(nil)
+	database.EXPECT().SetIgnoredAssetClasses(gomock.Any(), "user-1", gomock.Any()).Return(nil)
 
 	res := applyPreferences(t, database, rep, &archivev1.PreferencePart{
 		DisplayCurrency:     proto.String("gbp"),

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -979,34 +979,6 @@ func TxTypeToInstrumentKind(t typev1.TxType) string {
 	}
 }
 
-// AssetClassToTxTypeStrings returns the tx_type DB strings that map to the given asset class.
-func AssetClassToTxTypeStrings(assetClass string) []string {
-	var strs []string
-	for i := range typev1.TxType_name {
-		t := typev1.TxType(i)
-		if t == typev1.TxType_TX_TYPE_UNSPECIFIED {
-			continue
-		}
-		if TxTypeToAssetClass(t) == assetClass {
-			strs = append(strs, t.String())
-		}
-	}
-	return strs
-}
-
-// AssetClassToTxTypesMap builds the asset-class-to-tx-types mapping the ignore
-// rule writers need, covering exactly the asset classes the rules name.
-func AssetClassToTxTypesMap(rules []IgnoredAssetClass) map[string][]string {
-	mapping := make(map[string][]string)
-	for _, r := range rules {
-		if _, seen := mapping[r.AssetClass]; seen {
-			continue
-		}
-		mapping[r.AssetClass] = AssetClassToTxTypeStrings(r.AssetClass)
-	}
-	return mapping
-}
-
 // currencyCodeRE is the shape users.display_currency holds: an ISO 4217 code.
 var currencyCodeRE = regexp.MustCompile(`^[A-Z]{3}$`)
 
@@ -1255,11 +1227,12 @@ type IgnoredAssetClassDB interface {
 	ListIgnoredAssetClasses(ctx context.Context, userID string) ([]IgnoredAssetClass, error)
 	// SetIgnoredAssetClasses replaces all ignore rules for the user and deletes
 	// matching txs, synthetic INITIALIZE txs, and holding declarations atomically.
-	// assetClassToTxTypes maps each asset class to its tx_type DB strings.
-	SetIgnoredAssetClasses(ctx context.Context, userID string, rules []IgnoredAssetClass, assetClassToTxTypes map[string][]string) error
+	// A tx matches when its instrument's asset class matches a rule; a tx whose
+	// instrument is unresolved matches nothing.
+	SetIgnoredAssetClasses(ctx context.Context, userID string, rules []IgnoredAssetClass) error
 	// CountIgnoredTxs returns the number of regular txs and holding declarations
 	// that would be deleted if the given rules were applied (net new vs current).
-	CountIgnoredTxs(ctx context.Context, userID string, rules []IgnoredAssetClass, assetClassToTxTypes map[string][]string) (txCount int32, declCount int32, err error)
+	CountIgnoredTxs(ctx context.Context, userID string, rules []IgnoredAssetClass) (txCount int32, declCount int32, err error)
 }
 
 // StockSplit is a single stock split row. SplitFrom and SplitTo are the raw

--- a/server/db/postgres/ignored_asset_classes.go
+++ b/server/db/postgres/ignored_asset_classes.go
@@ -3,7 +3,6 @@ package postgres
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/google/uuid"
 	"github.com/leedenison/portfoliodb/server/db"
@@ -37,7 +36,7 @@ func (p *Postgres) ListIgnoredAssetClasses(ctx context.Context, userID string) (
 }
 
 // SetIgnoredAssetClasses implements db.IgnoredAssetClassDB.
-func (p *Postgres) SetIgnoredAssetClasses(ctx context.Context, userID string, rules []db.IgnoredAssetClass, assetClassToTxTypes map[string][]string) error {
+func (p *Postgres) SetIgnoredAssetClasses(ctx context.Context, userID string, rules []db.IgnoredAssetClass) error {
 	userUUID, err := uuid.Parse(userID)
 	if err != nil {
 		return fmt.Errorf("invalid user id: %w", err)
@@ -58,8 +57,8 @@ func (p *Postgres) SetIgnoredAssetClasses(ctx context.Context, userID string, ru
 			}
 		}
 
-		// 3. Delete matching regular txs and synthetic INITIALIZE txs.
-		if err := deleteIgnoredTxs(ctx, tx, userUUID, rules, assetClassToTxTypes); err != nil {
+		// 3. Delete matching txs, synthetic INITIALIZE txs included.
+		if err := deleteIgnoredTxs(ctx, tx, userUUID, rules); err != nil {
 			return err
 		}
 
@@ -72,7 +71,7 @@ func (p *Postgres) SetIgnoredAssetClasses(ctx context.Context, userID string, ru
 }
 
 // CountIgnoredTxs implements db.IgnoredAssetClassDB.
-func (p *Postgres) CountIgnoredTxs(ctx context.Context, userID string, rules []db.IgnoredAssetClass, assetClassToTxTypes map[string][]string) (int32, int32, error) {
+func (p *Postgres) CountIgnoredTxs(ctx context.Context, userID string, rules []db.IgnoredAssetClass) (int32, int32, error) {
 	userUUID, err := uuid.Parse(userID)
 	if err != nil {
 		return 0, 0, fmt.Errorf("invalid user id: %w", err)
@@ -81,7 +80,7 @@ func (p *Postgres) CountIgnoredTxs(ctx context.Context, userID string, rules []d
 		return 0, 0, nil
 	}
 
-	txCount, err := countMatchingTxs(ctx, p.q, userUUID, rules, assetClassToTxTypes)
+	txCount, err := countMatchingTxs(ctx, p.q, userUUID, rules)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -92,24 +91,14 @@ func (p *Postgres) CountIgnoredTxs(ctx context.Context, userID string, rules []d
 	return txCount, declCount, nil
 }
 
-// deleteIgnoredTxs deletes regular and synthetic txs matching the ignore rules.
-// Regular txs are matched by tx_type (reverse-mapped from asset class).
-// Synthetic INITIALIZE txs are matched by joining to instruments.asset_class.
-func deleteIgnoredTxs(ctx context.Context, tx queryable, userUUID uuid.UUID, rules []db.IgnoredAssetClass, assetClassToTxTypes map[string][]string) error {
+// deleteIgnoredTxs deletes txs, synthetic or not, whose instrument's asset
+// class matches an ignore rule. A posting whose instrument is unresolved has
+// no asset class and is left alone.
+func deleteIgnoredTxs(ctx context.Context, tx queryable, userUUID uuid.UUID, rules []db.IgnoredAssetClass) error {
 	for _, r := range rules {
-		txTypes := assetClassToTxTypes[r.AssetClass]
-		if len(txTypes) == 0 {
-			continue
-		}
-		// Delete regular txs by tx_type.
-		query, args := buildDeleteTxsQuery(userUUID, r, txTypes)
+		query, args := buildDeleteTxsQuery(userUUID, r)
 		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
 			return fmt.Errorf("delete ignored txs: %w", err)
-		}
-		// Delete synthetic INITIALIZE txs by instrument asset_class.
-		query, args = buildDeleteSyntheticTxsQuery(userUUID, r)
-		if _, err := tx.ExecContext(ctx, query, args...); err != nil {
-			return fmt.Errorf("delete ignored synthetic txs: %w", err)
 		}
 	}
 	return nil
@@ -126,38 +115,8 @@ func deleteIgnoredDeclarations(ctx context.Context, tx queryable, userUUID uuid.
 	return nil
 }
 
-// buildDeleteTxsQuery builds a DELETE for regular txs matching the rule's tx types.
-func buildDeleteTxsQuery(userUUID uuid.UUID, r db.IgnoredAssetClass, txTypes []string) (string, []any) {
-	// Build tx_type IN (...) placeholders starting at $3 or $4.
-	baseIdx := 3
-	if r.Account != "" {
-		baseIdx = 4
-	}
-	placeholders := make([]string, len(txTypes))
-	args := []any{userUUID, r.Broker}
-	if r.Account != "" {
-		args = append(args, r.Account)
-	}
-	for i, t := range txTypes {
-		placeholders[i] = fmt.Sprintf("$%d", baseIdx+i)
-		args = append(args, t)
-	}
-
-	accountClause := ""
-	if r.Account != "" {
-		accountClause = " AND account = $3"
-	}
-	query := fmt.Sprintf(`
-		DELETE FROM txs
-		WHERE user_id = $1 AND broker = $2%s
-		  AND synthetic_purpose IS NULL
-		  AND tx_type IN (%s)
-	`, accountClause, strings.Join(placeholders, ", "))
-	return query, args
-}
-
-// buildDeleteSyntheticTxsQuery builds a DELETE for synthetic INITIALIZE txs where the instrument's asset class matches.
-func buildDeleteSyntheticTxsQuery(userUUID uuid.UUID, r db.IgnoredAssetClass) (string, []any) {
+// buildDeleteTxsQuery builds a DELETE for txs where the instrument's asset class matches.
+func buildDeleteTxsQuery(userUUID uuid.UUID, r db.IgnoredAssetClass) (string, []any) {
 	args := []any{userUUID, r.Broker, r.AssetClass}
 	accountClause := ""
 	if r.Account != "" {
@@ -168,7 +127,6 @@ func buildDeleteSyntheticTxsQuery(userUUID uuid.UUID, r db.IgnoredAssetClass) (s
 		DELETE FROM txs t
 		USING instruments i
 		WHERE t.user_id = $1 AND t.broker = $2%s
-		  AND t.synthetic_purpose = 'INITIALIZE'
 		  AND t.instrument_id = i.id
 		  AND i.asset_class = $3
 	`, accountClause)
@@ -193,37 +151,25 @@ func buildDeleteDeclarationsQuery(userUUID uuid.UUID, r db.IgnoredAssetClass) (s
 	return query, args
 }
 
-// countMatchingTxs counts regular txs that match the given ignore rules.
-func countMatchingTxs(ctx context.Context, q queryable, userUUID uuid.UUID, rules []db.IgnoredAssetClass, assetClassToTxTypes map[string][]string) (int32, error) {
+// countMatchingTxs counts regular txs whose instrument's asset class matches the
+// given ignore rules. Synthetic txs are excluded: they are derived from holding
+// declarations, which are counted separately.
+func countMatchingTxs(ctx context.Context, q queryable, userUUID uuid.UUID, rules []db.IgnoredAssetClass) (int32, error) {
 	var total int32
 	for _, r := range rules {
-		txTypes := assetClassToTxTypes[r.AssetClass]
-		if len(txTypes) == 0 {
-			continue
-		}
-		baseIdx := 3
-		if r.Account != "" {
-			baseIdx = 4
-		}
-		placeholders := make([]string, len(txTypes))
-		args := []any{userUUID, r.Broker}
-		if r.Account != "" {
-			args = append(args, r.Account)
-		}
-		for i, t := range txTypes {
-			placeholders[i] = fmt.Sprintf("$%d", baseIdx+i)
-			args = append(args, t)
-		}
+		args := []any{userUUID, r.Broker, r.AssetClass}
 		accountClause := ""
 		if r.Account != "" {
-			accountClause = " AND account = $3"
+			accountClause = " AND t.account = $4"
+			args = append(args, r.Account)
 		}
 		query := fmt.Sprintf(`
-			SELECT COUNT(*) FROM txs
-			WHERE user_id = $1 AND broker = $2%s
-			  AND synthetic_purpose IS NULL
-			  AND tx_type IN (%s)
-		`, accountClause, strings.Join(placeholders, ", "))
+			SELECT COUNT(*) FROM txs t
+			JOIN instruments i ON t.instrument_id = i.id
+			WHERE t.user_id = $1 AND t.broker = $2%s
+			  AND t.synthetic_purpose IS NULL
+			  AND i.asset_class = $3
+		`, accountClause)
 		var count int32
 		if err := q.QueryRowxContext(ctx, query, args...).Scan(&count); err != nil {
 			return 0, fmt.Errorf("count ignored txs: %w", err)

--- a/server/db/postgres/ignored_asset_classes_test.go
+++ b/server/db/postgres/ignored_asset_classes_test.go
@@ -1,0 +1,143 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// seedIgnoreFixture writes one FIXED_INCOME posting and one STOCK posting for the
+// user under broker IBKR account A, returning the two instrument ids.
+func seedIgnoreFixture(t *testing.T, p *Postgres, userID string) (bondID, stockID string) {
+	t.Helper()
+	ctx := context.Background()
+	bondID = setupInstrumentWithCurrency(t, p, "BOND-1", db.AssetClassFixedIncome, "USD")
+	stockID = setupInstrumentWithCurrency(t, p, "STK-1", db.AssetClassStock, "USD")
+	at := time.Date(2024, 3, 1, 10, 0, 0, 0, time.UTC)
+	for desc, id := range map[string]string{"BOND-1": bondID, "STK-1": stockID} {
+		tx := &apiv1.Tx{Timestamp: timestamppb.New(at), InstrumentDescription: desc,
+			Type: typev1.TxType_BUYDEBT, Quantity: "1", Account: "A"}
+		if err := createTx(ctx, p, userID, "IBKR", "A", "", tx, id, nil); err != nil {
+			t.Fatalf("create tx %s: %v", desc, err)
+		}
+	}
+	return bondID, stockID
+}
+
+// remainingDescs returns the instrument descriptions of the user's surviving
+// postings, keyed for membership checks.
+func remainingDescs(t *testing.T, p *Postgres, userID string) map[string]bool {
+	t.Helper()
+	rows, err := p.q.QueryxContext(context.Background(),
+		`SELECT instrument_description FROM txs WHERE user_id = $1`, userID)
+	if err != nil {
+		t.Fatalf("list remaining: %v", err)
+	}
+	defer rows.Close()
+	out := map[string]bool{}
+	for rows.Next() {
+		var d string
+		if err := rows.Scan(&d); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		out[d] = true
+	}
+	return out
+}
+
+// A rule deletes every posting whose instrument carries the rule's asset class,
+// synthetic INITIALIZE pads included, and touches nothing else -- in particular
+// a posting whose instrument is unresolved has no asset class and survives.
+func TestSetIgnoredAssetClasses_DeletesByInstrumentAssetClass(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID := setupUser(t, p)
+	bondID, _ := seedIgnoreFixture(t, p, userID)
+
+	at := time.Date(2024, 3, 2, 10, 0, 0, 0, time.UTC)
+	insertRawPostingAs(t, p, userID, bondID, newTxGroup(t, p, userID), "IBKR", at, "INITIALIZE")
+	if _, err := p.q.ExecContext(ctx, `
+		INSERT INTO txs (user_id, broker, account, timestamp, instrument_description, tx_type,
+		                 quantity, instrument_id, weight, weight_commodity, group_id)
+		VALUES ($1::uuid, 'IBKR', 'A', $2, 'UNRESOLVED', 'BUYSTOCK', 1, NULL, 0, 'desc:UNRESOLVED', $3::uuid)
+	`, userID, at, newTxGroup(t, p, userID)); err != nil {
+		t.Fatalf("insert unresolved posting: %v", err)
+	}
+
+	rules := []db.IgnoredAssetClass{{Broker: "IBKR", AssetClass: db.AssetClassFixedIncome}}
+	if err := p.SetIgnoredAssetClasses(ctx, userID, rules); err != nil {
+		t.Fatalf("set ignored asset classes: %v", err)
+	}
+
+	got := remainingDescs(t, p, userID)
+	// insertRawPostingAs writes the synthetic pad with description USD.
+	for desc, want := range map[string]bool{"BOND-1": false, "USD": false, "STK-1": true, "UNRESOLVED": true} {
+		if got[desc] != want {
+			t.Errorf("posting %s survived = %v, want %v", desc, got[desc], want)
+		}
+	}
+
+	stored, err := p.ListIgnoredAssetClasses(ctx, userID)
+	if err != nil {
+		t.Fatalf("list rules: %v", err)
+	}
+	if len(stored) != 1 || stored[0].AssetClass != db.AssetClassFixedIncome {
+		t.Fatalf("stored rules = %v, want the FIXED_INCOME rule", stored)
+	}
+}
+
+// An account-scoped rule deletes only that account's postings.
+func TestSetIgnoredAssetClasses_AccountScopedRule(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID := setupUser(t, p)
+	bondID := setupInstrumentWithCurrency(t, p, "BOND-2", db.AssetClassFixedIncome, "USD")
+	at := time.Date(2024, 3, 1, 10, 0, 0, 0, time.UTC)
+	for _, account := range []string{"A", "B"} {
+		tx := &apiv1.Tx{Timestamp: timestamppb.New(at), InstrumentDescription: "BOND-2",
+			Type: typev1.TxType_BUYDEBT, Quantity: "1", Account: account}
+		if err := createTx(ctx, p, userID, "IBKR", account, "", tx, bondID, nil); err != nil {
+			t.Fatalf("create tx in %s: %v", account, err)
+		}
+	}
+
+	rules := []db.IgnoredAssetClass{{Broker: "IBKR", Account: "A", AssetClass: db.AssetClassFixedIncome}}
+	if err := p.SetIgnoredAssetClasses(ctx, userID, rules); err != nil {
+		t.Fatalf("set ignored asset classes: %v", err)
+	}
+
+	var accounts []string
+	if err := p.q.SelectContext(ctx, &accounts,
+		`SELECT account FROM txs WHERE user_id = $1`, userID); err != nil {
+		t.Fatalf("list remaining: %v", err)
+	}
+	if len(accounts) != 1 || accounts[0] != "B" {
+		t.Fatalf("remaining accounts = %v, want [B]", accounts)
+	}
+}
+
+// The count previews the regular postings a rule would delete. Synthetic pads
+// are excluded: they are derived from holding declarations, which are counted
+// separately.
+func TestCountIgnoredTxs_CountsRegularTxsOnly(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID := setupUser(t, p)
+	bondID, _ := seedIgnoreFixture(t, p, userID)
+	at := time.Date(2024, 3, 2, 10, 0, 0, 0, time.UTC)
+	insertRawPostingAs(t, p, userID, bondID, newTxGroup(t, p, userID), "IBKR", at, "INITIALIZE")
+
+	rules := []db.IgnoredAssetClass{{Broker: "IBKR", AssetClass: db.AssetClassFixedIncome}}
+	txCount, declCount, err := p.CountIgnoredTxs(ctx, userID, rules)
+	if err != nil {
+		t.Fatalf("count ignored txs: %v", err)
+	}
+	if txCount != 1 || declCount != 0 {
+		t.Fatalf("count = (%d, %d), want (1, 0)", txCount, declCount)
+	}
+}

--- a/server/db/vocab_test.go
+++ b/server/db/vocab_test.go
@@ -48,25 +48,3 @@ func TestValidCurrencyCode(t *testing.T) {
 		}
 	}
 }
-
-// The mapping covers exactly the asset classes the rules name, and names one
-// of them once however many rules mention it.
-func TestAssetClassToTxTypesMap_CoversEachAssetClassOnce(t *testing.T) {
-	m := AssetClassToTxTypesMap([]IgnoredAssetClass{
-		{Broker: "IBKR", AssetClass: AssetClassOption},
-		{Broker: "FIDELITY", AssetClass: AssetClassOption},
-		{Broker: "IBKR", AssetClass: AssetClassStock},
-	})
-	if len(m) != 2 {
-		t.Fatalf("mapping = %v, want two asset classes", m)
-	}
-	if len(m[AssetClassOption]) == 0 || len(m[AssetClassStock]) == 0 {
-		t.Fatalf("mapping = %v, want tx types for both", m)
-	}
-}
-
-func TestAssetClassToTxTypesMap_NoRulesIsEmpty(t *testing.T) {
-	if m := AssetClassToTxTypesMap(nil); len(m) != 0 {
-		t.Fatalf("mapping = %v, want empty", m)
-	}
-}

--- a/server/service/api/ignored_asset_classes.go
+++ b/server/service/api/ignored_asset_classes.go
@@ -33,8 +33,7 @@ func (s *Server) SetIgnoredAssetClasses(ctx context.Context, req *apiv1.SetIgnor
 	if err != nil {
 		return nil, err
 	}
-	mapping := db.AssetClassToTxTypesMap(rules)
-	if err := s.db.SetIgnoredAssetClasses(ctx, u.ID, rules, mapping); err != nil {
+	if err := s.db.SetIgnoredAssetClasses(ctx, u.ID, rules); err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}
 	return &apiv1.SetIgnoredAssetClassesResponse{}, nil
@@ -50,8 +49,7 @@ func (s *Server) CountIgnoredTxs(ctx context.Context, req *apiv1.CountIgnoredTxs
 	if err != nil {
 		return nil, err
 	}
-	mapping := db.AssetClassToTxTypesMap(rules)
-	txCount, declCount, err := s.db.CountIgnoredTxs(ctx, u.ID, rules, mapping)
+	txCount, declCount, err := s.db.CountIgnoredTxs(ctx, u.ID, rules)
 	if err != nil {
 		return nil, status.Error(codes.Internal, err.Error())
 	}

--- a/server/service/ingestion/hints.go
+++ b/server/service/ingestion/hints.go
@@ -7,16 +7,6 @@ import (
 	"github.com/leedenison/portfoliodb/server/identifier"
 )
 
-// TxTypeStored returns whether transactions of this type are stored. When false (e.g. SPLIT), the transaction is dropped before resolution.
-func TxTypeStored(t typev1.TxType) bool {
-	switch t {
-	case typev1.TxType_SPLIT:
-		return false
-	default:
-		return true
-	}
-}
-
 // TxTypeToSecurityTypeHint maps transaction type to the security type hint vocabulary (identifier package constants).
 // Delegates to db.TxTypeToAssetClass since the vocabularies are identical.
 func TxTypeToSecurityTypeHint(t typev1.TxType) string {
@@ -39,12 +29,6 @@ func HintsFromTx(tx *apiv1.Tx) identifier.Hints {
 		InstrumentKind:   TxTypeToInstrumentKind(tx.GetType()),
 		SecurityTypeHint: TxTypeToSecurityTypeHint(tx.GetType()),
 	}
-}
-
-// AssetClassToTxTypeStrings returns tx_type DB strings for the given asset class.
-// Delegates to db.AssetClassToTxTypeStrings.
-func AssetClassToTxTypeStrings(assetClass string) []string {
-	return db.AssetClassToTxTypeStrings(assetClass)
 }
 
 // TxIgnored returns whether a transaction should be ignored based on the user's ignore rules.

--- a/server/service/ingestion/hints_test.go
+++ b/server/service/ingestion/hints_test.go
@@ -5,7 +5,6 @@ import (
 	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
 	"github.com/leedenison/portfoliodb/server/db"
 	"github.com/leedenison/portfoliodb/server/identifier"
-	"sort"
 	"testing"
 )
 
@@ -78,55 +77,6 @@ func TestTxTypeToInstrumentKind(t *testing.T) {
 			t.Errorf("TxTypeToInstrumentKind(%v) = %q, want %q", tt.txType, got, tt.want)
 		}
 	}
-}
-
-func TestAssetClassToTxTypeStrings(t *testing.T) {
-	t.Run("CASH maps to expected types", func(t *testing.T) {
-		strs := AssetClassToTxTypeStrings(identifier.SecurityTypeHintCash)
-		sort.Strings(strs)
-		want := []string{"CASHFLOW", "INCOME", "INVEXPENSE", "JRNLFUND", "MARGININTEREST", "RETOFCAP"}
-		sort.Strings(want)
-		if len(strs) != len(want) {
-			t.Fatalf("got %v, want %v", strs, want)
-		}
-		for i := range strs {
-			if strs[i] != want[i] {
-				t.Errorf("index %d: got %q, want %q", i, strs[i], want[i])
-			}
-		}
-	})
-	t.Run("FUTURE maps to BUYFUTURE and SELLFUTURE", func(t *testing.T) {
-		strs := AssetClassToTxTypeStrings(identifier.SecurityTypeHintFuture)
-		sort.Strings(strs)
-		want := []string{"BUYFUTURE", "SELLFUTURE"}
-		if len(strs) != len(want) {
-			t.Fatalf("got %v, want %v", strs, want)
-		}
-		for i := range strs {
-			if strs[i] != want[i] {
-				t.Errorf("index %d: got %q, want %q", i, strs[i], want[i])
-			}
-		}
-	})
-	t.Run("ETF has no mapped types", func(t *testing.T) {
-		strs := AssetClassToTxTypeStrings(identifier.SecurityTypeHintETF)
-		if len(strs) != 0 {
-			t.Errorf("expected empty, got %v", strs)
-		}
-	})
-	t.Run("OPTION maps correctly", func(t *testing.T) {
-		strs := AssetClassToTxTypeStrings(identifier.SecurityTypeHintOption)
-		sort.Strings(strs)
-		want := []string{"BUYOPT", "CLOSUREOPT", "SELLOPT"}
-		if len(strs) != len(want) {
-			t.Fatalf("got %v, want %v", strs, want)
-		}
-		for i := range strs {
-			if strs[i] != want[i] {
-				t.Errorf("index %d: got %q, want %q", i, strs[i], want[i])
-			}
-		}
-	})
 }
 
 func TestTxIgnored(t *testing.T) {

--- a/server/service/ingestion/ingest.go
+++ b/server/service/ingestion/ingest.go
@@ -97,12 +97,11 @@ func ingestBatch(ctx context.Context, deps ingestDeps, p ingestParams, rep *arch
 		log.Printf("ingest: load ignored asset classes: %v", err)
 		ignoredClasses = nil
 	}
-	// Drop non-stored tx types (SPLIT, which the corporate event path owns) and
-	// whatever the user's ignore rules cover. Where the caller declared the
+	// Drop whatever the user's ignore rules cover. Where the caller declared the
 	// total, a dropped posting still counts as processed: its total is what the
 	// file carried, and a job that ended below its own total would read as
 	// unfinished.
-	txs, filteredIdx := filterStoredTxs(p.Txs, p.Broker, ignoredClasses)
+	txs, filteredIdx := filterIgnoredTxs(p.Txs, p.Broker, ignoredClasses)
 	if p.TotalDeclared {
 		rep.Advance(ctx, len(p.Txs)-len(txs))
 	}

--- a/server/service/ingestion/user_import_test.go
+++ b/server/service/ingestion/user_import_test.go
@@ -70,7 +70,7 @@ func TestProcessUserImport_AppliesPreferencesForTheJobsUser(t *testing.T) {
 		Parts:  partRows(archivev1.ArchivePart_PREFERENCES),
 	}, nil).AnyTimes()
 	database.EXPECT().SetDisplayCurrency(gomock.Any(), "user-7", "GBP").Return(nil)
-	database.EXPECT().SetIgnoredAssetClasses(gomock.Any(), "user-7", gomock.Any(), gomock.Any()).Return(nil)
+	database.EXPECT().SetIgnoredAssetClasses(gomock.Any(), "user-7", gomock.Any()).Return(nil)
 
 	var transitions []string
 	database.EXPECT().SetJobPartStatus(gomock.Any(), j.JobID, gomock.Any(), gomock.Any()).
@@ -106,7 +106,7 @@ func TestProcessUserImport_NoCurrencyEarnsNoNudge(t *testing.T) {
 	database.EXPECT().GetJob(gomock.Any(), j.JobID).Return(&db.JobDetail{
 		UserID: "user-7", Parts: partRows(archivev1.ArchivePart_PREFERENCES),
 	}, nil).AnyTimes()
-	database.EXPECT().SetIgnoredAssetClasses(gomock.Any(), "user-7", gomock.Any(), gomock.Any()).Return(nil)
+	database.EXPECT().SetIgnoredAssetClasses(gomock.Any(), "user-7", gomock.Any()).Return(nil)
 	database.EXPECT().SetJobPartStatus(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	if res := processUserImport(context.Background(), ingestDeps{DB: database}, j); res.displayCurrencySet {
@@ -159,7 +159,7 @@ func TestProcessUserImport_ResetsPartialProgressOnRerun(t *testing.T) {
 	}, nil).AnyTimes()
 	database.EXPECT().ResetJobPartProgress(gomock.Any(), j.JobID, archivev1.ArchivePart_PREFERENCES).Return(nil)
 	database.EXPECT().SetDisplayCurrency(gomock.Any(), "user-7", "GBP").Return(nil)
-	database.EXPECT().SetIgnoredAssetClasses(gomock.Any(), "user-7", gomock.Any(), gomock.Any()).Return(nil)
+	database.EXPECT().SetIgnoredAssetClasses(gomock.Any(), "user-7", gomock.Any()).Return(nil)
 	database.EXPECT().SetJobPartStatus(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 	processUserImport(context.Background(), ingestDeps{DB: database}, j)
@@ -211,7 +211,7 @@ func TestProcessUserImport_JobCountersAreTheSumOverParts(t *testing.T) {
 		}, nil),
 	)
 	database.EXPECT().SetDisplayCurrency(gomock.Any(), "user-7", "GBP").Return(nil)
-	database.EXPECT().SetIgnoredAssetClasses(gomock.Any(), "user-7", gomock.Any(), gomock.Any()).Return(nil)
+	database.EXPECT().SetIgnoredAssetClasses(gomock.Any(), "user-7", gomock.Any()).Return(nil)
 	database.EXPECT().SetJobTotalCount(gomock.Any(), j.JobID, int32(2)).Return(nil)
 	database.EXPECT().SetJobProcessedCount(gomock.Any(), j.JobID, int32(2)).Return(nil)
 
@@ -254,7 +254,7 @@ func TestProcessJob_UserArchive_NudgesThePriceFetcherOnlyForACurrency(t *testing
 				UserID: "user-7", Parts: partRows(archivev1.ArchivePart_PREFERENCES),
 			}, nil).AnyTimes()
 			database.EXPECT().SetDisplayCurrency(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
-			database.EXPECT().SetIgnoredAssetClasses(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+			database.EXPECT().SetIgnoredAssetClasses(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 			database.EXPECT().SetJobPartStatus(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 
 			trigger := make(chan struct{}, 1)

--- a/server/service/ingestion/worker.go
+++ b/server/service/ingestion/worker.go
@@ -264,14 +264,11 @@ func recomputeSplitAdjustedTxs(ctx context.Context, database db.DB, instrumentID
 	}
 }
 
-// filterStoredTxs returns only txs with stored types that are not ignored, along with their original indices.
-func filterStoredTxs(txs []*apiv1.Tx, broker string, ignored []db.IgnoredAssetClass) ([]*apiv1.Tx, []int) {
+// filterIgnoredTxs returns only txs not matching an ignore rule, along with their original indices.
+func filterIgnoredTxs(txs []*apiv1.Tx, broker string, ignored []db.IgnoredAssetClass) ([]*apiv1.Tx, []int) {
 	var filtered []*apiv1.Tx
 	var indices []int
 	for i, tx := range txs {
-		if !TxTypeStored(tx.Type) {
-			continue
-		}
 		if TxIgnored(tx, broker, ignored) {
 			continue
 		}

--- a/server/service/ingestion/worker_test.go
+++ b/server/service/ingestion/worker_test.go
@@ -176,7 +176,7 @@ func TestProcessBulk_BatchCache_ResolvesSameDescriptionOnce(t *testing.T) {
 	processJob(ctx, WorkerOptions{DB: database, IdentifierRegistry: registry}, j)
 }
 
-func TestProcessBulk_DropsTxTypeSplitTransactions(t *testing.T) {
+func TestProcessBulk_DropsIgnoredTxs(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
@@ -189,7 +189,7 @@ func TestProcessBulk_DropsTxTypeSplitTransactions(t *testing.T) {
 	before := timestamppb.Now()
 	postings := []*archivev1.Posting{
 		{Timestamp: from, InstrumentDescription: "AAPL", Type: typev1.TxType_BUYSTOCK, Quantity: "10", Account: "", GroupRef: proto.String("ref-1")},
-		{Timestamp: from, InstrumentDescription: "SPLIT", Type: typev1.TxType_SPLIT, Quantity: "1", Account: "", GroupRef: proto.String("ref-1")},
+		{Timestamp: from, InstrumentDescription: "GBP", Type: typev1.TxType_JRNLFUND, Quantity: "1", Account: "", GroupRef: proto.String("ref-1")},
 	}
 	payload := marshalPayload(t, &ingestionv1.UpsertTxsRequest{
 		Window: &archivev1.TxWindow{
@@ -200,14 +200,21 @@ func TestProcessBulk_DropsTxTypeSplitTransactions(t *testing.T) {
 			Postings:     postings,
 		},
 	})
-	j := &JobRequest{JobID: "job-split", JobType: "tx"}
+	j := &JobRequest{JobID: "job-ignored", JobType: "tx"}
 
 	database.EXPECT().
-		SetJobStatus(gomock.Any(), "job-split", apiv1.JobStatus_RUNNING).
+		SetJobStatus(gomock.Any(), "job-ignored", apiv1.JobStatus_RUNNING).
 		Return(nil)
-	expectLoadPayload(database, "job-split", "user-1", payload)
+	database.EXPECT().LoadJobPayload(gomock.Any(), "job-ignored").Return(payload, nil)
+	database.EXPECT().ClearJobPayload(gomock.Any(), "job-ignored").Return(nil)
+	database.EXPECT().GetJob(gomock.Any(), "job-ignored").Return(
+		&db.JobDetail{Status: apiv1.JobStatus_RUNNING, UserID: "user-1"}, nil,
+	)
+	database.EXPECT().ListIgnoredAssetClasses(gomock.Any(), "user-1").Return(
+		[]db.IgnoredAssetClass{{Broker: "IBKR", AssetClass: "CASH"}}, nil,
+	)
 	database.EXPECT().
-		SetJobTotalCount(gomock.Any(), "job-split", int32(1)).
+		SetJobTotalCount(gomock.Any(), "job-ignored", int32(1)).
 		Return(nil)
 	database.EXPECT().
 		FindInstrumentBySourceDescription(gomock.Any(), "IBKR:test:statement", "AAPL").
@@ -216,16 +223,16 @@ func TestProcessBulk_DropsTxTypeSplitTransactions(t *testing.T) {
 		EnsureInstrument(gomock.Any(), "", "", "", "AAPL", gomock.Any(), gomock.Any(), gomock.Any(), "", nil, nil, nil).
 		Return("aapl-id", nil)
 	database.EXPECT().
-		IncrJobProcessedCount(gomock.Any(), "job-split").
+		IncrJobProcessedCount(gomock.Any(), "job-ignored").
 		Return(nil)
 	database.EXPECT().
-		AppendIdentificationErrors(gomock.Any(), "job-split", gomock.Any()).
+		AppendIdentificationErrors(gomock.Any(), "job-ignored", gomock.Any()).
 		Return(nil)
 	database.EXPECT().
 		ListInstrumentsByIDs(gomock.Any(), []string{"aapl-id"}).
 		Return([]*db.InstrumentRow{{ID: "aapl-id"}}, nil)
 	database.EXPECT().
-		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", "job-split", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		ReplaceTxsInPeriod(gomock.Any(), "user-1", "IBKR", "job-ignored", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(_ context.Context, _, _, _ string, _, _ *timestamppb.Timestamp, storedTxs []*apiv1.Tx, ids []string, ws []db.Weight, _ []*time.Time) error {
 			supplied := userPostings(storedTxs)
 			if len(supplied) != 1 || supplied[0].InstrumentDescription != "AAPL" || supplied[0].Type != typev1.TxType_BUYSTOCK {
@@ -253,7 +260,7 @@ func TestProcessBulk_DropsTxTypeSplitTransactions(t *testing.T) {
 		ListHoldingDeclarations(gomock.Any(), "user-1").
 		Return(nil, nil)
 	database.EXPECT().
-		SetJobStatus(gomock.Any(), "job-split", apiv1.JobStatus_SUCCESS).
+		SetJobStatus(gomock.Any(), "job-ignored", apiv1.JobStatus_SUCCESS).
 		Return(nil)
 
 	processJob(ctx, WorkerOptions{DB: database, IdentifierRegistry: registry}, j)
@@ -591,7 +598,7 @@ func TestProcessBulk_TransferToStockAllowed(t *testing.T) {
 	processJob(ctx, WorkerOptions{DB: database, IdentifierRegistry: registry}, j)
 }
 
-func TestProcessSingle_DropsTxTypeSplitTransaction(t *testing.T) {
+func TestProcessSingle_DropsIgnoredTx(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 	database := mock.NewMockDB(ctrl)
@@ -604,20 +611,27 @@ func TestProcessSingle_DropsTxTypeSplitTransaction(t *testing.T) {
 		Window: &archivev1.TxWindow{
 			Broker:   typev1.Broker_IBKR,
 			Source:   "IBKR:test:statement",
-			Postings: []*archivev1.Posting{{Timestamp: timestamppb.Now(), InstrumentDescription: "SPLIT", Type: typev1.TxType_SPLIT, Quantity: "1", Account: ""}},
+			Postings: []*archivev1.Posting{{Timestamp: timestamppb.Now(), InstrumentDescription: "GBP", Type: typev1.TxType_JRNLFUND, Quantity: "1", Account: ""}},
 		},
 	})
-	j := &JobRequest{JobID: "job-single-split", JobType: "tx"}
+	j := &JobRequest{JobID: "job-single-ignored", JobType: "tx"}
 
 	database.EXPECT().
-		SetJobStatus(gomock.Any(), "job-single-split", apiv1.JobStatus_RUNNING).
+		SetJobStatus(gomock.Any(), "job-single-ignored", apiv1.JobStatus_RUNNING).
 		Return(nil)
-	expectLoadPayload(database, "job-single-split", "user-1", payload)
+	database.EXPECT().LoadJobPayload(gomock.Any(), "job-single-ignored").Return(payload, nil)
+	database.EXPECT().ClearJobPayload(gomock.Any(), "job-single-ignored").Return(nil)
+	database.EXPECT().GetJob(gomock.Any(), "job-single-ignored").Return(
+		&db.JobDetail{Status: apiv1.JobStatus_RUNNING, UserID: "user-1"}, nil,
+	)
+	database.EXPECT().ListIgnoredAssetClasses(gomock.Any(), "user-1").Return(
+		[]db.IgnoredAssetClass{{Broker: "IBKR", AssetClass: "CASH"}}, nil,
+	)
 	database.EXPECT().
 		ListHoldingDeclarations(gomock.Any(), "user-1").
 		Return(nil, nil)
 	database.EXPECT().
-		SetJobStatus(gomock.Any(), "job-single-split", apiv1.JobStatus_SUCCESS).
+		SetJobStatus(gomock.Any(), "job-single-ignored", apiv1.JobStatus_SUCCESS).
 		Return(nil)
 
 	processJob(ctx, WorkerOptions{DB: database, IdentifierRegistry: registry}, j)


### PR DESCRIPTION
Preparation for issue 0100 (replace TxType with a declared and resolved pair), under the old vocabulary so it lands independently.

## What

- The ignore rules' regular-posting delete and count switch from a `tx_type IN (...)` list reverse-mapped from the rule's asset class to the `instruments.asset_class` join the synthetic and declaration paths already use. `AssetClassToTxTypeStrings` and `AssetClassToTxTypesMap` delete with their only consumer, and `IgnoredAssetClassDB` drops the expansion-map parameter.
- `TxTypeStored` and the SPLIT drop in `filterStoredTxs` delete: no converter emits SPLIT, so the filter guarded a case nothing produces. The renamed `filterIgnoredTxs` keeps the ignore-rule filtering.
- New db integration tests pin the join semantics: synthetic INITIALIZE pads are deleted, an unresolved-instrument posting survives, account-scoped rules stay scoped, and the count previews regular postings only.

## Behaviour shifts (accepted, per adr/0045)

- A posting whose instrument is unresolved has no asset class and now survives a delete (the type-derived guess used to catch some of these).
- A rule catches a posting by what it resolved to rather than by what the broker called it.

The worker tests that pinned "a dropped leg keeps the survivors' grouping" and "a fully filtered batch is not a period clear" keep those properties through the ignore-rule path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)