### PR TITLE
Settle how a human assertion survives a regroup (0097)

### DIFF
--- a/docs/adr/0037-transfer-matches-are-links-not-postings.md
+++ b/docs/adr/0037-transfer-matches-are-links-not-postings.md
@@ -87,6 +87,16 @@ natural key ([0002](0002-transaction-ingestion-model.md)). See
 [0095](../issues/0095-match-imbalanced-groups-that-should-be-one.md) and
 [0091](../issues/0091-manual-transfer-match.md).
 
+That question is settled in [0049](0049-a-human-assertion-is-a-correlation.md), and in
+two parts, because the paragraph above conflates a hand-made *grouping* with a hand-made
+*match*. A grouping needs no key at all: it is recorded as a correlation on the postings
+it names, so it is already attached to them. A match keeps its group ids and relies on
+the engine writing only the groups it disagrees with, so an id survives every cycle that
+does not genuinely repartition it
+([0047](0047-grouping-runs-as-precedence-ordered-passes.md)). What remains true is that
+a re-upload takes both with the postings, and that this is reported rather than
+repaired.
+
 ## Ambiguity is left unmatched
 
 Two transfers of the same amount between the same pair of accounts in the same window

--- a/docs/adr/0041-server-owns-transaction-grouping.md
+++ b/docs/adr/0041-server-owns-transaction-grouping.md
@@ -70,6 +70,13 @@ and it does so as an ordinary correlation the engine consumes as evidence -- not
 as a partition the engine obeys, which is what this ADR and
 [0043](0043-grouping-does-not-travel-in-the-archive.md) both reject.
 
+**Human assertions need no anchor.** "Human assertions have to become inputs to the
+grouping pass, replayed on every run, which needs the postings they name to be
+identifiable" above assumes an assertion is stored beside the postings and has to find
+them again. [0049](0049-a-human-assertion-is-a-correlation.md) records that it is not:
+a hand-made grouping is a correlation written onto its members, so it is a field of the
+thing it names and 0002's missing natural key never comes up.
+
 **The broker-specific passes arrive as an ordering.**
 [0047](0047-grouping-runs-as-precedence-ordered-passes.md) makes the engine's pass
 order load-bearing for correctness rather than for tuning, and a single order has

--- a/docs/adr/0047-grouping-runs-as-precedence-ordered-passes.md
+++ b/docs/adr/0047-grouping-runs-as-precedence-ordered-passes.md
@@ -94,3 +94,31 @@ uploaded, and would destroy a hand-made transfer match every time an unrelated
 month was imported. [0049](0049-a-human-assertion-is-a-correlation.md) leans on
 this: it lets a manual transfer match stay keyed on group ids rather than
 needing a durable anchor of its own.
+
+**Writing only its disagreements is not the same as not being allowed to
+disagree**, and the distinction is load-bearing. Every stored group balances --
+`check_tx_group_balance()` sees to that, and whatever is left over is routed to an
+explicit residual -- so "balanced" cannot be what marks a group as settled. Nor
+can "balanced with no residual worse than `SOURCE_ROUNDING`", tempting as it is,
+because that is exactly what a converter's *wrong* pairing looks like: two legs
+whose amounts happened to agree closely enough, joined when they should not have
+been, or one leg joined to the wrong counterpart of two similar trades on the same
+day. Those are the errors the engine exists to correct, and after
+[0098](../issues/0098-retire-converter-side-grouping.md) there is no converter
+partition left to defer to in any case.
+
+It would also not survive the order data arrives in. A fragment that balances on
+its own today may be one whose third leg arrives next month, and a rule that
+forbade disturbing it would stop the engine doing the one thing
+[0041](0041-server-owns-transaction-grouping.md) built it for.
+
+So the two things a balance test looks like it offers are supplied elsewhere and
+better. The *protection* is precedence: a group whose members carry a `SCOPE_USER`
+correlation ([0049](0049-a-human-assertion-is-a-correlation.md)) is claimed by the
+highest-precedence pass as a must-link, so no later pass can take a member from
+it, and that holds whether or not the group balances -- which matters, because a
+person may well assert a grouping precisely because the legs do not. The
+*efficiency* is where the neighbourhood is seeded: starting from postings whose
+groups carry an unresolved residual is a sound and cheap way to choose where to
+look. Neither may become a rule about what the engine is permitted to conclude
+once it is looking, or it can only ever repair and never correct.

--- a/docs/adr/0047-grouping-runs-as-precedence-ordered-passes.md
+++ b/docs/adr/0047-grouping-runs-as-precedence-ordered-passes.md
@@ -74,3 +74,23 @@ tie-break. Two groups can each admit a row under the permissive reading, and
 nothing in the narrowing step ranks them; the converter's answer to that has always
 been to order the passes so the question never arises, and ordering the passes
 makes the second pass unnecessary rather than merely cheaper.
+
+## Amendments
+
+**The engine writes its disagreements, not its partition.** "A regroup must
+re-route inside the transaction that changes membership" above says what happens
+when membership moves, and leaves the impression that recomputing the partition
+means rewriting every group in reach. It does not. The engine compares its
+partition against the stored one and issues statements only where the two differ;
+a group it agrees with keeps its id, its residual and the `transfer_matches` rows
+keyed on it.
+
+That is the cheaper implementation as well as the safer one, but it is recorded
+here because something depends on it. The grouping job runs after every import,
+over a neighbourhood deliberately wider than the uploaded period
+([0097](../issues/0097-server-side-transaction-grouping.md)), so an engine that
+rebuilt the neighbourhood each cycle would churn ids for postings nobody
+uploaded, and would destroy a hand-made transfer match every time an unrelated
+month was imported. [0049](0049-a-human-assertion-is-a-correlation.md) leans on
+this: it lets a manual transfer match stay keyed on group ids rather than
+needing a durable anchor of its own.

--- a/docs/adr/0048-correlations-declare-their-own-semantics.md
+++ b/docs/adr/0048-correlations-declare-their-own-semantics.md
@@ -137,6 +137,21 @@ the archive carrying a per-file identity so an import could reconstruct the orig
 boundaries -- would make the archive preserve which upload a posting arrived in,
 which nothing else about a posting does.
 
+**`Scope` gains `SCOPE_USER`, and the asserter may be a person.** A hand-made
+grouping is recorded as a correlation on its member postings, with a synthesised
+token and `MATCH_EXACT`, so that the engine consumes a person's judgement and a
+source's stated grouping through one mechanism. None of the existing scopes fits:
+`FILE` binds to an ingestion job, and `ACCOUNT` and `BROKER` are both narrower
+than a grouping someone made precisely because the legs sat in different accounts
+or arrived from different brokers.
+
+The transcription contract above is unaffected. It binds converters, which must
+not manufacture evidence their source did not supply, and says nothing about a
+person deliberately supplying some. What it protects is the ability to tell
+inference from transcription on the wire, and a user assertion is neither -- it
+says so in its scope. See
+[0049](0049-a-human-assertion-is-a-correlation.md).
+
 ## Considered: a field per broker
 
 Carrying each source's grouping fields verbatim was rejected in 0042 and stays

--- a/docs/adr/0049-a-human-assertion-is-a-correlation.md
+++ b/docs/adr/0049-a-human-assertion-is-a-correlation.md
@@ -91,6 +91,17 @@ difference is not marginal -- without it, importing one month of one broker woul
 destroy manual matches on postings nobody touched. See
 [0047](0047-grouping-runs-as-precedence-ordered-passes.md).
 
+**A manual grouping is protected by precedence, not by leaving it alone.** An
+exact-token claim is a must-link ([0048](0048-correlations-declare-their-own-semantics.md)),
+and the pass that makes it runs first, so a later pass can add to an asserted
+group but can never take a member out of it. Nothing else is needed, and in
+particular no rule that spares a group the engine finds already settled: such a
+rule would hold whether or not a person had said anything, and would stop the
+engine correcting a partition that is wrong but balances. It would also protect
+the wrong groups -- an assertion is often made precisely because the legs do not
+balance, which is the case a balance-based rule leaves unprotected. See
+[0047](0047-grouping-runs-as-precedence-ordered-passes.md).
+
 **A manual transfer match is a different object and keeps a different answer.** It
 links two groups rather than joining postings, because the link records which
 account holds the other side ([0037](0037-transfer-matches-are-links-not-postings.md)),

--- a/docs/adr/0049-a-human-assertion-is-a-correlation.md
+++ b/docs/adr/0049-a-human-assertion-is-a-correlation.md
@@ -1,0 +1,101 @@
+# A human assertion is a correlation, not an anchor
+
+[0041](0041-server-owns-transaction-grouping.md) leaves a question open and
+[0037](0037-transfer-matches-are-links-not-postings.md) restates it: group ids
+churn when the partition is recomputed, so a grouping or a match a person
+asserted by hand "cannot be keyed on something that evaporates". Both conclude
+that human judgement has to become an input replayed on every run, "keyed on
+something that outlives the groups it currently names", and both record that
+what that key is remains open, because a posting has no natural key
+([0002](0002-transaction-ingestion-model.md)).
+
+**A person's grouping is recorded as a correlation on the postings it names, and
+there is no key.** The asserter synthesises a token, stamps it on each member
+with `SCOPE_USER` and `MATCH_EXACT`, and the engine's highest-precedence pass
+([0047](0047-grouping-runs-as-precedence-ordered-passes.md)) claims them together
+like any other exact match.
+
+The open question assumed the assertion would live beside the postings and have
+to find them again. It does not: a correlation is a field of a posting
+([0048](0048-correlations-declare-their-own-semantics.md)), so it is already
+attached to what it names. There is nothing to resolve, nothing to re-resolve
+after a regroup, and no case where the thing a stored assertion points at cannot
+be found. `SCOPE_USER` joins the vocabulary because none of the existing scopes
+fits: `FILE` binds to an ingestion job, and `ACCOUNT` and `BROKER` are both
+narrower than a manual grouping, which is most often made precisely because the
+legs are in different accounts or came from different brokers.
+
+This is what [0097](../issues/0097-server-side-transaction-grouping.md) means by
+one design serving both asserters. A source states a grouping as a shared token
+and the engine consumes it as evidence; a person does the same thing with a token
+nobody transcribed. The engine has one kind of evidence and no special case, and
+[0048](0048-correlations-declare-their-own-semantics.md)'s transcription contract
+is unaffected: it binds converters, which must not manufacture evidence the
+source did not supply, and says nothing about a person deliberately supplying
+some.
+
+## An assertion lives and dies with the postings it is written on
+
+Which is the whole of its lifecycle, and each half is what is wanted.
+
+**A re-upload destroys it.** Ingestion is idempotent by replacement
+([0002](0002-transaction-ingestion-model.md)), so the postings in the period go
+and the correlations on them go too. The user is told a manual grouping will be
+lost before the replace runs, and is not offered a rebuild. A rebuild would have
+to decide whether a row in the new statement is the row the person looked at,
+which is undecidable exactly when it matters -- the case where the broker
+restated the period is the case where the answer might no longer hold.
+
+**An archive round trip preserves it.** The archive carries correlations on the
+flat `Posting` in both directions, so an import re-creates the assertion along
+with the postings and the engine regroups to the partition the person asserted.
+That is consistent with
+[0043](0043-grouping-does-not-travel-in-the-archive.md), which drops the
+partition and keeps the evidence: an assertion travels as the evidence it is,
+not as a shape imposed on the postings, and the importer regroups from it like
+anything else.
+
+## Considered: a content fingerprint over the posting's transcribed fields
+
+The obvious reading of "keyed on something that outlives the groups it currently
+names": digest the fields a re-upload reproduces -- broker, account, timestamp,
+amounts, declared type, correlation tokens -- store assertions against that
+digest, and replay them on every run. It buys the one thing the decision above
+gives up, which is an assertion surviving a re-upload of its own period.
+
+Rejected because it pays for that with a resolution step that has no good answer
+when it fails. A digest either finds its postings or does not, and "does not" is
+ambiguous between the row having genuinely gone and the broker having restated it
+in a way the digest did not survive -- a corrected amount, a settlement date
+moved by a day. Distinguishing those needs a fuzzier match, and a fuzzy match on
+a person's assertion re-applies their judgement to rows they never saw. Nor is
+the digest cheap: identical rows are legal
+([0002](0002-transaction-ingestion-model.md) enforces no uniqueness), so it needs
+an occurrence index beside it, which reintroduces exactly the positional
+fragility it was meant to remove.
+
+The correlation carries no such ambiguity, because it is not a reference. It is
+present, or the posting is not.
+
+## Consequences
+
+**A regroup must not churn ids gratuitously.**
+[0037](0037-transfer-matches-are-links-not-postings.md) reasons about id churn as
+though a recomputed partition necessarily rewrites every group, and under that
+reading a `MANUAL` transfer match -- which is keyed on group ids and is not a
+correlation -- would break on every cycle. It does not have to: the engine
+compares its partition against the stored one and writes only where the two
+differ, so a group it agrees with keeps its id. Since the grouping job runs after
+every import over a neighbourhood far wider than the uploaded period, the
+difference is not marginal -- without it, importing one month of one broker would
+destroy manual matches on postings nobody touched. See
+[0047](0047-grouping-runs-as-precedence-ordered-passes.md).
+
+**A manual transfer match is a different object and keeps a different answer.** It
+links two groups rather than joining postings, because the link records which
+account holds the other side ([0037](0037-transfer-matches-are-links-not-postings.md)),
+and merging the two groups would erase the account boundary the pairing exists to
+express. So it stays keyed on group ids and relies on the stability above, rather
+than becoming a correlation. What becomes a correlation is the non-transfer
+repair in [0095](../issues/0095-match-imbalanced-groups-that-should-be-one.md),
+which is a merge and therefore a grouping.

--- a/docs/issues/0091-manual-transfer-match.md
+++ b/docs/issues/0091-manual-transfer-match.md
@@ -39,5 +39,9 @@ A hand-made match can stop making sense without anyone touching it: a later uplo
 change the residual of a group it names, or remove the clearing leg it was made
 against. 0095 carries the question of what happens then -- survive, drop, or flag for
 review -- and it needs an answer here too, because this is where the match is created.
-Related but separate is that a regroup churns group ids, so the anchor a manual match
-is keyed on has to outlive the groups it names; that is settled in 0097.
+
+The related worry about a regroup churning group ids is settled and does not land here:
+adr/0049-a-human-assertion-is-a-correlation.md keeps a match keyed on its group ids and
+requires the grouping engine to write only the groups it disagrees with, so a manual
+match survives every cycle that does not genuinely repartition it. A re-upload still
+takes it, along with the postings.

--- a/docs/issues/0095-match-imbalanced-groups-that-should-be-one.md
+++ b/docs/issues/0095-match-imbalanced-groups-that-should-be-one.md
@@ -62,6 +62,20 @@ without anyone being asked. What is left here is the half 0097 cannot do -- the 
 whose evidence does not identify the occurrence, where the answer is a person's
 judgement rather than a rule.
 
+## Recording the human answer
+
+A hand-made grouping -- the merge repair above, not a transfer match -- is recorded as
+a correlation on the postings it joins: a synthesised token, `MATCH_EXACT`, and
+`SCOPE_USER`, which the grouping engine claims through its highest-precedence pass like
+any other exact match. adr/0049-a-human-assertion-is-a-correlation.md settles this. What
+lands here is the writer: the `SCOPE_USER` value in the vocabulary, the API and UI that
+create and remove an assertion, and the warning shown before a re-upload that would
+destroy one.
+
+A hand-made transfer match stays a link keyed on group ids, for the reason
+adr/0037-transfer-matches-are-links-not-postings.md gives, and survives on the engine
+writing only the groups it disagrees with.
+
 ## A manual match whose target stops making sense
 
 Distinct from the id churn adr/0037-transfer-matches-are-links-not-postings.md now records, and not fixed by anchoring a match to

--- a/docs/issues/0097-server-side-transaction-grouping.md
+++ b/docs/issues/0097-server-side-transaction-grouping.md
@@ -61,6 +61,15 @@ the engine can run in shadow over stored postings and be required to reproduce
 `group_ref` exactly before anything depends on it. Do this before 0098 flips the
 switch.
 
+The oracle is not infallible, and the bar has to be read with that in mind. The
+engine is free to disagree with a converter's pairing, including one that balances
+with nothing worse than a `SOURCE_ROUNDING` residual, because that is what a
+wrong pairing of two similar trades looks like
+(adr/0047-grouping-runs-as-precedence-ordered-passes.md). So a divergence may be
+the engine being right. Zero divergences is still the bar to start from, since
+any other number is unfalsifiable, but each one is looked at rather than counted
+as a failure.
+
 ## Settled: how a human assertion survives
 
 adr/0049-a-human-assertion-is-a-correlation.md answers the question this issue was

--- a/docs/issues/0097-server-side-transaction-grouping.md
+++ b/docs/issues/0097-server-side-transaction-grouping.md
@@ -2,7 +2,7 @@
 status: open
 title: Derive transaction groups on the server
 milestone: M15
-dependencies: [0096, 0100]
+dependencies: [0096, 0100, 0102]
 ---
 
 Build the pass that decides which postings are legs of one economic event, from
@@ -61,15 +61,28 @@ the engine can run in shadow over stored postings and be required to reproduce
 `group_ref` exactly before anything depends on it. Do this before 0098 flips the
 switch.
 
-## Open
+## Settled: how a human assertion survives
 
-A regroup churns group ids, so a human assertion -- a hand-made transfer match, and
-later a hand-made grouping -- cannot be keyed on them. Human judgement has to become an
-input replayed on every run, anchored on something durable, and a posting has no
-natural key (adr/0002-transaction-ingestion-model.md). Settle this here rather than in 0091 or 0095, both of which
-depend on the answer.
+adr/0049-a-human-assertion-is-a-correlation.md answers the question this issue was
+asked to settle, and answers it by removing it. A hand-made grouping is a correlation
+written onto the postings it names, with a synthesised token, `MATCH_EXACT` and a new
+`SCOPE_USER`, so there is no anchor to resolve: the assertion is a field of the thing
+it names. It dies with a re-upload, which the user is warned about rather than having
+rebuilt, and survives an archive round trip because the archive carries correlations.
+The engine consumes it through the same exact-token pass that honours an OFX `FITID`,
+which is what "one design should serve both asserters" comes to.
 
-A source-asserted grouping is the same mechanism with a different asserter: an
-assertion, replayed on every run, that the engine consumes as its
-highest-precedence evidence (adr/0048-correlations-declare-their-own-semantics.md).
-One design should serve both.
+A hand-made transfer *match* is a different object -- a link between groups, not a
+join between postings -- and keeps its group ids. What makes that safe is the engine
+writing only the groups it disagrees with, so a cycle that repartitions nothing churns
+no ids. That is a requirement on this issue's write path, not a detail of it.
+
+The writer, the `SCOPE_USER` value, the manual-grouping API and UI, and the re-upload
+warning land in 0095.
+
+## Evidence this needs and does not have
+
+The converters compare two independently transcribed cash totals; the standard format
+carries only one of them, because a security trade row's `Amount` is used inside
+`assignFidelityGroups` and then discarded. 0102 closes that before the engine is
+built.

--- a/docs/issues/0102-source-cash-total-on-a-trade-row.md
+++ b/docs/issues/0102-source-cash-total-on-a-trade-row.md
@@ -1,0 +1,60 @@
+---
+status: open
+title: Carry the source's own cash total for a trade row
+milestone: M15
+---
+
+Transcribe the cash total a source states for a row whose own quantity is not
+money, so that grouping has the figure the broker wrote rather than one derived
+from two other fields.
+
+## Motivation
+
+adr/0041-server-owns-transaction-grouping.md moves grouping to the server, and
+0097 builds the engine. The evidence the engine reads is short of what the
+converter it must reproduce reads, in one specific place.
+
+For a cash row Fidelity's `Amount` becomes the posting's `quantity`, so it
+reaches the server exactly. For a security trade row it is parsed, used inside
+`assignFidelityGroups`, and then discarded: the posting is built from `quantity`
+and `unit_price` alone. So where the converter compares two independently
+transcribed totals -- which is what its own comment says the pairing rests on,
+"quantity * unit price is derived from different fields, which makes it an
+independent check" -- the server has one transcribed number and one derived.
+
+That is not broker idiosyncrasy, so it is not something a converter should be
+left to work around. Every source reports a trade's cash total and rounds the
+unit price it quotes, so the loss is the same everywhere: an exact equality that
+identifies a cash leg degrades into a tolerance band wide enough to admit a
+different trade of a similar size. It is also wrong rather than merely weaker for
+Schwab, where 0073 records commission netted into `Amount` against
+split-adjusted quantities and as-traded prices, so `quantity * unit_price` is not
+the consideration at all. A server that derives the consideration derives a
+different number per broker; a source that states it is transcribing, which is
+what adr/0048-correlations-declare-their-own-semantics.md asks converters for.
+
+## Design
+
+`settlement_amount` on the posting: the cash total the source stated for the row,
+denominated in the `settlement_currency` already beside it. Optional, and
+transcribed rather than computed -- a converter that has to work it out from
+other columns has inferred it and should emit nothing.
+
+Populated only where the posting's own quantity is not money. On a cash posting
+the quantity is already that total, so carrying it twice would create a second
+figure to disagree with the first, and validation rejects it there.
+
+Per converter: Fidelity CSV and the extension's Fidelity JSON already parse the
+`Amount` cell; OFX already reads `TOTAL` to build the cash leg.
+
+## Scope
+
+It has to be stored and to travel in the archive, for the reason the correlations
+do: a rebuild from an archive would otherwise leave the engine with less evidence
+than the upload had.
+
+**Weights and balancing are out of scope.** adr/0024-group-balance-is-checked-on-weight.md
+weighs a `TRADE_ASSET` leg at `quantity * unit_price`, and
+adr/0029-posting-weight-is-stored.md fixes that at the fact's own time. Weighing
+on this field instead would move every trade group's `SOURCE_ROUNDING` residual
+and is a separate argument. This is grouping evidence and a cross-check.


### PR DESCRIPTION
Settles the design question 0097 was asked to answer, and opens the prerequisite
issue the engine needs. Docs only.

## A human assertion needs no anchor

0041 and 0037 both leave the same question open: a regroup churns group ids, so a
hand-made grouping or match cannot be keyed on them, and a posting has no natural
key to fall back on (0002). Both conclude that human judgement has to become an
input replayed on every run, anchored on something durable, and leave what that
anchor is unsettled.

New ADR 0049 answers it by removing the question. A hand-made grouping is
recorded as a correlation on the postings it names -- a synthesised token,
`MATCH_EXACT`, and a new `SCOPE_USER` -- so it is a field of the thing it names
rather than a reference to it. There is nothing to resolve after a regroup and no
case where the target cannot be found. It dies with a re-upload, which is
reported rather than repaired, and survives an archive round trip because the
archive already carries correlations. The engine consumes it through the same
exact-token pass that honours an OFX `FITID`, which is what 0097 means by one
design serving both asserters.

The rejected alternative -- a content fingerprint over the posting's transcribed
fields -- is recorded with its reasons: it buys survival across a re-upload at
the cost of a resolution step whose failure is ambiguous between "the row is
gone" and "the broker restated it", and needs an occurrence index beside it
because identical rows are legal.

A hand-made transfer *match* is a different object and keeps a different answer.
It links two groups rather than joining postings, so merging them would erase the
account boundary the pairing exists to express (0037). It stays keyed on group
ids, and 0047 gains the requirement that makes that safe: **the engine writes the
groups it disagrees with, not its whole partition.** That is not a detail -- the
grouping job runs after every import over a neighbourhood far wider than the
uploaded period, so an engine that rebuilt the neighbourhood each cycle would
destroy manual matches on postings nobody uploaded.

## The evidence abstraction has a hole (issue 0102)

The converters pair a trade with its cash row by comparing two independently
transcribed totals -- the broker's own `Amount` on each row -- and cross-check
with `quantity * unit_price`, which comes from different fields. The standard
format carries only one of the two: for a cash row the `Amount` becomes the
posting's `quantity`, but for a security trade row it is used inside
`assignFidelityGroups` and then discarded.

So a server-side engine would have one transcribed number and one derived one,
and the exact equality that identifies a cash leg degrades into a tolerance band
wide enough to admit a different trade of a similar size. That is not broker
idiosyncrasy: every source reports a trade's cash total and rounds the price it
quotes. It is also wrong rather than merely weaker for Schwab, where 0073 records
commission netted into `Amount` against split-adjusted quantities and as-traded
prices, so `quantity * unit_price` is not the consideration at all.

0102 closes it with a transcribed `settlement_amount` on rows whose own quantity
is not money, and 0097 now depends on it. Weights and balancing are explicitly
out of scope there.

## Not included

No spec changes. The spec states what the system does and the engine does not
exist yet; nothing currently in `docs/spec/postings.md` or `docs/spec/tx-types.md`
becomes untrue by these decisions. Those sections are rewritten by the PRs that
build each piece, so the spec never describes code that is not there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
