### PR TITLE
Carry the source's own cash total for a trade row (0102)

### DIFF
--- a/client/lib/csv/converters/fidelity-csv.test.ts
+++ b/client/lib/csv/converters/fidelity-csv.test.ts
@@ -952,3 +952,53 @@ describe("correlations", () => {
     expect(result.postings[1].correlations).toEqual([]);
   });
 });
+
+
+describe("the source's own cash total", () => {
+  const HEAD =
+    "Order date,Completion date,Transaction type,Investments,Product Wrapper,Account Number,Source investment,Amount,Quantity,Price per unit,Reference Number,Status";
+  const convert = (rows: string[]) =>
+    convertFidelityToStandard([HEAD, ...rows].join("\n"), { currency: "GBP" });
+
+  // The number the pairing rules actually match on. It is independent of
+  // quantity * unit price, which the export rounds, so the two disagreeing is
+  // evidence that two legs do not belong together.
+  it("transcribes Amount on a security row, unsigned", () => {
+    const result = convert([
+      "8 Feb 2022,10 Feb 2022,Sell,Legal & General Global Health,ISA,AG1,,20514.62,2676,7.67,795832439,Completed",
+    ]);
+
+    expect(result.postings[0].settlementAmount).toBe("20514.62");
+    // Not quantity * unit price, which is 20524.92 here: the whole point is that
+    // the two come from different fields.
+    expect(result.postings[0].quantity).toBe("-2676");
+  });
+
+  it("keeps the magnitude of a purchase, which the export writes negative", () => {
+    const result = convert([
+      "8 Feb 2022,10 Feb 2022,Buy,Legal & General Global Health,ISA,AG1,,-4487.98,585,7.67,795832440,Completed",
+    ]);
+
+    expect(result.postings[0].settlementAmount).toBe("4487.98");
+  });
+
+  // A cash row's quantity is already the amount, so stating it again would put
+  // the same figure on the posting twice and leave two values to disagree.
+  it("states nothing on a cash row", () => {
+    const result = convert([
+      "8 Feb 2022,10 Feb 2022,Cash In From Sell,Cash,ISA,AG1,,20514.62,20514.62,1,795832441,Completed",
+    ]);
+
+    expect(result.postings[0].settlementAmount).toBeUndefined();
+  });
+
+  it("states nothing on a derived counter-leg", () => {
+    const result = convert([
+      "8 Feb 2022,10 Feb 2022,Cash Dividend,Cash,Investment Account,AG1,,23.40,23.40,1,441416483,Completed",
+    ]);
+
+    expect(result.postings).toHaveLength(2);
+    expect(result.postings[1].accountType).toBe(AccountType.INCOME);
+    expect(result.postings[1].settlementAmount).toBeUndefined();
+  });
+});

--- a/client/lib/csv/converters/fidelity-csv.ts
+++ b/client/lib/csv/converters/fidelity-csv.ts
@@ -697,6 +697,14 @@ export function convertFidelityToStandard(
         ...(cashRow ? { tradingCurrency: currency } : {}),
         // Presence, not truthiness: a reported price of zero is a price.
         ...(unitPriceDec !== undefined ? { unitPrice: unitPriceDec.toString() } : {}),
+        // The export's own Amount for the row, unsigned, on the rows where it is
+        // not already the quantity. A cash row's quantity is this figure, so
+        // repeating it there would put the same number on the posting twice;
+        // a security row's quantity is a share count, and this is the second
+        // independently transcribed number grouping identifies its cash leg by.
+        ...(!cashRow && amountDec !== undefined
+          ? { settlementAmount: amountDec.abs().toString() }
+          : {}),
         ...(correlation ? { correlations: [correlation] } : {}),
         ...(identifierHints.length > 0 ? { identifierHints } : {}),
       })

--- a/client/lib/ofx/parser.test.ts
+++ b/client/lib/ofx/parser.test.ts
@@ -424,6 +424,35 @@ describe("groups and charges", () => {
     expect(refs).toEqual(new Set(["20251015U10000018371888432"]));
   });
 
+  // The cash that actually settled, charges included, which is not the cash leg
+  // this trade settles through: that one is the consideration alone, because the
+  // commission is posted as a leg of its own. The two differing by exactly the
+  // charge is what makes this an independent figure rather than a restatement.
+  it("transcribes TOTAL on the security leg, charge and all", () => {
+    const result = parse(GBP_BUY);
+
+    const security = result.postings.find((t) => mustBe(t.brokerTxType, TxType.TRADE_ASSET))!;
+    expect(security.settlementAmount).toBe("23092.22034");
+
+    const cash = result.postings.find((t) => mustBe(t.brokerTxType, TxType.TRADE_CASH))!;
+    expect(cash.quantity).toBe("-23080.68");
+    expect(cash.settlementAmount).toBeUndefined();
+  });
+
+  it("states nothing on an income row, whose quantity is already the amount", () => {
+    const result = parse(`<INCOME>
+      <INVTRAN><FITID>div-1</FITID><DTTRADE>20251016092129.000[-4:EDT]</DTTRADE></INVTRAN>
+      <SECID><UNIQUEID>IE00B4ND3603</UNIQUEID><UNIQUEIDTYPE>ISIN</UNIQUEIDTYPE></SECID>
+      <INCOMETYPE>DIV
+      <TOTAL>137.08
+      <CURRENCY><CURRATE>1.0</CURRATE><CURSYM>GBP</CURSYM></CURRENCY>
+    </INCOME>`);
+
+    const income = result.postings.find((t) => t.accountType !== AccountType.INCOME)!;
+    expect(income.quantity).toBe("137.08");
+    expect(income.settlementAmount).toBeUndefined();
+  });
+
   it("splits the commission out of the netted total", () => {
     const result = parse(GBP_BUY);
 

--- a/client/lib/ofx/parser.ts
+++ b/client/lib/ofx/parser.ts
@@ -376,6 +376,20 @@ export function parseOfxStatement(text: string): OfxParseResult {
       });
       legs.push(security);
 
+      // TOTAL verbatim, on the legs whose quantity is not already money. It is
+      // the cash that actually settled, so it carries the COMMISSION and TAXES
+      // the same record reports separately, and it therefore does not equal the
+      // cash leg derived below -- that one is the consideration alone, because
+      // the charge is posted as a leg of its own. Transcribing TOTAL rather than
+      // the difference is the point: the difference is computed here, and a
+      // computed figure is evidence of nothing.
+      if (!isCashTx) {
+        const stated = dec(inner, "TOTAL");
+        if (stated !== undefined) {
+          security.settlementAmount = stated.abs().toString();
+        }
+      }
+
       // The income a reinvestment consumed, derived because the source reports
       // no row for it. It shares the trade's group so the money balances the
       // units.

--- a/extension/src/brokers/fidelity-json.test.ts
+++ b/extension/src/brokers/fidelity-json.test.ts
@@ -581,3 +581,39 @@ describe("correlations", () => {
     expect(expense.correlations).toEqual([]);
   });
 });
+
+describe("the source's own cash total", () => {
+  // valuation, not units times pricePerUnit: 913 x 79.848724 is 72901.88, which
+  // is the figure the cross-check compares against rather than the one grouping
+  // matches on.
+  it("transcribes valuation on a security row, unsigned", () => {
+    const result = convertFidelityJson(json({ ...BUY, debitCreditIndicator: "DEBIT" }));
+
+    expect(result.postings[0]!.settlementAmount).toBe("72909.39");
+    expect(result.postings[0]!.quantity).toBe("-913");
+  });
+
+  // A cash row's quantity is already the valuation, so stating it again would
+  // put the same figure on the posting twice.
+  it("states nothing on a cash row", () => {
+    const result = convertFidelityJson(
+      json({
+        accountNumber: "AW10000001",
+        transactionType: "Cash In From Sell",
+        assetName: "Cash",
+        isin: "AA00K0000000",
+        currency: "GBP",
+        status: "Completed",
+        pricePerUnit: 1,
+        dealDate: "15/04/2025",
+        settlementDate: "15/04/2025",
+        debitCreditIndicator: "CREDIT",
+        units: 20000,
+        valuation: 20000,
+      })
+    );
+
+    expect(result.postings[0]!.quantity).toBe("20000");
+    expect(result.postings[0]!.settlementAmount).toBeUndefined();
+  });
+});

--- a/extension/src/brokers/fidelity-json.ts
+++ b/extension/src/brokers/fidelity-json.ts
@@ -246,6 +246,17 @@ export function convertFidelityJson(
         ...(row.pricePerUnit !== undefined
           ? { unitPrice: (decimalFromNumber(row.pricePerUnit) ?? ZERO).toString() }
           : {}),
+        // The payload's own valuation for the row, on the rows where it is not
+        // already the quantity. A cash row's quantity is this figure; a security
+        // row's is a share count, and this is the second independently
+        // transcribed number grouping identifies its cash leg by.
+        ...(!cashRow && row.valuation !== undefined
+          ? {
+              settlementAmount: (decimalFromNumber(row.valuation) ?? ZERO)
+                .abs()
+                .toString(),
+            }
+          : {}),
         ...(correlations.length > 0 ? { correlations } : {}),
         ...(identifierHints.length > 0 ? { identifierHints } : {}),
       })

--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -164,6 +164,12 @@ message Tx {
   // Unset means no claim. Not authoritative: the canonical class comes from
   // identifier plugins. See docs/adr/0013-security-type-hint-vs-asset-class.md.
   portfoliodb.type.v1.AssetClass asset_class_hint = 20 [(buf.validate.field).enum.defined_only = true];
+  // The cash total the source stated for this row, in settlement_currency,
+  // unsigned. Same semantics as the archive Posting's settlement_amount:
+  // transcribed rather than computed, and present only where the posting's own
+  // quantity is not money. Grouping evidence; it has no part in weight or
+  // balance.
+  optional string settlement_amount = 21 [(buf.validate.field).string.pattern = "^[0-9]+(\\.[0-9]+)?$"];
 }
 
 // ApiService provides gRPC endpoints for the web front end: portfolio CRUD,

--- a/proto/archive/v1/txs.proto
+++ b/proto/archive/v1/txs.proto
@@ -204,4 +204,33 @@ message Posting {
   // See docs/adr/0013-security-type-hint-vs-asset-class.md and
   // docs/adr/0045-tx-type-does-not-encode-asset-class.md.
   portfoliodb.type.v1.AssetClass asset_class_hint = 16 [(buf.validate.field).enum.defined_only = true];
+  // The cash total the source stated for the row this was transcribed from, in
+  // settlement_currency, unsigned.
+  //
+  // Transcribed, never computed: a converter that would have to work the figure
+  // out from other columns has inferred it and emits nothing. That is what makes
+  // it independent of quantity * unit_price, which is derived from different
+  // fields, and so what lets grouping use one to identify a cash leg and the
+  // other to check the identification.
+  //
+  // Present only where the posting's own quantity is not money -- that is, where
+  // the posting may be a TRADE_ASSET. On a money posting the quantity is already
+  // this total, and carrying it twice would create a second figure to disagree
+  // with the first.
+  //
+  // It is the source's own figure and nothing more, so it carries whatever the
+  // source put in it. Both sources that state one state the cash that actually
+  // settled, charges included: an OFX TOTAL carries the COMMISSION and TAXES the
+  // same record reports separately, and a Fidelity purchase carries its dealing
+  // fee. So it equals the cash leg it settles through only where the source
+  // levied nothing, and a reader that needs them to agree exactly wants the
+  // wrong number. Netting it out here would be the computation a converter is
+  // forbidden to do, because a computed figure is evidence of nothing.
+  //
+  // It has no part in weight or balance. A TRADE_ASSET leg weighs at
+  // quantity * unit_price and goes on doing so
+  // (docs/adr/0024-group-balance-is-checked-on-weight.md), so the difference
+  // between the two figures stays visible as the group's SOURCE_ROUNDING
+  // residual rather than being absorbed here.
+  optional string settlement_amount = 17 [(buf.validate.field).string.pattern = "^[0-9]+(\\.[0-9]+)?$"];
 }

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -335,6 +335,9 @@ type ExportPosting struct {
 	UnitPrice          *decimal.Decimal
 	TradingCurrency    string
 	SettlementCurrency string
+	// The cash total the source stated for the row, or nil on a posting whose
+	// own quantity is already money.
+	SettlementAmount *decimal.Decimal
 	// The share count this posting is denominated in, or nil when it is the
 	// posting's own timestamp date. The column is NOT NULL and the insert
 	// trigger defaults it to that date, so only a value that differs from it

--- a/server/db/postgres/txs.go
+++ b/server/db/postgres/txs.go
@@ -27,15 +27,15 @@ var psql = sq.StatementBuilder.PlaceholderFormat(sq.Dollar)
 const insertPostingSQL = `
 	WITH g AS (
 		INSERT INTO tx_groups (user_id, timestamp, job_id)
-		VALUES ($1, $4, $18)
+		VALUES ($1, $4, $19)
 		RETURNING id
 	)
 	INSERT INTO txs (user_id, broker, account, timestamp, instrument_description,
 	                 broker_tx_type, resolved_tx_type, asset_class_hint,
 	                 quantity, trading_currency, settlement_currency, unit_price,
-	                 instrument_id, share_count_basis, account_type,
+	                 settlement_amount, instrument_id, share_count_basis, account_type,
 	                 weight, weight_commodity, group_id)
-	SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14::date, $15, $16, $17, g.id FROM g
+	SELECT $1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15::date, $16, $17, $18, g.id FROM g
 	RETURNING id, group_id
 `
 
@@ -45,9 +45,9 @@ const insertPostingInGroupSQL = `
 	INSERT INTO txs (user_id, broker, account, timestamp, instrument_description,
 	                 broker_tx_type, resolved_tx_type, asset_class_hint,
 	                 quantity, trading_currency, settlement_currency, unit_price,
-	                 instrument_id, share_count_basis, account_type,
+	                 settlement_amount, instrument_id, share_count_basis, account_type,
 	                 weight, weight_commodity, group_id)
-	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14::date, $15, $16, $17, $18)
+	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15::date, $16, $17, $18, $19)
 	RETURNING id
 `
 
@@ -167,6 +167,10 @@ func insertPostings(ctx context.Context, exec queryable, userUUID uuid.UUID, bro
 		if err != nil {
 			return fmt.Errorf("invalid unit price %q: %w", t.GetUnitPrice(), err)
 		}
+		settlement, err := parseOptDecimal(t.SettlementAmount)
+		if err != nil {
+			return fmt.Errorf("invalid settlement amount %q: %w", t.GetSettlementAmount(), err)
+		}
 		w := db.Weight{Amount: qty, Commodity: "inst:" + instUUID.String()}
 		if i < len(weights) {
 			w = weights[i]
@@ -182,7 +186,7 @@ func insertPostings(ctx context.Context, exec queryable, userUUID uuid.UUID, bro
 			userUUID, broker, acc, ts, t.InstrumentDescription,
 			pq.Array(brokerTypes), resolvedStr, nullStr(db.AssetClassToStr(t.GetAssetClassHint())), qty,
 			nullStr(t.TradingCurrency), nullStr(t.SettlementCurrency), nullDecimal(price),
-			instUUID, basis, acctTypeStr, w.Amount, w.Commodity,
+			nullDecimal(settlement), instUUID, basis, acctTypeStr, w.Amount, w.Commodity,
 		}
 		ref := t.GetGroupRef()
 		var txID uuid.UUID
@@ -412,6 +416,7 @@ type exportPosting struct {
 	UnitPrice          *decimal.Decimal `db:"unit_price"`
 	TradingCurrency    string           `db:"trading_currency"`
 	SettlementCurrency string           `db:"settlement_currency"`
+	SettlementAmount   *decimal.Decimal `db:"settlement_amount"`
 	ShareCountBasis    *time.Time       `db:"share_count_basis"`
 }
 
@@ -460,7 +465,7 @@ func (p *Postgres) ListTxsForExport(ctx context.Context, userID string, periodFr
 			COALESCE(best_id.identifier_type, '') AS identifier_type,
 			COALESCE(best_id.value, '') AS value,
 			COALESCE(best_id.domain, '') AS domain,
-			t.quantity, t.unit_price,
+			t.quantity, t.unit_price, t.settlement_amount,
 			COALESCE(t.trading_currency, '') AS trading_currency,
 			COALESCE(t.settlement_currency, '') AS settlement_currency,
 			-- A basis equal to the posting's own date is the as-traded
@@ -507,6 +512,7 @@ func (p *Postgres) ListTxsForExport(ctx context.Context, userID string, periodFr
 			UnitPrice:          r.UnitPrice,
 			TradingCurrency:    r.TradingCurrency,
 			SettlementCurrency: r.SettlementCurrency,
+			SettlementAmount:   r.SettlementAmount,
 			ShareCountBasis:    r.ShareCountBasis,
 		}
 	}
@@ -830,15 +836,16 @@ func routeSurvivors(ctx context.Context, exec queryable, userUUID uuid.UUID, gro
 		// NULL share_count_basis leaves the insert trigger to seed it from the
 		// posting's own timestamp, and the split-adjusted pair is seeded the same way,
 		// exactly as for an uploaded posting. A routed leg has no source row, so no
-		// correlation is written for it: it transcribes nothing and there is nothing
-		// the source said about why it belongs with anything. The returned id is
+		// correlation and no settlement amount is written for it: it transcribes
+		// nothing, so there is nothing the source said about why it belongs with
+		// anything, and no figure of the source's to carry. The returned id is
 		// read and dropped: the statement returns one because the upload path
 		// needs it to hang correlations on.
 		var txID uuid.UUID
 		if err := exec.QueryRowContext(ctx, insertPostingInGroupSQL,
 			userUUID, r.broker, r.account, r.timestamp, desc,
 			r.brokerTxTypes, r.resolvedTxType, nil, amount,
-			trading, settlement, nil, nullUUID(instID), nil, acctType,
+			trading, settlement, nil, nil, nullUUID(instID), nil, acctType,
 			amount, r.commodity, r.groupID,
 		).Scan(&txID); err != nil {
 			return fmt.Errorf("insert routed posting: %w", err)

--- a/server/db/postgres/txs_test.go
+++ b/server/db/postgres/txs_test.go
@@ -1339,6 +1339,50 @@ func TestListTxsForExport_ShareCountBasisOnlyWhenRestated(t *testing.T) {
 	}
 }
 
+// The source's own cash total survives the round trip, because an archive that
+// dropped it would leave a rebuilt instance with less evidence to group on than
+// the upload had.
+func TestListTxsForExport_CarriesTheSourcesCashTotal(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|exp-amt", "U", "u@exp-amt.com")
+	instID, err := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{
+		{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "AMT", Canonical: false},
+	}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+	ts := time.Date(2024, 1, 15, 10, 0, 0, 0, time.UTC)
+	stated := "20514.62"
+	price := "7.67"
+	if err := createTx(ctx, p, userID, "IBKR", "a", "",
+		&apiv1.Tx{Timestamp: timestamppb.New(ts), InstrumentDescription: "AMT", BrokerTxType: []typev1.TxType{typev1.TxType_TRADE_ASSET}, ResolvedTxType: typev1.TxType_TRADE_ASSET, Quantity: "-2676", UnitPrice: &price, SettlementAmount: &stated},
+		instID, nil); err != nil {
+		t.Fatalf("create priced tx: %v", err)
+	}
+	if err := createTx(ctx, p, userID, "IBKR", "a", "",
+		&apiv1.Tx{Timestamp: timestamppb.New(ts.Add(time.Hour)), InstrumentDescription: "AMT", BrokerTxType: []typev1.TxType{typev1.TxType_TRADE_CASH}, ResolvedTxType: typev1.TxType_TRADE_CASH, Quantity: "20514.62"},
+		instID, nil); err != nil {
+		t.Fatalf("create cash tx: %v", err)
+	}
+
+	rows, err := p.ListTxsForExport(ctx, userID, nil, nil)
+	if err != nil {
+		t.Fatalf("list txs for export: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("rows = %d, want 2", len(rows))
+	}
+	if rows[0].SettlementAmount == nil || rows[0].SettlementAmount.String() != stated {
+		t.Fatalf("settlement amount = %v, want %s", rows[0].SettlementAmount, stated)
+	}
+	// A money posting's quantity is already the total, so nothing is stored
+	// beside it to disagree with.
+	if rows[1].SettlementAmount != nil {
+		t.Fatalf("money posting reports a settlement amount: %v", rows[1].SettlementAmount)
+	}
+}
+
 // Ordered by broker, then group, then posting, so the export assembles its
 // windows and groups in a single scan and two exports of the same data agree.
 func TestListTxsForExport_OrderedForGrouping(t *testing.T) {

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -85,7 +85,17 @@ CREATE INDEX idx_tx_groups_job_id ON tx_groups (job_id);
 -- no claim; the canonical class lives on the instrument.
 --
 -- The amounts as the source wrote them: quantity, unit_price, trading_currency,
--- settlement_currency. Transcribed and exact; see Numeric types below.
+-- settlement_currency, settlement_amount. Transcribed and exact; see Numeric types
+-- below.
+-- settlement_amount is the cash total the source stated for the row, in
+-- settlement_currency and unsigned. It is transcribed rather than worked out from
+-- other columns, which is what makes it independent of quantity * unit_price and so
+-- what lets grouping identify a cash leg on one figure and check the identification
+-- against the other. NULL on a posting whose own quantity is already money, since
+-- carrying the same total twice would leave two figures to disagree. It contributes
+-- nothing to weight: a TRADE_ASSET leg still weighs at quantity * unit_price, so the
+-- gap between the two figures stays visible as the group's SOURCE_ROUNDING residual.
+-- See docs/adr/0024-group-balance-is-checked-on-weight.md.
 --
 -- What the source called this row lives in tx_correlations below, not in columns
 -- here: a reference number and a counterparty pointer are two series of the same
@@ -174,6 +184,7 @@ CREATE TABLE txs (
   unit_price                NUMERIC,
   trading_currency          TEXT,
   settlement_currency       TEXT,
+  settlement_amount         NUMERIC CHECK (settlement_amount IS NULL OR settlement_amount >= 0),
 
   account_type              TEXT NOT NULL DEFAULT 'USER'
                               CHECK (account_type IN ('USER', 'EQUITY', 'INCOME', 'EXPENSE',

--- a/server/service/api/txs_export.go
+++ b/server/service/api/txs_export.go
@@ -120,6 +120,9 @@ func posting(r db.ExportPosting) *archivev1.Posting {
 	if r.UnitPrice != nil {
 		p.UnitPrice = proto.String(r.UnitPrice.String())
 	}
+	if r.SettlementAmount != nil {
+		p.SettlementAmount = proto.String(r.SettlementAmount.String())
+	}
 	if r.TradingCurrency != "" {
 		p.TradingCurrency = proto.String(r.TradingCurrency)
 	}

--- a/server/service/ingestion/tx_import.go
+++ b/server/service/ingestion/tx_import.go
@@ -150,6 +150,9 @@ func archiveTx(p *archivev1.Posting) *apiv1.Tx {
 	if p.UnitPrice != nil {
 		tx.UnitPrice = proto.String(p.GetUnitPrice())
 	}
+	if p.SettlementAmount != nil {
+		tx.SettlementAmount = proto.String(p.GetSettlementAmount())
+	}
 	// The archive can name several identifiers per posting, which the flat CSV
 	// could not. They are hints rather than an assertion: resolution still runs,
 	// and an instrument the importing instance already holds wins.

--- a/server/service/ingestion/validate.go
+++ b/server/service/ingestion/validate.go
@@ -28,7 +28,30 @@ func ValidateTx(tx *apiv1.Tx, rowIndex int32) []*apiv1.ValidationError {
 		errs = append(errs, &apiv1.ValidationError{RowIndex: rowIndex, Field: "instrument_description", Message: "required"})
 	}
 	errs = append(errs, validateBrokerTxType(tx.GetBrokerTxType(), rowIndex)...)
+	errs = append(errs, validateSettlementAmount(tx, rowIndex)...)
 	return errs
+}
+
+// validateSettlementAmount rejects the source's cash total on a posting whose
+// own quantity is already that total.
+//
+// A posting is money exactly when it cannot be a trade's asset leg, which is the
+// same predicate the converters apply to decide whether to read a row's amount as
+// its quantity. Carrying the total again on such a row would put the same figure
+// on the posting twice and leave two values to disagree, and grouping reads it
+// precisely because it is a second, independently transcribed number.
+func validateSettlementAmount(tx *apiv1.Tx, rowIndex int32) []*apiv1.ValidationError {
+	if tx.SettlementAmount == nil {
+		return nil
+	}
+	if txtype.MayBe(tx.GetBrokerTxType(), typev1.TxType_TRADE_ASSET) {
+		return nil
+	}
+	return []*apiv1.ValidationError{{
+		RowIndex: rowIndex,
+		Field:    "settlement_amount",
+		Message:  "not carried on a money posting, whose quantity is already the amount",
+	}}
 }
 
 // validateBrokerTxType checks the declared candidate set: non-empty, every

--- a/server/service/ingestion/validate_test.go
+++ b/server/service/ingestion/validate_test.go
@@ -133,3 +133,44 @@ func TestValidateTxs_perTxErrors(t *testing.T) {
 		t.Fatalf("expected a 'required' error, got %v", errs)
 	}
 }
+
+// TestValidateSettlementAmount pins where the source's own cash total may be
+// stated. A posting is money exactly when it cannot be a trade's asset leg, and
+// on such a posting the quantity is already that total.
+func TestValidateSettlementAmount(t *testing.T) {
+	validTs := timestamppb.Now()
+	amount := "20514.62"
+	tx := func(set []typev1.TxType, settlement *string) *apiv1.Tx {
+		return &apiv1.Tx{
+			Timestamp:             validTs,
+			InstrumentDescription: "AAPL",
+			BrokerTxType:          set,
+			Quantity:              "10",
+			SettlementAmount:      settlement,
+		}
+	}
+	tests := []struct {
+		name string
+		tx   *apiv1.Tx
+		want int
+	}{
+		{"stated on a trade's asset leg", tx([]typev1.TxType{typev1.TxType_TRADE_ASSET}, &amount), 0},
+		// The source said only TRADE, so the row may yet be an asset leg.
+		{"stated on an unnarrowed trade", tx([]typev1.TxType{typev1.TxType_TRADE}, &amount), 0},
+		{"stated on a trade's cash leg", tx([]typev1.TxType{typev1.TxType_TRADE_CASH}, &amount), 1},
+		{"stated on a transfer", tx([]typev1.TxType{typev1.TxType_TRANSFER}, &amount), 1},
+		// Fidelity's Cash In: money under either reading, so the quantity is
+		// already the amount.
+		{"stated on a declared ambiguity between two money readings", tx([]typev1.TxType{typev1.TxType_TRADE_CASH, typev1.TxType_TRANSFER}, &amount), 1},
+		{"absent on a money row", tx([]typev1.TxType{typev1.TxType_DIVIDEND}, nil), 0},
+		{"absent on an asset leg", tx([]typev1.TxType{typev1.TxType_TRADE_ASSET}, nil), 0},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ValidateTx(tc.tx, 0)
+			if len(got) != tc.want {
+				t.Fatalf("ValidateTx() returned %d errors, want %d: %v", len(got), tc.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes the evidence gap 0097 needs closed before the server-side grouping engine
is built. The issue file for 0102 is opened in #399; this is the implementation.

## The gap

`assignFidelityGroups` pairs a trade with its cash row by matching the broker's
own `Amount` on each, and cross-checks the pairing against
`quantity * unit_price`, which comes from different fields -- that independence
is the whole point, and the converter says so at `fidelity-csv.ts:394`.

Only one of those two numbers reached the server. For a cash row the `Amount`
becomes the posting's `quantity` (line 621), but for a security trade row it went
into `legs[i].amount`, lived inside the grouping function, and died there.

So a server-side engine would have had one transcribed number and one derived
one, and the exact equality that identifies a cash leg would degrade into a 0.75%
band -- wide enough to admit a different trade of a similar size on the same day.
That is not broker idiosyncrasy: every source reports a trade's cash total and
rounds the unit price it quotes. It is also wrong rather than merely weaker for
Schwab, where 0073 records commission netted into `Amount` against split-adjusted
quantities and as-traded prices, so `quantity * unit_price` is not the
consideration at all.

## What lands

`settlement_amount` on `archive.v1.Posting` (17) and `api.v1.Tx` (21), a
`NUMERIC` column on `txs`, and population from Fidelity's `Amount`, the extension
payload's `valuation`, and OFX's `TOTAL`.

**It is the source's figure and nothing else.** Both sources that state one state
the cash that actually settled, charges included: an OFX `TOTAL` carries the
`COMMISSION` and `TAXES` the same record reports separately, and a Fidelity
purchase carries its dealing fee. So it equals the cash leg it settles through
only where the source levied nothing -- which is exactly why the converter's buy
pass is an inequality and its sell pass an equality. Netting it out here would be
the computation a converter is forbidden to do, because a computed figure is
evidence of nothing.

**Absent wherever the quantity is already money.** Validation enforces it on
`MayBe(broker_tx_type, TRADE_ASSET)`, which is the same predicate `isCashRow`
uses to decide whether to read a row's amount as its quantity, so no posting ever
carries the same total twice and there are never two figures to disagree.

**Weight and balance are untouched.** A `TRADE_ASSET` leg still weighs at
`quantity * unit_price` (ADR 0024, ADR 0029), so the gap between the two figures
stays visible as the group's `SOURCE_ROUNDING` residual rather than being
quietly absorbed. Using this field for weight would move every trade group's
residual and is a separate argument.

## Not included

`ListTxs` does not carry it. The archive must, or a rebuilt instance would have
less evidence to group on than the upload had, but the transactions page has no
use for it and adding it there would be surface with no consumer.

## Testing

`make check`, `make server-test`, `make client-test`, `make extension-test` and
`make db-test` all pass. New coverage: the Fidelity CSV and extension converters
(stated on a security row unsigned, absent on a cash row and on a derived
counter-leg), the OFX parser (`TOTAL` on the security leg charge and all, absent
on income), `ValidateTx`, and a db round trip through `ListTxsForExport`.

One regression caught by `make db-test` and fixed: `routeSurvivors` reuses
`insertPostingInGroupSQL`, so the added parameter had to reach it too. A routed
residual transcribes nothing, so it passes NULL -- there is no figure of the
source's to carry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
