### PR TITLE
Add the trade rules, and require a claim's members to be free (0097)

### DIFF
--- a/server/grouping/grouping.go
+++ b/server/grouping/grouping.go
@@ -18,6 +18,8 @@ import (
 	"context"
 	"sort"
 
+	"github.com/shopspring/decimal"
+
 	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
 	"github.com/leedenison/portfoliodb/server/db"
 	"github.com/leedenison/portfoliodb/server/txtype"
@@ -28,20 +30,30 @@ import (
 // and its tests state the numbers they depend on.
 type Opts struct {
 	// Money is the widest difference between two money figures that still reads as
-	// the same amount. It is residual.Tolerance's money value, and it is here
-	// rather than imported so a rule's band and the balancer's cannot drift apart
-	// silently: they are the same claim about how finely a source quotes money.
-	Money string
+	// the same amount. It is residual.Tolerance's money value said again, and
+	// deliberately: a difference this rule would tolerate is one the balancer will
+	// route to SOURCE_ROUNDING, so a pairing it accepts leaves a residual that
+	// reads as the source disagreeing with itself rather than as a missing leg.
+	Money decimal.Decimal
 	// ConsiderationBand is the widest relative gap tolerated between a cash leg and
-	// its trade's quantity * unit price. The export rounds the price it quotes, and
-	// the error that leaves is worst on a cheap unit.
-	ConsiderationBand string
+	// its trade's quantity * unit price.
+	//
+	// The two never agree exactly, because the export rounds the unit price it
+	// quotes and the error that leaves is the half-digit it dropped as a fraction
+	// of the price -- worst on a cheap unit, since the same half-digit is a larger
+	// share of a smaller number. The widest correctly paired trade in the sample
+	// exports is 0.56% out. This clears every real pairing while rejecting a
+	// swapped cash row, which is off by whole percentage points.
+	ConsiderationBand decimal.Decimal
 }
 
 // DefaultOpts is the calibrated configuration, measured against the sample exports
 // by the converter rules this engine has to reproduce.
 func DefaultOpts() Opts {
-	return Opts{Money: "0.005", ConsiderationBand: "0.0075"}
+	return Opts{
+		Money:             decimal.RequireFromString("0.005"),
+		ConsiderationBand: decimal.RequireFromString("0.0075"),
+	}
 }
 
 // DefaultRules is the ordering that applies to every source.

--- a/server/grouping/trade.go
+++ b/server/grouping/trade.go
@@ -1,0 +1,348 @@
+package grouping
+
+import (
+	"context"
+	"math"
+	"sort"
+	"time"
+
+	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/txtype"
+)
+
+// The trade rules in the order they claim.
+//
+// Disposals go before acquisitions because a disposal's test is equality and an
+// acquisition's is an inequality: the source states the same total on a sale and its
+// cash in, while a purchase's total carries charges the cash row does not. The
+// weaker test must not take a row the stronger one can identify outright.
+//
+// Both go before the cash-for-cash rule, which reproduces the converter's ordering
+// of security trades ahead of trades of the account's own cash: nothing in the
+// sample exports needs it -- no bucket holds a cash and a security trade of equal
+// amount -- but five hold both kinds, so this keeps which one wins from depending on
+// the order a broker happened to export them in.
+const (
+	DisposalPrecedence    = 900
+	AcquisitionPrecedence = 800
+	CashTradePrecedence   = 700
+)
+
+// Disposal pairs a sold asset with the money that came in for it.
+func Disposal() Rule {
+	return trade{name: "disposal", precedence: DisposalPrecedence}
+}
+
+// Acquisition pairs a bought asset with the money that went out for it.
+func Acquisition() Rule {
+	return trade{name: "acquisition", precedence: AcquisitionPrecedence, acquiring: true}
+}
+
+// trade pairs an asset leg with the cash leg that settles it.
+//
+// The broker row type that named which cash row settles which trade -- Fidelity
+// calls a sale's cash in a "Cash In From Sell" and a purchase's cash out a "Cash Out
+// For Buy" -- does not survive into the standard format, and does not need to. What
+// it encoded is the direction the money moved, which is the sign of the cash
+// posting's own quantity, and which kind of trade it settles, which the declared set
+// already distinguishes. What it encoded beyond that narrows candidates without
+// identifying an occurrence, and the ranking below does that better.
+type trade struct {
+	name       string
+	precedence int
+	// acquiring says which way the asset moved: an acquisition takes money out and
+	// a disposal brings it in.
+	acquiring bool
+}
+
+func (t trade) Name() string { return t.name }
+
+func (t trade) Precedence() int { return t.precedence }
+
+// Expand asks for the accounts' postings on the same days.
+//
+// The trade rules pair within one account on one day, because both legs of a trade
+// settle together -- unlike a deposit run, which the source can spread across two.
+func (t trade) Expand(ctx context.Context, userID string, ps []db.GroupingPosting, r db.GroupingReader, held []string) ([]db.GroupingPosting, error) {
+	return expandByDay(ctx, userID, ps, r, held)
+}
+
+// expandByDay is the read every rule that buckets on a settlement day makes. Shared
+// so the three of them cannot disagree about where a day starts.
+func expandByDay(ctx context.Context, userID string, ps []db.GroupingPosting, r db.GroupingReader, held []string) ([]db.GroupingPosting, error) {
+	qs := make([]db.DateQuery, 0, len(ps))
+	for _, p := range ps {
+		y, m, d := p.Timestamp.UTC().Date()
+		day := time.Date(y, m, d, 0, 0, 0, 0, time.UTC)
+		qs = append(qs, db.DateQuery{
+			Broker:  p.Broker,
+			Account: p.Account,
+			From:    day,
+			Before:  day.AddDate(0, 0, 1),
+		})
+	}
+	if len(qs) == 0 {
+		return nil, nil
+	}
+	return r.PostingsByDates(ctx, userID, distinct(qs), held)
+}
+
+// Apply pairs each asset leg with a cash leg, ranked globally.
+//
+// Ranking is across the whole neighbourhood before any claim is made, so that one
+// trade cannot strand another by taking its cash row. The converter learned this on
+// its buy pass and its sell pass does without, taking the first candidate in row
+// order; doing it for both is strictly better evidence and costs nothing.
+func (t trade) Apply(ps []db.GroupingPosting, st *State, opts Opts) {
+	var assets, cash []db.GroupingPosting
+	for _, p := range ps {
+		if st.Taken(p.ID) {
+			continue
+		}
+		switch {
+		case t.isAssetLeg(p):
+			assets = append(assets, p)
+		case t.isCashLeg(p):
+			cash = append(cash, p)
+		}
+	}
+
+	var cands []candidate
+	for _, a := range assets {
+		for _, c := range cash {
+			if bucket(a) != bucket(c) {
+				continue
+			}
+			if !t.amountsAgree(a, c, opts) {
+				continue
+			}
+			if !consistent(a, c, opts) {
+				continue
+			}
+			cands = append(cands, candidate{
+				assetID:  a.ID,
+				cashID:   c.ID,
+				distance: ordinalDistance(a, c),
+			})
+		}
+	}
+	sort.Slice(cands, func(i, j int) bool { return cands[i].betterThan(cands[j]) })
+
+	// Best first, skipping whatever an earlier claim of this same pass has taken.
+	// Claim refuses one naming a posting that has gone, so the skip is the whole of
+	// the bookkeeping.
+	for _, c := range cands {
+		st.Claim(
+			Member{ID: c.assetID, Resolved: typev1.TxType_TRADE_ASSET},
+			Member{ID: c.cashID, Resolved: typev1.TxType_TRADE_CASH},
+		)
+	}
+}
+
+// isAssetLeg reports whether this posting could be the asset side of the trade this
+// rule claims: a commodity that is not money, moving in this rule's direction, whose
+// declared set admits being a trade's asset leg.
+//
+// The admissibility test is 0044's *may be* predicate doing real work: it is what
+// stops this rule claiming a row whose source said it was definitely a transfer.
+func (t trade) isAssetLeg(p db.GroupingPosting) bool {
+	if isMoney(p) || p.SettlementAmount == nil {
+		return false
+	}
+	if !txtype.MayBe(p.Declared, typev1.TxType_TRADE_ASSET) {
+		return false
+	}
+	return p.Quantity.IsPositive() == t.acquiring && !p.Quantity.IsZero()
+}
+
+// isCashLeg reports whether this posting could be the money that settles the trade:
+// money moving opposite to the asset, admitting a trade's cash leg.
+func (t trade) isCashLeg(p db.GroupingPosting) bool {
+	if !isMoney(p) {
+		return false
+	}
+	if !txtype.MayBe(p.Declared, typev1.TxType_TRADE_CASH) {
+		return false
+	}
+	return p.Quantity.IsNegative() == t.acquiring && !p.Quantity.IsZero()
+}
+
+// amountsAgree applies the test that separates the two directions.
+//
+// A sale's cash in equals the proceeds the source stated for the sale, so equality
+// identifies it. A purchase's cash out is the consideration while the source's total
+// for the purchase carries the charges as well, so the two differ by a fee -- and a
+// fee cannot be negative, which is what rules out the cash row of a larger trade in
+// the same bucket. The inequality is the whole of the test in that direction: it is
+// weaker than equality, which is why the disposal rule claims first.
+func (t trade) amountsAgree(asset, cash db.GroupingPosting, opts Opts) bool {
+	stated := asset.SettlementAmount.Abs()
+	paid := cash.Quantity.Abs()
+	if t.acquiring {
+		return stated.Sub(paid).GreaterThan(opts.Money.Neg())
+	}
+	return stated.Sub(paid).Abs().LessThan(opts.Money)
+}
+
+// consistent cross-checks a pairing against the trade's own quantity and price.
+//
+// Both amount tests above match one figure the source stated against another, so
+// neither notices a cash row that is internally consistent but belongs to a
+// different trade. quantity * unit price comes from different fields, which makes it
+// an independent check: a swapped cash row misses it by percentage points, while a
+// fee gap is around 0.02% of a trade and sits far inside the band. So this cannot
+// replace the fee rule and the fee rule cannot replace this.
+//
+// A relative test, so it divides, which puts it past the exactness boundary by
+// construction -- a band this wide would not notice the difference anyway. See
+// docs/adr/0026-exact-decimals-bounded-by-closure.md.
+func consistent(asset, cash db.GroupingPosting, opts Opts) bool {
+	if asset.UnitPrice == nil {
+		// Nothing quoted to check against. Absence is not evidence of a bad
+		// pairing, so the amount test stands on its own.
+		return true
+	}
+	expected := asset.Quantity.Mul(*asset.UnitPrice).Abs()
+	if expected.IsZero() {
+		return true
+	}
+	return cash.Quantity.Abs().Sub(expected).Abs().Div(expected).LessThanOrEqual(opts.ConsiderationBand)
+}
+
+// CashTrade pairs the two halves of a movement of the account's own cash.
+//
+// Fidelity models an account's cash as a tradable asset, so money leaving is
+// reported as a sale of cash and money arriving as a purchase of it, each settling
+// against a cash row beside it. Both postings are money by the time they reach here
+// and neither can be a trade's asset leg, so the rules above pass over them: what
+// identifies the pair instead is that the two are equal and opposite in one account
+// on one day, which is a stronger statement than either of those rules gets to make.
+func CashTrade() Rule { return cashTrade{} }
+
+type cashTrade struct{}
+
+func (cashTrade) Name() string { return "cash_trade" }
+
+func (cashTrade) Precedence() int { return CashTradePrecedence }
+
+func (cashTrade) Expand(ctx context.Context, userID string, ps []db.GroupingPosting, r db.GroupingReader, held []string) ([]db.GroupingPosting, error) {
+	return expandByDay(ctx, userID, ps, r, held)
+}
+
+func (cashTrade) Apply(ps []db.GroupingPosting, st *State, _ Opts) {
+	var out, in []db.GroupingPosting
+	for _, p := range ps {
+		if st.Taken(p.ID) || !isMoney(p) || p.Quantity.IsZero() {
+			continue
+		}
+		// Both sides must be a trade's cash leg under every reading. A row that
+		// might be a transfer is not one of these: the money that actually moved
+		// stands on its own and the deposit rules are what claim it.
+		if !txtype.MustBe(p.Declared, typev1.TxType_TRADE_CASH) {
+			continue
+		}
+		if p.Quantity.IsNegative() {
+			out = append(out, p)
+		} else {
+			in = append(in, p)
+		}
+	}
+
+	var cands []candidate
+	for _, a := range out {
+		for _, b := range in {
+			if bucket(a) != bucket(b) {
+				continue
+			}
+			// Exact, with no tolerance: these are two statements of one movement
+			// of money rather than a total and a price-derived figure, so there is
+			// nothing for a rounding to creep into.
+			if !a.Quantity.Add(b.Quantity).IsZero() {
+				continue
+			}
+			cands = append(cands, candidate{assetID: a.ID, cashID: b.ID, distance: ordinalDistance(a, b)})
+		}
+	}
+	sort.Slice(cands, func(i, j int) bool { return cands[i].betterThan(cands[j]) })
+
+	for _, c := range cands {
+		st.Claim(
+			Member{ID: c.assetID, Resolved: typev1.TxType_TRADE_CASH},
+			Member{ID: c.cashID, Resolved: typev1.TxType_TRADE_CASH},
+		)
+	}
+}
+
+// candidate is one feasible pairing and how good it is.
+type candidate struct {
+	assetID  string
+	cashID   string
+	distance int64
+}
+
+// betterThan orders candidates within a rule: nearest references first, then the
+// posting ids, so a shuffled input yields identical output.
+func (c candidate) betterThan(o candidate) bool {
+	if c.distance != o.distance {
+		return c.distance < o.distance
+	}
+	if c.assetID != o.assetID {
+		return c.assetID < o.assetID
+	}
+	return c.cashID < o.cashID
+}
+
+// noOrdinal ranks a pairing with nothing to compare behind every pairing that has
+// something. A source with no numbering is not thereby a worse match, but a pairing
+// backed by proximity is a better one, and the ids below still make the order total.
+const noOrdinal = int64(math.MaxInt64)
+
+// ordinalDistance is the nearest gap between the two postings' reference numbers,
+// over the series both carry.
+//
+// Nothing is parsed: the ordinal arrives as a number because the converter put one
+// there, and a source whose identifiers are opaque declares no ordinal rather than
+// being discovered to have none. Compared within a label, so an order id is never
+// measured against a settlement reference.
+func ordinalDistance(a, b db.GroupingPosting) int64 {
+	best := noOrdinal
+	for _, ca := range a.Correlations {
+		if !ca.Declares(db.MatchOrdinal) || ca.Ordinal == nil {
+			continue
+		}
+		for _, cb := range b.Correlations {
+			if cb.Label != ca.Label || !cb.Declares(db.MatchOrdinal) || cb.Ordinal == nil {
+				continue
+			}
+			d := *ca.Ordinal - *cb.Ordinal
+			if d < 0 {
+				d = -d
+			}
+			if d < best {
+				best = d
+			}
+		}
+	}
+	return best
+}
+
+// isMoney reports whether this posting's quantity is an amount of money rather than
+// a count of something.
+//
+// A posting is money exactly when it cannot be a trade's asset leg, which is the
+// predicate the converters apply to decide whether to read a row's amount as its
+// quantity. It is derived rather than carried because a second field saying the same
+// thing could disagree with the declared set.
+func isMoney(p db.GroupingPosting) bool {
+	return !txtype.MayBe(p.Declared, typev1.TxType_TRADE_ASSET)
+}
+
+// bucket is the account and day two legs of a trade must share.
+//
+// The day is the posting's own, in UTC as stored. The converter buckets on the date
+// string the source wrote, which is the same statement made before parsing: both
+// legs of a trade carry it identically, and pairing only needs them to agree.
+func bucket(p db.GroupingPosting) string {
+	return p.Account + "\x00" + p.Timestamp.UTC().Format("2006-01-02")
+}

--- a/server/grouping/trade_test.go
+++ b/server/grouping/trade_test.go
@@ -1,0 +1,334 @@
+package grouping
+
+import (
+	"testing"
+	"time"
+
+	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/shopspring/decimal"
+)
+
+func dec(s string) decimal.Decimal { return decimal.RequireFromString(s) }
+
+func decp(s string) *decimal.Decimal {
+	d := dec(s)
+	return &d
+}
+
+func day(d int) time.Time {
+	return time.Date(2022, 2, d, 10, 0, 0, 0, time.UTC)
+}
+
+// security builds a trade's asset leg: a share count, the price the source quoted,
+// and the cash total it stated for the row.
+func security(id string, qty, price, stated string, d int, ref int64) db.GroupingPosting {
+	p := posting(id, typev1.TxType_TRADE_ASSET)
+	p.Quantity = dec(qty)
+	p.UnitPrice = decp(price)
+	p.SettlementAmount = decp(stated)
+	p.InstrumentID = "inst-1"
+	p.Timestamp = day(d)
+	return withRef(p, ref)
+}
+
+// money builds a cash posting: the quantity is the amount, signed, and there is no
+// settlement amount because the quantity already is one.
+func money(id, qty string, d int, ref int64, declared ...typev1.TxType) db.GroupingPosting {
+	p := posting(id, declared...)
+	p.Quantity = dec(qty)
+	p.InstrumentID = "gbp"
+	p.Timestamp = day(d)
+	return withRef(p, ref)
+}
+
+// withRef stamps a Fidelity-shaped reference: the cell verbatim as the token, the
+// number it carries as the ordinal, and the span the source declares.
+func withRef(p db.GroupingPosting, ref int64) db.GroupingPosting {
+	if ref == 0 {
+		return p
+	}
+	span := int64(8)
+	ordinal := ref
+	p.Correlations = append(p.Correlations, db.Correlation{
+		Token:       decimal.NewFromInt(ref).String(),
+		Ordinal:     &ordinal,
+		OrdinalSpan: &span,
+		Scope:       db.ScopeFile,
+		Match:       []string{db.MatchExact, db.MatchOrdinal},
+	})
+	return p
+}
+
+func tradeRules() []Rule { return []Rule{Disposal(), Acquisition(), CashTrade()} }
+
+func TestTrade(t *testing.T) {
+	tests := []struct {
+		name string
+		ps   []db.GroupingPosting
+		want [][]string
+	}{
+		{
+			// 2676 units at a quoted 7.67 is 20524.92, while the source states
+			// 20514.62 -- 0.05% out, which is the rounding in the price it printed.
+			name: "pairs a sale with the cash that came in for it",
+			ps: []db.GroupingPosting{
+				security("a", "-2676", "7.67", "20514.62", 10, 795832439),
+				money("b", "20514.62", 10, 795832440, typev1.TxType_TRADE_CASH),
+			},
+			want: [][]string{{"a", "b"}},
+		},
+		{
+			// The purchase's stated total carries the dealing fee; the cash row is
+			// the consideration alone, so the two differ by the charge.
+			name: "pairs a purchase across the fee gap",
+			ps: []db.GroupingPosting{
+				security("a", "585", "7.67", "4497.98", 10, 795832441),
+				money("b", "-4487.98", 10, 795832442, typev1.TxType_TRADE_CASH),
+			},
+			want: [][]string{{"a", "b"}},
+		},
+		{
+			// A fee cannot be negative, so a cash row larger than the purchase's
+			// own total belongs to a different trade.
+			name: "refuses a purchase whose cash row exceeds its total",
+			ps: []db.GroupingPosting{
+				security("a", "585", "7.67", "4487.98", 10, 795832441),
+				money("b", "-4497.98", 10, 795832442, typev1.TxType_TRADE_CASH),
+			},
+			want: [][]string{{"a"}, {"b"}},
+		},
+		{
+			// The amounts agree to the penny but 8000 units at 3.75 is 30000,
+			// which the cash row misses by whole percentage points. The
+			// cross-check is what catches a cash row that belongs elsewhere.
+			name: "rejects a cash row inconsistent with quantity times price",
+			ps: []db.GroupingPosting{
+				security("a", "-8000", "3.75", "8000", 10, 795832439),
+				money("b", "8000", 10, 795832440, typev1.TxType_TRADE_CASH),
+			},
+			want: [][]string{{"a"}, {"b"}},
+		},
+		{
+			name: "does not pair across accounts",
+			ps: []db.GroupingPosting{
+				security("a", "-2676", "7.67", "20514.62", 10, 795832439),
+				func() db.GroupingPosting {
+					p := money("b", "20514.62", 10, 795832440, typev1.TxType_TRADE_CASH)
+					p.Account = "A2"
+					return p
+				}(),
+			},
+			want: [][]string{{"a"}, {"b"}},
+		},
+		{
+			name: "does not pair across settlement days",
+			ps: []db.GroupingPosting{
+				security("a", "-2676", "7.67", "20514.62", 10, 795832439),
+				money("b", "20514.62", 11, 795832440, typev1.TxType_TRADE_CASH),
+			},
+			want: [][]string{{"a"}, {"b"}},
+		},
+		{
+			// The money moved the wrong way for a sale, so it settles nothing here.
+			name: "does not pair a sale with money going out",
+			ps: []db.GroupingPosting{
+				security("a", "-2676", "7.67", "20514.62", 10, 795832439),
+				money("b", "-20514.62", 10, 795832440, typev1.TxType_TRADE_CASH),
+			},
+			want: [][]string{{"a"}, {"b"}},
+		},
+		{
+			// A row the source said is definitely a transfer is not a trade's cash
+			// leg under any reading, which is the may-be predicate doing real work.
+			name: "does not take a row declared a transfer",
+			ps: []db.GroupingPosting{
+				security("a", "-2676", "7.67", "20514.62", 10, 795832439),
+				money("b", "20514.62", 10, 795832440, typev1.TxType_TRANSFER),
+			},
+			want: [][]string{{"a"}, {"b"}},
+		},
+		{
+			// Fidelity's Cash In is a trade's cash leg or a transfer and the
+			// wording cannot tell them apart, so a trade may still claim it -- and
+			// claiming it is what settles which of the two it was.
+			name: "takes a row that may be either",
+			ps: []db.GroupingPosting{
+				security("a", "-2676", "7.67", "20514.62", 10, 795832439),
+				money("b", "20514.62", 10, 795832440, typev1.TxType_TRADE_CASH, typev1.TxType_TRANSFER),
+			},
+			want: [][]string{{"a", "b"}},
+		},
+		{
+			// Both sides are money and neither can be an asset leg, so the trade
+			// rules pass over them and the equal-and-opposite pair identifies
+			// itself.
+			name: "pairs a movement of the account's own cash",
+			ps: []db.GroupingPosting{
+				money("a", "-20000", 10, 791691783, typev1.TxType_TRADE_CASH),
+				money("b", "20000", 10, 791691784, typev1.TxType_TRADE_CASH),
+			},
+			want: [][]string{{"a", "b"}},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := members(Partition(tc.ps, tradeRules(), DefaultOpts()))
+			if !equal(got, tc.want) {
+				t.Fatalf("partition = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// Two sales of the same size on one day are told apart by which cash row each
+// broker reference sits next to. The converter's sell pass takes the first candidate
+// in row order and would depend on the export's ordering here; ranking on the
+// evidence does not.
+func TestTrade_DoesNotCrossPairTwoSalesOnOneDay(t *testing.T) {
+	ps := []db.GroupingPosting{
+		security("sell1", "-1000", "10", "10000", 10, 500000100),
+		money("cash1", "10000", 10, 500000101, typev1.TxType_TRADE_CASH),
+		security("sell2", "-1000", "10", "10000", 10, 500000200),
+		money("cash2", "10000", 10, 500000201, typev1.TxType_TRADE_CASH),
+	}
+	got := members(Partition(ps, tradeRules(), DefaultOpts()))
+	want := [][]string{{"cash1", "sell1"}, {"cash2", "sell2"}}
+	if !equal(got, want) {
+		t.Fatalf("partition = %v, want %v", got, want)
+	}
+}
+
+// Candidates are ranked across the whole neighbourhood before any claim is made, so
+// a purchase whose cash row another purchase could also use does not lose it to
+// whichever happened to be considered first.
+//
+// Two identical purchases and two identical cash rows: on amount alone every pairing
+// is feasible, so nothing but the references says which belongs to which. Taken in
+// slice order the first purchase would take whichever cash row it met first and the
+// second would take what was left, giving gaps of 10 and 8; ranked, each takes the
+// row issued beside it, giving 1 and 1.
+//
+// Best-first is greedy rather than globally optimal, which is what the converter
+// does too. It is the ranking that carries the weight, not the search.
+func TestTrade_OneBuyDoesNotStrandAnother(t *testing.T) {
+	ps := []db.GroupingPosting{
+		security("buy2", "100", "10", "1002", 10, 110),
+		security("buy1", "100", "10", "1002", 10, 101),
+		money("cashA", "-1000", 10, 102, typev1.TxType_TRADE_CASH),
+		money("cashB", "-1000", 10, 111, typev1.TxType_TRADE_CASH),
+	}
+	got := members(Partition(ps, tradeRules(), DefaultOpts()))
+	want := [][]string{{"buy1", "cashA"}, {"buy2", "cashB"}}
+	if !equal(got, want) {
+		t.Fatalf("partition = %v, want %v", got, want)
+	}
+}
+
+// A disposal's test is equality and an acquisition's an inequality, so the weaker
+// test must not take a row the stronger one identifies outright.
+func TestTrade_DisposalClaimsBeforeAcquisition(t *testing.T) {
+	// The cash out could settle the purchase, and it exactly matches the sale's
+	// stated total. Precedence is what decides, not the order of the slice.
+	ps := []db.GroupingPosting{
+		security("sale", "-100", "10", "1000", 10, 800000010),
+		money("cashIn", "1000", 10, 800000011, typev1.TxType_TRADE_CASH),
+		security("buy", "100", "10", "1200", 10, 800000020),
+		money("cashOut", "-1000", 10, 800000021, typev1.TxType_TRADE_CASH),
+	}
+	got := members(Partition(ps, tradeRules(), DefaultOpts()))
+	want := [][]string{{"buy", "cashOut"}, {"cashIn", "sale"}}
+	if !equal(got, want) {
+		t.Fatalf("partition = %v, want %v", got, want)
+	}
+}
+
+// A security sale claims its cash in before a sale of the account's own cash can
+// take it, which is what keeps the answer from depending on the order the broker
+// exported the two.
+func TestTrade_SecurityBeatsCashForTheSameRow(t *testing.T) {
+	ps := []db.GroupingPosting{
+		security("sale", "-100", "10", "1000", 10, 795832439),
+		money("cashIn", "1000", 10, 795832440, typev1.TxType_TRADE_CASH),
+		money("cashSale", "-1000", 10, 791691783, typev1.TxType_TRADE_CASH),
+	}
+	got := members(Partition(ps, tradeRules(), DefaultOpts()))
+	want := [][]string{{"cashIn", "sale"}, {"cashSale"}}
+	if !equal(got, want) {
+		t.Fatalf("partition = %v, want %v", got, want)
+	}
+}
+
+// The rule that claims a posting resolves it, so a Cash In that paired with a sale
+// is settled as that trade's cash leg rather than staying ambiguous.
+func TestTrade_ClaimingResolvesTheType(t *testing.T) {
+	ps := []db.GroupingPosting{
+		security("a", "-2676", "7.67", "20514.62", 10, 795832439),
+		money("b", "20514.62", 10, 795832440, typev1.TxType_TRADE_CASH, typev1.TxType_TRANSFER),
+	}
+	gs := Partition(ps, tradeRules(), DefaultOpts())
+
+	if got := resolvedOf(gs, "a"); got != typev1.TxType_TRADE_ASSET {
+		t.Fatalf("a resolved to %v, want TRADE_ASSET", got)
+	}
+	if got := resolvedOf(gs, "b"); got != typev1.TxType_TRADE_CASH {
+		t.Fatalf("b resolved to %v, want TRADE_CASH", got)
+	}
+}
+
+// A charge is dated on the order date while its trade settles later, and its money
+// is accounted for by its own row, so nothing here should fold one into a trade.
+func TestTrade_LeavesAChargeAlone(t *testing.T) {
+	ps := []db.GroupingPosting{
+		security("a", "-2676", "7.67", "20514.62", 10, 795832439),
+		money("b", "20514.62", 10, 795832440, typev1.TxType_TRADE_CASH),
+		money("fee", "-10.30", 10, 795832441, typev1.TxType_TRANSACTION_COST),
+	}
+	got := members(Partition(ps, tradeRules(), DefaultOpts()))
+	want := [][]string{{"a", "b"}, {"fee"}}
+	if !equal(got, want) {
+		t.Fatalf("partition = %v, want %v", got, want)
+	}
+}
+
+// A source that stated the grouping outright is honoured first, and a trade rule may
+// then add to what it named but may not take a member out of it.
+func TestTrade_AddsToAGroupTheSourceNamed(t *testing.T) {
+	fee := money("fee", "-10.30", 10, 0, typev1.TxType_TRANSACTION_COST)
+	ps := []db.GroupingPosting{
+		correlated(security("a", "-2676", "7.67", "20514.62", 10, 0), "", "fit1", db.ScopeAccount, db.MatchExact),
+		correlated(money("b", "20514.62", 10, 0, typev1.TxType_TRADE_CASH), "", "fit1", db.ScopeAccount, db.MatchExact),
+		fee,
+	}
+	rules := append([]Rule{Exact{}}, tradeRules()...)
+	got := members(Partition(ps, rules, DefaultOpts()))
+	// The trade rule cannot re-role a and b, so the pair the source named stands
+	// and the fee stays outside it.
+	want := [][]string{{"a", "b"}, {"fee"}}
+	if !equal(got, want) {
+		t.Fatalf("partition = %v, want %v", got, want)
+	}
+}
+
+func TestTrade_IsOrderIndependent(t *testing.T) {
+	ps := []db.GroupingPosting{
+		security("sell1", "-1000", "10", "10000", 10, 500000100),
+		money("cash1", "10000", 10, 500000101, typev1.TxType_TRADE_CASH),
+		security("buy1", "100", "10", "1002", 10, 500000200),
+		money("cash2", "-1000", 10, 500000201, typev1.TxType_TRADE_CASH),
+		money("fee", "-2", 10, 500000202, typev1.TxType_TRANSACTION_COST),
+	}
+	want := members(Partition(ps, tradeRules(), DefaultOpts()))
+	for i := range 20 {
+		shuffled := make([]db.GroupingPosting, len(ps))
+		copy(shuffled, ps)
+		// Rotate rather than randomise: every starting position is covered and the
+		// test states which orderings it checked.
+		for j := range shuffled {
+			shuffled[j] = ps[(j+i)%len(ps)]
+		}
+		if got := members(Partition(shuffled, tradeRules(), DefaultOpts())); !equal(got, want) {
+			t.Fatalf("rotation %d: partition = %v, want %v", i, got, want)
+		}
+	}
+}


### PR DESCRIPTION
**Stacked on #402.** Three rules pairing a trade with the money that settles it,
plus a correction to the engine that building them exposed.

## The rules

`disposal` (900), `acquisition` (800), `cash_trade` (700).

**The broker row type does not survive into the standard format, and does not
need to.** Fidelity names a sale's cash in a `Cash In From Sell` and a purchase's
cash out a `Cash Out For Buy`, and `cashLegType` maps between them. What that
encodes is two things the server already has: the direction the money moved,
which is the sign of the cash posting's own quantity, and which kind of trade it
settles, which the declared set distinguishes (`{TRADE_CASH}` against
`{TRADE_CASH, TRANSFER}`). What it encodes beyond that narrows candidates without
identifying an occurrence, and reference proximity does that better.

**A disposal's test is equality; an acquisition's is an inequality.** The source
states the same total on a sale and on its cash in, so equality identifies the
row outright — this is what #400's `settlement_amount` bought, and without it the
test would have degraded to the 0.75% band. A purchase's total carries the
charges while the cash row is the consideration alone, so the two differ by a
fee, and a fee cannot be negative. Disposals therefore claim first: the weaker
test must not take a row the stronger one can identify.

Both cross-check against `quantity × unit_price`, which comes from different
fields and so catches a cash row that is internally consistent but belongs to a
different trade — a swapped row misses by whole percentage points while a fee gap
sits far inside the band, which is why neither test can replace the other.

**Both rules rank globally on reference proximity.** The converter does this on
its buy pass and not on its sell pass, which takes the first candidate in row
order; doing it for both is strictly better evidence and costs nothing.

`cash_trade` handles Fidelity modelling an account's cash as a tradable asset. By
the time those rows reach the server both sides are money and neither can be an
asset leg, so the rules above pass over them; what identifies the pair is that
the two are exactly equal and opposite in one account on one day. It runs last,
which reproduces the converter's ordering of security trades ahead of cash ones.

## The engine correction

`accept()` allowed a claim whose members were partly taken, merging with the
group holding the taken one. I had written that as ADR 0048's *"a later pass may
add to the group"*. It is not that, and the trade rules made it fail loudly: a
rule's own next-ranked claim attaches to the claim it just made, so two purchases
competing for one cash row ended in **one group holding all four postings**
rather than one purchase keeping the row and the other going without. That is
precisely the stranding global ranking exists to prevent.

A claim is now dropped whole unless every posting it names is free. Adding to a
group an earlier rule assembled is consequently not expressible, and nothing
needs it — every rule proposes a complete grouping rather than an extension of
someone else's. When one wants to extend, it will have to say which member is the
anchor and which are its contribution, because that distinction is exactly what
the engine cannot infer from a flat member list.

## Testing

Ten table cases plus six named ones: both directions, the negative-fee refusal,
the consideration cross-check, account and day boundaries, wrong-direction money,
a declared transfer refused and a declared ambiguity taken, cash-for-cash,
cross-pairing two sales in a day, precedence between the rules, resolution by the
claiming rule, a charge left alone, and order independence.

Two fixtures are worth noting. The stranding test needed rebuilding: my first
attempt asserted a globally optimal matching, but best-first is greedy — as the
converter's is — so the fixture now demonstrates what ranking actually buys
(each purchase takes the row issued beside it, gaps of 1 and 1, rather than 10
and 8 in slice order). And `Opts` now carries decimals rather than strings.

`make check`, `make server-test` and `make db-test` pass. Nothing calls
`Partition` outside tests, so no behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
