### PR TITLE
Add the deposit-run rule and complete the rule set (0097)

### DIFF
--- a/server/grouping/deposit.go
+++ b/server/grouping/deposit.go
@@ -1,0 +1,231 @@
+package grouping
+
+import (
+	"context"
+	"sort"
+
+	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/txtype"
+)
+
+// DepositPrecedence puts deposit runs last.
+//
+// A run is only ever built from money rows the trade rules did not want, which is
+// what stops a deposit taking the cash row of a trade of the same amount on the same
+// day. The converter proved the ordering against its sample exports and it is
+// correctness rather than tuning here for the same reason: a claim is irrevocable,
+// so whichever rule goes first decides.
+const DepositPrecedence = 600
+
+// Deposit groups the run of money rows a deposit into a product account is reported
+// through.
+//
+// Money paid into a wrapper arrives as a run of rows of one amount: the subscription
+// is credited, spent, and credited again as the money that lands. No security is
+// involved, and the three are one event. Left ungrouped they are separate
+// single-posting groups, two of them transfers, so the account reports twice the
+// contribution it received and a residual the size of the deposit lands in IMBALANCE.
+func Deposit() Rule { return deposit{} }
+
+type deposit struct{}
+
+func (deposit) Name() string { return "deposit_run" }
+
+func (deposit) Precedence() int { return DepositPrecedence }
+
+// Expand asks for the accounts' postings whose references fall within the span of
+// these, in both directions -- a posting can be the row that opens a run or a row
+// some earlier reference opened.
+//
+// The span is the source's own, carried on the correlation, because how densely a
+// broker issues references is a fact about its numbering rather than a grouping
+// policy. A server-side constant would be wrong for every broker but one.
+//
+// No date bound. A run in the sample exports settles across two days -- the lump sum
+// and its spend complete on the 11th and the arrival on the 14th -- so a date bucket
+// would split it.
+func (deposit) Expand(ctx context.Context, userID string, ps []db.GroupingPosting, r db.GroupingReader, held []string) ([]db.GroupingPosting, error) {
+	var qs []db.OrdinalQuery
+	for _, p := range ps {
+		for _, c := range p.Correlations {
+			if !c.Declares(db.MatchOrdinal) || c.Ordinal == nil || c.OrdinalSpan == nil {
+				continue
+			}
+			qs = append(qs, db.OrdinalQuery{
+				Broker:  p.Broker,
+				Account: p.Account,
+				Label:   c.Label,
+				Low:     *c.Ordinal - *c.OrdinalSpan,
+				High:    *c.Ordinal + *c.OrdinalSpan,
+			})
+		}
+	}
+	if len(qs) == 0 {
+		return nil, nil
+	}
+	return r.PostingsByOrdinals(ctx, userID, distinct(qs), held)
+}
+
+// Apply builds a run from each row that could open one.
+//
+// What separates one deposit from another is the account, the amount agreeing to the
+// penny, and the trade rules having already taken the cash rows they need. The span
+// is a guard against a distant coincidence rather than the thing that discriminates:
+// every span from the widest real run upward groups the same runs.
+//
+// Openers are walked in reference order rather than interleaved by quality, which is
+// how the converter walks them: an earlier run takes the rows it needs and a later
+// one builds from what is left. Each takes the nearest row of each direction still
+// free, so a row another rule claimed costs the run that row rather than the step,
+// and the run reaches past it.
+func (d deposit) Apply(ps []db.GroupingPosting, st *State, opts Opts) {
+	var openers, members []db.GroupingPosting
+	for _, p := range ps {
+		if st.Taken(p.ID) || !isMoney(p) || p.Quantity.IsZero() {
+			continue
+		}
+		// The row that opens a run is money arriving that the source says is a
+		// transfer under every reading. That declaration is also what routes the
+		// finished group's residual to TRANSFER_CLEARING, where the departure it
+		// answers is waiting.
+		if p.Quantity.IsPositive() && txtype.MustBe(p.Declared, typev1.TxType_TRANSFER) {
+			openers = append(openers, p)
+			// A row that opens a run is not a step in someone else's. The source
+			// reports a run as a subscription credited, spent and credited again,
+			// and it is the middle two that carry a trade's cash leg in their
+			// declaration; a second arrival that says only "transfer" is a second
+			// deposit rather than more of this one.
+			continue
+		}
+		if txtype.MayBe(p.Declared, typev1.TxType_TRADE_CASH) || txtype.MayBe(p.Declared, typev1.TxType_TRANSFER) {
+			members = append(members, p)
+		}
+	}
+	sort.Slice(openers, func(i, j int) bool { return byOrdinal(openers[i], openers[j]) })
+
+	for _, o := range openers {
+		if st.Taken(o.ID) {
+			continue
+		}
+		ms := []Member{{ID: o.ID, Resolved: typev1.TxType_TRANSFER}}
+		if m, ok := d.nearest(o, members, st, opts, true); ok {
+			ms = append(ms, member(m))
+		}
+		if m, ok := d.nearest(o, members, st, opts, false); ok {
+			ms = append(ms, member(m))
+		}
+		// A lump sum with no run at all is money paid in from outside and stands on
+		// its own, which is what Claim refusing a lone member already says.
+		st.Claim(ms...)
+	}
+}
+
+// nearest returns the closest still-free money row this opener could have moved in
+// one direction: the subscription being spent, or the money landing.
+//
+// One row per direction, never two, because the source reports a run as one row per
+// step and a second row of the same amount and direction inside the span is a
+// different deposit rather than more of this one.
+//
+// Nearest wins, which is what keeps two runs of nearly equal amount in one account
+// apart: each takes the rows issued beside it. A row another rule has taken, or one
+// an earlier opener of this same pass took, is passed over rather than ending the
+// search -- so a run whose closest step went elsewhere reaches to the next rather
+// than losing the step.
+func (d deposit) nearest(o db.GroupingPosting, members []db.GroupingPosting, st *State, opts Opts, spending bool) (db.GroupingPosting, bool) {
+	span, ok := ordinalSpan(o)
+	if !ok {
+		return db.GroupingPosting{}, false
+	}
+	var best db.GroupingPosting
+	found := false
+	for _, m := range members {
+		if st.Taken(m.ID) || m.ID == o.ID {
+			continue
+		}
+		if m.Account != o.Account || m.Broker != o.Broker || m.Quantity.IsNegative() != spending {
+			continue
+		}
+		gap, ok := forwardGap(o, m)
+		// Strictly ascending: the run climbs away from the row that opened it, so a
+		// lower reference belongs to something earlier rather than to this.
+		if !ok || gap <= 0 || gap > span {
+			continue
+		}
+		if m.Quantity.Abs().Sub(o.Quantity.Abs()).Abs().GreaterThanOrEqual(opts.Money) {
+			continue
+		}
+		if !found || byOrdinal(m, best) {
+			best, found = m, true
+		}
+	}
+	return best, found
+}
+
+// member resolves one row of a run.
+//
+// The rule that claims a row is what resolves it, and this rule claims a movement of
+// money into an account. So a row whose declared set admits a transfer is settled as
+// one -- which is what narrows Fidelity's Cash In, reported the same way whether
+// money arrived from elsewhere or a switch's sale settled. A row that cannot be a
+// transfer is the subscription being spent inside the account, and keeps what its own
+// declaration says.
+func member(m db.GroupingPosting) Member {
+	if txtype.MayBe(m.Declared, typev1.TxType_TRANSFER) {
+		return Member{ID: m.ID, Resolved: typev1.TxType_TRANSFER}
+	}
+	return Member{ID: m.ID, Resolved: txtype.Resolve(m.Declared)}
+}
+
+// ordinalSpan returns how far apart two references may be and still be about one
+// event, as the source states it on this posting.
+func ordinalSpan(p db.GroupingPosting) (int64, bool) {
+	for _, c := range p.Correlations {
+		if c.Declares(db.MatchOrdinal) && c.Ordinal != nil && c.OrdinalSpan != nil {
+			return *c.OrdinalSpan, true
+		}
+	}
+	return 0, false
+}
+
+// forwardGap returns how far b's reference sits after a's, in the series both carry.
+// Directed, unlike the distance the trade rules rank on: a run ascends, so which
+// side a reference falls on is the evidence.
+func forwardGap(a, b db.GroupingPosting) (int64, bool) {
+	for _, ca := range a.Correlations {
+		if !ca.Declares(db.MatchOrdinal) || ca.Ordinal == nil {
+			continue
+		}
+		for _, cb := range b.Correlations {
+			if cb.Label != ca.Label || !cb.Declares(db.MatchOrdinal) || cb.Ordinal == nil {
+				continue
+			}
+			return *cb.Ordinal - *ca.Ordinal, true
+		}
+	}
+	return 0, false
+}
+
+// byOrdinal orders two postings by the reference they carry, falling back to the id
+// so the order is total and a shuffled input yields identical output.
+func byOrdinal(a, b db.GroupingPosting) bool {
+	oa, aok := firstOrdinal(a)
+	ob, bok := firstOrdinal(b)
+	if aok && bok && oa != ob {
+		return oa < ob
+	}
+	if aok != bok {
+		return aok
+	}
+	return a.ID < b.ID
+}
+
+func firstOrdinal(p db.GroupingPosting) (int64, bool) {
+	for _, c := range p.Correlations {
+		if c.Declares(db.MatchOrdinal) && c.Ordinal != nil {
+			return *c.Ordinal, true
+		}
+	}
+	return 0, false
+}

--- a/server/grouping/deposit_test.go
+++ b/server/grouping/deposit_test.go
@@ -1,0 +1,268 @@
+package grouping
+
+import (
+	"testing"
+
+	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+)
+
+// The three rows a deposit into a product account is reported through, shaped as the
+// converters emit them. The subscription is credited as a transfer, spent as a
+// trade's cash leg, and credited again through the row Fidelity reports the same way
+// whether money arrived from elsewhere or a switch's sale settled.
+func lumpSum(id, qty string, d int, ref int64) db.GroupingPosting {
+	return money(id, qty, d, ref, typev1.TxType_TRANSFER)
+}
+
+func spend(id, qty string, d int, ref int64) db.GroupingPosting {
+	return money(id, qty, d, ref, typev1.TxType_TRADE_CASH)
+}
+
+func landing(id, qty string, d int, ref int64) db.GroupingPosting {
+	return money(id, qty, d, ref, typev1.TxType_TRADE_CASH, typev1.TxType_TRANSFER)
+}
+
+func allRules() []Rule {
+	return append(tradeRules(), Deposit())
+}
+
+func TestDeposit(t *testing.T) {
+	tests := []struct {
+		name string
+		ps   []db.GroupingPosting
+		want [][]string
+	}{
+		{
+			name: "groups the run a deposit is reported through",
+			ps: []db.GroupingPosting{
+				lumpSum("open", "20000", 10, 971613428),
+				spend("spent", "-20000", 10, 971613429),
+				landing("landed", "20000", 10, 971613430),
+			},
+			want: [][]string{{"landed", "open", "spent"}},
+		},
+		{
+			// The run ascends from the row that opened it, so the date the trade
+			// rules bucket on would split this one. Reference proximity holds it.
+			name: "groups a run whose rows settled on different days",
+			ps: []db.GroupingPosting{
+				lumpSum("open", "20000", 11, 559604931),
+				spend("spent", "-20000", 11, 559604932),
+				landing("landed", "20000", 14, 559604933),
+			},
+			want: [][]string{{"landed", "open", "spent"}},
+		},
+		{
+			// Money paid in from outside with no run behind it stands on its own.
+			name: "leaves a lump sum with no run alone",
+			ps: []db.GroupingPosting{
+				lumpSum("open", "20000", 10, 822942572),
+			},
+			want: [][]string{{"open"}},
+		},
+		{
+			// A run climbs away from its opener, so a row numbered before it
+			// belongs to something earlier.
+			name: "does not take a row numbered before the opener",
+			ps: []db.GroupingPosting{
+				lumpSum("open", "20000", 10, 971613430),
+				spend("earlier", "-20000", 10, 971613428),
+			},
+			want: [][]string{{"earlier"}, {"open"}},
+		},
+		{
+			// The span travels with the evidence because how densely a broker
+			// issues references is a fact about its numbering. Nine is past the
+			// eight this source declares.
+			name: "respects the span the source declared",
+			ps: []db.GroupingPosting{
+				lumpSum("open", "20000", 10, 971613428),
+				spend("far", "-20000", 10, 971613437),
+			},
+			want: [][]string{{"far"}, {"open"}},
+		},
+		{
+			name: "does not build a run across accounts",
+			ps: []db.GroupingPosting{
+				lumpSum("open", "20000", 10, 971613428),
+				func() db.GroupingPosting {
+					p := spend("spent", "-20000", 10, 971613429)
+					p.Account = "A2"
+					return p
+				}(),
+			},
+			want: [][]string{{"open"}, {"spent"}},
+		},
+		{
+			// The amount has to agree to the penny: a run is one sum moving through
+			// the account, not two amounts that happen to be close.
+			name: "does not take a row of a different amount",
+			ps: []db.GroupingPosting{
+				lumpSum("open", "20000", 10, 971613428),
+				spend("other", "-19000", 10, 971613429),
+			},
+			want: [][]string{{"open"}, {"other"}},
+		},
+		{
+			// Two deposits into one account, interleaved, differing by a pound.
+			// Each takes the rows issued beside it.
+			name: "separates two runs of nearly equal amount in one account",
+			ps: []db.GroupingPosting{
+				lumpSum("open1", "19996", 10, 700000100),
+				spend("spent1", "-19996", 10, 700000101),
+				landing("landed1", "19996", 10, 700000102),
+				lumpSum("open2", "19995", 10, 700000103),
+				spend("spent2", "-19995", 10, 700000104),
+				landing("landed2", "19995", 10, 700000105),
+			},
+			want: [][]string{
+				{"landed1", "open1", "spent1"},
+				{"landed2", "open2", "spent2"},
+			},
+		},
+		{
+			// A second lump sum is a second deposit, not a further step in this
+			// one, so it is never swallowed as a member.
+			name: "does not take another lump sum as a member",
+			ps: []db.GroupingPosting{
+				lumpSum("open1", "20000", 10, 700000100),
+				lumpSum("open2", "20000", 10, 700000101),
+			},
+			want: [][]string{{"open1"}, {"open2"}},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := members(Partition(tc.ps, allRules(), DefaultOpts()))
+			if !equal(got, tc.want) {
+				t.Fatalf("partition = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// Deposit runs are built last, only ever from money rows the trade rules did not
+// want, which is what stops a deposit taking the cash row of a trade of the same
+// amount on the same day.
+func TestDeposit_DoesNotTakeTheDaysTradeCashRow(t *testing.T) {
+	ps := []db.GroupingPosting{
+		// The purchase and the cash row that settles it, sitting inside the run's
+		// reference span and carrying the same amount as the deposit.
+		security("buy", "100", "200", "20000", 10, 971613493),
+		spend("tradeCash", "-20000", 10, 971613494),
+		lumpSum("open", "20000", 10, 971613492),
+		landing("landed", "20000", 10, 971613495),
+	}
+	got := members(Partition(ps, allRules(), DefaultOpts()))
+	// The trade keeps its cash row; the run is built from what is left.
+	want := [][]string{{"buy", "tradeCash"}, {"landed", "open"}}
+	if !equal(got, want) {
+		t.Fatalf("partition = %v, want %v", got, want)
+	}
+}
+
+// The rule that claims a row resolves it. A deposit's opener and the money that
+// lands are the movement; the subscription spent inside the account cannot be a
+// transfer under any reading and keeps what its own declaration says.
+func TestDeposit_ClaimingResolvesTheRun(t *testing.T) {
+	ps := []db.GroupingPosting{
+		lumpSum("open", "20000", 10, 971613428),
+		spend("spent", "-20000", 10, 971613429),
+		landing("landed", "20000", 10, 971613430),
+	}
+	gs := Partition(ps, allRules(), DefaultOpts())
+
+	if got := resolvedOf(gs, "open"); got != typev1.TxType_TRANSFER {
+		t.Fatalf("open resolved to %v, want TRANSFER", got)
+	}
+	// Declared {TRADE_CASH, TRANSFER}: claiming it as the money that landed is what
+	// settles which of the two it was, and what routes the group's residual to
+	// TRANSFER_CLEARING rather than IMBALANCE.
+	if got := resolvedOf(gs, "landed"); got != typev1.TxType_TRANSFER {
+		t.Fatalf("landed resolved to %v, want TRANSFER", got)
+	}
+	if got := resolvedOf(gs, "spent"); got != typev1.TxType_TRADE_CASH {
+		t.Fatalf("spent resolved to %v, want TRADE_CASH", got)
+	}
+}
+
+// A member another rule took costs the run that member rather than the whole run,
+// which is what the smaller variants each opener states are for. The engine drops a
+// claim naming a taken posting whole, so without them the run would collapse.
+func TestDeposit_FallsBackToAPartialRun(t *testing.T) {
+	ps := []db.GroupingPosting{
+		lumpSum("open", "20000", 10, 971613428),
+		spend("spent", "-20000", 10, 971613429),
+		landing("landed", "20000", 10, 971613430),
+		// A sale of exactly the landing's amount, settling the same day, which the
+		// disposal rule claims before the run is built.
+		security("sale", "-100", "200", "20000", 10, 971613431),
+	}
+	got := members(Partition(ps, allRules(), DefaultOpts()))
+	want := [][]string{{"landed", "sale"}, {"open", "spent"}}
+	if !equal(got, want) {
+		t.Fatalf("partition = %v, want %v", got, want)
+	}
+}
+
+// The nearest row of a direction may be one another rule has taken, and the run
+// should then reach past it rather than go without that step. This is why an opener
+// states its whole ranked field rather than its best pair.
+func TestDeposit_ReachesPastARowAnotherRuleTook(t *testing.T) {
+	ps := []db.GroupingPosting{
+		lumpSum("open", "20000", 10, 971613428),
+		// The nearer spend, which the purchase below claims first.
+		spend("tradeCash", "-20000", 10, 971613429),
+		security("buy", "100", "200", "20000", 10, 971613427),
+		// The run's own spend, further away but still inside the span.
+		spend("spent", "-20000", 10, 971613432),
+		landing("landed", "20000", 10, 971613433),
+	}
+	got := members(Partition(ps, allRules(), DefaultOpts()))
+	want := [][]string{{"buy", "tradeCash"}, {"landed", "open", "spent"}}
+	if !equal(got, want) {
+		t.Fatalf("partition = %v, want %v", got, want)
+	}
+}
+
+// Two deposits of the same amount in one account, close enough that both could take
+// either spend row. The first opener takes the row beside it and the second reaches
+// to the next, rather than proposing a row that has gone and losing its whole run.
+//
+// This is the state no list fixed before the rule starts could see: the competition
+// is between two claims of the same pass, not between rules.
+func TestDeposit_SecondOpenerReachesPastTheFirstsRow(t *testing.T) {
+	ps := []db.GroupingPosting{
+		lumpSum("open1", "20000", 10, 700000100),
+		lumpSum("open2", "20000", 10, 700000101),
+		spend("spent1", "-20000", 10, 700000102),
+		spend("spent2", "-20000", 10, 700000103),
+	}
+	got := members(Partition(ps, allRules(), DefaultOpts()))
+	want := [][]string{{"open1", "spent1"}, {"open2", "spent2"}}
+	if !equal(got, want) {
+		t.Fatalf("partition = %v, want %v", got, want)
+	}
+}
+
+func TestDeposit_IsOrderIndependent(t *testing.T) {
+	ps := []db.GroupingPosting{
+		lumpSum("open1", "19996", 10, 700000100),
+		spend("spent1", "-19996", 10, 700000101),
+		landing("landed1", "19996", 10, 700000102),
+		lumpSum("open2", "19995", 10, 700000103),
+		spend("spent2", "-19995", 10, 700000104),
+		landing("landed2", "19995", 10, 700000105),
+	}
+	want := members(Partition(ps, allRules(), DefaultOpts()))
+	for i := range len(ps) {
+		rotated := make([]db.GroupingPosting, len(ps))
+		for j := range rotated {
+			rotated[j] = ps[(j+i)%len(ps)]
+		}
+		if got := members(Partition(rotated, allRules(), DefaultOpts())); !equal(got, want) {
+			t.Fatalf("rotation %d: partition = %v, want %v", i, got, want)
+		}
+	}
+}

--- a/server/grouping/grouping.go
+++ b/server/grouping/grouping.go
@@ -64,7 +64,7 @@ func DefaultOpts() Opts {
 // the rules, so a variant list is a table and not a restructuring. See
 // docs/adr/0047-grouping-runs-as-precedence-ordered-passes.md.
 func DefaultRules() []Rule {
-	return []Rule{Exact{}}
+	return []Rule{Exact{}, Disposal(), Acquisition(), CashTrade(), Deposit()}
 }
 
 // Member is one posting of a derived group and what the rule that claimed it


### PR DESCRIPTION
**Stacked on #403.** The last rule, which completes `DefaultRules()`.

## The run

Money paid into a product account arrives as a run of rows of one amount: the
subscription credited, spent, and credited again as the money that lands. Left
ungrouped they are separate single-posting groups, two of them transfers, so the
account reports twice the contribution it received and a residual the size of the
deposit lands in `IMBALANCE`.

Identified by account, an amount agreeing to the penny, and a **directed**
reference gap — not by the date bucket the trade rules use, because a run in the
sample exports settles across two days (lump sum and spend on the 11th, arrival
on the 14th). It claims **last**, so a run is only ever built from money rows the
trade rules did not want, which is what stops a deposit taking the cash row of a
trade of the same amount on the same day.

**The span comes from the correlation, not a constant.** This is what
`ordinal_span` is on the wire for (ADR 0048): how densely a broker issues
references is a fact about its numbering, and a server-side constant would be
wrong for every broker but one. `DEPOSIT_REF_SPAN` no longer exists on this side.

**Resolution follows the claiming rule.** The opener and the money that lands are
the movement, so a member whose declared set admits a transfer is settled as one
— that narrows Fidelity's `Cash In`, reported identically whether money arrived
from elsewhere or a switch's sale settled, and it is what routes the group's
residual to `TRANSFER_CLEARING` rather than `IMBALANCE`. The subscription spent
inside the account cannot be a transfer under any reading and keeps `TRADE_CASH`.

## Two things worth review

**An opener states every run it could form, nearest first, rather than its best
one.** The engine drops a claim naming a taken posting whole (#403), so proposing
only the best pair would lose the entire run whenever one member went elsewhere.
Stating the ranked field lets the run reach past a row another rule took, which
is what the converter achieves by skipping `usedCash` while it picks. I built the
single-best version first, noticed it fell back further than the converter would,
and rewrote it — `TestDeposit_ReachesPastARowAnotherRuleTook` pins the
difference.

**A row that opens a run is kept out of the member pool.** `DEPOSIT_ROWS` never
includes the opening row type, so a second arrival that says only "transfer" is a
second deposit rather than a further step in this one. Without the exclusion two
lump sums of equal amount inside one span could swallow each other.

## Testing

Nine table cases plus five named ones: the full run, a run across two days, a
lone lump sum, the directed-gap refusal, the declared span, account and amount
boundaries, two interleaved runs a pound apart, one lump sum not taking another,
precedence against the day's trade, resolution of all three roles, the partial
fallback, reaching past a taken row, and order independence.

`make check`, `make server-test` and `make db-test` pass. Nothing calls
`Partition` outside tests, so no behaviour changes.

Next: the neighbourhood closure that consumes `Reach`, the shadow worker, and the
`TriggerGrouping` RPC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
