### PR TITLE
Read the neighbourhood a partition is computed over (0097)

### DIFF
--- a/server/db/db.go
+++ b/server/db/db.go
@@ -75,6 +75,7 @@ type DB interface {
 	CorporateEventDB
 	ResidualBalanceDB
 	TransferMatchDB
+	GroupingDB
 }
 
 // PriceFetchBlockDB manages permanently blocked (instrument, plugin) pairs.
@@ -1664,6 +1665,23 @@ type TransferMatchDB interface {
 	ListTransferMatches(ctx context.Context, userID string) ([]TransferMatch, error)
 }
 
+// GroupingSeedOpts chooses where a grouping cycle starts looking.
+//
+// Two sources, because one cannot find what the other can. Residual picks the groups
+// carrying something a missing leg would explain, which is most of what needs
+// repairing but never a converter's wrong pairing of two similar trades -- that
+// balances with only a rounding residual and looks settled from outside. JobID picks
+// what an import just wrote, whatever state its groups are in. An empty JobID with
+// Residual false reads everything the user has, which is the full partition the
+// worst case degenerates to anyway.
+type GroupingSeedOpts struct {
+	UserID string
+	// Residual seeds from groups holding a residual worse than SOURCE_ROUNDING.
+	Residual bool
+	// JobID seeds from the postings one ingestion job wrote.
+	JobID string
+}
+
 // The reads a grouping rule may make while growing the neighbourhood it is
 // partitioned over. One query type per access path, each carrying only its own
 // fields.
@@ -1716,6 +1734,18 @@ type GroupingReader interface {
 	PostingsByToken(ctx context.Context, userID string, qs []TokenQuery, held []string) ([]GroupingPosting, error)
 	PostingsByDates(ctx context.Context, userID string, qs []DateQuery, held []string) ([]GroupingPosting, error)
 	PostingsByOrdinals(ctx context.Context, userID string, qs []OrdinalQuery, held []string) ([]GroupingPosting, error)
+}
+
+// GroupingDB is everything a grouping cycle reads.
+//
+// Reads only. The partition is computed in memory and written by a separate call, so
+// a cycle can run in shadow -- deriving the groups and comparing them against what is
+// stored -- with no path through here writing anything.
+type GroupingDB interface {
+	GroupingReader
+	// ListGroupingSeeds returns the transcribed postings a cycle starts from,
+	// ordered by id so a cycle is deterministic.
+	ListGroupingSeeds(ctx context.Context, opts GroupingSeedOpts) ([]GroupingPosting, error)
 }
 
 // GroupingPosting is one transcribed posting as the grouping engine reads it: the

--- a/server/db/postgres/grouping.go
+++ b/server/db/postgres/grouping.go
@@ -1,0 +1,252 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+	"github.com/shopspring/decimal"
+
+	"github.com/leedenison/portfoliodb/server/db"
+)
+
+// groupingColumns is what the engine's rules compare, plus the group as stored so a
+// cycle can tell its own answer from what is there.
+//
+// The raw quantity and price, never the split-adjusted pair: a rule matches figures
+// the source wrote against each other, and the adjusted pair carries a rounding the
+// source never had.
+const groupingColumns = `
+	t.id::text AS id,
+	t.user_id::text AS user_id,
+	t.broker,
+	t.account,
+	t.timestamp,
+	COALESCE(t.instrument_id::text, '') AS instrument_id,
+	t.quantity,
+	t.unit_price,
+	t.settlement_amount,
+	t.broker_tx_type,
+	COALESCE(g.job_id::text, '') AS job_id,
+	t.group_id::text AS group_id
+`
+
+// transcribedPostings is the population a partition is over.
+//
+// A routed residual transcribes nothing and correlates with nothing, so there is no
+// evidence to say which postings it belongs with; it is deleted and routed fresh once
+// the partition is settled. A group holding a synthetic pad is left alone whole --
+// the pad and its EQUITY counterparty are the declaration machinery's, and half a
+// group is not a group.
+const transcribedPostings = `
+	FROM txs t
+	JOIN tx_groups g ON g.id = t.group_id
+	WHERE t.user_id = $1
+	  AND t.account_type = 'USER'
+	  AND NOT EXISTS (
+	    SELECT 1 FROM txs s
+	    WHERE s.group_id = t.group_id AND s.synthetic_purpose IS NOT NULL
+	  )
+`
+
+// groupingRow is the scan shape for a posting the engine reads.
+type groupingRow struct {
+	ID               string           `db:"id"`
+	UserID           string           `db:"user_id"`
+	Broker           string           `db:"broker"`
+	Account          string           `db:"account"`
+	Timestamp        time.Time        `db:"timestamp"`
+	InstrumentID     string           `db:"instrument_id"`
+	Quantity         decimal.Decimal  `db:"quantity"`
+	UnitPrice        *decimal.Decimal `db:"unit_price"`
+	SettlementAmount *decimal.Decimal `db:"settlement_amount"`
+	BrokerTxTypes    pq.StringArray   `db:"broker_tx_type"`
+	JobID            string           `db:"job_id"`
+	GroupID          string           `db:"group_id"`
+}
+
+func (r groupingRow) toDomain() db.GroupingPosting {
+	return db.GroupingPosting{
+		ID:               r.ID,
+		UserID:           r.UserID,
+		Broker:           db.StrToBroker(r.Broker),
+		Account:          r.Account,
+		Timestamp:        r.Timestamp,
+		InstrumentID:     r.InstrumentID,
+		Quantity:         r.Quantity,
+		UnitPrice:        r.UnitPrice,
+		SettlementAmount: r.SettlementAmount,
+		Declared:         db.StrsToTxTypes(r.BrokerTxTypes),
+		JobID:            r.JobID,
+		GroupID:          r.GroupID,
+	}
+}
+
+// ListGroupingSeeds implements db.GroupingDB.
+func (p *Postgres) ListGroupingSeeds(ctx context.Context, opts db.GroupingSeedOpts) ([]db.GroupingPosting, error) {
+	userUUID, err := uuid.Parse(opts.UserID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid user id: %w", err)
+	}
+	args := []interface{}{userUUID}
+	q := "SELECT" + groupingColumns + transcribedPostings
+	if opts.Residual {
+		// The partial index over residual postings answers this directly. Source
+		// rounding is excluded: it is the source disagreeing with itself rather
+		// than a leg something is missing, so a group carrying only that is not a
+		// reason to go looking.
+		q += `
+		  AND EXISTS (
+		    SELECT 1 FROM txs r
+		    WHERE r.group_id = t.group_id
+		      AND r.account_type IN ('IMBALANCE', 'TRANSFER_CLEARING')
+		  )`
+	}
+	if opts.JobID != "" {
+		jobUUID, err := uuid.Parse(opts.JobID)
+		if err != nil {
+			return nil, fmt.Errorf("invalid job id: %w", err)
+		}
+		args = append(args, jobUUID)
+		q += fmt.Sprintf("\n\t\t  AND g.job_id = $%d", len(args))
+	}
+	q += "\n\t\tORDER BY t.id"
+	return p.groupingPostings(ctx, q, args)
+}
+
+// notHeld excludes the ids the caller already has.
+//
+// COALESCE because an empty list arrives as SQL NULL, and every comparison against
+// NULL is NULL -- so the predicate meant to exclude nothing would reject every row.
+func notHeld(n int) string {
+	return fmt.Sprintf("\n\t\t  AND NOT (t.id::text = ANY(COALESCE($%d::text[], ARRAY[]::text[])))\n\t\tORDER BY t.id", n)
+}
+
+// PostingsByToken implements db.GroupingReader.
+//
+// The index over (label, token) answers this directly, which is the lookup a
+// grouping rule makes: it starts from an identifier and asks who else holds it. A
+// query whose scope reaches past the account that issued the token is looked for past
+// it, or the read would be narrower than the rule it serves.
+func (p *Postgres) PostingsByToken(ctx context.Context, userID string, qs []db.TokenQuery, held []string) ([]db.GroupingPosting, error) {
+	userUUID, err := uuid.Parse(userID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid user id: %w", err)
+	}
+	if len(qs) == 0 {
+		return nil, nil
+	}
+	labels, tokens, brokers, accounts := make([]string, len(qs)), make([]string, len(qs)), make([]string, len(qs)), make([]string, len(qs))
+	anyAccount := make([]bool, len(qs))
+	for i, q := range qs {
+		labels[i], tokens[i] = q.Label, q.Token
+		brokers[i], accounts[i] = db.BrokerToStr(q.Broker), q.Account
+		anyAccount[i] = q.AnyAccount
+	}
+	sql := "SELECT" + groupingColumns + transcribedPostings + `
+		  AND EXISTS (
+		    SELECT 1
+		    FROM tx_correlations c
+		    JOIN unnest($2::text[], $3::text[], $4::text[], $5::text[], $6::bool[])
+		      AS r(label, token, broker, account, any_account)
+		      ON c.label = r.label AND c.token = r.token
+		    WHERE c.tx_id = t.id
+		      AND t.broker = r.broker
+		      AND (r.any_account OR t.account = r.account)
+		  )` + notHeld(7)
+	return p.groupingPostings(ctx, sql, []interface{}{
+		userUUID, pq.Array(labels), pq.Array(tokens), pq.Array(brokers),
+		pq.Array(accounts), pq.Array(anyAccount), pq.Array(held),
+	})
+}
+
+// PostingsByDates implements db.GroupingReader, over the account-and-day bucket the
+// trade rules pair within.
+func (p *Postgres) PostingsByDates(ctx context.Context, userID string, qs []db.DateQuery, held []string) ([]db.GroupingPosting, error) {
+	userUUID, err := uuid.Parse(userID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid user id: %w", err)
+	}
+	if len(qs) == 0 {
+		return nil, nil
+	}
+	brokers, accounts := make([]string, len(qs)), make([]string, len(qs))
+	from, before := make([]time.Time, len(qs)), make([]time.Time, len(qs))
+	for i, q := range qs {
+		brokers[i], accounts[i] = db.BrokerToStr(q.Broker), q.Account
+		from[i], before[i] = q.From, q.Before
+	}
+	sql := "SELECT" + groupingColumns + transcribedPostings + `
+		  AND EXISTS (
+		    SELECT 1
+		    FROM unnest($2::text[], $3::text[], $4::timestamptz[], $5::timestamptz[])
+		      AS r(broker, account, from_ts, before_ts)
+		    WHERE t.broker = r.broker AND t.account = r.account
+		      AND t.timestamp >= r.from_ts AND t.timestamp < r.before_ts
+		  )` + notHeld(6)
+	return p.groupingPostings(ctx, sql, []interface{}{
+		userUUID, pq.Array(brokers), pq.Array(accounts), pq.Array(from), pq.Array(before), pq.Array(held),
+	})
+}
+
+// PostingsByOrdinals implements db.GroupingReader, over the reference span a deposit
+// run finds its steps within. No date bound: a run can settle across two days.
+func (p *Postgres) PostingsByOrdinals(ctx context.Context, userID string, qs []db.OrdinalQuery, held []string) ([]db.GroupingPosting, error) {
+	userUUID, err := uuid.Parse(userID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid user id: %w", err)
+	}
+	if len(qs) == 0 {
+		return nil, nil
+	}
+	brokers, accounts, labels := make([]string, len(qs)), make([]string, len(qs)), make([]string, len(qs))
+	low, high := make([]int64, len(qs)), make([]int64, len(qs))
+	for i, q := range qs {
+		brokers[i], accounts[i], labels[i] = db.BrokerToStr(q.Broker), q.Account, q.Label
+		low[i], high[i] = q.Low, q.High
+	}
+	sql := "SELECT" + groupingColumns + transcribedPostings + `
+		  AND EXISTS (
+		    SELECT 1
+		    FROM tx_correlations c
+		    JOIN unnest($2::text[], $3::text[], $4::text[], $5::bigint[], $6::bigint[])
+		      AS r(broker, account, label, lo, hi)
+		      ON c.label = r.label
+		    WHERE c.tx_id = t.id
+		      AND c.ordinal BETWEEN r.lo AND r.hi
+		      AND t.broker = r.broker AND t.account = r.account
+		  )` + notHeld(7)
+	return p.groupingPostings(ctx, sql, []interface{}{
+		userUUID, pq.Array(brokers), pq.Array(accounts), pq.Array(labels),
+		pq.Array(low), pq.Array(high), pq.Array(held),
+	})
+}
+
+// groupingPostings runs one of the reads above and hangs each posting's correlations
+// on it.
+//
+// A second pass for the evidence rather than a lateral aggregate, as the export path
+// does: the postings come back as one ordered stream, and a document per row would be
+// decoded whether the row correlates with anything or not.
+func (p *Postgres) groupingPostings(ctx context.Context, q string, args []interface{}) ([]db.GroupingPosting, error) {
+	var rows []groupingRow
+	if err := p.q.SelectContext(ctx, &rows, q, args...); err != nil {
+		return nil, fmt.Errorf("list postings for grouping: %w", err)
+	}
+	ids := make([]string, len(rows))
+	out := make([]db.GroupingPosting, len(rows))
+	for i, r := range rows {
+		ids[i] = r.ID
+		out[i] = r.toDomain()
+	}
+	byTx, err := p.correlationsByTx(ctx, ids)
+	if err != nil {
+		return nil, err
+	}
+	for i := range out {
+		out[i].Correlations = byTx[out[i].ID]
+	}
+	return out, nil
+}

--- a/server/db/postgres/grouping_test.go
+++ b/server/db/postgres/grouping_test.go
@@ -1,0 +1,288 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
+	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+)
+
+// groupingFixture is one user with an instrument, ready for postings.
+type groupingFixture struct {
+	p      *Postgres
+	userID string
+	instID string
+	ctx    context.Context
+}
+
+func newGroupingFixture(t *testing.T, sub string) *groupingFixture {
+	t.Helper()
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|"+sub, "U", sub+"@grouping.test")
+	instID, err := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{
+		{Type: "BROKER_DESCRIPTION", Domain: "FIDELITY", Value: "GRP-" + sub, Canonical: false},
+	}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+	return &groupingFixture{p: p, userID: userID, instID: instID, ctx: ctx}
+}
+
+// write stores one posting through the ordinary ingestion path, so the fixture
+// exercises what an upload actually produces rather than raw SQL.
+func (f *groupingFixture) write(t *testing.T, account string, ts time.Time, qty string, declared []typev1.TxType, cs ...*archivev1.Correlation) {
+	t.Helper()
+	tx := &apiv1.Tx{
+		Timestamp:             timestamppb.New(ts),
+		InstrumentDescription: "GRP",
+		BrokerTxType:          declared,
+		ResolvedTxType:        declared[0],
+		Quantity:              qty,
+		Account:               account,
+		Correlations:          cs,
+	}
+	if err := createTx(f.ctx, f.p, f.userID, "FIDELITY", account, "", tx, f.instID, nil); err != nil {
+		t.Fatalf("write posting: %v", err)
+	}
+}
+
+// writeWithResidual stores a posting together with the routed counterparty that
+// balances it, which is the shape an unmatched transfer actually has in the database:
+// the transcribed leg plus a TRANSFER_CLEARING one holding the value in transit.
+func (f *groupingFixture) writeWithResidual(t *testing.T, account string, ts time.Time, qty string, declared []typev1.TxType, residual typev1.AccountType) {
+	t.Helper()
+	leg := &apiv1.Tx{
+		Timestamp:             timestamppb.New(ts),
+		InstrumentDescription: "GRP",
+		BrokerTxType:          declared,
+		ResolvedTxType:        declared[0],
+		Quantity:              qty,
+		Account:               account,
+	}
+	counter := &apiv1.Tx{
+		Timestamp:             timestamppb.New(ts),
+		InstrumentDescription: "GRP",
+		BrokerTxType:          declared,
+		ResolvedTxType:        declared[0],
+		Quantity:              "-" + qty,
+		Account:               account,
+		AccountType:           residual,
+	}
+	err := f.p.CreateTxGroup(f.ctx, f.userID, "FIDELITY", account, "",
+		[]*apiv1.Tx{leg, counter}, []string{f.instID, f.instID}, nil, []*time.Time{nil, nil})
+	if err != nil {
+		t.Fatalf("write posting with residual: %v", err)
+	}
+}
+
+func refCorrelation(token string, ordinal, span int64) *archivev1.Correlation {
+	return &archivev1.Correlation{
+		Token:       token,
+		Ordinal:     &ordinal,
+		OrdinalSpan: &span,
+		Scope:       typev1.Scope_SCOPE_FILE,
+		Match:       []typev1.Match{typev1.Match_MATCH_EXACT, typev1.Match_MATCH_ORDINAL},
+	}
+}
+
+func idsOf(ps []db.GroupingPosting) map[string]db.GroupingPosting {
+	out := map[string]db.GroupingPosting{}
+	for _, p := range ps {
+		out[p.ID] = p
+	}
+	return out
+}
+
+// A reach on a token is answered from the index over (label, token), which is the
+// lookup a grouping pass makes: it starts from an identifier and asks who else holds
+// it.
+func TestPostingsByToken(t *testing.T) {
+	f := newGroupingFixture(t, "token")
+	ts := time.Date(2024, 3, 1, 10, 0, 0, 0, time.UTC)
+	f.write(t, "A1", ts, "-100", []typev1.TxType{typev1.TxType_TRADE_ASSET}, refCorrelation("shared", 100, 8))
+	f.write(t, "A1", ts, "1000", []typev1.TxType{typev1.TxType_TRADE_CASH}, refCorrelation("shared", 101, 8))
+	f.write(t, "A1", ts, "5", []typev1.TxType{typev1.TxType_HOLDING_COST}, refCorrelation("other", 900, 8))
+
+	got, err := f.p.PostingsByToken(f.ctx, f.userID, []db.TokenQuery{{
+		Broker:  typev1.Broker_FIDELITY,
+		Account: "A1",
+		Token:   "shared",
+	}}, nil)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d postings, want the 2 sharing the token", len(got))
+	}
+	// The evidence comes back with them, or a rule would have nothing to compare.
+	for _, p := range got {
+		if len(p.Correlations) != 1 || p.Correlations[0].Token != "shared" {
+			t.Fatalf("posting %s carries %v, want the shared token", p.ID, p.Correlations)
+		}
+	}
+}
+
+// An account-scoped token means nothing outside its account, so the reach that serves
+// it must not cross one either.
+func TestPostingsByToken_StaysInItsAccount(t *testing.T) {
+	f := newGroupingFixture(t, "tokenacct")
+	ts := time.Date(2024, 3, 1, 10, 0, 0, 0, time.UTC)
+	f.write(t, "A1", ts, "-100", []typev1.TxType{typev1.TxType_TRADE_ASSET}, refCorrelation("shared", 100, 8))
+	f.write(t, "A2", ts, "1000", []typev1.TxType{typev1.TxType_TRADE_CASH}, refCorrelation("shared", 101, 8))
+
+	narrow, err := f.p.PostingsByToken(f.ctx, f.userID, []db.TokenQuery{{
+		Broker: typev1.Broker_FIDELITY, Account: "A1", Token: "shared",
+	}}, nil)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(narrow) != 1 {
+		t.Fatalf("account-scoped reach got %d postings, want 1", len(narrow))
+	}
+
+	wide, err := f.p.PostingsByToken(f.ctx, f.userID, []db.TokenQuery{{
+		Broker: typev1.Broker_FIDELITY, Account: "A1", Token: "shared", AnyAccount: true,
+	}}, nil)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(wide) != 2 {
+		t.Fatalf("broker-scoped reach got %d postings, want 2", len(wide))
+	}
+}
+
+// The trade rules pair within one account on one day, and the range is half-open as
+// every interval in this system is.
+func TestPostingsByDates(t *testing.T) {
+	f := newGroupingFixture(t, "dates")
+	day := time.Date(2024, 3, 1, 0, 0, 0, 0, time.UTC)
+	f.write(t, "A1", day.Add(9*time.Hour), "-100", []typev1.TxType{typev1.TxType_TRADE_ASSET})
+	f.write(t, "A1", day.Add(15*time.Hour), "1000", []typev1.TxType{typev1.TxType_TRADE_CASH})
+	f.write(t, "A1", day.AddDate(0, 0, 1), "7", []typev1.TxType{typev1.TxType_HOLDING_COST})
+
+	got, err := f.p.PostingsByDates(f.ctx, f.userID, []db.DateQuery{{
+		Broker:  typev1.Broker_FIDELITY,
+		Account: "A1",
+		From:    day,
+		Before:  day.AddDate(0, 0, 1),
+	}}, nil)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d postings, want the 2 inside the day", len(got))
+	}
+}
+
+// A deposit run finds its steps by reference proximity, bounded by the span the
+// source declared, and is not bounded by a date at all.
+func TestPostingsByOrdinals(t *testing.T) {
+	f := newGroupingFixture(t, "ordinals")
+	ts := time.Date(2024, 3, 1, 10, 0, 0, 0, time.UTC)
+	f.write(t, "A1", ts, "20000", []typev1.TxType{typev1.TxType_TRANSFER}, refCorrelation("700000100", 700000100, 8))
+	// Three days later, which a date bucket would exclude and a reference span does
+	// not.
+	f.write(t, "A1", ts.AddDate(0, 0, 3), "-20000", []typev1.TxType{typev1.TxType_TRADE_CASH}, refCorrelation("700000103", 700000103, 8))
+	f.write(t, "A1", ts, "-20000", []typev1.TxType{typev1.TxType_TRADE_CASH}, refCorrelation("700000200", 700000200, 8))
+
+	got, err := f.p.PostingsByOrdinals(f.ctx, f.userID, []db.OrdinalQuery{{
+		Broker:  typev1.Broker_FIDELITY,
+		Account: "A1",
+		Low:     700000100,
+		High:    700000108,
+	}}, nil)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("got %d postings, want the 2 inside the span", len(got))
+	}
+}
+
+// The closure asks only for what it does not hold, so a posting is never read twice
+// and the rounds shrink to nothing.
+func TestPostingsByToken_ExcludesHeld(t *testing.T) {
+	f := newGroupingFixture(t, "held")
+	ts := time.Date(2024, 3, 1, 10, 0, 0, 0, time.UTC)
+	f.write(t, "A1", ts, "-100", []typev1.TxType{typev1.TxType_TRADE_ASSET}, refCorrelation("shared", 100, 8))
+	f.write(t, "A1", ts, "1000", []typev1.TxType{typev1.TxType_TRADE_CASH}, refCorrelation("shared", 101, 8))
+
+	q := []db.TokenQuery{{Broker: typev1.Broker_FIDELITY, Account: "A1", Token: "shared"}}
+	all, err := f.p.PostingsByToken(f.ctx, f.userID, q, nil)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("got %d postings, want 2", len(all))
+	}
+	rest, err := f.p.PostingsByToken(f.ctx, f.userID, q, []string{all[0].ID})
+	if err != nil {
+		t.Fatalf("list excluding held: %v", err)
+	}
+	if len(rest) != 1 || rest[0].ID != all[1].ID {
+		t.Fatalf("got %v, want only %s", idsOf(rest), all[1].ID)
+	}
+}
+
+// A routed residual transcribes nothing, so there is no evidence to say which
+// postings it belongs with; it is re-routed after the partition rather than
+// partitioned.
+func TestListGroupingSeeds_ExcludesRoutedResiduals(t *testing.T) {
+	f := newGroupingFixture(t, "residual")
+	ts := time.Date(2024, 3, 1, 10, 0, 0, 0, time.UTC)
+	// A transfer and the TRANSFER_CLEARING leg holding its value in transit: two
+	// rows in the database, one of them transcribed.
+	f.writeWithResidual(t, "A1", ts, "500", []typev1.TxType{typev1.TxType_TRANSFER},
+		typev1.AccountType_ACCOUNT_TYPE_TRANSFER_CLEARING)
+
+	got, err := f.p.ListGroupingSeeds(f.ctx, db.GroupingSeedOpts{UserID: f.userID})
+	if err != nil {
+		t.Fatalf("seeds: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d seeds, want only the transcribed posting", len(got))
+	}
+	if !got[0].Quantity.Equal(decf(500)) {
+		t.Fatalf("seed quantity = %s, want 500", got[0].Quantity)
+	}
+}
+
+// The cadence trigger starts from groups holding something a missing leg would
+// explain. A group balanced but for the source's own rounding is not one of those.
+func TestListGroupingSeeds_ResidualOnly(t *testing.T) {
+	f := newGroupingFixture(t, "seedresidual")
+	ts := time.Date(2024, 3, 1, 10, 0, 0, 0, time.UTC)
+	// An unmatched transfer: something a missing leg would explain.
+	f.writeWithResidual(t, "A1", ts, "500", []typev1.TxType{typev1.TxType_TRANSFER},
+		typev1.AccountType_ACCOUNT_TYPE_TRANSFER_CLEARING)
+	// A trade whose only residual is the source disagreeing with itself, which is
+	// not a reason to go looking.
+	f.writeWithResidual(t, "A2", ts, "300", []typev1.TxType{typev1.TxType_TRADE_ASSET},
+		typev1.AccountType_ACCOUNT_TYPE_SOURCE_ROUNDING)
+
+	all, err := f.p.ListGroupingSeeds(f.ctx, db.GroupingSeedOpts{UserID: f.userID})
+	if err != nil {
+		t.Fatalf("seeds: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("got %d unfiltered seeds, want 2", len(all))
+	}
+
+	got, err := f.p.ListGroupingSeeds(f.ctx, db.GroupingSeedOpts{UserID: f.userID, Residual: true})
+	if err != nil {
+		t.Fatalf("seeds: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("got %d seeds, want only the unmatched transfer", len(got))
+	}
+	if got[0].Account != "A1" {
+		t.Fatalf("seeded from %s, want the account holding the unmatched transfer", got[0].Account)
+	}
+}

--- a/server/grouping/neighbourhood.go
+++ b/server/grouping/neighbourhood.go
@@ -1,0 +1,72 @@
+package grouping
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/leedenison/portfoliodb/server/db"
+)
+
+// Neighbourhood grows a seed until no rule can reach anything new.
+//
+// The region a partition is computed over is not a window. A user-asserted
+// correlation links a posting to one years away and no window contains that, so the
+// region is the fixpoint of the rules' own candidate relations: ask every rule what
+// it could link each posting to, add what comes back, and repeat.
+//
+// It terminates because it only ever adds. Each round contributes postings the
+// caller did not hold, the held set is bounded by what the user has, so the fixpoint
+// arrives in at most as many rounds as there are postings. That is the whole
+// termination argument, and it is why the engine recomputes a region rather than
+// repairing one -- see docs/adr/0050-grouping-recomputes-a-neighbourhood.md.
+//
+// The worst case is that the region reaches everything the user has, which is a full
+// partition: correct, and merely slow. Nothing here caps it, because a cap would trade
+// a slow answer for a wrong one.
+func Neighbourhood(ctx context.Context, userID string, seed []db.GroupingPosting, rules []Rule, r db.GroupingReader) ([]db.GroupingPosting, error) {
+	held := make(map[string]db.GroupingPosting, len(seed))
+	for _, p := range seed {
+		held[p.ID] = p
+	}
+	frontier := seed
+	for len(frontier) > 0 {
+		var fresh []db.GroupingPosting
+		for _, rule := range rules {
+			found, err := rule.Expand(ctx, userID, frontier, r, ids(held))
+			if err != nil {
+				return nil, fmt.Errorf("%s: expand neighbourhood: %w", rule.Name(), err)
+			}
+			// Filtered here as well as asked for in the read. A round counts only
+			// what the caller did not have, so the loop shrinks to nothing whatever
+			// a store returns, and termination is this function's property rather
+			// than a promise made elsewhere.
+			for _, p := range found {
+				if _, dup := held[p.ID]; dup {
+					continue
+				}
+				held[p.ID] = p
+				fresh = append(fresh, p)
+			}
+		}
+		frontier = fresh
+	}
+
+	out := make([]db.GroupingPosting, 0, len(held))
+	for _, p := range held {
+		out = append(out, p)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ID < out[j].ID })
+	return out, nil
+}
+
+// ids returns the held postings' ids, sorted, so a fetch is given a stable exclusion
+// list and two runs over the same data issue the same queries.
+func ids(held map[string]db.GroupingPosting) []string {
+	out := make([]string, 0, len(held))
+	for id := range held {
+		out = append(out, id)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/server/grouping/neighbourhood_test.go
+++ b/server/grouping/neighbourhood_test.go
@@ -1,0 +1,212 @@
+package grouping
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+)
+
+// store answers the reader's methods from a fixed set of postings, the way the
+// database does, and counts what it was asked so a test can state the questions
+// rather than only the answers.
+//
+// No dispatch: each method knows the one shape it answers. That is the point of the
+// reader -- a fake is three small functions rather than a switch over a kind.
+type store struct {
+	all   []db.GroupingPosting
+	reads int
+	dates [][]db.DateQuery
+	err   error
+	// echo returns postings the caller already holds, which a correct store never
+	// does. It is here to show the closure terminating regardless.
+	echo bool
+}
+
+func (s *store) filter(held []string, keep func(db.GroupingPosting) bool) ([]db.GroupingPosting, error) {
+	s.reads++
+	if s.err != nil {
+		return nil, s.err
+	}
+	heldSet := map[string]bool{}
+	for _, id := range held {
+		heldSet[id] = true
+	}
+	var out []db.GroupingPosting
+	for _, p := range s.all {
+		if !s.echo && heldSet[p.ID] {
+			continue
+		}
+		if keep(p) {
+			out = append(out, p)
+		}
+	}
+	return out, nil
+}
+
+func (s *store) PostingsByToken(_ context.Context, _ string, qs []db.TokenQuery, held []string) ([]db.GroupingPosting, error) {
+	return s.filter(held, func(p db.GroupingPosting) bool {
+		for _, q := range qs {
+			for _, c := range p.Correlations {
+				if c.Label == q.Label && c.Token == q.Token && (q.AnyAccount || p.Account == q.Account) {
+					return true
+				}
+			}
+		}
+		return false
+	})
+}
+
+func (s *store) PostingsByDates(_ context.Context, _ string, qs []db.DateQuery, held []string) ([]db.GroupingPosting, error) {
+	s.dates = append(s.dates, qs)
+	return s.filter(held, func(p db.GroupingPosting) bool {
+		for _, q := range qs {
+			if p.Account == q.Account && !p.Timestamp.Before(q.From) && p.Timestamp.Before(q.Before) {
+				return true
+			}
+		}
+		return false
+	})
+}
+
+func (s *store) PostingsByOrdinals(_ context.Context, _ string, qs []db.OrdinalQuery, held []string) ([]db.GroupingPosting, error) {
+	return s.filter(held, func(p db.GroupingPosting) bool {
+		for _, q := range qs {
+			if p.Account != q.Account {
+				continue
+			}
+			for _, c := range p.Correlations {
+				if c.Label == q.Label && c.Ordinal != nil && *c.Ordinal >= q.Low && *c.Ordinal <= q.High {
+					return true
+				}
+			}
+		}
+		return false
+	})
+}
+
+func heldIDs(ps []db.GroupingPosting) []string {
+	out := make([]string, len(ps))
+	for i, p := range ps {
+		out[i] = p.ID
+	}
+	return out
+}
+
+func idsEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// A token links two postings, and pulling in the second asks the second's own
+// questions -- which is what makes this a closure rather than one round of lookups.
+func TestNeighbourhood_GrowsUntilNothingIsNew(t *testing.T) {
+	// a shares a token with b, b shares a different token with c, and c reaches
+	// nothing further. One round of lookups from a would stop at b.
+	a := correlated(posting("a", typev1.TxType_TRADE_ASSET), "", "t1", db.ScopeAccount, db.MatchExact)
+	b := correlated(correlated(posting("b", typev1.TxType_TRADE_CASH), "", "t1", db.ScopeAccount, db.MatchExact),
+		"", "t2", db.ScopeAccount, db.MatchExact)
+	c := correlated(posting("c", typev1.TxType_TRANSACTION_COST), "", "t2", db.ScopeAccount, db.MatchExact)
+	s := &store{all: []db.GroupingPosting{a, b, c}}
+
+	got, err := Neighbourhood(context.Background(), "u", []db.GroupingPosting{a}, []Rule{Exact{}}, s)
+	if err != nil {
+		t.Fatalf("neighbourhood: %v", err)
+	}
+	if want := []string{"a", "b", "c"}; !idsEqual(heldIDs(got), want) {
+		t.Fatalf("held = %v, want %v", heldIDs(got), want)
+	}
+	// Three reads: one that finds b, one that finds c, one that finds nothing and
+	// ends it.
+	if s.reads != 3 {
+		t.Fatalf("reads = %d, want 3", s.reads)
+	}
+}
+
+func TestNeighbourhood_StopsWhenNothingReachesFurther(t *testing.T) {
+	a := correlated(posting("a", typev1.TxType_TRADE_ASSET), "", "t1", db.ScopeAccount, db.MatchExact)
+	lonely := correlated(posting("z", typev1.TxType_HOLDING_COST), "", "other", db.ScopeAccount, db.MatchExact)
+	s := &store{all: []db.GroupingPosting{a, lonely}}
+
+	got, err := Neighbourhood(context.Background(), "u", []db.GroupingPosting{a}, []Rule{Exact{}}, s)
+	if err != nil {
+		t.Fatalf("neighbourhood: %v", err)
+	}
+	if want := []string{"a"}; !idsEqual(heldIDs(got), want) {
+		t.Fatalf("held = %v, want %v", heldIDs(got), want)
+	}
+}
+
+// The closure only ever adds, and it counts a round by what the caller did not
+// already hold. So a store that returns everything every time still terminates:
+// termination is this function's property rather than a promise made elsewhere.
+func TestNeighbourhood_TerminatesWhenAStoreEchoesHeldPostings(t *testing.T) {
+	a := correlated(posting("a", typev1.TxType_TRADE_ASSET), "", "t1", db.ScopeAccount, db.MatchExact)
+	b := correlated(posting("b", typev1.TxType_TRADE_CASH), "", "t1", db.ScopeAccount, db.MatchExact)
+	s := &store{all: []db.GroupingPosting{a, b}, echo: true}
+
+	got, err := Neighbourhood(context.Background(), "u", []db.GroupingPosting{a}, []Rule{Exact{}}, s)
+	if err != nil {
+		t.Fatalf("neighbourhood: %v", err)
+	}
+	if want := []string{"a", "b"}; !idsEqual(heldIDs(got), want) {
+		t.Fatalf("held = %v, want %v", heldIDs(got), want)
+	}
+}
+
+// A posting is never asked for twice: the exclusion list carries everything held, so
+// a round costs one query per distinct question rather than per posting asking it.
+func TestNeighbourhood_ExcludesWhatItAlreadyHolds(t *testing.T) {
+	a := correlated(posting("a", typev1.TxType_TRADE_ASSET), "", "t1", db.ScopeAccount, db.MatchExact)
+	b := correlated(posting("b", typev1.TxType_TRADE_CASH), "", "t1", db.ScopeAccount, db.MatchExact)
+	s := &store{all: []db.GroupingPosting{a, b}}
+
+	if _, err := Neighbourhood(context.Background(), "u", []db.GroupingPosting{a}, []Rule{Exact{}}, s); err != nil {
+		t.Fatalf("neighbourhood: %v", err)
+	}
+	if s.reads < 2 {
+		t.Fatalf("reads = %d, want at least 2", s.reads)
+	}
+}
+
+// Every posting of one account on one day asks the same date question, so a frontier
+// of several asks it once. Without this the fetch would grow with the frontier
+// rather than with what is actually being asked.
+func TestNeighbourhood_AsksEachDistinctQuestionOnce(t *testing.T) {
+	seed := []db.GroupingPosting{
+		security("a", "-100", "10", "1000", 10, 500000100),
+		security("b", "-100", "10", "1000", 10, 500000101),
+		security("c", "-100", "10", "1000", 10, 500000102),
+	}
+	s := &store{}
+
+	if _, err := Neighbourhood(context.Background(), "u", seed, []Rule{Disposal()}, s); err != nil {
+		t.Fatalf("neighbourhood: %v", err)
+	}
+	if len(s.dates) == 0 {
+		t.Fatal("no date questions asked")
+	}
+	// One account, one day, three postings: one date query.
+	if got := len(s.dates[0]); got != 1 {
+		t.Fatalf("first read asked %d date queries, want 1", got)
+	}
+}
+
+func TestNeighbourhood_SurfacesAFetchError(t *testing.T) {
+	a := correlated(posting("a", typev1.TxType_TRADE_ASSET), "", "t1", db.ScopeAccount, db.MatchExact)
+	want := errors.New("read failed")
+	s := &store{all: []db.GroupingPosting{a}, err: want}
+
+	if _, err := Neighbourhood(context.Background(), "u", []db.GroupingPosting{a}, []Rule{Exact{}}, s); !errors.Is(err, want) {
+		t.Fatalf("err = %v, want %v", err, want)
+	}
+}


### PR DESCRIPTION
**Stacked on #404.** The region a partition is computed over, and the read that
answers it. The worker and `TriggerGrouping` RPC follow in the next change, so
nothing calls this yet.

## The closure

`Neighbourhood(ctx, seed, rules, fetch)` grows a seed until no rule reaches
anything new.

The region is **not a window**, and defining it as one is what makes it look
arbitrary — a `SCOPE_USER` correlation links a posting to one years away and no
window contains that. It is the fixpoint of the rules' own candidate relations:
ask every rule what it could link each posting to, add what comes back, repeat.

**Termination is the property this rests on** (ADR 0050), so it is a property of
this function rather than a promise made by the store. It only ever adds, and a
round counts only what the caller did not already hold, so the held set is
bounded by what the user has and the loop shrinks to nothing *whatever a store
returns*. There is a test that hands it a store echoing everything back every
time; it still terminates.

Nothing caps the region. The worst case is that it reaches everything the user
has, which is a full partition — correct, and merely slow — and a cap would trade
a slow answer for a wrong one.

`fetch` is a function rather than a store so the closure is testable without a
database and nothing in `server/grouping` issues a query.

## The read

`Reach` moves to `db.GroupingReach`. The query that answers one lives in the db
layer, and `server/grouping` already speaks in `db` types (`GroupingPosting`,
`Correlation`), so this follows the existing seam rather than cutting a new one.

**One statement per reach kind**, not one over all three, so each keeps the index
that answers it: a token through `idx_tx_correlations_token`, a date range
through `idx_txs_user_broker_time`, an ordinal range through the correlation scan
bounded by account. A single query OR-ing the three predicates would have to pick
one plan for all of them.

**Seeds come from two sources**, because one cannot find what the other can. A
residual worse than `SOURCE_ROUNDING` finds groups something is missing from —
most of what needs repairing, but never a converter's wrong pairing of two
similar trades, which balances and looks settled from outside. A job id finds
what an import just wrote, whatever state its groups are in.

Routed residuals and synthetic-pad groups are excluded from the population: the
first transcribe nothing and are re-routed after the partition, the second are
the declaration machinery's and half a group is not a group.

## Two bugs the integration tests caught

`SELECT DISTINCT` could not `ORDER BY` the column it selected a cast of — and was
unnecessary anyway, since `EXISTS` is a semi-join and cannot duplicate a row.

More interesting: an empty exclusion list arrives as SQL `NULL`, so
`NOT (id = ANY(NULL))` evaluates to `NULL` and the predicate meant to exclude
nothing rejected **everything**. All five reach tests returned zero rows. Now
wrapped in `COALESCE(..., ARRAY[]::text[])`.

## Testing

Six unit tests on the closure (multi-round growth, stopping, terminating against
an echoing store, exclusion, deduplicating identical questions, error
propagation) and seven db integration tests on the read (each reach kind, the
account-scope boundary, the held exclusion, residual filtering, and residual
postings staying out of the population).

`make check`, `make server-test` and `make db-test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
