### PR TITLE
Run the grouping engine in shadow (0097)

### DIFF
--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -287,6 +287,11 @@ service ApiService {
   // correction. A cycle reads every unmatched side rather than a window, so
   // running it more often than needed costs one query and finds nothing new.
   rpc TriggerTransferMatch(TriggerTransferMatchRequest) returns (TriggerTransferMatchResponse);
+  // Trigger a transaction grouping cycle (admin-only). Returns immediately; the
+  // pass runs async. For use by an external cron job or CLI, and after an import.
+  // A cycle derives the partition from stored evidence and reports how it differs
+  // from the one stored; it writes nothing until the converters are retired.
+  rpc TriggerGrouping(TriggerGroupingRequest) returns (TriggerGroupingResponse);
 
   // Corporate event import / export. Mirrors the price import/export RPCs:
   // import is async via the job queue, export streams every event with the
@@ -1162,6 +1167,10 @@ message UpdateCorporateEventPluginResponse {
 message TriggerCorporateEventFetchRequest {}
 
 message TriggerCorporateEventFetchResponse {}
+
+message TriggerGroupingRequest {}
+
+message TriggerGroupingResponse {}
 
 message TriggerTransferMatchRequest {}
 

--- a/server/cmd/portfoliodb/main.go
+++ b/server/cmd/portfoliodb/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/leedenison/portfoliodb/server/db"
 	"github.com/leedenison/portfoliodb/server/db/migrate"
 	"github.com/leedenison/portfoliodb/server/db/postgres"
+	"github.com/leedenison/portfoliodb/server/grouping"
 	"github.com/leedenison/portfoliodb/server/identifier"
 	"github.com/leedenison/portfoliodb/server/identifier/description"
 	"github.com/leedenison/portfoliodb/server/inflationfetcher"
@@ -249,6 +250,7 @@ func main() {
 	priceTrigger := make(chan struct{}, 1)
 	corporateEventTrigger := make(chan struct{}, 1)
 	transferMatchTrigger := make(chan struct{}, 1)
+	groupingTrigger := make(chan struct{}, 1)
 	queue := make(chan *ingestion.JobRequest, 256)
 	workers := worker.NewRegistry()
 	ctx, cancel := context.WithCancel(context.Background())
@@ -264,12 +266,14 @@ func main() {
 		PriceTrigger:          priceTrigger,
 		CorporateEventTrigger: corporateEventTrigger,
 		TransferMatchTrigger:  transferMatchTrigger,
+		GroupingTrigger:       groupingTrigger,
 		Workers:               workers,
 	})
 	go pricefetcher.RunWorker(ctx, database, priceRegistry, counter, logger.WithCategory(serverLogger, "server/pricefetcher"), priceTrigger, workers)
 	go inflationfetcher.RunWorker(ctx, database, inflationRegistry, counter, logger.WithCategory(serverLogger, "server/inflationfetcher"), inflationTrigger, workers)
 	go corporateevents.RunWorker(ctx, database, corporateEventRegistry, counter, logger.WithCategory(serverLogger, "server/corporateevents"), corporateEventTrigger, workers)
 	go transfermatch.RunWorker(ctx, database, counter, logger.WithCategory(serverLogger, "server/transfermatch"), transferMatchTrigger, workers)
+	go grouping.RunWorker(ctx, database, counter, logger.WithCategory(serverLogger, "server/grouping"), groupingTrigger, workers)
 	// Re-enqueue incomplete jobs from a previous run.
 	if pending, err := database.ListPendingJobs(ctx); err == nil {
 		for _, p := range pending {
@@ -327,6 +331,7 @@ func main() {
 		CorporateEventRegistry: corporateEventRegistry,
 		CorporateEventTrigger:  corporateEventTrigger,
 		TransferMatchTrigger:   transferMatchTrigger,
+		GroupingTrigger:        groupingTrigger,
 		WorkerRegistry:         workers,
 		EnqueueJob:             api.JobEnqueuer(enqueueJob),
 	}))

--- a/server/db/postgres/grouping.go
+++ b/server/db/postgres/grouping.go
@@ -3,6 +3,7 @@ package postgres
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/google/uuid"
@@ -43,13 +44,20 @@ const groupingColumns = `
 const transcribedPostings = `
 	FROM txs t
 	JOIN tx_groups g ON g.id = t.group_id
-	WHERE t.user_id = $1
+	WHERE t.user_id = $1::uuid
 	  AND t.account_type = 'USER'
 	  AND NOT EXISTS (
 	    SELECT 1 FROM txs s
 	    WHERE s.group_id = t.group_id AND s.synthetic_purpose IS NOT NULL
 	  )
 `
+
+// anyUsersPostings is transcribedPostings with the user optional, for the seed read:
+// a cycle triggered by an import knows whose data it wrote, and one on a cadence
+// sweeps every user.
+var anyUsersPostings = strings.Replace(transcribedPostings,
+	"WHERE t.user_id = $1::uuid",
+	"WHERE ($1 = '' OR t.user_id = $1::uuid)", 1)
 
 // groupingRow is the scan shape for a posting the engine reads.
 type groupingRow struct {
@@ -86,12 +94,13 @@ func (r groupingRow) toDomain() db.GroupingPosting {
 
 // ListGroupingSeeds implements db.GroupingDB.
 func (p *Postgres) ListGroupingSeeds(ctx context.Context, opts db.GroupingSeedOpts) ([]db.GroupingPosting, error) {
-	userUUID, err := uuid.Parse(opts.UserID)
-	if err != nil {
-		return nil, fmt.Errorf("invalid user id: %w", err)
+	if opts.UserID != "" {
+		if _, err := uuid.Parse(opts.UserID); err != nil {
+			return nil, fmt.Errorf("invalid user id: %w", err)
+		}
 	}
-	args := []interface{}{userUUID}
-	q := "SELECT" + groupingColumns + transcribedPostings
+	args := []interface{}{opts.UserID}
+	q := "SELECT" + groupingColumns + anyUsersPostings
 	if opts.Residual {
 		// The partial index over residual postings answers this directly. Source
 		// rounding is excluded: it is the source disagreeing with itself rather
@@ -112,7 +121,7 @@ func (p *Postgres) ListGroupingSeeds(ctx context.Context, opts db.GroupingSeedOp
 		args = append(args, jobUUID)
 		q += fmt.Sprintf("\n\t\t  AND g.job_id = $%d", len(args))
 	}
-	q += "\n\t\tORDER BY t.id"
+	q += "\n\t\tORDER BY t.user_id, t.id"
 	return p.groupingPostings(ctx, q, args)
 }
 

--- a/server/grouping/shadow.go
+++ b/server/grouping/shadow.go
@@ -1,0 +1,117 @@
+package grouping
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/leedenison/portfoliodb/server/db"
+)
+
+// Divergence is how a derived partition differs from the one already stored.
+//
+// Counted in groups rather than postings, because a partition is a set of sets and
+// the question a shadow run asks is which of them the engine would have drawn
+// differently. A group is Agreed when its membership is exactly a stored group's;
+// anything else is a disagreement, whether the engine joined two stored groups, split
+// one, or moved a single posting between them.
+type Divergence struct {
+	// Groups is how many the engine derived, Stored how many it found.
+	Groups int
+	Stored int
+	// Agreed is the number of derived groups whose membership matches a stored
+	// group exactly.
+	Agreed int
+	// Joined is derived groups holding postings from more than one stored group,
+	// and Split is stored groups whose postings the engine put in more than one.
+	// A regroup is usually both at once, so they overlap and do not sum.
+	Joined int
+	Split  int
+	// Examples names a few disagreements, so a report says which rather than only
+	// how many. Bounded, because a first shadow run over a corpus the engine has
+	// never seen can disagree about everything.
+	Examples []string
+}
+
+// Agrees reports whether the engine drew exactly the partition already stored, which
+// is the bar a shadow run has to clear before anything depends on it.
+func (d Divergence) Agrees() bool {
+	return d.Groups == d.Stored && d.Agreed == d.Groups
+}
+
+// maxExamples bounds what a divergence carries. Enough to see the shape of a
+// disagreement in a log line, few enough that a corpus-wide mismatch does not
+// produce a corpus-sized message.
+const maxExamples = 5
+
+// Compare measures a derived partition against the one the postings already sit in.
+//
+// The stored partition is the converters' answer, which is what makes this the
+// validation 0097 asks for: the engine has to reproduce it before it is allowed to
+// replace it. It is not an oracle, though. The engine may disagree because it is
+// right -- a converter's wrong pairing of two similar trades balances and looks
+// settled -- so a divergence is something to look at rather than a failure to count.
+func Compare(ps []db.GroupingPosting, gs []Group) Divergence {
+	storedOf := make(map[string]string, len(ps))
+	storedSize := map[string]int{}
+	for _, p := range ps {
+		storedOf[p.ID] = p.GroupID
+		storedSize[p.GroupID]++
+	}
+
+	d := Divergence{Groups: len(gs), Stored: len(storedSize)}
+	// Which stored groups each derived group drew from, so a derived group that
+	// joined two is visible, and a stored group drawn into several is too.
+	derivedPerStored := map[string]map[int]bool{}
+	for i, g := range gs {
+		seen := map[string]bool{}
+		for _, m := range g.Members {
+			s := storedOf[m.ID]
+			seen[s] = true
+			if derivedPerStored[s] == nil {
+				derivedPerStored[s] = map[int]bool{}
+			}
+			derivedPerStored[s][i] = true
+		}
+		switch {
+		case len(seen) > 1:
+			d.Joined++
+			d.note(fmt.Sprintf("joined %d stored groups into %s", len(seen), memberList(g)))
+		case len(seen) == 1 && storedSize[only(seen)] == len(g.Members):
+			d.Agreed++
+		default:
+			d.note(fmt.Sprintf("took %s out of a stored group of %d", memberList(g), storedSize[only(seen)]))
+		}
+	}
+	for _, derived := range derivedPerStored {
+		if len(derived) > 1 {
+			d.Split++
+		}
+	}
+	return d
+}
+
+func (d *Divergence) note(s string) {
+	if len(d.Examples) < maxExamples {
+		d.Examples = append(d.Examples, s)
+	}
+}
+
+// only returns the single key of a one-element set.
+func only(m map[string]bool) string {
+	for k := range m {
+		return k
+	}
+	return ""
+}
+
+// memberList names a group by its postings, ordered, so two runs describe the same
+// disagreement the same way.
+func memberList(g Group) string {
+	ids := make([]string, 0, len(g.Members))
+	for _, m := range g.Members {
+		ids = append(ids, m.ID)
+	}
+	sort.Strings(ids)
+	return "[" + strings.Join(ids, " ") + "]"
+}

--- a/server/grouping/shadow_test.go
+++ b/server/grouping/shadow_test.go
@@ -1,0 +1,133 @@
+package grouping
+
+import (
+	"testing"
+
+	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+)
+
+// stored puts a posting in a group, which is what a shadow run measures against.
+func stored(p db.GroupingPosting, groupID string) db.GroupingPosting {
+	p.GroupID = groupID
+	return p
+}
+
+// derived builds a partition by hand, so a test states the two sides separately
+// rather than deriving one from the other.
+func derived(groups ...[]string) []Group {
+	out := make([]Group, 0, len(groups))
+	for _, ids := range groups {
+		g := Group{}
+		for _, id := range ids {
+			g.Members = append(g.Members, Member{ID: id, Resolved: typev1.TxType_TRADE_CASH})
+		}
+		out = append(out, g)
+	}
+	return out
+}
+
+func TestCompare(t *testing.T) {
+	ps := []db.GroupingPosting{
+		stored(posting("a", typev1.TxType_TRADE_ASSET), "g1"),
+		stored(posting("b", typev1.TxType_TRADE_CASH), "g1"),
+		stored(posting("c", typev1.TxType_TRADE_ASSET), "g2"),
+		stored(posting("d", typev1.TxType_TRADE_CASH), "g2"),
+	}
+	tests := []struct {
+		name   string
+		gs     []Group
+		agrees bool
+		agreed int
+		joined int
+		split  int
+	}{
+		{
+			name:   "agrees when the partition is the stored one",
+			gs:     derived([]string{"a", "b"}, []string{"c", "d"}),
+			agrees: true,
+			agreed: 2,
+		},
+		{
+			// The engine drew one group where the converters drew two.
+			name:   "counts a join",
+			gs:     derived([]string{"a", "b", "c", "d"}),
+			joined: 1,
+			split:  0,
+		},
+		{
+			// And the other way: what the converters held together, the engine
+			// left apart. Both stored groups are split.
+			name:  "counts a split",
+			gs:    derived([]string{"a"}, []string{"b"}, []string{"c"}, []string{"d"}),
+			split: 2,
+		},
+		{
+			// A regroup is usually both at once, which is why the two do not sum
+			// to the number of disagreements.
+			name:   "counts a move as both",
+			gs:     derived([]string{"a", "b", "c"}, []string{"d"}),
+			joined: 1,
+			split:  1,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			d := Compare(ps, tc.gs)
+			if d.Agrees() != tc.agrees {
+				t.Fatalf("Agrees() = %v, want %v (%+v)", d.Agrees(), tc.agrees, d)
+			}
+			if d.Agreed != tc.agreed {
+				t.Fatalf("agreed = %d, want %d", d.Agreed, tc.agreed)
+			}
+			if d.Joined != tc.joined {
+				t.Fatalf("joined = %d, want %d", d.Joined, tc.joined)
+			}
+			if d.Split != tc.split {
+				t.Fatalf("split = %d, want %d", d.Split, tc.split)
+			}
+		})
+	}
+}
+
+// A first run over a corpus the engine has never seen can disagree about
+// everything, and a report of that size is not a report.
+func TestCompare_BoundsItsExamples(t *testing.T) {
+	var ps []db.GroupingPosting
+	var groups [][]string
+	for i := range 40 {
+		id := string(rune('a' + i%26))
+		id += string(rune('0' + i/26))
+		ps = append(ps,
+			stored(posting(id+"x", typev1.TxType_TRADE_ASSET), "g"+id),
+			stored(posting(id+"y", typev1.TxType_TRADE_CASH), "g"+id),
+		)
+		// Each derived group takes one leg out of a stored pair, so every one of
+		// them disagrees.
+		groups = append(groups, []string{id + "x"})
+	}
+	d := Compare(ps, derived(groups...))
+	if d.Agrees() {
+		t.Fatal("Agrees() = true, want a disagreement")
+	}
+	if len(d.Examples) != maxExamples {
+		t.Fatalf("examples = %d, want %d", len(d.Examples), maxExamples)
+	}
+}
+
+// The count is of groups rather than postings, so a partition and the stored one are
+// compared as sets of sets.
+func TestCompare_CountsGroupsNotPostings(t *testing.T) {
+	ps := []db.GroupingPosting{
+		stored(posting("a", typev1.TxType_TRADE_ASSET), "g1"),
+		stored(posting("b", typev1.TxType_TRADE_CASH), "g1"),
+		stored(posting("c", typev1.TxType_HOLDING_COST), "g2"),
+	}
+	d := Compare(ps, derived([]string{"a", "b"}, []string{"c"}))
+	if d.Groups != 2 || d.Stored != 2 {
+		t.Fatalf("groups = %d, stored = %d, want 2 and 2", d.Groups, d.Stored)
+	}
+	if !d.Agrees() {
+		t.Fatalf("Agrees() = false, want true (%+v)", d)
+	}
+}

--- a/server/grouping/worker.go
+++ b/server/grouping/worker.go
@@ -1,0 +1,175 @@
+package grouping
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/telemetry"
+	"github.com/leedenison/portfoliodb/server/worker"
+)
+
+const name = "grouping"
+
+// RunWorker derives transaction groups on each signal, and blocks until ctx is
+// cancelled. Rapid signals are debounced by the buffered trigger channel.
+//
+// A job rather than part of ingestion, for the reason transfer matching is: the legs
+// of one event can arrive in separate imports, so the partition is a function of all
+// stored state rather than of one upload's payload. Inline it would also have to fail
+// an otherwise-correct import to report a failure, or swallow one inside a success.
+//
+// Two things signal it, both on the same channel. The TriggerGrouping RPC is what an
+// external cron job or CLI calls, and is how a cycle runs on a cadence -- there is no
+// clock in this process. The ingestion worker fires it after a tx import commits, so
+// legs that have just landed beside older ones are joined without waiting for the
+// next tick.
+func RunWorker(ctx context.Context, database db.DB, counter telemetry.CounterIncrementer, log *slog.Logger, trigger <-chan struct{}, workers *worker.Registry) {
+	if workers != nil {
+		workers.SetIdle(name)
+	}
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case _, ok := <-trigger:
+			if !ok {
+				return
+			}
+			runCycle(ctx, database, counter, log, workers)
+		}
+	}
+}
+
+// runCycle derives the partition of every neighbourhood a seed reaches, and reports
+// how it differs from what is stored.
+//
+// It writes nothing. Until a shadow run reproduces the converters' partition there is
+// nothing to justify replacing it, so this cycle exists to measure the disagreement
+// and 0098 is what turns the answer into the stored one.
+func runCycle(ctx context.Context, database db.DB, counter telemetry.CounterIncrementer, log *slog.Logger, workers *worker.Registry) {
+	if counter != nil {
+		counter.Incr(ctx, "grouping.cycles")
+	}
+	defer func() {
+		if workers != nil {
+			workers.SetIdle(name)
+		}
+	}()
+
+	// Every user, seeded from the groups holding something a missing leg would
+	// explain. An import nudge could seed from its own job instead, which is
+	// narrower; it is not wired that way yet because a shadow cycle wants the
+	// widest view it can get of where the engine and the converters differ.
+	seeds, err := database.ListGroupingSeeds(ctx, db.GroupingSeedOpts{Residual: true})
+	if err != nil {
+		if log != nil {
+			log.ErrorContext(ctx, "grouping: list seeds", "err", err)
+		}
+		return
+	}
+	if len(seeds) == 0 {
+		return
+	}
+	if workers != nil {
+		workers.SetRunning(name, fmt.Sprintf("Grouping from %d postings", len(seeds)))
+	}
+	if counter != nil {
+		counter.IncrBy(ctx, "grouping.seeds", int64(len(seeds)))
+	}
+
+	total := Divergence{}
+	for _, userID := range usersOf(seeds) {
+		d, err := cycleUser(ctx, database, userID, byUser(seeds, userID))
+		if err != nil {
+			if log != nil {
+				log.ErrorContext(ctx, "grouping: derive", "user", userID, "err", err)
+			}
+			continue
+		}
+		total.Groups += d.Groups
+		total.Stored += d.Stored
+		total.Agreed += d.Agreed
+		total.Joined += d.Joined
+		total.Split += d.Split
+		for _, e := range d.Examples {
+			total.note(e)
+		}
+	}
+
+	if counter != nil {
+		counter.IncrBy(ctx, "grouping.groups", int64(total.Groups))
+		counter.IncrBy(ctx, "grouping.agreed", int64(total.Agreed))
+		counter.IncrBy(ctx, "grouping.joined", int64(total.Joined))
+		counter.IncrBy(ctx, "grouping.split", int64(total.Split))
+	}
+	if log != nil {
+		// Logged whether or not anything differs. A cycle that agrees everywhere is
+		// the result 0098 is waiting for, so it is worth being able to see it
+		// happen rather than inferring it from silence.
+		log.InfoContext(ctx, "grouping shadow",
+			"derived", total.Groups, "stored", total.Stored, "agreed", total.Agreed,
+			"joined", total.Joined, "split", total.Split, "examples", total.Examples)
+	}
+}
+
+// cycleUser grows each seed's neighbourhood, partitions it, and measures the result
+// against what is stored.
+//
+// Neighbourhoods are grown one seed at a time and the ones that overlap are answered
+// from the same reads, since a posting already held is never asked for again. A seed
+// swallowed by an earlier neighbourhood costs one round that finds nothing.
+func cycleUser(ctx context.Context, database db.DB, userID string, seeds []db.GroupingPosting) (Divergence, error) {
+	rules := DefaultRules()
+	opts := DefaultOpts()
+	done := map[string]bool{}
+	var total Divergence
+	for _, seed := range seeds {
+		if done[seed.ID] {
+			continue
+		}
+		ps, err := Neighbourhood(ctx, userID, []db.GroupingPosting{seed}, rules, database)
+		if err != nil {
+			return Divergence{}, err
+		}
+		for _, p := range ps {
+			done[p.ID] = true
+		}
+		d := Compare(ps, Partition(ps, rules, opts))
+		total.Groups += d.Groups
+		total.Stored += d.Stored
+		total.Agreed += d.Agreed
+		total.Joined += d.Joined
+		total.Split += d.Split
+		for _, e := range d.Examples {
+			total.note(e)
+		}
+	}
+	return total, nil
+}
+
+// usersOf lists the users the seeds belong to, in the order the read returned them,
+// so a cycle is deterministic.
+func usersOf(seeds []db.GroupingPosting) []string {
+	seen := map[string]bool{}
+	var out []string
+	for _, s := range seeds {
+		if seen[s.UserID] {
+			continue
+		}
+		seen[s.UserID] = true
+		out = append(out, s.UserID)
+	}
+	return out
+}
+
+func byUser(seeds []db.GroupingPosting, userID string) []db.GroupingPosting {
+	var out []db.GroupingPosting
+	for _, s := range seeds {
+		if s.UserID == userID {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/server/grouping/worker_test.go
+++ b/server/grouping/worker_test.go
@@ -1,0 +1,122 @@
+package grouping
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/db/mock"
+	"go.uber.org/mock/gomock"
+)
+
+// seeded puts a posting in a user and a stored group, which is the shape a seed read
+// returns.
+func seeded(p db.GroupingPosting, userID, groupID string) db.GroupingPosting {
+	p.UserID = userID
+	p.GroupID = groupID
+	return p
+}
+
+// TestRunCycle_SeedsFromResidualGroups verifies the cadence cycle starts from the
+// groups holding something a missing leg would explain, rather than from everything.
+func TestRunCycle_SeedsFromResidualGroups(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockDB := mock.NewMockDB(ctrl)
+
+	mockDB.EXPECT().ListGroupingSeeds(gomock.Any(), db.GroupingSeedOpts{Residual: true}).
+		Return(nil, nil)
+
+	runCycle(context.Background(), mockDB, nil, nil, nil)
+}
+
+// TestRunCycle_WritesNothing is the property the shadow run rests on: until the engine
+// reproduces the converters' partition there is nothing to justify replacing it, so a
+// cycle reads and reports and leaves the data alone.
+//
+// gomock fails an unexpected call, so naming only the reads is what asserts it.
+func TestRunCycle_WritesNothing(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockDB := mock.NewMockDB(ctrl)
+
+	a := seeded(correlated(posting("a", typev1.TxType_TRADE_ASSET), "", "t1", db.ScopeAccount, db.MatchExact), "u1", "g1")
+	b := seeded(correlated(posting("b", typev1.TxType_TRADE_CASH), "", "t1", db.ScopeAccount, db.MatchExact), "u1", "g1")
+
+	mockDB.EXPECT().ListGroupingSeeds(gomock.Any(), gomock.Any()).
+		Return([]db.GroupingPosting{a}, nil)
+	mockDB.EXPECT().PostingsByToken(gomock.Any(), "u1", gomock.Any(), gomock.Any()).
+		Return([]db.GroupingPosting{b}, nil).AnyTimes()
+	mockDB.EXPECT().PostingsByDates(gomock.Any(), "u1", gomock.Any(), gomock.Any()).
+		Return(nil, nil).AnyTimes()
+	mockDB.EXPECT().PostingsByOrdinals(gomock.Any(), "u1", gomock.Any(), gomock.Any()).
+		Return(nil, nil).AnyTimes()
+
+	runCycle(context.Background(), mockDB, nil, nil, nil)
+}
+
+// TestRunCycle_PartitionsEachUsersOwnData verifies a neighbourhood never crosses a
+// user. The reads take a user id, and a cycle that mixed two would ask one user's
+// questions of another's data.
+func TestRunCycle_PartitionsEachUsersOwnData(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockDB := mock.NewMockDB(ctrl)
+
+	one := seeded(posting("a", typev1.TxType_TRADE_ASSET), "u1", "g1")
+	two := seeded(posting("b", typev1.TxType_TRADE_ASSET), "u2", "g2")
+	one.SettlementAmount, two.SettlementAmount = decp("100"), decp("100")
+
+	mockDB.EXPECT().ListGroupingSeeds(gomock.Any(), gomock.Any()).
+		Return([]db.GroupingPosting{one, two}, nil)
+	seen := map[string]bool{}
+	mockDB.EXPECT().PostingsByDates(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, userID string, _ []db.DateQuery, _ []string) ([]db.GroupingPosting, error) {
+			seen[userID] = true
+			return nil, nil
+		}).AnyTimes()
+	mockDB.EXPECT().PostingsByToken(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, nil).AnyTimes()
+	mockDB.EXPECT().PostingsByOrdinals(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, nil).AnyTimes()
+
+	runCycle(context.Background(), mockDB, nil, nil, nil)
+
+	if !seen["u1"] || !seen["u2"] {
+		t.Fatalf("read for users %v, want both u1 and u2", seen)
+	}
+}
+
+// TestRunCycle_SurvivesAReadError verifies a failure ends the cycle rather than the
+// process. The next trigger runs it again.
+func TestRunCycle_SurvivesAReadError(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockDB := mock.NewMockDB(ctrl)
+
+	mockDB.EXPECT().ListGroupingSeeds(gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("read failed"))
+
+	runCycle(context.Background(), mockDB, nil, nil, nil)
+}
+
+// TestRunCycle_SurvivesOneUsersFailure verifies a neighbourhood that cannot be read
+// costs that user's result rather than the whole cycle.
+func TestRunCycle_SurvivesOneUsersFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockDB := mock.NewMockDB(ctrl)
+
+	one := seeded(posting("a", typev1.TxType_TRADE_ASSET), "u1", "g1")
+	two := seeded(posting("b", typev1.TxType_TRADE_ASSET), "u2", "g2")
+
+	mockDB.EXPECT().ListGroupingSeeds(gomock.Any(), gomock.Any()).
+		Return([]db.GroupingPosting{one, two}, nil)
+	mockDB.EXPECT().PostingsByToken(gomock.Any(), "u1", gomock.Any(), gomock.Any()).
+		Return(nil, errors.New("read failed")).AnyTimes()
+	mockDB.EXPECT().PostingsByToken(gomock.Any(), "u2", gomock.Any(), gomock.Any()).
+		Return(nil, nil).AnyTimes()
+	mockDB.EXPECT().PostingsByDates(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, nil).AnyTimes()
+	mockDB.EXPECT().PostingsByOrdinals(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil, nil).AnyTimes()
+
+	runCycle(context.Background(), mockDB, nil, nil, nil)
+}

--- a/server/service/api/residual_balances.go
+++ b/server/service/api/residual_balances.go
@@ -118,3 +118,27 @@ func (s *Server) TriggerTransferMatch(ctx context.Context, req *apiv1.TriggerTra
 	}
 	return &apiv1.TriggerTransferMatchResponse{}, nil
 }
+
+// TriggerGrouping signals the grouping engine to run a cycle. Admin only. Returns
+// immediately; the pass runs asynchronously.
+//
+// The same shape as TriggerTransferMatch and for the same reasons: an external cron
+// job or CLI calls this, the ingestion worker fires the same channel after a tx
+// import, and the channel is buffered to one so a burst of either collapses into a
+// single pass.
+//
+// A cycle currently derives the partition and reports how it differs from the one
+// stored, without writing. So calling it is cheap in the strongest sense -- there is
+// nothing it can leave behind.
+func (s *Server) TriggerGrouping(ctx context.Context, req *apiv1.TriggerGroupingRequest) (*apiv1.TriggerGroupingResponse, error) {
+	if _, authErr := auth.RequireAdmin(ctx); authErr != nil {
+		return nil, authErr
+	}
+	if s.groupingTrigger != nil {
+		select {
+		case s.groupingTrigger <- struct{}{}:
+		default:
+		}
+	}
+	return &apiv1.TriggerGroupingResponse{}, nil
+}

--- a/server/service/api/residual_balances_test.go
+++ b/server/service/api/residual_balances_test.go
@@ -289,3 +289,54 @@ func TestTriggerTransferMatch_NilTrigger(t *testing.T) {
 		t.Fatalf("TriggerTransferMatch with nil trigger should succeed: %v", err)
 	}
 }
+
+func TestTriggerGrouping_RequiresAdmin(t *testing.T) {
+	srv, _ := newAPIServerWithMock(t)
+	ctx := authCtx("user-1", "sub|user")
+	_, err := srv.TriggerGrouping(ctx, &apiv1.TriggerGroupingRequest{})
+	testutil.RequireGRPCCode(t, err, codes.PermissionDenied)
+}
+
+func TestTriggerGrouping_Success(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(func() { ctrl.Finish() })
+	mockDB := mock.NewMockDB(ctrl)
+	trigger := make(chan struct{}, 1)
+	srv := NewServer(ServerConfig{DB: mockDB, GroupingTrigger: trigger})
+
+	ctx := adminCtx("admin-1", "sub|admin")
+	if _, err := srv.TriggerGrouping(ctx, &apiv1.TriggerGroupingRequest{}); err != nil {
+		t.Fatalf("TriggerGrouping: %v", err)
+	}
+	select {
+	case <-trigger:
+	default:
+		t.Error("expected a signal on the trigger channel")
+	}
+}
+
+// TestTriggerGrouping_NonBlocking verifies a cron job calling this while a pass is
+// already pending returns rather than waiting, as the other trigger endpoints do.
+func TestTriggerGrouping_NonBlocking(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(func() { ctrl.Finish() })
+	mockDB := mock.NewMockDB(ctrl)
+	trigger := make(chan struct{}, 1)
+	trigger <- struct{}{}
+	srv := NewServer(ServerConfig{DB: mockDB, GroupingTrigger: trigger})
+
+	ctx := adminCtx("admin-1", "sub|admin")
+	if _, err := srv.TriggerGrouping(ctx, &apiv1.TriggerGroupingRequest{}); err != nil {
+		t.Fatalf("TriggerGrouping should not block: %v", err)
+	}
+}
+
+// TestTriggerGrouping_NilTrigger verifies the RPC is a no-op rather than an error
+// where no worker is wired.
+func TestTriggerGrouping_NilTrigger(t *testing.T) {
+	srv, _ := newAPIServerWithMock(t)
+	ctx := adminCtx("admin-1", "sub|admin")
+	if _, err := srv.TriggerGrouping(ctx, &apiv1.TriggerGroupingRequest{}); err != nil {
+		t.Fatalf("TriggerGrouping with nil trigger should succeed: %v", err)
+	}
+}

--- a/server/service/api/server.go
+++ b/server/service/api/server.go
@@ -32,6 +32,7 @@ type Server struct {
 	corporateEventRegistry *corporateevents.Registry
 	corporateEventTrigger  chan<- struct{}
 	transferMatchTrigger   chan<- struct{}
+	groupingTrigger        chan<- struct{}
 	workerRegistry         *worker.Registry
 	enqueueJob             JobEnqueuer
 }
@@ -50,6 +51,7 @@ type ServerConfig struct {
 	CorporateEventRegistry *corporateevents.Registry  // optional; enables display_name in corporate event plugin list
 	CorporateEventTrigger  chan<- struct{}            // optional; when set, TriggerCorporateEventFetch sends on it
 	TransferMatchTrigger   chan<- struct{}            // optional; when set, TriggerTransferMatch sends on it
+	GroupingTrigger        chan<- struct{}            // optional; when set, TriggerGrouping sends on it
 	WorkerRegistry         *worker.Registry           // optional; when set, ListWorkers returns worker status
 	EnqueueJob             JobEnqueuer                // optional; when set, ImportPrices enqueues async jobs
 }
@@ -69,6 +71,7 @@ func NewServer(cfg ServerConfig) *Server {
 		corporateEventRegistry: cfg.CorporateEventRegistry,
 		corporateEventTrigger:  cfg.CorporateEventTrigger,
 		transferMatchTrigger:   cfg.TransferMatchTrigger,
+		groupingTrigger:        cfg.GroupingTrigger,
 		workerRegistry:         cfg.WorkerRegistry,
 		enqueueJob:             cfg.EnqueueJob,
 	}

--- a/server/service/ingestion/worker.go
+++ b/server/service/ingestion/worker.go
@@ -55,6 +55,10 @@ type WorkerOptions struct {
 	// TransferMatchTrigger is fired after a tx import that produced new state;
 	// nil disables transfer-matcher nudging.
 	TransferMatchTrigger chan<- struct{}
+	// GroupingTrigger is fired alongside it, for the same reason: an import can
+	// have supplied a leg that belongs with one stored months ago. nil disables
+	// grouping nudging.
+	GroupingTrigger chan<- struct{}
 	// Workers is the per-process worker status registry shown in the admin
 	// UI; nil disables status reporting.
 	Workers *worker.Registry
@@ -111,6 +115,7 @@ func processJob(ctx context.Context, opts WorkerOptions, j *JobRequest) {
 			// import may also have supplied the second side of a transfer
 			// whose first side arrived months ago.
 			pluginutil.Trigger(opts.TransferMatchTrigger)
+			pluginutil.Trigger(opts.GroupingTrigger)
 		}
 	case db.JobTypeSystemArchive:
 		res := processSystemImport(ctx, opts.DB, opts.IdentifierRegistry, j)
@@ -144,6 +149,7 @@ func processJob(ctx context.Context, opts WorkerOptions, j *JobRequest) {
 				log.Printf("user archive job %s: recalc INITIALIZE txs: %v", j.JobID, err)
 			}
 			pluginutil.Trigger(opts.TransferMatchTrigger)
+			pluginutil.Trigger(opts.GroupingTrigger)
 		}
 		if res.displayCurrencySet || res.txsStored {
 			pluginutil.Trigger(opts.PriceTrigger)


### PR DESCRIPTION
**Stacked on #405.** The worker, the comparison it reports, and the RPC that
starts it. This completes the engine's plumbing; #405 supplied the region it
works over.

## It writes nothing

That is the point rather than an omission. Until the engine reproduces the
converters' partition there is nothing to justify replacing it, so a cycle
derives, measures and leaves the data alone. 0098 is what turns the answer into
the stored one.

`TestRunCycle_WritesNothing` asserts it structurally: gomock fails an unexpected
call, so naming only the reads is the assertion.

## The comparison

`Compare` measures a derived partition against the one the postings already sit
in, counted **in groups rather than postings**, because a partition is a set of
sets and the question a shadow run asks is which of them the engine would have
drawn differently. It separates a join (the engine drew one group where the
converters drew two) from a split (the reverse), and notes that a regroup is
usually both at once, so the two overlap and do not sum.

Examples are bounded at five. A first run over a corpus the engine has never seen
can disagree about everything, and a report of that size is not a report.

**The stored partition is not an oracle**, and the doc comment says so. The
engine may disagree because it is *right* — a converter's wrong pairing of two
similar trades balances with only a `SOURCE_ROUNDING` residual and looks settled
from outside — so a divergence is something to look at rather than a failure to
count. Zero divergences stays the bar to start from because anything else is
unfalsifiable.

## The worker

`server/transfermatch/worker.go`'s shape throughout: a buffered trigger, a cycle
that reads and reports, every collaborator nil-tolerant so `runCycle` is testable
with mocks and nothing else.

Seeds come from the residual-bearing groups across **every** user, and each
user's neighbourhoods are grown and partitioned separately — the reads take a
user id, and a cycle that mixed two would ask one user's questions of another's
data. There's a test for that specifically. Overlapping neighbourhoods cost one
round that finds nothing, since a posting already held is never asked for again.

`TriggerGrouping` is what a cron job or CLI calls, and the ingestion worker fires
the same channel after a tx import — for the reason transfer matching does: an
import can have supplied a leg belonging with one stored months ago.

One db change: the seed read takes an optional user so a cadence cycle can sweep
every one, which is the pattern `unmatchedTransferSidesSQL` already uses.

## Testing

Four table cases on `Compare` (agreement, join, split, a move counted as both)
plus example bounding and the group-not-posting count; five worker tests via
gomock; four on the RPC handler.

`make check`, `make server-test` and `make db-test` pass.

Next, and last: applying the diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
