### PR TITLE
Validate the engine against the sample exports (0097)

### DIFF
--- a/client/lib/csv/converters/shadow-extract.test.ts
+++ b/client/lib/csv/converters/shadow-extract.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Converts the sample Fidelity exports and dumps what the grouping engine reads,
+ * so the Go side can be run in shadow against them.
+ *
+ * Not a test: it asserts nothing and writes files. It is here because vitest is the
+ * only thing that can run the converters, and it is opt-in so an ordinary run does
+ * neither. See server/grouping/shadow_masters_test.go for what consumes the dump.
+ *
+ *   SHADOW_EXTRACT=1 make client-test
+ */
+import { describe, it } from "vitest";
+import { readFileSync, writeFileSync, mkdirSync, existsSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import { AccountType, Match, Scope } from "@/gen/type/v1/type_pb";
+import { convertFidelityToStandard } from "./fidelity-csv";
+
+const ROOT = resolve(process.cwd(), "..");
+const MASTERS = resolve(ROOT, "local/masters");
+const OUT = resolve(ROOT, "local/shadow");
+
+/**
+ * Whatever Fidelity exports are sitting in local/masters, found rather than named:
+ * an export is named after whoever it belongs to, and no such name goes in the
+ * repository.
+ */
+const sources = () =>
+  readdirSync(MASTERS).filter((f) => /fidelity.*\.csv$/i.test(f));
+
+/** The currency these exports are denominated in; the converter requires one. */
+const CURRENCY = "GBP";
+
+const scopeName = (s: number) => Scope[s] ?? "";
+const matchName = (m: number) => Match[m] ?? "";
+
+describe("shadow extract", () => {
+  it.skipIf(!process.env.SHADOW_EXTRACT)("dumps the postings the engine reads", () => {
+    if (!existsSync(MASTERS)) {
+      console.log("no local/masters; nothing to extract");
+      return;
+    }
+    mkdirSync(OUT, { recursive: true });
+    for (const file of sources()) {
+      const path = resolve(MASTERS, file);
+      const result = convertFidelityToStandard(readFileSync(path, "utf8"), {
+        currency: CURRENCY,
+      });
+      const rows = result.postings.map((p, i) => ({
+        id: `p${i}`,
+        account: p.account,
+        timestamp: p.timestamp ? new Date(Number(p.timestamp.seconds) * 1000).toISOString() : "",
+        quantity: p.quantity,
+        unit_price: p.unitPrice,
+        settlement_amount: p.settlementAmount,
+        broker_tx_type: p.brokerTxType.map((t) => t),
+        account_type: p.accountType,
+        is_user: p.accountType === AccountType.UNSPECIFIED || p.accountType === AccountType.USER,
+        group_ref: p.groupRef ?? "",
+        correlations: p.correlations.map((c) => ({
+          label: c.label,
+          token: c.token,
+          ordinal: c.ordinal === undefined ? null : Number(c.ordinal),
+          ordinal_span: c.ordinalSpan === undefined ? null : Number(c.ordinalSpan),
+          scope: scopeName(c.scope),
+          match: c.match.map(matchName),
+        })),
+      }));
+      const out = resolve(OUT, file.replace(/\.csv$/, ".json"));
+      writeFileSync(out, JSON.stringify(rows, null, 1));
+      console.log(
+        `${file}: ${rows.length} postings, ${rows.filter((r) => r.is_user).length} transcribed, ` +
+          `${new Set(rows.filter((r) => r.group_ref).map((r) => r.group_ref)).size} named groups, ` +
+          `${result.errors.length} errors -> ${out}`
+      );
+    }
+  });
+});

--- a/server/grouping/shadow_masters_test.go
+++ b/server/grouping/shadow_masters_test.go
@@ -1,0 +1,187 @@
+//go:build shadow
+
+// Package-level shadow run against the sample exports.
+//
+// Build-tagged because the exports it reads are gitignored: they are real broker
+// data and belong in local/ rather than in the repository. Run it with
+//
+//	go test -tags shadow ./server/grouping/ -run TestShadow -v
+//
+// after the extraction harness has written local/shadow/*.json.
+package grouping
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/txtype"
+	"github.com/shopspring/decimal"
+)
+
+type shadowCorrelation struct {
+	Label       string   `json:"label"`
+	Token       string   `json:"token"`
+	Ordinal     *int64   `json:"ordinal"`
+	OrdinalSpan *int64   `json:"ordinal_span"`
+	Scope       string   `json:"scope"`
+	Match       []string `json:"match"`
+}
+
+type shadowPosting struct {
+	ID               string              `json:"id"`
+	Account          string              `json:"account"`
+	Timestamp        string              `json:"timestamp"`
+	Quantity         string              `json:"quantity"`
+	UnitPrice        *string             `json:"unit_price"`
+	SettlementAmount *string             `json:"settlement_amount"`
+	BrokerTxType     []int               `json:"broker_tx_type"`
+	IsUser           bool                `json:"is_user"`
+	GroupRef         string              `json:"group_ref"`
+	Correlations     []shadowCorrelation `json:"correlations"`
+}
+
+// toDomain converts one extracted posting into what the engine reads.
+//
+// group_ref becomes the stored group, which is what makes this a shadow run: the
+// converters' partition is the thing being reproduced. A posting the converter left
+// unnamed is its own group, as it would be once stored.
+func (p shadowPosting) toDomain(i int) db.GroupingPosting {
+	ts, _ := time.Parse(time.RFC3339, p.Timestamp)
+	declared := make([]typev1.TxType, 0, len(p.BrokerTxType))
+	for _, t := range p.BrokerTxType {
+		declared = append(declared, typev1.TxType(t))
+	}
+	group := p.GroupRef
+	if group == "" {
+		group = fmt.Sprintf("solo-%d", i)
+	}
+	out := db.GroupingPosting{
+		ID:        p.ID,
+		UserID:    "shadow",
+		Broker:    typev1.Broker_FIDELITY,
+		Account:   p.Account,
+		Timestamp: ts,
+		Quantity:  decimal.RequireFromString(p.Quantity),
+		Declared:  declared,
+		JobID:     "shadow-job",
+		GroupID:   group,
+	}
+	if p.UnitPrice != nil {
+		d := decimal.RequireFromString(*p.UnitPrice)
+		out.UnitPrice = &d
+	}
+	if p.SettlementAmount != nil {
+		d := decimal.RequireFromString(*p.SettlementAmount)
+		out.SettlementAmount = &d
+	}
+	for _, c := range p.Correlations {
+		out.Correlations = append(out.Correlations, db.Correlation{
+			Label:       c.Label,
+			Token:       c.Token,
+			Ordinal:     c.Ordinal,
+			OrdinalSpan: c.OrdinalSpan,
+			Scope:       c.Scope,
+			Match:       c.Match,
+		})
+	}
+	return out
+}
+
+func TestShadowAgainstMasters(t *testing.T) {
+	dir := filepath.Join("..", "..", "local", "shadow")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Skipf("no %s: run the extraction harness first", dir)
+	}
+	for _, e := range entries {
+		if filepath.Ext(e.Name()) != ".json" {
+			continue
+		}
+		t.Run(e.Name(), func(t *testing.T) {
+			raw, err := os.ReadFile(filepath.Join(dir, e.Name()))
+			if err != nil {
+				t.Fatalf("read: %v", err)
+			}
+			var rows []shadowPosting
+			if err := json.Unmarshal(raw, &rows); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			// Only the transcribed postings are partitioned. A derived counter-leg
+			// and a routed residual carry no evidence and are re-derived after.
+			var ps []db.GroupingPosting
+			for i, r := range rows {
+				if !r.IsUser {
+					continue
+				}
+				ps = append(ps, r.toDomain(i))
+			}
+
+			gs := Partition(ps, DefaultRules(), DefaultOpts())
+			d := Compare(ps, gs)
+			t.Logf("postings=%d derived=%d stored=%d agreed=%d joined=%d split=%d",
+				len(ps), d.Groups, d.Stored, d.Agreed, d.Joined, d.Split)
+			t.Logf("  %s", breakdown(ps, gs))
+			for _, ex := range d.Examples {
+				t.Logf("  %s", ex)
+			}
+			if !d.Agrees() {
+				t.Errorf("engine did not reproduce the converter's partition")
+			}
+		})
+	}
+}
+
+// breakdown counts which kind of event the engine decided each multi-posting group
+// is, so the run can be checked against the counts the converter's rules are pinned
+// to: sells 91/91, buys 78/78, and 21 deposit runs across both masters.
+func breakdown(ps []db.GroupingPosting, gs []Group) string {
+	byID := map[string]db.GroupingPosting{}
+	for _, p := range ps {
+		byID[p.ID] = p
+	}
+	var sells, buys, runs, cash, reinvest, other int
+	for _, g := range gs {
+		if len(g.Members) < 2 {
+			continue
+		}
+		var transfer, asset, sold, income bool
+		cashLegs := 0
+		for _, m := range g.Members {
+			switch {
+			case m.Resolved == typev1.TxType_TRANSFER:
+				transfer = true
+			case m.Resolved == typev1.TxType_TRADE_ASSET:
+				asset = true
+				sold = byID[m.ID].Quantity.IsNegative()
+			case m.Resolved == typev1.TxType_TRADE_CASH:
+				cashLegs++
+			case txtype.ResolvedMustBe(m.Resolved, typev1.TxType_INCOME):
+				income = true
+			}
+		}
+		switch {
+		case transfer:
+			runs++
+		case asset && income:
+			// A reinvestment is a compressed two-event group -- the units bought
+			// plus the dividend that paid for them -- rather than a purchase.
+			reinvest++
+		case asset && sold:
+			sells++
+		case asset:
+			buys++
+		case cashLegs == 2:
+			cash++
+		default:
+			other++
+		}
+	}
+	return fmt.Sprintf("groups>1: security sells=%d buys=%d cash-for-cash=%d deposit runs=%d reinvestments=%d other=%d",
+		sells, buys, cash, runs, reinvest, other)
+}


### PR DESCRIPTION
**Stacked on #406.** The acceptance test 0097 asks for, and its result.

## It reproduces the converters exactly

Both Fidelity exports, no divergences:

| export | transcribed postings | derived groups | stored | agreed | joined | split |
|---|---|---|---|---|---|---|
| A | 739 | 617 | 617 | **617** | 0 | 0 |
| B | 674 | 574 | 574 | **574** | 0 | 0 |

That is the bar 0098 was waiting on.

## Why it is two halves

The converters are TypeScript and the engine is Go. An opt-in vitest harness
converts whatever Fidelity exports are in `local/masters` and dumps what the
engine reads; a build-tagged Go test partitions the dump and compares against the
`group_ref` the converter assigned.

Both are inert without `local/` — the exports are real broker data and gitignored
— and **neither names a file**, since an export is named after whoever it belongs
to. The extractor globs; the Go side reads whatever JSON it finds.

```
SHADOW_EXTRACT=1 <compose> run --rm -e SHADOW_EXTRACT=1 client npm run test:run
go test -tags shadow ./server/grouping/ -run TestShadow -v
```

## The result is not vacuous

Worth checking, since a passing comparison could mean the engine is reading back
the answer it is being measured against.

Run with **only** the exact-token rule, every posting lands in its own group and
109 and 92 stored groups split — so the trade and deposit rules are doing all the
work. That same run shows the exact-token rule claiming *nothing* on this data:
no two Fidelity rows share a reference number, because the group is named for the
trade row's reference while each posting correlates on its own. So the highest-
precedence rule cannot be trivially reproducing `group_ref` here.

## Reconciling the pinned counts

**Deposit runs reconcile exactly.** The two exports hold 24 `Cash In Lump Sum`
rows and the engine builds 21 runs. The other three are the standalone lump sums
the converter's own comment describes ("the sample has three, all into a cash
management account"). 24 − 3 = 21, the pinned figure.

**The sell and buy figures do not, and the raw data says why.** The exports now
hold 92 buy-family and 88 sell-family rows, against comments in `fidelity-csv.ts`
claiming 78 buys and 91 sells. Those were measured by hand at some earlier point
and have drifted from the files as they stand. The engine pairs 91 of the 92 buy
rows, and the converter pairs the same 91 — they agree posting for posting.

So this is a stale comment rather than an engine discrepancy: the partition
matching exactly is the criterion, and it does. Re-measuring the per-pass tallies
in `fidelity-csv.ts` is worth doing separately, and I have not touched them here.

## Not covered

Only Fidelity. The IBKR OFX exports are not in the dump, and OFX grouping is
transcribed rather than inferred, so the exact-token rule would carry it — worth
running before 0098 flips the switch, but it exercises a different rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
