### PR TITLE
Write the groups the engine derives (0097)

### DIFF
--- a/server/cmd/portfoliodb/main.go
+++ b/server/cmd/portfoliodb/main.go
@@ -70,6 +70,11 @@ var buildRevision = "dev"
 
 func main() {
 	grpcAddr := flag.String("grpc-addr", envOrDefault("PORTFOLIODB_GRPC_ADDR", ":50051"), "gRPC listen address")
+	// Off until a shadow run over a corpus has been looked at: the cycle derives the
+	// partition either way, and this decides whether it writes what it derived.
+	// 0098 is what turns it on for good.
+	applyGrouping := flag.Bool("apply-grouping", os.Getenv("PORTFOLIODB_APPLY_GROUPING") == "1",
+		"write the transaction groups the engine derives, rather than only reporting how they differ")
 	dbURL := flag.String("db-url", os.Getenv("PORTFOLIODB_DB_URL"), "PostgreSQL connection URL")
 	redisURL := flag.String("redis-url", envOrDefault("PORTFOLIODB_REDIS_URL", os.Getenv("REDIS_URL")), "Redis connection URL for sessions")
 	flag.Parse()
@@ -273,7 +278,7 @@ func main() {
 	go inflationfetcher.RunWorker(ctx, database, inflationRegistry, counter, logger.WithCategory(serverLogger, "server/inflationfetcher"), inflationTrigger, workers)
 	go corporateevents.RunWorker(ctx, database, corporateEventRegistry, counter, logger.WithCategory(serverLogger, "server/corporateevents"), corporateEventTrigger, workers)
 	go transfermatch.RunWorker(ctx, database, counter, logger.WithCategory(serverLogger, "server/transfermatch"), transferMatchTrigger, workers)
-	go grouping.RunWorker(ctx, database, counter, logger.WithCategory(serverLogger, "server/grouping"), groupingTrigger, workers)
+	go grouping.RunWorker(ctx, database, counter, logger.WithCategory(serverLogger, "server/grouping"), groupingTrigger, workers, *applyGrouping)
 	// Re-enqueue incomplete jobs from a previous run.
 	if pending, err := database.ListPendingJobs(ctx); err == nil {
 		for _, p := range pending {

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -1736,6 +1736,32 @@ type GroupingReader interface {
 	PostingsByOrdinals(ctx context.Context, userID string, qs []OrdinalQuery, held []string) ([]GroupingPosting, error)
 }
 
+// GroupChange is one group the engine drew that the stored partition does not have,
+// and what it concluded about each of its members.
+//
+// Only disagreements are carried. A group whose membership is already stored produces
+// no change at all, which is what keeps its id -- and the transfer matches keyed on
+// that id -- through a cycle that repartitioned nothing.
+type GroupChange struct {
+	Members []GroupMemberChange
+}
+
+// GroupMemberChange is one posting of a changed group.
+//
+// Moving separates the two things a regroup does to a posting. A member that is
+// moving joins the new group; one that is not is already where the engine wants it
+// and is only being retyped, because the resolved value is derived from the partition
+// and can change while the membership does not.
+type GroupMemberChange struct {
+	ID string
+	// FromGroupID is the group the posting is leaving, so its residuals can be
+	// routed again. Empty for a member that is not moving.
+	FromGroupID string
+	// Resolved is the stored spelling of what the claiming rule concluded.
+	Resolved string
+	Moving   bool
+}
+
 // GroupingDB is everything a grouping cycle reads.
 //
 // Reads only. The partition is computed in memory and written by a separate call, so
@@ -1746,6 +1772,11 @@ type GroupingDB interface {
 	// ListGroupingSeeds returns the transcribed postings a cycle starts from,
 	// ordered by id so a cycle is deterministic.
 	ListGroupingSeeds(ctx context.Context, opts GroupingSeedOpts) ([]GroupingPosting, error)
+	// ApplyGrouping writes the groups the engine drew that are not already stored,
+	// re-routing the residuals of every group it touched, and returns how many
+	// postings moved. All in one transaction: the deferred balance constraint is
+	// what lets a group be observed unbalanced between the move and the routing.
+	ApplyGrouping(ctx context.Context, userID string, changes []GroupChange) (int, error)
 }
 
 // GroupingPosting is one transcribed posting as the grouping engine reads it: the
@@ -1785,8 +1816,10 @@ type GroupingPosting struct {
 	// JobID is the ingestion job that wrote the posting, and is what a SCOPE_FILE
 	// correlation is comparable within.
 	JobID string
-	// GroupID is the partition as it stands. The engine reads it only to compare
-	// its own answer against it, never as evidence.
+	// GroupID is the partition as it stands, and Resolved what the last cycle
+	// concluded about this posting. The engine reads both only to tell its own
+	// answer from what is there, never as evidence.
 	GroupID      string
+	Resolved     string
 	Correlations []Correlation
 }

--- a/server/db/postgres/grouping.go
+++ b/server/db/postgres/grouping.go
@@ -31,7 +31,8 @@ const groupingColumns = `
 	t.settlement_amount,
 	t.broker_tx_type,
 	COALESCE(g.job_id::text, '') AS job_id,
-	t.group_id::text AS group_id
+	t.group_id::text AS group_id,
+	t.resolved_tx_type
 `
 
 // transcribedPostings is the population a partition is over.
@@ -73,6 +74,7 @@ type groupingRow struct {
 	BrokerTxTypes    pq.StringArray   `db:"broker_tx_type"`
 	JobID            string           `db:"job_id"`
 	GroupID          string           `db:"group_id"`
+	Resolved         string           `db:"resolved_tx_type"`
 }
 
 func (r groupingRow) toDomain() db.GroupingPosting {
@@ -89,6 +91,7 @@ func (r groupingRow) toDomain() db.GroupingPosting {
 		Declared:         db.StrsToTxTypes(r.BrokerTxTypes),
 		JobID:            r.JobID,
 		GroupID:          r.GroupID,
+		Resolved:         r.Resolved,
 	}
 }
 

--- a/server/db/postgres/grouping_apply.go
+++ b/server/db/postgres/grouping_apply.go
@@ -1,0 +1,142 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/lib/pq"
+
+	"github.com/leedenison/portfoliodb/server/db"
+)
+
+// newGroupSQL creates the group a regrouped posting moves into. It takes the
+// timestamp of the earliest posting joining it, as an ingested group takes the
+// timestamp of its first leg, and no job: a group the engine drew was not written by
+// an upload.
+const newGroupSQL = `
+	INSERT INTO tx_groups (user_id, timestamp)
+	SELECT $1::uuid, MIN(t.timestamp)
+	FROM txs t WHERE t.id = ANY($2::uuid[])
+	RETURNING id
+`
+
+// moveGroupSQL reassigns a posting and settles what the claiming rule resolved it
+// to. The two travel together because the rule that claims a row is what resolves it,
+// so a partition written without the resolution would leave a group whose residual is
+// classified against types nothing derived.
+const moveGroupSQL = `
+	UPDATE txs SET group_id = $1::uuid, resolved_tx_type = $2
+	WHERE id = ANY($3::uuid[])
+`
+
+// resolveOnlySQL settles a posting the engine typed differently without moving it,
+// for a group whose membership it agreed with.
+const resolveOnlySQL = `
+	UPDATE txs SET resolved_tx_type = $1 WHERE id = ANY($2::uuid[])
+`
+
+// dropResidualsSQL removes the routed counterparties of the groups a regroup
+// touched, so they can be routed fresh against the membership that now holds.
+//
+// A residual carries no evidence of its own, so it cannot be repartitioned; it is
+// arithmetic on the legs of the group it sits in, and once those move it is
+// arithmetic on nothing.
+const dropResidualsSQL = `
+	DELETE FROM txs
+	WHERE group_id = ANY($1::uuid[])
+	  AND account_type IN (` + residualAccountTypes + `)
+`
+
+// ApplyGrouping implements db.GroupingDB.
+//
+// One transaction, because check_tx_group_balance() is DEFERRABLE INITIALLY DEFERRED
+// and its update trigger fires on group_id changing. Every intermediate state here is
+// unbalanced -- a posting moved out of a group leaves it short until the residual is
+// routed again -- and the deferral is what makes that expressible at all. Leaving the
+// re-routing to a later statement would expose a moment where the constraint fires on
+// data that was valid before the regroup began.
+//
+// It writes only what it disagrees with. A group whose membership the engine drew
+// exactly as stored produces no statement, keeps its id, and keeps the transfer
+// matches keyed on that id. That is what stops a cycle over a neighbourhood far wider
+// than an upload from churning ids for postings nobody touched. See
+// docs/adr/0047-grouping-runs-as-precedence-ordered-passes.md.
+func (p *Postgres) ApplyGrouping(ctx context.Context, userID string, changes []db.GroupChange) (int, error) {
+	userUUID, err := uuid.Parse(userID)
+	if err != nil {
+		return 0, fmt.Errorf("invalid user id: %w", err)
+	}
+	if len(changes) == 0 {
+		return 0, nil
+	}
+	moved := 0
+	err = p.runInTx(ctx, func(exec queryable) error {
+		touched := map[string]bool{}
+		for _, c := range changes {
+			for _, m := range c.Members {
+				if m.FromGroupID != "" {
+					touched[m.FromGroupID] = true
+				}
+			}
+		}
+
+		for _, c := range changes {
+			var move []string
+			var moveType string
+			byType := map[string][]string{}
+			for _, m := range c.Members {
+				if m.Moving {
+					move = append(move, m.ID)
+					moveType = m.Resolved
+					continue
+				}
+				byType[m.Resolved] = append(byType[m.Resolved], m.ID)
+			}
+			// A posting the engine agreed about but retyped is settled where it
+			// stands. The type is derived from the partition, so it can change
+			// while the membership does not.
+			for resolved, ids := range byType {
+				if _, err := exec.ExecContext(ctx, resolveOnlySQL, resolved, pq.Array(ids)); err != nil {
+					return fmt.Errorf("resolve postings: %w", err)
+				}
+			}
+			if len(move) == 0 {
+				continue
+			}
+			var groupID uuid.UUID
+			if err := exec.QueryRowContext(ctx, newGroupSQL, userUUID, pq.Array(move)).Scan(&groupID); err != nil {
+				return fmt.Errorf("create group: %w", err)
+			}
+			if _, err := exec.ExecContext(ctx, moveGroupSQL, groupID, moveType, pq.Array(move)); err != nil {
+				return fmt.Errorf("move postings: %w", err)
+			}
+			touched[groupID.String()] = true
+			moved += len(move)
+		}
+
+		ids := make([]string, 0, len(touched))
+		for id := range touched {
+			ids = append(ids, id)
+		}
+		if _, err := exec.ExecContext(ctx, dropResidualsSQL, pq.Array(ids)); err != nil {
+			return fmt.Errorf("drop residuals: %w", err)
+		}
+		// A group the regroup emptied goes with its residuals, and one that kept
+		// something is re-dated to what it has left, exactly as a period replace
+		// leaves them.
+		if _, err := exec.ExecContext(ctx, deleteEmptiedGroupsSQL, pq.Array(ids)); err != nil {
+			return fmt.Errorf("delete emptied groups: %w", err)
+		}
+		if _, err := exec.ExecContext(ctx, repointGroupTimestampsSQL, pq.Array(ids)); err != nil {
+			return fmt.Errorf("repoint group timestamps: %w", err)
+		}
+		// The matches naming a group whose membership moved are cache, and the
+		// matcher rebuilds them from the same evidence on its next cycle.
+		if _, err := exec.ExecContext(ctx, deleteTouchedMatchesSQL, pq.Array(ids)); err != nil {
+			return fmt.Errorf("delete touched matches: %w", err)
+		}
+		return routeSurvivors(ctx, exec, userUUID, pq.Array(ids))
+	})
+	return moved, err
+}

--- a/server/db/postgres/grouping_apply_test.go
+++ b/server/db/postgres/grouping_apply_test.go
@@ -1,0 +1,183 @@
+package postgres
+
+import (
+	"testing"
+	"time"
+
+	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+)
+
+// groupsOf reads back which group each posting sits in, and what it resolved to.
+func groupsOf(t *testing.T, f *groupingFixture) map[string]string {
+	t.Helper()
+	rows, err := f.p.q.QueryContext(f.ctx,
+		`SELECT id::text, group_id::text FROM txs WHERE user_id = $1::uuid AND account_type = 'USER'`,
+		f.userID)
+	if err != nil {
+		t.Fatalf("read groups: %v", err)
+	}
+	defer rows.Close()
+	out := map[string]string{}
+	for rows.Next() {
+		var id, group string
+		if err := rows.Scan(&id, &group); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		out[id] = group
+	}
+	return out
+}
+
+func residualsOf(t *testing.T, f *groupingFixture) int {
+	t.Helper()
+	var n int
+	err := f.p.q.QueryRowContext(f.ctx,
+		`SELECT count(*) FROM txs WHERE user_id = $1::uuid AND account_type IN (`+residualAccountTypes+`)`,
+		f.userID).Scan(&n)
+	if err != nil {
+		t.Fatalf("count residuals: %v", err)
+	}
+	return n
+}
+
+// Two transfers stored as separate groups, each balanced by its own clearing leg --
+// the shape a converter leaves when it cannot see two legs together. Joining them is
+// the repair the engine exists to make.
+func TestApplyGrouping_JoinsTwoStoredGroups(t *testing.T) {
+	f := newGroupingFixture(t, "apply-join")
+	ts := time.Date(2024, 3, 1, 10, 0, 0, 0, time.UTC)
+	f.writeWithResidual(t, "A1", ts, "500", []typev1.TxType{typev1.TxType_TRANSFER},
+		typev1.AccountType_ACCOUNT_TYPE_TRANSFER_CLEARING)
+	f.writeWithResidual(t, "A1", ts, "-500", []typev1.TxType{typev1.TxType_TRANSFER},
+		typev1.AccountType_ACCOUNT_TYPE_TRANSFER_CLEARING)
+
+	before := groupsOf(t, f)
+	if len(before) != 2 {
+		t.Fatalf("stored %d transcribed postings, want 2", len(before))
+	}
+	var ids []string
+	var changes []db.GroupMemberChange
+	for id, group := range before {
+		ids = append(ids, id)
+		changes = append(changes, db.GroupMemberChange{
+			ID: id, FromGroupID: group, Resolved: "TRANSFER", Moving: true,
+		})
+	}
+
+	moved, err := f.p.ApplyGrouping(f.ctx, f.userID, []db.GroupChange{{Members: changes}})
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if moved != 2 {
+		t.Fatalf("moved %d postings, want 2", moved)
+	}
+
+	after := groupsOf(t, f)
+	if after[ids[0]] != after[ids[1]] {
+		t.Fatalf("postings are in %s and %s, want one group", after[ids[0]], after[ids[1]])
+	}
+	if after[ids[0]] == before[ids[0]] {
+		t.Fatal("the joined group kept a stored id, want a new one")
+	}
+	// The two legs cancel, so the joined group needs no residual at all -- which is
+	// the point of joining them. Both old ones are gone.
+	if n := residualsOf(t, f); n != 0 {
+		t.Fatalf("%d residuals left, want none: the joined group balances", n)
+	}
+}
+
+// The regroup and the re-routing commit together. Every state in between is
+// unbalanced -- a posting moved out leaves its group short until the residual is
+// routed again -- and the deferred constraint is what makes that expressible. If the
+// transaction were split, this would fail at the first COMMIT.
+func TestApplyGrouping_LeavesEveryGroupBalanced(t *testing.T) {
+	f := newGroupingFixture(t, "apply-balance")
+	ts := time.Date(2024, 3, 1, 10, 0, 0, 0, time.UTC)
+	f.writeWithResidual(t, "A1", ts, "500", []typev1.TxType{typev1.TxType_TRANSFER},
+		typev1.AccountType_ACCOUNT_TYPE_TRANSFER_CLEARING)
+	f.writeWithResidual(t, "A1", ts, "-300", []typev1.TxType{typev1.TxType_TRANSFER},
+		typev1.AccountType_ACCOUNT_TYPE_TRANSFER_CLEARING)
+
+	before := groupsOf(t, f)
+	var changes []db.GroupMemberChange
+	for id, group := range before {
+		changes = append(changes, db.GroupMemberChange{
+			ID: id, FromGroupID: group, Resolved: "TRANSFER", Moving: true,
+		})
+	}
+	if _, err := f.p.ApplyGrouping(f.ctx, f.userID, []db.GroupChange{{Members: changes}}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	// 500 and -300 leave 200 over, so the joined group carries exactly one routed
+	// counterparty rather than the two it started with.
+	if n := residualsOf(t, f); n != 1 {
+		t.Fatalf("%d residuals, want 1 for what the joined legs leave over", n)
+	}
+	// Draining forces the deferred triggers to fire now. testDBTx rolls back and
+	// never commits, so without this the constraint would never be evaluated and
+	// the test would prove nothing about balance at all.
+	if err := drainBalanceChecks(t, f.p); err != nil {
+		t.Fatalf("balance check after regroup: %v", err)
+	}
+}
+
+// A retype settles a posting where it stands, because the resolved value is derived
+// from the partition and can change while the membership does not.
+func TestApplyGrouping_RetypesWithoutMoving(t *testing.T) {
+	f := newGroupingFixture(t, "apply-retype")
+	ts := time.Date(2024, 3, 1, 10, 0, 0, 0, time.UTC)
+	f.writeWithResidual(t, "A1", ts, "500", []typev1.TxType{typev1.TxType_TRADE_CASH, typev1.TxType_TRANSFER},
+		typev1.AccountType_ACCOUNT_TYPE_TRANSFER_CLEARING)
+
+	before := groupsOf(t, f)
+	var id string
+	for k := range before {
+		id = k
+	}
+	if _, err := f.p.ApplyGrouping(f.ctx, f.userID, []db.GroupChange{{
+		Members: []db.GroupMemberChange{{ID: id, Resolved: "TRANSFER"}},
+	}}); err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+
+	after := groupsOf(t, f)
+	if after[id] != before[id] {
+		t.Fatalf("posting moved to %s, want it left in %s", after[id], before[id])
+	}
+	var resolved string
+	if err := f.p.q.QueryRowContext(f.ctx, `SELECT resolved_tx_type FROM txs WHERE id = $1::uuid`, id).Scan(&resolved); err != nil {
+		t.Fatalf("read resolved: %v", err)
+	}
+	if resolved != "TRANSFER" {
+		t.Fatalf("resolved = %q, want TRANSFER", resolved)
+	}
+}
+
+// Nothing to change is not an empty transaction, it is no transaction: a cycle that
+// agrees everywhere touches nothing at all.
+func TestApplyGrouping_NoChangesWritesNothing(t *testing.T) {
+	f := newGroupingFixture(t, "apply-none")
+	ts := time.Date(2024, 3, 1, 10, 0, 0, 0, time.UTC)
+	f.writeWithResidual(t, "A1", ts, "500", []typev1.TxType{typev1.TxType_TRANSFER},
+		typev1.AccountType_ACCOUNT_TYPE_TRANSFER_CLEARING)
+
+	before := groupsOf(t, f)
+	moved, err := f.p.ApplyGrouping(f.ctx, f.userID, nil)
+	if err != nil {
+		t.Fatalf("apply: %v", err)
+	}
+	if moved != 0 {
+		t.Fatalf("moved %d postings, want 0", moved)
+	}
+	after := groupsOf(t, f)
+	for id, group := range before {
+		if after[id] != group {
+			t.Fatalf("posting %s moved from %s to %s", id, group, after[id])
+		}
+	}
+	if n := residualsOf(t, f); n != 1 {
+		t.Fatalf("%d residuals, want the original 1 untouched", n)
+	}
+}

--- a/server/db/postgres/grouping_test.go
+++ b/server/db/postgres/grouping_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/shopspring/decimal"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
@@ -71,7 +72,7 @@ func (f *groupingFixture) writeWithResidual(t *testing.T, account string, ts tim
 		InstrumentDescription: "GRP",
 		BrokerTxType:          declared,
 		ResolvedTxType:        declared[0],
-		Quantity:              "-" + qty,
+		Quantity:              decimal.RequireFromString(qty).Neg().String(),
 		Account:               account,
 		AccountType:           residual,
 	}

--- a/server/grouping/diff.go
+++ b/server/grouping/diff.go
@@ -1,0 +1,99 @@
+package grouping
+
+import (
+	"sort"
+
+	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+)
+
+// Diff is what the engine would change about the partition already stored.
+//
+// A derived group whose membership is exactly a stored group's produces nothing,
+// however the two were arrived at. That is the whole of what keeps a cycle from
+// churning ids: the engine runs over a neighbourhood far wider than any upload, and
+// most of what it sees it agrees with.
+//
+// Where it does agree about membership it may still disagree about type, because the
+// resolved value is derived from the partition and a rule settles it when it claims.
+// Those are carried as members that are not moving, so the group keeps its id and its
+// postings are retyped where they stand.
+func Diff(ps []db.GroupingPosting, gs []Group) []db.GroupChange {
+	stored := map[string][]string{}
+	storedOf := map[string]string{}
+	resolvedOfStored := map[string]string{}
+	for _, p := range ps {
+		stored[p.GroupID] = append(stored[p.GroupID], p.ID)
+		storedOf[p.ID] = p.GroupID
+		resolvedOfStored[p.ID] = p.Resolved
+	}
+	for _, ids := range stored {
+		sort.Strings(ids)
+	}
+
+	var out []db.GroupChange
+	for _, g := range gs {
+		ids := make([]string, 0, len(g.Members))
+		for _, m := range g.Members {
+			ids = append(ids, m.ID)
+		}
+		sort.Strings(ids)
+
+		if same(stored[storedOf[ids[0]]], ids) {
+			// Membership agrees. Anything left is a retype, and a group with none
+			// of those is not a change at all.
+			var c db.GroupChange
+			for _, m := range g.Members {
+				if resolvedOfStored[m.ID] == resolvedStr(m.Resolved) {
+					continue
+				}
+				c.Members = append(c.Members, db.GroupMemberChange{
+					ID:       m.ID,
+					Resolved: resolvedStr(m.Resolved),
+				})
+			}
+			if len(c.Members) > 0 {
+				out = append(out, c)
+			}
+			continue
+		}
+
+		c := db.GroupChange{}
+		for _, m := range g.Members {
+			c.Members = append(c.Members, db.GroupMemberChange{
+				ID:          m.ID,
+				FromGroupID: storedOf[m.ID],
+				Resolved:    resolvedStr(m.Resolved),
+				Moving:      true,
+			})
+		}
+		sort.Slice(c.Members, func(i, j int) bool { return c.Members[i].ID < c.Members[j].ID })
+		out = append(out, c)
+	}
+	return out
+}
+
+// same reports whether two sorted id lists hold the same postings.
+func same(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// resolvedStr is the stored spelling of a resolved type, empty where the vocabulary
+// does not know it. Empty never equals a stored value, so an unknown type reads as a
+// change and is written -- which fails loudly at the column CHECK rather than quietly
+// leaving a posting typed as something it is not.
+func resolvedStr(t typev1.TxType) string {
+	v, err := db.TxTypeToStr(t)
+	if err != nil {
+		return ""
+	}
+	return v
+}

--- a/server/grouping/diff_test.go
+++ b/server/grouping/diff_test.go
@@ -1,0 +1,114 @@
+package grouping
+
+import (
+	"testing"
+
+	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+)
+
+// resolved records what a previous cycle concluded about a posting, which is what a
+// retype is measured against.
+func resolvedAs(p db.GroupingPosting, t typev1.TxType) db.GroupingPosting {
+	p.Resolved = resolvedStr(t)
+	return p
+}
+
+// The property the whole design rests on: a group the engine drew exactly as stored
+// produces no statement at all, so it keeps its id and the transfer matches keyed on
+// it. Without this a cycle over a neighbourhood far wider than an upload would churn
+// ids for postings nobody touched.
+func TestDiff_WritesNothingWhereItAgrees(t *testing.T) {
+	ps := []db.GroupingPosting{
+		resolvedAs(stored(posting("a", typev1.TxType_TRADE_ASSET), "g1"), typev1.TxType_TRADE_ASSET),
+		resolvedAs(stored(posting("b", typev1.TxType_TRADE_CASH), "g1"), typev1.TxType_TRADE_CASH),
+		resolvedAs(stored(posting("c", typev1.TxType_HOLDING_COST), "g2"), typev1.TxType_HOLDING_COST),
+	}
+	gs := []Group{
+		{Members: []Member{
+			{ID: "a", Resolved: typev1.TxType_TRADE_ASSET},
+			{ID: "b", Resolved: typev1.TxType_TRADE_CASH},
+		}},
+		{Members: []Member{{ID: "c", Resolved: typev1.TxType_HOLDING_COST}}},
+	}
+	if got := Diff(ps, gs); len(got) != 0 {
+		t.Fatalf("diff = %+v, want nothing", got)
+	}
+}
+
+// A group the engine drew differently moves whole, and every member carries the group
+// it is leaving so that group's residuals can be routed again.
+func TestDiff_MovesAGroupItDrewDifferently(t *testing.T) {
+	ps := []db.GroupingPosting{
+		resolvedAs(stored(posting("a", typev1.TxType_TRADE_ASSET), "g1"), typev1.TxType_AMBIGUOUS),
+		resolvedAs(stored(posting("b", typev1.TxType_TRADE_CASH), "g2"), typev1.TxType_AMBIGUOUS),
+	}
+	gs := []Group{{Members: []Member{
+		{ID: "a", Resolved: typev1.TxType_TRADE_ASSET},
+		{ID: "b", Resolved: typev1.TxType_TRADE_CASH},
+	}}}
+
+	got := Diff(ps, gs)
+	if len(got) != 1 || len(got[0].Members) != 2 {
+		t.Fatalf("diff = %+v, want one change of two members", got)
+	}
+	for _, m := range got[0].Members {
+		if !m.Moving {
+			t.Fatalf("member %s is not moving, want the whole group to move", m.ID)
+		}
+	}
+	if got[0].Members[0].FromGroupID != "g1" || got[0].Members[1].FromGroupID != "g2" {
+		t.Fatalf("members leave %q and %q, want g1 and g2",
+			got[0].Members[0].FromGroupID, got[0].Members[1].FromGroupID)
+	}
+}
+
+// The resolved value is derived from the partition, so it can change while the
+// membership does not -- a Cash In that stays where it is but is settled as a
+// trade's cash leg rather than staying ambiguous. That is a retype in place, and the
+// group keeps its id.
+func TestDiff_RetypesWithoutMoving(t *testing.T) {
+	ps := []db.GroupingPosting{
+		resolvedAs(stored(posting("a", typev1.TxType_TRADE_ASSET), "g1"), typev1.TxType_TRADE_ASSET),
+		resolvedAs(stored(posting("b", typev1.TxType_TRADE_CASH, typev1.TxType_TRANSFER), "g1"), typev1.TxType_AMBIGUOUS),
+	}
+	gs := []Group{{Members: []Member{
+		{ID: "a", Resolved: typev1.TxType_TRADE_ASSET},
+		{ID: "b", Resolved: typev1.TxType_TRADE_CASH},
+	}}}
+
+	got := Diff(ps, gs)
+	if len(got) != 1 {
+		t.Fatalf("diff = %+v, want one change", got)
+	}
+	if len(got[0].Members) != 1 || got[0].Members[0].ID != "b" {
+		t.Fatalf("change names %+v, want only the retyped posting", got[0].Members)
+	}
+	if got[0].Members[0].Moving {
+		t.Fatal("retyped posting is moving, want it settled where it stands")
+	}
+	if got[0].Members[0].Resolved != "TRADE_CASH" {
+		t.Fatalf("resolved = %q, want TRADE_CASH", got[0].Members[0].Resolved)
+	}
+}
+
+// A group the engine split writes both halves, since neither membership is the one
+// stored.
+func TestDiff_SplitsWriteBothHalves(t *testing.T) {
+	ps := []db.GroupingPosting{
+		resolvedAs(stored(posting("a", typev1.TxType_TRADE_ASSET), "g1"), typev1.TxType_TRADE_ASSET),
+		resolvedAs(stored(posting("b", typev1.TxType_TRADE_CASH), "g1"), typev1.TxType_TRADE_CASH),
+		resolvedAs(stored(posting("c", typev1.TxType_HOLDING_COST), "g1"), typev1.TxType_HOLDING_COST),
+	}
+	gs := []Group{
+		{Members: []Member{
+			{ID: "a", Resolved: typev1.TxType_TRADE_ASSET},
+			{ID: "b", Resolved: typev1.TxType_TRADE_CASH},
+		}},
+		{Members: []Member{{ID: "c", Resolved: typev1.TxType_HOLDING_COST}}},
+	}
+	got := Diff(ps, gs)
+	if len(got) != 2 {
+		t.Fatalf("diff = %+v, want both halves written", got)
+	}
+}

--- a/server/grouping/worker.go
+++ b/server/grouping/worker.go
@@ -25,7 +25,7 @@ const name = "grouping"
 // clock in this process. The ingestion worker fires it after a tx import commits, so
 // legs that have just landed beside older ones are joined without waiting for the
 // next tick.
-func RunWorker(ctx context.Context, database db.DB, counter telemetry.CounterIncrementer, log *slog.Logger, trigger <-chan struct{}, workers *worker.Registry) {
+func RunWorker(ctx context.Context, database db.DB, counter telemetry.CounterIncrementer, log *slog.Logger, trigger <-chan struct{}, workers *worker.Registry, apply bool) {
 	if workers != nil {
 		workers.SetIdle(name)
 	}
@@ -37,18 +37,19 @@ func RunWorker(ctx context.Context, database db.DB, counter telemetry.CounterInc
 			if !ok {
 				return
 			}
-			runCycle(ctx, database, counter, log, workers)
+			runCycle(ctx, database, counter, log, workers, apply)
 		}
 	}
 }
 
-// runCycle derives the partition of every neighbourhood a seed reaches, and reports
-// how it differs from what is stored.
+// runCycle derives the partition of every neighbourhood a seed reaches, reports how
+// it differs from what is stored, and writes the difference where asked to.
 //
-// It writes nothing. Until a shadow run reproduces the converters' partition there is
-// nothing to justify replacing it, so this cycle exists to measure the disagreement
-// and 0098 is what turns the answer into the stored one.
-func runCycle(ctx context.Context, database db.DB, counter telemetry.CounterIncrementer, log *slog.Logger, workers *worker.Registry) {
+// apply is off by default and 0098 is what turns it on, once a shadow run over a
+// corpus has been looked at. Off, the cycle is a measurement and can leave nothing
+// behind; on, it writes only what it disagrees with, so a cycle that repartitions
+// nothing writes nothing either way.
+func runCycle(ctx context.Context, database db.DB, counter telemetry.CounterIncrementer, log *slog.Logger, workers *worker.Registry, apply bool) {
 	if counter != nil {
 		counter.Incr(ctx, "grouping.cycles")
 	}
@@ -81,7 +82,7 @@ func runCycle(ctx context.Context, database db.DB, counter telemetry.CounterIncr
 
 	total := Divergence{}
 	for _, userID := range usersOf(seeds) {
-		d, err := cycleUser(ctx, database, userID, byUser(seeds, userID))
+		d, err := cycleUser(ctx, database, userID, byUser(seeds, userID), apply)
 		if err != nil {
 			if log != nil {
 				log.ErrorContext(ctx, "grouping: derive", "user", userID, "err", err)
@@ -120,7 +121,7 @@ func runCycle(ctx context.Context, database db.DB, counter telemetry.CounterIncr
 // Neighbourhoods are grown one seed at a time and the ones that overlap are answered
 // from the same reads, since a posting already held is never asked for again. A seed
 // swallowed by an earlier neighbourhood costs one round that finds nothing.
-func cycleUser(ctx context.Context, database db.DB, userID string, seeds []db.GroupingPosting) (Divergence, error) {
+func cycleUser(ctx context.Context, database db.DB, userID string, seeds []db.GroupingPosting, apply bool) (Divergence, error) {
 	rules := DefaultRules()
 	opts := DefaultOpts()
 	done := map[string]bool{}
@@ -136,7 +137,17 @@ func cycleUser(ctx context.Context, database db.DB, userID string, seeds []db.Gr
 		for _, p := range ps {
 			done[p.ID] = true
 		}
-		d := Compare(ps, Partition(ps, rules, opts))
+		gs := Partition(ps, rules, opts)
+		if apply {
+			// Written per neighbourhood rather than per cycle: each is its own
+			// transaction, so a failure costs one region rather than the run, and
+			// the balance constraint is evaluated over a set of groups that were
+			// all decided together.
+			if _, err := database.ApplyGrouping(ctx, userID, Diff(ps, gs)); err != nil {
+				return Divergence{}, err
+			}
+		}
+		d := Compare(ps, gs)
 		total.Groups += d.Groups
 		total.Stored += d.Stored
 		total.Agreed += d.Agreed

--- a/server/grouping/worker_test.go
+++ b/server/grouping/worker_test.go
@@ -28,7 +28,7 @@ func TestRunCycle_SeedsFromResidualGroups(t *testing.T) {
 	mockDB.EXPECT().ListGroupingSeeds(gomock.Any(), db.GroupingSeedOpts{Residual: true}).
 		Return(nil, nil)
 
-	runCycle(context.Background(), mockDB, nil, nil, nil)
+	runCycle(context.Background(), mockDB, nil, nil, nil, false)
 }
 
 // TestRunCycle_WritesNothing is the property the shadow run rests on: until the engine
@@ -52,7 +52,7 @@ func TestRunCycle_WritesNothing(t *testing.T) {
 	mockDB.EXPECT().PostingsByOrdinals(gomock.Any(), "u1", gomock.Any(), gomock.Any()).
 		Return(nil, nil).AnyTimes()
 
-	runCycle(context.Background(), mockDB, nil, nil, nil)
+	runCycle(context.Background(), mockDB, nil, nil, nil, false)
 }
 
 // TestRunCycle_PartitionsEachUsersOwnData verifies a neighbourhood never crosses a
@@ -79,7 +79,7 @@ func TestRunCycle_PartitionsEachUsersOwnData(t *testing.T) {
 	mockDB.EXPECT().PostingsByOrdinals(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil, nil).AnyTimes()
 
-	runCycle(context.Background(), mockDB, nil, nil, nil)
+	runCycle(context.Background(), mockDB, nil, nil, nil, false)
 
 	if !seen["u1"] || !seen["u2"] {
 		t.Fatalf("read for users %v, want both u1 and u2", seen)
@@ -95,7 +95,7 @@ func TestRunCycle_SurvivesAReadError(t *testing.T) {
 	mockDB.EXPECT().ListGroupingSeeds(gomock.Any(), gomock.Any()).
 		Return(nil, errors.New("read failed"))
 
-	runCycle(context.Background(), mockDB, nil, nil, nil)
+	runCycle(context.Background(), mockDB, nil, nil, nil, false)
 }
 
 // TestRunCycle_SurvivesOneUsersFailure verifies a neighbourhood that cannot be read
@@ -118,5 +118,5 @@ func TestRunCycle_SurvivesOneUsersFailure(t *testing.T) {
 	mockDB.EXPECT().PostingsByOrdinals(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil, nil).AnyTimes()
 
-	runCycle(context.Background(), mockDB, nil, nil, nil)
+	runCycle(context.Background(), mockDB, nil, nil, nil, false)
 }


### PR DESCRIPTION
**Stacked on #407.** The last piece: turning a derived partition into stored
state, behind `--apply-grouping` (or `PORTFOLIODB_APPLY_GROUPING=1`) which is off
until a shadow run over a corpus has been looked at. 0098 turns it on for good.

## Writing only the disagreements

`Diff` is what makes it safe to run this over a neighbourhood far wider than any
upload. A derived group whose membership is exactly a stored group's produces
**no statement at all**, so it keeps its id and the transfer matches keyed on that
id. Without it, a cycle triggered by importing one month would churn ids for
postings nobody uploaded — and ADR 0049 leans on that not happening, since it is
what lets a manual transfer match stay keyed on group ids rather than needing a
durable anchor.

It separates the two things a regroup does to a posting:

- **Moving** — the member joins a new group, and carries the group it is leaving
  so that group's residuals can be routed again.
- **Retyped in place** — the member is already where the engine wants it, and only
  its resolved value changed. That happens because the resolved value is derived
  from the partition: a `Cash In` settled as a trade's cash leg rather than
  staying `AMBIGUOUS`, without moving anywhere.

## One transaction, and why it has to be

Every intermediate state is unbalanced: a posting moved out of a group leaves it
short until the residual is routed again. `check_tx_group_balance()` is
`DEFERRABLE INITIALLY DEFERRED` and its update trigger already fires on
`group_id` changing, which is exactly what makes that expressible — splitting the
transaction would fail at the first commit.

`TestApplyGrouping_LeavesEveryGroupBalanced` **drains the deferred triggers**
rather than relying on the rollback. `testDBTx` never commits, so without draining
the constraint would never be evaluated and the test would prove nothing about
balance at all.

Residuals of every touched group are dropped and routed fresh through the same
`routeSurvivors` a period replace uses. A residual carries no evidence of its own,
so it cannot be repartitioned — it is arithmetic on the legs of its group, and
once those move it is arithmetic on nothing.

## Testing

Four unit tests on `Diff` (agreement writes nothing, a join moves whole with both
origins recorded, a retype stays put, a split writes both halves) and four db
integration tests on `ApplyGrouping` (joining two stored groups leaves no residual
at all since the legs cancel; a partial join leaves exactly one; a retype does not
move; no changes touch nothing).

`make check`, `make server-test` and `make db-test` pass, and the shadow run in
#407 still reports zero divergences with this on the branch.

## What this completes

0097 end to end: the evidence (#400), the engine (#402–#404), the region and the
read (#405), the shadow cycle and RPC (#406), the validation (#407), and the
write. What remains for 0098 is flipping the flag, deleting `group_ref` and the
converters' pairing rules, and confirming an archive carrying evidence alone
regroups to the same partition on import.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
