### PR TITLE
Re-measure the Fidelity pairing tallies, and close 0102

### DIFF
--- a/client/lib/csv/converters/fidelity-csv.ts
+++ b/client/lib/csv/converters/fidelity-csv.ts
@@ -353,7 +353,8 @@ function cashLegType(leg: FidelityLeg): string {
  * Fidelity reports the cash side of a trade as a separate row, so the two legs are
  * paired here rather than a cash leg being derived, which would post the money
  * twice. Both rules are measured against the sample exports in local/masters: sells
- * pair 91/91 -- 69 of a security and 22 of cash -- and buys 78/78.
+ * pair 88/88 -- 66 of a security and 22 of cash -- and buys 92/92 -- 91 of a
+ * security and 1 of cash.
  *
  * Which cash row a trade pairs with is cashLegType's to say.
  *

--- a/docs/adr/0047-grouping-runs-as-precedence-ordered-passes.md
+++ b/docs/adr/0047-grouping-runs-as-precedence-ordered-passes.md
@@ -41,7 +41,7 @@ resolved, and the imbalance report would churn on every regroup.
 
 **Claims are irrevocable, so the precedence list is correctness, not tuning.** With
 no backtracking, the ordering decides the partition. The converter's ordering is
-justified against measured data -- 21 deposit runs, sells 91/91, buys 78/78 -- and
+justified against measured data -- 21 deposit runs, sells 88/88, buys 92/92 -- and
 a single server-side ordering has no one broker's data to justify it against, so an
 order that is right for one source may be wrong for the next. Expect pressure
 toward a per-broker precedence list. That is

--- a/docs/issues/0097-server-side-transaction-grouping.md
+++ b/docs/issues/0097-server-side-transaction-grouping.md
@@ -56,7 +56,7 @@ upload window this can be widened freely, because it reads stored data and fetch
 nothing.
 
 **Validation.** The converters are the oracle. Their rules are pinned against the
-sample exports with exact counts -- sells 91/91, buys 78/78, deposit runs 21/21 -- so
+sample exports with exact counts -- sells 88/88, buys 92/92, 21 deposit runs -- so
 the engine can run in shadow over stored postings and be required to reproduce
 `group_ref` exactly before anything depends on it. Do this before 0098 flips the
 switch.

--- a/docs/issues/0102-source-cash-total-on-a-trade-row.md
+++ b/docs/issues/0102-source-cash-total-on-a-trade-row.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Carry the source's own cash total for a trade row
 milestone: M15
 ---

--- a/server/grouping/shadow_masters_test.go
+++ b/server/grouping/shadow_masters_test.go
@@ -139,7 +139,7 @@ func TestShadowAgainstMasters(t *testing.T) {
 
 // breakdown counts which kind of event the engine decided each multi-posting group
 // is, so the run can be checked against the counts the converter's rules are pinned
-// to: sells 91/91, buys 78/78, and 21 deposit runs across both masters.
+// to: sells 88/88, buys 92/92, and 21 deposit runs across both masters.
 func breakdown(ps []db.GroupingPosting, gs []Group) string {
 	byID := map[string]db.GroupingPosting{}
 	for _, p := range ps {


### PR DESCRIPTION
The counts the Fidelity trade passes are pinned to had drifted from the exports
they were measured against. The 0097 shadow run noticed and left them for a
separate pass, since the criterion there is the partition matching exactly rather
than the per-pass tallies.

Re-measured two ways that agree: the engine's own breakdown of the shadow
partition, and the converter's output joined back to the exports by reference
number.

* Sells pair **88/88** -- 66 of a security and 22 of cash -- against a comment
  claiming 91/91 and 69 of a security.
* Buys pair **92/92** -- 91 of a security and 1 of cash -- against 78/78.

The three places quoting those figures -- the shadow test, 0097's acceptance bar
and adr/0047's justification for the precedence order -- say the same thing as
the converter again.

The other measured claims in the converter were checked rather than assumed, and
stand: 21 deposit runs from 24 lump sums, a widest deposit reference span of 7,
and five (account, date) buckets holding both a cash and a security trade with no
equal-amount collision between the two kinds. 0064 keeps its own figures, which
record what the export held when the rules were first written.

0102 closes. `settlement_amount` travels in the archive and on the API, is stored
on `txs`, is rejected on a posting whose quantity is already money, and is
populated by both Fidelity converters and by OFX -- all landed in #400.

Comments and frontmatter only; no behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)