### PR TITLE
Value a matched transfer's in-flight legs (0090)

### DIFF
--- a/docs/adr/0022-typed-per-account-cash-flow-boundary.md
+++ b/docs/adr/0022-typed-per-account-cash-flow-boundary.md
@@ -81,6 +81,18 @@ holding vanish for the days between the two sides of a matched transfer, so
 in-flight value is included in valuation for matched pairs whose accounts are
 both portfolio members, and excluded otherwise.
 
+Valuation has since landed that rule ([0090](../issues/0090-net-and-value-matched-transfers.md)).
+The pairs a portfolio values are `portfolio_in_flight_txs`, a view beside
+`portfolio_matched_txs` because it asks the same question about membership -- of the
+counterpart's own clearing leg, which is the test that reads identically from either
+side of a pair. One consequence is worth stating plainly rather than discovering. This
+ADR rejected portfolio-relative *classification* partly because adding an account to a
+portfolio would move every past return figure; netting was always going to be read at
+query time, and now valuation is too, so a historical value series moves when membership
+changes or when the matcher runs. That is the price of not storing a decision that
+depends on data which has not arrived, and it is the price this ADR already accepted for
+netting.
+
 0020's remaining consequences stand. An INITIALIZE row (see
 [0011](0011-synthetic-initialize-transactions.md)) is a pad with no counterparty
 and needs an `EQUITY` posting to satisfy the invariant, and the invariant is

--- a/docs/spec/postings.md
+++ b/docs/spec/postings.md
@@ -148,9 +148,23 @@ in portfolio value and a fake return blip. Holding value in transit is what a cl
 account is for. So: exclude from holdings display always; include in valuation only for
 matched pairs where both accounts are members. Including an unmatched in-flight balance
 would assert the money is coming back to a member account, which is the thing we do not
-know. Matching now supplies the pairing this rule needs, but nothing reads it yet:
-valuation still reads `USER` only, and netting a matched pair in portfolio cash flows
-is a separate change (0090).
+know.
+
+Valuation reads the pairing through `portfolio_in_flight_txs`, which names the clearing
+legs a portfolio values. Membership is tested against the counterpart's own clearing
+leg rather than against its group, because that leg carries the counterpart account and
+the commodity the match is keyed on, so the test reads the same from either side and a
+pair is admitted whole or not at all. The counterpart is not required to fall inside the
+valuation window: value still in transit when the window closes is value held, and
+asking for its arrival would reinstate the dip the rule exists to remove. Valuing a
+user rather than a portfolio needs no membership test at all, both groups being the
+same user's by construction.
+
+Two things follow. Valuation and holdings disagree while a transfer is in transit, by
+design: the value is in the total and the position is in neither account's holdings.
+And a valuation of a past window moves when the matcher runs, because what nets is read
+at query time rather than stored -- the price of not recording a decision that depends
+on data which has not arrived.
 
 The transaction list is not filtered. It is a ledger view, and hiding the counterparty
 legs would make groups look unbalanced and hide the residuals that make a converter's

--- a/server/db/postgres/transfer_matches_test.go
+++ b/server/db/postgres/transfer_matches_test.go
@@ -13,13 +13,6 @@ import (
 	"time"
 )
 
-// transferFixture stands up the two sides of one transfer hop as ingestion would
-// leave them: a journal posting in each account, each balanced by a
-// TRANSFER_CLEARING counterparty holding the value in transit. It returns the group
-// ids of the departure and the arrival.
-//
-// The rows are the 2025-04-15 lump sum from the Fidelity master, whose references
-// differ by 3.
 // fidelityCorrelations is the evidence a Fidelity export supplies for one row: a
 // reference number, comparable by equality and by distance, and the account the
 // source names as the other side where it names one.
@@ -44,29 +37,68 @@ func fidelityCorrelations(t *testing.T, ref, counterparty string) []*archivev1.C
 	return out
 }
 
+// transferSpec is what varies between the transfers a fixture builds: the commodity
+// the value moves in, the amount leaving the departure account, the two accounts,
+// and the date each side's own statement gave it.
+//
+// The two dates are separate because that is the case the pairing exists for. A
+// broker reports each side on its own statement, and it is the days between them
+// that a matched pair has to hold value over.
+type transferSpec struct {
+	instID   string
+	desc     string
+	qty      string // signed as the departure account sees it, so negative
+	depart   time.Time
+	arrive   time.Time
+	fromAcct string
+	toAcct   string
+}
+
+// fidelityLumpSum is the 2025-04-15 lump sum from the Fidelity master, whose two
+// sides carry references differing by 3. Both sides are dated the same day, which is
+// how the export has them.
+func fidelityLumpSum(instID string) transferSpec {
+	base := time.Date(2025, 4, 15, 0, 0, 0, 0, time.UTC)
+	return transferSpec{
+		instID: instID, desc: "GBP", qty: "-20000",
+		depart: base, arrive: base,
+		fromAcct: "AG10000001", toAcct: "AW10000001",
+	}
+}
+
+// transferFixture stands up the two sides of the Fidelity lump sum.
 func transferFixture(t *testing.T, p *Postgres, userID, instID string) (from, to string) {
 	t.Helper()
+	return transferFixtureAt(t, p, userID, fidelityLumpSum(instID))
+}
+
+// transferFixtureAt stands up the two sides of one transfer hop as ingestion would
+// leave them: a journal posting in each account, each balanced by a
+// TRANSFER_CLEARING counterparty holding the value in transit. It returns the group
+// ids of the departure and the arrival.
+//
+// One replacement period covers both sides, so a caller seeding a position for the
+// transfer to move must date it outside [depart, arrive].
+func transferFixtureAt(t *testing.T, p *Postgres, userID string, s transferSpec) (from, to string) {
+	t.Helper()
 	ctx := context.Background()
-	base := time.Date(2025, 4, 15, 0, 0, 0, 0, time.UTC)
-	period := func() (*timestamppb.Timestamp, *timestamppb.Timestamp) {
-		return timestamppb.New(base), timestamppb.New(base.Add(24 * time.Hour))
-	}
-	side := func(account, qty, ref, counterparty string) []*apiv1.Tx {
+	side := func(account, qty, ref, counterparty string, at time.Time) []*apiv1.Tx {
 		return []*apiv1.Tx{
-			{Timestamp: timestamppb.New(base), InstrumentDescription: "GBP", BrokerTxType: []typev1.TxType{typev1.TxType_TRANSFER}, ResolvedTxType: typev1.TxType_TRANSFER,
+			{Timestamp: timestamppb.New(at), InstrumentDescription: s.desc, BrokerTxType: []typev1.TxType{typev1.TxType_TRANSFER}, ResolvedTxType: typev1.TxType_TRANSFER,
 				Quantity: qty, Account: account, GroupRef: ref,
 				Correlations: fidelityCorrelations(t, ref, counterparty)},
 			// The clearing counterparty, equal and opposite, as routing writes it:
 			// no reference of its own, because it was transcribed from no row.
-			{Timestamp: timestamppb.New(base), InstrumentDescription: "GBP", BrokerTxType: []typev1.TxType{typev1.TxType_TRANSFER}, ResolvedTxType: typev1.TxType_TRANSFER,
+			{Timestamp: timestamppb.New(at), InstrumentDescription: s.desc, BrokerTxType: []typev1.TxType{typev1.TxType_TRANSFER}, ResolvedTxType: typev1.TxType_TRANSFER,
 				Quantity: negate(t, qty), Account: account, GroupRef: ref,
 				AccountType: typev1.AccountType_ACCOUNT_TYPE_TRANSFER_CLEARING},
 		}
 	}
-	f, b := period()
-	txs := append(side("AG10000001", "-20000", "971613411", ""),
-		side("AW10000001", "20000", "971613414", "AG10000001")...)
-	ids := []string{instID, instID, instID, instID}
+	f := timestamppb.New(s.depart)
+	b := timestamppb.New(s.arrive.Add(24 * time.Hour))
+	txs := append(side(s.fromAcct, s.qty, "971613411", "", s.depart),
+		side(s.toAcct, negate(t, s.qty), "971613414", s.fromAcct, s.arrive)...)
+	ids := []string{s.instID, s.instID, s.instID, s.instID}
 	if err := p.ReplaceTxsInPeriod(ctx, userID, "FIDELITY", "", f, b, txs, ids, nil, nil); err != nil {
 		t.Fatalf("replace: %v", err)
 	}

--- a/server/db/postgres/valuation.go
+++ b/server/db/postgres/valuation.go
@@ -11,29 +11,57 @@ import (
 )
 
 // valuationQuery returns the full SQL for portfolio valuation with FX conversion.
-// portfolioFilter is the WHERE clause fragment that scopes transactions:
-//   - Portfolio mode: "INNER JOIN portfolio_matched_txs m ON m.tx_id = t.id AND m.portfolio_id = $1"
-//   - User mode:      "WHERE t.user_id = $1 AND t.timestamp::date < $3"
+// portfolioMode selects the txSource fragment that scopes and filters the postings:
+// a join to portfolio_matched_txs, or a bare user_id predicate.
 //
 // The query uses $1 for the scope ID (portfolio or user), $2/$3 for the
 // half-open [from, before) date range,
 // and $4 for displayCurrency.
 func valuationQuery(portfolioMode bool) string {
 	var txSource string
-	// Only USER postings are valued. Income, charges and residuals are not positions,
-	// and an unmatched TRANSFER_CLEARING balance would assert that money in transit is
-	// coming back to an account we hold, which is the thing we do not know. Matched
-	// pairs whose accounts are both portfolio members are value in transit and belong
-	// in valuation; including them needs the pairing from 0068.
+	// USER postings are valued, and so are the TRANSFER_CLEARING legs of a matched pair
+	// whose other side is in scope. Income, charges and residuals are not positions, and
+	// an unmatched clearing balance is not one either: including it would assert that
+	// money in transit is coming back to an account we hold, which is the thing we do
+	// not know.
+	//
+	// A matched pair holds its value flat rather than needing anything carried over the
+	// days in between. The departure group is a negative leg and a positive clearing
+	// leg, the arrival group the mirror, so admitting both makes each group contribute
+	// exactly zero to daily_qty on its own date and the running position never moves.
+	// It generalises past the two-leg case: a journal charging a fee is USER -q,
+	// EXPENSE +f, TRANSFER_CLEARING +q-f, which nets to -f -- correct, since the fee
+	// really did leave.
+	//
+	// Which pairs a portfolio values is portfolio_in_flight_txs, defined beside
+	// portfolio_matched_txs because it is the same question about membership. The
+	// external flow query reads the same view the other way round, so the two cannot
+	// disagree about what nets.
+	//
+	// Written as an OR with account_type = 'USER' first so the subquery stays a subplan
+	// the scan skips for the USER postings that dominate the table, as
+	// residual_balances.go does for its anti-join.
 	if portfolioMode {
 		txSource = `
     FROM txs t
     INNER JOIN portfolio_matched_txs m ON m.tx_id = t.id AND m.portfolio_id = $1
-    WHERE t.timestamp::date < $3 AND t.account_type = 'USER'`
+    WHERE t.timestamp::date < $3
+      AND (t.account_type = 'USER'
+           OR EXISTS (SELECT 1 FROM portfolio_in_flight_txs f
+                      WHERE f.tx_id = t.id AND f.portfolio_id = $1))`
 	} else {
+		// A match alone is the whole test here. Both groups belong to the same user by
+		// construction -- the matcher partitions its candidates by user before proposing
+		// anything -- and every account of the user is in scope, so there is no
+		// membership left to ask about and no need for the view.
 		txSource = `
     FROM txs t
-    WHERE t.user_id = $1 AND t.timestamp::date < $3 AND t.account_type = 'USER'`
+    WHERE t.user_id = $1 AND t.timestamp::date < $3
+      AND (t.account_type = 'USER'
+           OR (t.account_type = 'TRANSFER_CLEARING' AND EXISTS (
+               SELECT 1 FROM transfer_matches tm
+               WHERE tm.instrument_id = t.instrument_id
+                 AND (tm.from_group_id = t.group_id OR tm.to_group_id = t.group_id))))`
 	}
 
 	return `

--- a/server/db/postgres/valuation_bench_test.go
+++ b/server/db/postgres/valuation_bench_test.go
@@ -42,6 +42,12 @@ type valuationLoad struct {
 	// the bound is present but never load-bearing, since every span runs to the
 	// end of the window anyway.
 	delistedEvery int
+
+	// Matched transfers spread across the window, each in transit for five days.
+	// With none, the clearing branch of the posting filter matches nothing and
+	// portfolio_in_flight_txs is never probed for a row it can return, so the
+	// figure reports only the cost of asking.
+	matchedTransfers int
 }
 
 // foreignCurrencies are cycled across the instruments valuationLoad marks as
@@ -62,7 +68,7 @@ const preWindow = 30 * db.Day
 // weekday bars, which is the shape the valuation query is slowest on: a wide
 // date grid over a hypertable with a gap at every weekend. It returns the user
 // and the half-open valuation window.
-func seedValuationLoad(t testing.TB, p *Postgres, load valuationLoad) (string, time.Time, time.Time) {
+func seedValuationLoad(t testing.TB, p *Postgres, load valuationLoad) (userID, portfolioID string, from, before time.Time) {
 	t.Helper()
 	ctx := context.Background()
 
@@ -71,8 +77,8 @@ func seedValuationLoad(t testing.TB, p *Postgres, load valuationLoad) (string, t
 		t.Fatalf("create user: %v", err)
 	}
 
-	from := d(2020, 1, 1)
-	before := from.AddDate(load.years, 0, 0)
+	from = d(2020, 1, 1)
+	before = from.AddDate(load.years, 0, 0)
 	histFrom := from.Add(-preWindow)
 	// The opening position predates the bar history, so every day of the window
 	// has a holding to value rather than opening on a closed position.
@@ -153,6 +159,22 @@ func seedValuationLoad(t testing.TB, p *Postgres, load valuationLoad) (string, t
 		seedWeekdayBars(t, p, inst.id, histFrom, barsBefore, decf(100))
 	}
 
+	seedMatchedTransfers(t, p, userID, load.matchedTransfers, from, before)
+
+	// One broker filter, so the portfolio is the whole load: the portfolio-mode
+	// query differs from the user-mode one in the filter view it joins and in
+	// probing portfolio_in_flight_txs, and holding the data constant is what
+	// leaves those two as the only difference between the timings.
+	port, err := p.CreatePortfolio(ctx, userID, "Bench")
+	if err != nil {
+		t.Fatalf("create portfolio: %v", err)
+	}
+	if err := p.SetPortfolioFilters(ctx, port.Id, []db.PortfolioFilter{
+		{FilterType: "broker", FilterValue: "BENCH"},
+	}); err != nil {
+		t.Fatalf("set portfolio filters: %v", err)
+	}
+
 	// Everything above was written inside the test's transaction, which rolls
 	// back, so autovacuum never sees any of it and the planner would otherwise
 	// cost the query against a database it believes to be empty. That is not a
@@ -166,10 +188,63 @@ func seedValuationLoad(t testing.TB, p *Postgres, load valuationLoad) (string, t
 	// statistics are real but describe the table as it was before the import.
 	// See 0103.
 	if _, err := p.q.ExecContext(ctx,
-		`ANALYZE txs, tx_groups, eod_prices, price_coverage, instruments, instrument_identifiers`); err != nil {
+		`ANALYZE txs, tx_groups, transfer_matches, eod_prices, price_coverage, instruments, instrument_identifiers`); err != nil {
 		t.Fatalf("analyze: %v", err)
 	}
-	return userID, from, before
+	return userID, port.Id, from, before
+}
+
+// seedMatchedTransfers writes n matched cash transfers, each moving money out of
+// one account and into another five days later, spread evenly across the window.
+//
+// Written as raw postings rather than through ingestion because the replacement
+// period above already owns the whole window, and because the group ids are needed
+// to write the links and a RETURNING is the cheapest way to have them. Each pair is
+// balanced in its own right, so the group invariant holds as it would in production.
+func seedMatchedTransfers(t testing.TB, p *Postgres, userID string, n int, from, before time.Time) {
+	t.Helper()
+	if n == 0 {
+		return
+	}
+	ctx := context.Background()
+	cashID, err := p.FindInstrumentByIdentifier(ctx, "CURRENCY", "", "USD")
+	if err != nil || cashID == "" {
+		t.Fatalf("USD cash instrument not found: %v", err)
+	}
+	// A group and its two legs: the account's own and the clearing counterparty
+	// that holds the value in transit, equal and opposite.
+	side := func(account string, at time.Time, qty string) string {
+		var groupID string
+		if err := p.q.QueryRowContext(ctx, `
+			INSERT INTO tx_groups (user_id, timestamp) VALUES ($1::uuid, $2::timestamptz)
+			RETURNING id`, userID, at).Scan(&groupID); err != nil {
+			t.Fatalf("create transfer group: %v", err)
+		}
+		if _, err := p.q.ExecContext(ctx, `
+			INSERT INTO txs (user_id, broker, account, timestamp, instrument_description,
+				instrument_id, broker_tx_type, resolved_tx_type, quantity, account_type,
+				group_id, weight, weight_commodity, share_count_basis, split_adjusted_quantity)
+			SELECT $1::uuid, 'BENCH', $2, $3::timestamptz, 'USD CASH', $4::uuid,
+				ARRAY['TRANSFER'], 'TRANSFER', q, at, $5::uuid, q, 'cur:USD',
+				$3::timestamptz::date, q
+			FROM (VALUES ($6::numeric, 'USER'), (-$6::numeric, 'TRANSFER_CLEARING')) v(q, at)
+		`, userID, account, at, cashID, groupID, qty); err != nil {
+			t.Fatalf("insert transfer legs: %v", err)
+		}
+		return groupID
+	}
+	span := before.Sub(from)
+	for i := range n {
+		depart := from.Add(span * time.Duration(i) / time.Duration(n))
+		fromGroup := side(fmt.Sprintf("xfer-out-%03d", i), depart, "-1000")
+		toGroup := side(fmt.Sprintf("xfer-in-%03d", i), depart.Add(5*db.Day), "1000")
+		if _, err := p.q.ExecContext(ctx, `
+			INSERT INTO transfer_matches (user_id, from_group_id, to_group_id, instrument_id, method)
+			VALUES ($1::uuid, $2::uuid, $3::uuid, $4::uuid, 'REFERENCE')
+		`, userID, fromGroup, toGroup, cashID); err != nil {
+			t.Fatalf("insert transfer match: %v", err)
+		}
+	}
 }
 
 // seedWeekdayBars writes one bar per weekday over [from, before) and declares
@@ -246,51 +321,80 @@ func TestValuationQueryPerformance(t *testing.T) {
 		txsPerInstrument: 20,
 		foreignEvery:     5,
 		delistedEvery:    10,
+		matchedTransfers: 20,
 	}
 	seedStart := time.Now()
-	userID, from, before := seedValuationLoad(t, p, load)
+	userID, portfolioID, from, before := seedValuationLoad(t, p, load)
 	days := int(before.Sub(from) / db.Day)
 	t.Logf("seeded %d instruments x %d years (%d txs each, 1 in %d foreign, 1 in %d delisted) in %s",
 		load.instruments, load.years, load.txsPerInstrument, load.foreignEvery, load.delistedEvery,
 		time.Since(seedStart).Round(time.Millisecond))
 
-	for _, display := range []string{"USD", "GBP"} {
-		// Warm caches, then time.
-		if _, err := p.GetUserValuation(ctx, userID, from, before, display); err != nil {
-			t.Fatalf("warmup %s: %v", display, err)
-		}
-		const runs = 5
-		var total time.Duration
-		for range runs {
-			start := time.Now()
-			points, err := p.GetUserValuation(ctx, userID, from, before, display)
-			if err != nil {
-				t.Fatalf("valuation %s: %v", display, err)
+	// Both scopes, because they are different queries: user mode asks only whether
+	// a match names the group, while portfolio mode joins the filter view and probes
+	// portfolio_in_flight_txs, which joins it twice more. The gap between the two
+	// lines is what that costs.
+	scopes := []struct {
+		name string
+		run  func(display string) ([]db.ValuationPoint, error)
+	}{
+		{"user", func(display string) ([]db.ValuationPoint, error) {
+			return p.GetUserValuation(ctx, userID, from, before, display)
+		}},
+		{"portfolio", func(display string) ([]db.ValuationPoint, error) {
+			return p.GetPortfolioValuation(ctx, portfolioID, from, before, display)
+		}},
+	}
+	for _, scope := range scopes {
+		for _, display := range []string{"USD", "GBP"} {
+			// Warm caches, then time.
+			if _, err := scope.run(display); err != nil {
+				t.Fatalf("warmup %s %s: %v", scope.name, display, err)
 			}
-			total += time.Since(start)
-			if len(points) == 0 {
-				t.Fatalf("no valuation points in %s", display)
+			const runs = 5
+			var total time.Duration
+			for range runs {
+				start := time.Now()
+				points, err := scope.run(display)
+				if err != nil {
+					t.Fatalf("valuation %s %s: %v", scope.name, display, err)
+				}
+				total += time.Since(start)
+				if len(points) == 0 {
+					t.Fatalf("no valuation points in %s %s", scope.name, display)
+				}
 			}
+			t.Logf("%s display %s: %s mean over %d runs (%d instruments x %d days)",
+				scope.name, display, (total / runs).Round(time.Millisecond), runs, load.instruments, days)
 		}
-		t.Logf("display %s: %s mean over %d runs (%d instruments x %d days)",
-			display, (total / runs).Round(time.Millisecond), runs, load.instruments, days)
 	}
 
-	// The plan for the fuller of the two: displaying in a currency that is not
-	// USD is the only shape in which every FX branch is reachable.
-	var plan string
-	rows, err := p.q.QueryContext(ctx,
-		`EXPLAIN (ANALYZE, BUFFERS) `+valuationQuery(false), userID, from, before, "GBP")
-	if err != nil {
-		t.Fatalf("explain: %v", err)
-	}
-	defer func() { _ = rows.Close() }()
-	for rows.Next() {
-		var line string
-		if err := rows.Scan(&line); err != nil {
-			t.Fatalf("scan plan: %v", err)
+	// The plan for the fullest shape of each: displaying in a currency that is not
+	// USD is the only one in which every FX branch is reachable, and portfolio mode
+	// is the only one that reaches the filter view at all.
+	for _, mode := range []struct {
+		name  string
+		query string
+		scope string
+	}{
+		{"user", valuationQuery(false), userID},
+		{"portfolio", valuationQuery(true), portfolioID},
+	} {
+		var plan string
+		rows, err := p.q.QueryContext(ctx,
+			`EXPLAIN (ANALYZE, BUFFERS) `+mode.query, mode.scope, from, before, "GBP")
+		if err != nil {
+			t.Fatalf("explain %s: %v", mode.name, err)
 		}
-		plan += line + "\n"
+		for rows.Next() {
+			var line string
+			if err := rows.Scan(&line); err != nil {
+				_ = rows.Close()
+				t.Fatalf("scan %s plan: %v", mode.name, err)
+			}
+			plan += line + "\n"
+		}
+		_ = rows.Close()
+		t.Logf("%s plan:\n%s", mode.name, plan)
 	}
-	t.Logf("plan:\n%s", plan)
 }

--- a/server/db/postgres/valuation_test.go
+++ b/server/db/postgres/valuation_test.go
@@ -1344,3 +1344,444 @@ func TestGetUserValuation_ExcludesDatesAfterCloseAcrossInexactSplit(t *testing.T
 		}
 	}
 }
+
+// The tests below cover in-flight value: the TRANSFER_CLEARING legs of a matched
+// pair, which valuation admits and holdings do not. See portfolio_in_flight_txs in
+// server/migrations/001_initial.sql.
+
+// dailyValues indexes a valuation series by date. A day on which a portfolio holds
+// nothing produces no point at all rather than a zero, and the dip these tests are
+// about is exactly such a day, so asserting on it means asking for a date the series
+// may not carry.
+func dailyValues(points []db.ValuationPoint) map[string]float64 {
+	out := make(map[string]float64, len(points))
+	for _, pt := range points {
+		out[pt.Date.Format("2006-01-02")] = pt.TotalValue
+	}
+	return out
+}
+
+// inFlightSpec is the transfer these tests move: 20,000 US dollars leaving one
+// Fidelity account on 15 April and arriving in another on the 20th. The commodity is
+// the seeded USD cash instrument and the display currency is USD throughout, so a
+// value equals a quantity and no price or FX fixture is needed.
+func inFlightSpec(t *testing.T, p *Postgres, depart, arrive time.Time) transferSpec {
+	t.Helper()
+	usdInstID, err := p.FindInstrumentByIdentifier(context.Background(), "CURRENCY", "", "USD")
+	if err != nil || usdInstID == "" {
+		t.Fatalf("USD cash instrument not found: %v", err)
+	}
+	return transferSpec{
+		instID: usdInstID, desc: "USD CASH", qty: "-20000",
+		depart: depart, arrive: arrive,
+		fromAcct: "AG10000001", toAcct: "AW10000001",
+	}
+}
+
+// openingCash seeds the balance a transfer moves, dated before the transfer so that
+// the fixture's own replacement period does not take it back out again.
+func openingCash(t *testing.T, p *Postgres, userID, instID, account string, at time.Time, qty string) {
+	t.Helper()
+	ctx := context.Background()
+	txs := []*apiv1.Tx{{
+		Timestamp: timestamppb.New(at), InstrumentDescription: "USD CASH",
+		BrokerTxType: []typev1.TxType{typev1.TxType_INCOME}, ResolvedTxType: typev1.TxType_INCOME,
+		Quantity: qty, Account: account,
+	}}
+	from := timestamppb.New(at.Add(-1 * time.Hour))
+	to := timestamppb.New(at.Add(1 * time.Hour))
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "FIDELITY", "", from, to, txs, []string{instID}, nil, nil); err != nil {
+		t.Fatalf("opening cash: %v", err)
+	}
+}
+
+// accountPortfolio builds a portfolio that is exactly the named accounts.
+func accountPortfolio(t *testing.T, p *Postgres, userID, name string, accounts ...string) string {
+	t.Helper()
+	ctx := context.Background()
+	port, err := p.CreatePortfolio(ctx, userID, name)
+	if err != nil {
+		t.Fatalf("create portfolio: %v", err)
+	}
+	filters := make([]db.PortfolioFilter, len(accounts))
+	for i, a := range accounts {
+		filters[i] = db.PortfolioFilter{FilterType: "account", FilterValue: a}
+	}
+	if err := p.SetPortfolioFilters(ctx, port.Id, filters); err != nil {
+		t.Fatalf("set filters: %v", err)
+	}
+	return port.Id
+}
+
+// matchTransfer records the link the transfermatch worker would write.
+func matchTransfer(t *testing.T, p *Postgres, userID, from, to, instID string) {
+	t.Helper()
+	n, err := p.CreateTransferMatches(context.Background(), []db.TransferMatch{{
+		UserID: userID, FromGroupID: from, ToGroupID: to,
+		InstrumentID: instID, Method: db.TransferMatchPointer,
+	}})
+	if err != nil || n != 1 {
+		t.Fatalf("create transfer match: wrote %d, err %v", n, err)
+	}
+}
+
+// april is the window these tests value over: 10 April up to but not including
+// 25 April, which brackets both sides of the transfer with days either side.
+func april(day int) time.Time { return time.Date(2025, 4, day, 0, 0, 0, 0, time.UTC) }
+
+// TestGetPortfolioValuation_MatchedPairHoldsValueFlat verifies that a transfer
+// between two accounts of one portfolio does not move the portfolio's value on any
+// day, including the five days it spends in transit. Admitting both clearing legs
+// makes each group net to zero on its own date, so the running position never moves.
+func TestGetPortfolioValuation_MatchedPairHoldsValueFlat(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+
+	userID, _ := p.GetOrCreateUser(ctx, "sub|val-flight-flat", "U", "u@flight-flat.com")
+	spec := inFlightSpec(t, p, april(15), april(20))
+	openingCash(t, p, userID, spec.instID, spec.fromAcct, april(1), "20000")
+	from, to := transferFixtureAt(t, p, userID, spec)
+	matchTransfer(t, p, userID, from, to, spec.instID)
+	port := accountPortfolio(t, p, userID, "Both", spec.fromAcct, spec.toAcct)
+
+	points, err := p.GetPortfolioValuation(ctx, port, april(10), april(25), "USD")
+	if err != nil {
+		t.Fatalf("get valuation: %v", err)
+	}
+	values := dailyValues(points)
+	for day := 10; day < 25; day++ {
+		got := values[april(day).Format("2006-01-02")]
+		if got != 20000 {
+			t.Errorf("value on April %d: want 20000, got %v", day, got)
+		}
+	}
+}
+
+// TestGetPortfolioValuation_MatchedPairIsInvisibleToHoldings verifies the other half
+// of the same rule on the same fixture: a clearing leg valuation admits is still not
+// a position, so mid-transit the departure account holds nothing and the arrival
+// account does not hold it yet.
+func TestGetPortfolioValuation_MatchedPairIsInvisibleToHoldings(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+
+	userID, _ := p.GetOrCreateUser(ctx, "sub|val-flight-hold", "U", "u@flight-hold.com")
+	spec := inFlightSpec(t, p, april(15), april(20))
+	openingCash(t, p, userID, spec.instID, spec.fromAcct, april(1), "20000")
+	from, to := transferFixtureAt(t, p, userID, spec)
+	matchTransfer(t, p, userID, from, to, spec.instID)
+	port := accountPortfolio(t, p, userID, "Both", spec.fromAcct, spec.toAcct)
+
+	holdings, _, err := p.ComputeHoldingsForPortfolio(ctx, port, timestamppb.New(april(17)))
+	if err != nil {
+		t.Fatalf("compute holdings: %v", err)
+	}
+	for _, h := range holdings {
+		t.Errorf("expected no holdings in transit, got %s %s", h.GetSplitAdjustedQuantity(), h.GetInstrumentDescription())
+	}
+}
+
+// TestGetPortfolioValuation_UnmatchedTransferDips verifies the behaviour the pairing
+// exists to remove, so that the fixed case above is pinned against something. With no
+// match the two clearing legs are excluded and the money is nowhere for five days.
+func TestGetPortfolioValuation_UnmatchedTransferDips(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+
+	userID, _ := p.GetOrCreateUser(ctx, "sub|val-flight-dip", "U", "u@flight-dip.com")
+	spec := inFlightSpec(t, p, april(15), april(20))
+	openingCash(t, p, userID, spec.instID, spec.fromAcct, april(1), "20000")
+	transferFixtureAt(t, p, userID, spec)
+	port := accountPortfolio(t, p, userID, "Both", spec.fromAcct, spec.toAcct)
+
+	points, err := p.GetPortfolioValuation(ctx, port, april(10), april(25), "USD")
+	if err != nil {
+		t.Fatalf("get valuation: %v", err)
+	}
+	values := dailyValues(points)
+	for day := 10; day < 25; day++ {
+		want := 20000.0
+		if day >= 15 && day < 20 {
+			want = 0
+		}
+		got := values[april(day).Format("2006-01-02")]
+		if got != want {
+			t.Errorf("value on April %d: want %v, got %v", day, want, got)
+		}
+	}
+}
+
+// TestGetPortfolioValuation_MatchedPairOnlyDepartureIsMember verifies that a matched
+// pair does not net for a portfolio holding only the account the value left. From
+// that portfolio's point of view the money really did leave, and it does not come
+// back.
+func TestGetPortfolioValuation_MatchedPairOnlyDepartureIsMember(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+
+	userID, _ := p.GetOrCreateUser(ctx, "sub|val-flight-depart", "U", "u@flight-depart.com")
+	spec := inFlightSpec(t, p, april(15), april(20))
+	openingCash(t, p, userID, spec.instID, spec.fromAcct, april(1), "20000")
+	from, to := transferFixtureAt(t, p, userID, spec)
+	matchTransfer(t, p, userID, from, to, spec.instID)
+	port := accountPortfolio(t, p, userID, "Departure", spec.fromAcct)
+
+	points, err := p.GetPortfolioValuation(ctx, port, april(10), april(25), "USD")
+	if err != nil {
+		t.Fatalf("get valuation: %v", err)
+	}
+	values := dailyValues(points)
+	for day := 10; day < 25; day++ {
+		want := 20000.0
+		if day >= 15 {
+			want = 0
+		}
+		got := values[april(day).Format("2006-01-02")]
+		if got != want {
+			t.Errorf("value on April %d: want %v, got %v", day, want, got)
+		}
+	}
+}
+
+// TestGetPortfolioValuation_MatchedPairOnlyArrivalIsMember is the mirror: a portfolio
+// holding only the receiving account sees nothing until the money arrives.
+func TestGetPortfolioValuation_MatchedPairOnlyArrivalIsMember(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+
+	userID, _ := p.GetOrCreateUser(ctx, "sub|val-flight-arrive", "U", "u@flight-arrive.com")
+	spec := inFlightSpec(t, p, april(15), april(20))
+	openingCash(t, p, userID, spec.instID, spec.fromAcct, april(1), "20000")
+	from, to := transferFixtureAt(t, p, userID, spec)
+	matchTransfer(t, p, userID, from, to, spec.instID)
+	port := accountPortfolio(t, p, userID, "Arrival", spec.toAcct)
+
+	points, err := p.GetPortfolioValuation(ctx, port, april(10), april(25), "USD")
+	if err != nil {
+		t.Fatalf("get valuation: %v", err)
+	}
+	values := dailyValues(points)
+	for day := 10; day < 25; day++ {
+		want := 0.0
+		if day >= 20 {
+			want = 20000
+		}
+		got := values[april(day).Format("2006-01-02")]
+		if got != want {
+			t.Errorf("value on April %d: want %v, got %v", day, want, got)
+		}
+	}
+}
+
+// TestGetPortfolioValuation_CounterpartArrivesAfterWindowEnd verifies that value
+// still in transit when the window closes is still value held. This is the test that
+// fails if anyone date-bounds portfolio_in_flight_txs: the arrival falls outside the
+// window entirely, and requiring it inside would reinstate the dip for exactly the
+// days the pairing exists to cover.
+func TestGetPortfolioValuation_CounterpartArrivesAfterWindowEnd(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+
+	userID, _ := p.GetOrCreateUser(ctx, "sub|val-flight-late", "U", "u@flight-late.com")
+	spec := inFlightSpec(t, p, april(15), time.Date(2025, 5, 20, 0, 0, 0, 0, time.UTC))
+	openingCash(t, p, userID, spec.instID, spec.fromAcct, april(1), "20000")
+	from, to := transferFixtureAt(t, p, userID, spec)
+	matchTransfer(t, p, userID, from, to, spec.instID)
+	port := accountPortfolio(t, p, userID, "Both", spec.fromAcct, spec.toAcct)
+
+	points, err := p.GetPortfolioValuation(ctx, port, april(10), april(25), "USD")
+	if err != nil {
+		t.Fatalf("get valuation: %v", err)
+	}
+	values := dailyValues(points)
+	for day := 10; day < 25; day++ {
+		got := values[april(day).Format("2006-01-02")]
+		if got != 20000 {
+			t.Errorf("value on April %d: want 20000, got %v", day, got)
+		}
+	}
+}
+
+// TestGetPortfolioValuation_SecurityTransferValuedInTransit verifies that a journal
+// moving shares rather than money is valued in transit at the share price, and does
+// not report as unpriced.
+func TestGetPortfolioValuation_SecurityTransferValuedInTransit(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+
+	userID, _ := p.GetOrCreateUser(ctx, "sub|val-flight-sec", "U", "u@flight-sec.com")
+	instID, err := p.EnsureInstrument(ctx, "STOCK", "", "USD", "AAPL", "", "", []db.IdentifierInput{
+		{Type: "BROKER_DESCRIPTION", Domain: "FIDELITY", Value: "AAPL Corp", Canonical: false},
+	}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+	prices := make([]db.EODPrice, 0, 15)
+	for day := 10; day < 25; day++ {
+		prices = append(prices, db.EODPrice{
+			InstrumentID: instID, PriceDate: april(day), Close: decf(150.0), DataProvider: "test",
+		})
+	}
+	if err := p.UpsertPrices(ctx, prices); err != nil {
+		t.Fatalf("upsert prices: %v", err)
+	}
+
+	spec := transferSpec{
+		instID: instID, desc: "AAPL Corp", qty: "-10",
+		depart: april(15), arrive: april(20),
+		fromAcct: "AG10000001", toAcct: "AW10000001",
+	}
+	openTxs := []*apiv1.Tx{{
+		Timestamp: timestamppb.New(april(1)), InstrumentDescription: "AAPL Corp",
+		BrokerTxType: []typev1.TxType{typev1.TxType_TRADE_ASSET}, ResolvedTxType: typev1.TxType_TRADE_ASSET,
+		Quantity: "10", Account: spec.fromAcct,
+	}}
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "FIDELITY", "",
+		timestamppb.New(april(1).Add(-time.Hour)), timestamppb.New(april(1).Add(time.Hour)),
+		openTxs, []string{instID}, nil, nil); err != nil {
+		t.Fatalf("opening shares: %v", err)
+	}
+	from, to := transferFixtureAt(t, p, userID, spec)
+	matchTransfer(t, p, userID, from, to, instID)
+	port := accountPortfolio(t, p, userID, "Both", spec.fromAcct, spec.toAcct)
+
+	points, err := p.GetPortfolioValuation(ctx, port, april(10), april(25), "USD")
+	if err != nil {
+		t.Fatalf("get valuation: %v", err)
+	}
+	values := dailyValues(points)
+	for day := 10; day < 25; day++ {
+		got := values[april(day).Format("2006-01-02")]
+		if got != 1500 {
+			t.Errorf("value on April %d: want 1500, got %v", day, got)
+		}
+	}
+	for _, pt := range points {
+		if len(pt.UnpricedInstruments) != 0 {
+			t.Errorf("unpriced on %v: %v", pt.Date, pt.UnpricedInstruments)
+		}
+	}
+}
+
+// TestGetPortfolioValuation_MatchedPairIsScopedToItsOwnPortfolio verifies that the
+// membership test names one portfolio on both sides. A pair matched between two
+// accounts of one portfolio must not be admitted into another portfolio that holds
+// neither.
+func TestGetPortfolioValuation_MatchedPairIsScopedToItsOwnPortfolio(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+
+	userID, _ := p.GetOrCreateUser(ctx, "sub|val-flight-scope", "U", "u@flight-scope.com")
+	spec := inFlightSpec(t, p, april(15), april(20))
+	openingCash(t, p, userID, spec.instID, spec.fromAcct, april(1), "20000")
+	openingCash(t, p, userID, spec.instID, "AX10000001", april(2), "500")
+	from, to := transferFixtureAt(t, p, userID, spec)
+	matchTransfer(t, p, userID, from, to, spec.instID)
+	other := accountPortfolio(t, p, userID, "Other", "AX10000001")
+
+	points, err := p.GetPortfolioValuation(ctx, other, april(10), april(25), "USD")
+	if err != nil {
+		t.Fatalf("get valuation: %v", err)
+	}
+	values := dailyValues(points)
+	for day := 10; day < 25; day++ {
+		got := values[april(day).Format("2006-01-02")]
+		if got != 500 {
+			t.Errorf("value on April %d: want 500, got %v", day, got)
+		}
+	}
+}
+
+// TestGetUserValuation_MatchedPairHoldsValueFlat verifies the user-mode branch, which
+// asks only whether a match names the group: every account of the user is in scope,
+// so there is no membership left to test.
+func TestGetUserValuation_MatchedPairHoldsValueFlat(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+
+	userID, _ := p.GetOrCreateUser(ctx, "sub|val-flight-user", "U", "u@flight-user.com")
+	spec := inFlightSpec(t, p, april(15), april(20))
+	openingCash(t, p, userID, spec.instID, spec.fromAcct, april(1), "20000")
+	from, to := transferFixtureAt(t, p, userID, spec)
+	matchTransfer(t, p, userID, from, to, spec.instID)
+
+	points, err := p.GetUserValuation(ctx, userID, april(10), april(25), "USD")
+	if err != nil {
+		t.Fatalf("get valuation: %v", err)
+	}
+	values := dailyValues(points)
+	for day := 10; day < 25; day++ {
+		got := values[april(day).Format("2006-01-02")]
+		if got != 20000 {
+			t.Errorf("value on April %d: want 20000, got %v", day, got)
+		}
+	}
+}
+
+// TestGetUserValuation_MatchInAnotherCommodityIsNotAdmitted verifies that a match is
+// keyed on the commodity as well as the group. A journal moving shares and money
+// together leaves a residual in each, and matching the cash side says nothing about
+// where the shares are: valuing them would assert they are coming back when only the
+// money is accounted for.
+func TestGetUserValuation_MatchInAnotherCommodityIsNotAdmitted(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+
+	userID, _ := p.GetOrCreateUser(ctx, "sub|val-flight-commodity", "U", "u@flight-commodity.com")
+	spec := inFlightSpec(t, p, april(15), april(20))
+	openingCash(t, p, userID, spec.instID, spec.fromAcct, april(1), "20000")
+
+	secID, err := p.EnsureInstrument(ctx, "STOCK", "", "USD", "AAPL", "", "", []db.IdentifierInput{
+		{Type: "BROKER_DESCRIPTION", Domain: "FIDELITY", Value: "AAPL Corp", Canonical: false},
+	}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+	if err := p.UpsertPrices(ctx, []db.EODPrice{
+		{InstrumentID: secID, PriceDate: april(15), Close: decf(150.0), DataProvider: "test"},
+	}); err != nil {
+		t.Fatalf("upsert prices: %v", err)
+	}
+	openTxs := []*apiv1.Tx{{
+		Timestamp: timestamppb.New(april(2)), InstrumentDescription: "AAPL Corp",
+		BrokerTxType: []typev1.TxType{typev1.TxType_TRADE_ASSET}, ResolvedTxType: typev1.TxType_TRADE_ASSET,
+		Quantity: "10", Account: spec.fromAcct,
+	}}
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "FIDELITY", "",
+		timestamppb.New(april(2).Add(-time.Hour)), timestamppb.New(april(2).Add(time.Hour)),
+		openTxs, []string{secID}, nil, nil); err != nil {
+		t.Fatalf("opening shares: %v", err)
+	}
+
+	from, to := transferFixtureAt(t, p, userID, spec)
+
+	// The departure group also moves the shares out, leaving a second residual in a
+	// commodity the match will not name. Written directly because the fixture builds
+	// one commodity, and as a balanced pair so the group invariant still holds.
+	for _, leg := range []struct {
+		qty         string
+		accountType string
+	}{{"-10", "USER"}, {"10", "TRANSFER_CLEARING"}} {
+		if _, err := p.q.ExecContext(ctx, `
+			INSERT INTO txs (user_id, broker, account, timestamp, instrument_description,
+				instrument_id, broker_tx_type, resolved_tx_type, quantity, account_type,
+				group_id, weight, weight_commodity, share_count_basis, split_adjusted_quantity)
+			VALUES ($1::uuid, 'FIDELITY', $2, $3::timestamptz, 'AAPL Corp', $4::uuid,
+				ARRAY['TRANSFER'], 'TRANSFER', $5::numeric, $6,
+				$7::uuid, $5::numeric, 'inst:'||$4, $3::timestamptz::date, $5::numeric)
+		`, userID, spec.fromAcct, april(15), secID, leg.qty, leg.accountType, from); err != nil {
+			t.Fatalf("insert %s security leg: %v", leg.accountType, err)
+		}
+	}
+	matchTransfer(t, p, userID, from, to, spec.instID)
+
+	points, err := p.GetUserValuation(ctx, userID, april(15), april(16), "USD")
+	if err != nil {
+		t.Fatalf("get valuation: %v", err)
+	}
+	// The cash is matched and holds flat at 20,000. The shares have left and their
+	// clearing leg is unmatched, so their 10 x 150 must not be added back.
+	if got := dailyValues(points)[april(15).Format("2006-01-02")]; got != 20000 {
+		t.Errorf("value on April 15: want 20000, got %v", got)
+	}
+}

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -644,6 +644,55 @@ WHERE
        OR (t.instrument_id IS NOT NULL
            AND t.instrument_id::text IN (SELECT filter_value FROM portfolio_filters WHERE portfolio_id = p.id AND filter_type = 'instrument')));
 
+-- The TRANSFER_CLEARING postings a portfolio values: one side of a matched pair
+-- whose other side matches the same portfolio's filters.
+--
+-- An in-flight balance is never a position, so holdings exclude it always. Valuation
+-- is a different question. The two sides of a transfer are dated by their own
+-- statements, so dropping both clearing legs makes the transferred holding vanish for
+-- the days in between -- a dip in portfolio value and a fake return blip. Holding
+-- value in transit is what a clearing account is for. An unmatched leg is never here:
+-- including it would assert that money in transit is coming back to an account we
+-- hold, which is the thing we do not know. See docs/spec/postings.md and
+-- docs/adr/0022-typed-per-account-cash-flow-boundary.md.
+--
+-- The counterpart is tested through its own clearing leg rather than through its
+-- group, because that leg carries the counterpart account and the commodity the match
+-- is keyed on. That makes the test symmetric -- whichever of the two legs is being
+-- tested asks the same question of the other -- so a pair is admitted whole or not at
+-- all. A test against the counterpart's USER leg would not be, since an instrument
+-- filter can admit one and not the other.
+--
+-- No date bound. A match is a fact about the pair rather than about a valuation
+-- window, and value still in transit when a window closes is value held. Bounding it
+-- would reinstate the dip for exactly the days the pairing exists to cover.
+--
+-- The CASE picks the counterpart group: a plain equality on idx_txs_group_id, which
+-- CHECK (from_group_id <> to_group_id) makes unambiguous.
+--
+-- The counterpart's membership is an EXISTS rather than a fourth join, which reads
+-- the same -- portfolio_matched_txs holds at most one row per (portfolio, tx) -- and
+-- plans very differently. As a join the planner ordered it last and matched it with a
+-- join filter, materialising the filter view and discarding 43,160 rows to keep 40,
+-- which cost 90ms of a 490ms portfolio valuation. As a semi-join the equality reaches
+-- the scan and the cost returns to the noise floor. Every row estimate in here is 1,
+-- so the shape has to make the pushdown unavoidable rather than merely available.
+CREATE VIEW portfolio_in_flight_txs AS
+SELECT m.portfolio_id, t.id AS tx_id
+FROM txs t
+JOIN portfolio_matched_txs m ON m.tx_id = t.id
+JOIN transfer_matches tm
+  ON tm.instrument_id = t.instrument_id
+ AND (tm.from_group_id = t.group_id OR tm.to_group_id = t.group_id)
+JOIN txs c
+  ON c.group_id = CASE WHEN tm.from_group_id = t.group_id
+                       THEN tm.to_group_id ELSE tm.from_group_id END
+ AND c.account_type = 'TRANSFER_CLEARING'
+ AND c.instrument_id = tm.instrument_id
+WHERE t.account_type = 'TRANSFER_CLEARING'
+  AND EXISTS (SELECT 1 FROM portfolio_matched_txs cm
+              WHERE cm.tx_id = c.id AND cm.portfolio_id = m.portfolio_id);
+
 -- EOD price cache. Stores end-of-day OHLCV data per instrument per date.
 -- Every row is a bar a provider actually reported: non-trading days (weekends,
 -- holidays) simply have no row. Valuation carries the last close forward over


### PR DESCRIPTION
First of two PRs for 0090. This half makes valuation read `transfer_matches`; netting a matched pair in portfolio cash flows follows in a stacked PR.

## The problem

Valuation reads `account_type = 'USER'` only. The two sides of a transfer are dated by their own statements, so between them the transferred holding vanishes from the portfolio total -- a dip in value and a fake return blip on days when the money is simply in transit.

## The change

Admit the `TRANSFER_CLEARING` legs of a matched pair whose other side is in scope. The dip goes by arithmetic, not by carrying a value across the gap: the departure group is a negative leg and a positive clearing leg, the arrival group the mirror, so each contributes exactly zero to `daily_qty` on its own date and the running position never moves. It generalises past the two-leg case -- a journal charging a fee nets to the fee, which is correct.

**No CTE, join or carry-forward is added to the valuation pipeline.** The change is one predicate in the posting filter. `merged_txs`, `cumulative`, `holding_spans`, `daily_holdings`, the price carry-forward and `valued` are untouched.

Which pairs a portfolio values is a new view, `portfolio_in_flight_txs`, defined beside `portfolio_matched_txs` because it asks the same question about membership. Two properties it records:

- It tests the counterpart's **own clearing leg** rather than its group. That leg carries the counterpart account and the commodity the match is keyed on, so the test reads identically from either side and a pair is admitted whole or not at all. A test against the counterpart's `USER` leg would not be symmetric under an instrument filter.
- It applies **no date bound**. Value still in transit when a window closes is value held, and requiring the arrival inside the window would reinstate the dip for exactly the days the pairing exists to cover.

User-mode valuation needs no membership test at all: both groups belong to the same user by construction, so a match alone is the whole question.

## Performance

The counterpart's membership is an `EXISTS` rather than a fourth join. As a join the planner ordered it last and matched it with a join filter, materialising the filter view and discarding 43,160 rows to keep 40 -- 90ms of a 490ms portfolio valuation. As a semi-join the equality reaches the scan and the cost returns to the noise floor.

Measured against `main` on the same load (50 instruments x 5 years x 20 txs, 20 matched transfers):

| | main | this branch |
|---|---|---|
| user, USD / GBP | 431 / 460ms | 422 / 446ms |
| portfolio, USD / GBP | 406 / 435ms | 418 / 414ms |

The benchmark had to grow to see any of this: it timed user mode only, where neither the filter view nor the new view is reached. It now times both scopes, prints both plans, and seeds matched transfers via a new `matchedTransfers` field on `valuationLoad`.

## Tests

Ten new cases in `valuation_test.go`, all of which fail against `main`'s query where they should. They pin: no dip when both accounts are members; the dip that remains when unmatched; a pair matched but only half-owned staying external in both directions; a counterpart arriving after the window ends (the test that fails if anyone date-bounds the view); a security transfer valued in transit; user mode; scoping to one portfolio; and that a match in one commodity does not admit a residual in another.

`transferFixture` grows a `transferSpec` so the two sides can carry separate dates, which is the case the pairing exists for; its four existing call sites are unchanged.

## Docs

`docs/spec/postings.md` Visibility now states what valuation reads and the two consequences: valuation and holdings disagree while a transfer is in transit, by design, and a past valuation moves when the matcher runs. `docs/adr/0022` gains a paragraph recording that the instability it rejected for classification is now accepted for valuation too, for the reason it already accepted it for netting.

## Verification

`make fmt`, `make vet`, `make lint-go` (0 issues), `make db-test`, `make server-test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)