### PR TITLE
Reconcile 0095 and 0091 against server-side grouping (0095)

### DIFF
--- a/docs/adr/0037-transfer-matches-are-links-not-postings.md
+++ b/docs/adr/0037-transfer-matches-are-links-not-postings.md
@@ -174,3 +174,35 @@ commits. Neither is redundant: a cadence alone would leave a just-imported trans
 reported as unmatched until it came round, and the ingestion nudge alone would never
 retry a cycle that failed. Running it more often than needed is cheap, since a cycle
 reads every side no match names and writes nothing when there is nothing new.
+
+## Amendments
+
+**A `MANUAL` match is derived too, and is not keyed on group ids.** "Derived and
+disposable" above says a `MANUAL` match "cannot be rebuilt from evidence, which is
+precisely what made it manual", and concludes that it keeps its group ids and relies
+on the engine writing only the groups it disagrees with. Both halves are wrong now.
+
+It can be rebuilt from evidence, because a person supplies some. A hand-made pairing
+is recorded as a `SCOPE_USER` correlation on the two sides' postings, exactly as a
+hand-made grouping is, and the matcher gains a pass above the pointer pass that reads
+it. `MANUAL` stops meaning "inserted by hand and preserved" and starts meaning
+"derived from a person's assertion" -- which puts every method in the table on the
+same footing, and makes the link disposable in the same way. See
+[0049](0049-a-human-assertion-is-a-correlation.md) and
+[0095](../issues/0095-match-imbalanced-groups-that-should-be-one.md).
+
+It also had to change, rather than merely being an improvement. The id-keyed link was
+never as durable as this ADR assumed: `applyChanges` drops every `transfer_matches`
+row naming a group a posting left or the engine created, and nothing rebuilt a
+`MANUAL` one. So a hand-made link was already destroyed by any genuine repartition of
+either side, silently.
+
+**"The matcher only ever inserts" no longer holds either.** It was true of the
+matcher and false of the system: the regroup and the period replace both delete
+matches naming a touched group. What makes that safe is the rebuild above, not the
+matcher's restraint.
+
+The rest of this ADR stands. A match is still a link rather than a merge for
+transfers, and still records which account holds the other side, for the reason "A
+link rather than a merge" gives; what changed is where the `MANUAL` link comes from,
+not what it is.

--- a/docs/adr/0048-correlations-declare-their-own-semantics.md
+++ b/docs/adr/0048-correlations-declare-their-own-semantics.md
@@ -175,6 +175,28 @@ the declared type alone -- a row that must be income has its other side in incom
 so the server derives it rather than the converter, and it is recreated on every
 regroup like a routed residual.
 
+**`SCOPE_USER` reaches the whole of a user's data, and needs no operator of its own.**
+Two details the amendment above left implicit, settled in
+[0095](../issues/0095-match-imbalanced-groups-that-should-be-one.md).
+
+Its comparability set is everything this user has. The other scopes narrow to a job,
+an account or a broker because that is as far as the issuer's numbering is unique; a
+person's token is unique because they minted it, and narrowing it would defeat the
+assertion in exactly the cases -- legs in different accounts, legs from different
+brokers -- that make someone reach for it.
+
+And a hand-made *pairing* of two transfer sides declares `MATCH_EXACT` like a
+hand-made grouping, rather than a fourth operator meaning "these are opposite sides of
+one transfer". What the two assertions mean differs, but the difference is already
+carried by the postings: where every member must be a transfer the claim pairs their
+groups, where none is it merges them, and a mixed set is refused when it is asserted.
+An operator would restate what the type already says.
+
+`MATCH_ACCOUNT` was the other candidate and does not fit. It names another posting's
+account rather than an occurrence, so it cannot say which of that account's sides is
+meant -- which is the ambiguity a person is being asked to resolve, and the reason the
+matcher leaves such a pair alone in the first place.
+
 ## Considered: a field per broker
 
 Carrying each source's grouping fields verbatim was rejected in 0042 and stays

--- a/docs/adr/0049-a-human-assertion-is-a-correlation.md
+++ b/docs/adr/0049-a-human-assertion-is-a-correlation.md
@@ -110,3 +110,66 @@ express. So it stays keyed on group ids and relies on the stability above, rathe
 than becoming a correlation. What becomes a correlation is the non-transfer
 repair in [0095](../issues/0095-match-imbalanced-groups-that-should-be-one.md),
 which is a merge and therefore a grouping.
+
+## Amendments
+
+**A change to any member destroys the whole assertion, and the reason is cost.**
+"An assertion lives and dies with the postings it is written on" above is stated
+all-or-nothing, but a replace is scoped to one broker and one period while an
+assertion is most often made precisely across those boundaries, so partial death is
+the ordinary case rather than the exotic one. Two guarantees settle it, and
+deliberately no more:
+
+1. A person is warned before an import commits that would modify a posting carrying
+   a user-asserted correlation.
+2. When such a posting is modified, that correlation and every other user-asserted
+   correlation sharing its token are deleted.
+
+The person re-asserts. Everything else considered here -- replaying the survivors,
+flagging them, deciding whether a two-of-three fragment still means what it meant --
+needs the assertion to record how many postings it named and then needs a judgement
+about a set nobody asserted. The rejection of the content fingerprint above turns on
+exactly that: a resolution step with no good answer when it fails. This has no such
+step, and it needs no arity, because deletion is by token and the token index already
+finds the siblings.
+
+**The archive round trip survives on ordering.** The replace collects the tokens
+carried by the postings it is about to delete, deletes the postings, deletes the
+correlations surviving elsewhere under those tokens, and only then inserts the
+incoming postings with their own. The deletion therefore reaches what pre-dated the
+write and nothing the write supplied, so an archive carrying a whole assertion
+re-creates it and the promise above is kept.
+
+**A manual transfer match is not a different object after all.** The consequence
+above says it "links two groups rather than joining postings" and so "stays keyed on
+group ids rather than becoming a correlation". It becomes a correlation as well. A
+person stamps the same synthesised token, with `MATCH_EXACT` and `SCOPE_USER`, on
+each side; what decides whether the engine merges those postings or pairs their
+groups is the postings' own type, not anything the assertion says. Where every named
+posting must be a transfer the grouping engine declines the claim and the matcher
+links the two groups, which preserves the account boundary
+[0022](0022-typed-per-account-cash-flow-boundary.md) depends on and is the whole of
+what [0037](0037-transfer-matches-are-links-not-postings.md) was protecting. Where
+none is, the assertion merges. A mixed set is refused when it is asserted.
+
+So "one design serves both asserters" reaches further than this ADR claimed: one
+evidence shape serves a source and a person, and the same shape serves a merge and a
+pairing, with the type doing the discriminating that a second operator would
+otherwise have to.
+
+The reversal was forced rather than chosen. The id-keyed link this ADR left in place
+does not in fact survive: `applyChanges` drops every `transfer_matches` row naming a
+group a posting left or the engine created, and nothing rebuilds a `MANUAL` one, so a
+hand-made link is destroyed by any genuine repartition of either side. "A regroup must
+not churn ids gratuitously" above is still true and still worth having -- a cycle that
+agrees with the stored partition writes nothing -- but nothing about human judgement
+depends on it any more.
+
+**What a person still cannot say.** An exact-token claim is a must-link, so an
+assertion only ever adds. There is no way to record that two postings do *not* belong
+together, which means a pairing the engine derives wrongly cannot be repaired by hand.
+For the same reason an assertion cannot be outranked by evidence arriving later: it is
+protected by precedence, so a source-stated grouping that contradicts it loses, and
+nothing reports that it did. Both are recorded as non-goals in
+[0095](../issues/0095-match-imbalanced-groups-that-should-be-one.md) rather than
+settled here.

--- a/docs/issues/0091-manual-transfer-match.md
+++ b/docs/issues/0091-manual-transfer-match.md
@@ -1,47 +1,23 @@
 ---
-status: open
+status: closed
 title: Match or unmatch a transfer by hand
 milestone: M12
 dependencies: [0068]
 ---
 
-Let an admin pair two sides of a transfer the matcher left alone, and break a pair it
-got wrong.
+Subsumed by 0095.
 
-## Motivation
+Pairing two sides of a transfer by hand is the transfer case of the one writer 0095
+builds: a synthesised token with `MATCH_EXACT` and `SCOPE_USER` on each side, which
+the matcher reads and turns into a link. The same writer serves the non-transfer
+repair, so there is nothing separate left here to build.
 
-0068 matches only on evidence that identifies the occurrence, and deliberately leaves
-everything else alone: a cross-broker transfer, which no sample calibrates, and any
-pair whose candidates it cannot tell apart. Those are exactly the cases a person
-looking at the transfers report can resolve at a glance, and there is no way to record
-the answer.
+Breaking a pair the matcher got wrong is not attempted, and the design settled here
+is why rather than merely when. A hand-made assertion is a must-link, so it can only
+ever add; the engine recomputes a neighbourhood from scratch on every cycle, so
+deleting a link it derived is undone by the next run. Recording a negative would need
+a mechanism this design does not have. 0095 records it as a stated non-goal.
 
-The other half is the wrong pair. A heuristic match is disposable by design, but
-nothing can currently remove one, so an error stands until the groups are replaced by a
-re-upload.
-
-## Design
-
-The storage already allows both. `transfer_matches.method` carries `MANUAL`, and the
-matcher only ever inserts -- never updates, never deletes -- so a hand-made match
-survives every rebuild. What is missing is the API and the UI.
-
-- Create and delete a match from the transfers view of `/admin/imbalance`, where the
-  unmatched sides are already listed.
-- Deleting a heuristic match makes both sides unmatched again, and the next cycle will
-  re-propose it. Something has to stop that: either a deletion is recorded so the pair
-  is not re-proposed, or a deletion is only offered together with a replacement match.
-  Settle which when this is picked up.
-
-## Staleness
-
-A hand-made match can stop making sense without anyone touching it: a later upload can
-change the residual of a group it names, or remove the clearing leg it was made
-against. 0095 carries the question of what happens then -- survive, drop, or flag for
-review -- and it needs an answer here too, because this is where the match is created.
-
-The related worry about a regroup churning group ids is settled and does not land here:
-adr/0049-a-human-assertion-is-a-correlation.md keeps a match keyed on its group ids and
-requires the grouping engine to write only the groups it disagrees with, so a manual
-match survives every cycle that does not genuinely repartition it. A re-upload still
-takes it, along with the postings.
+This issue's own design is also out of date and should not be read as current: it
+rested on the matcher only ever inserting, which stopped being true when 0097 landed
+a regroup that drops the matches naming any group it repartitions.

--- a/docs/issues/0095-match-imbalanced-groups-that-should-be-one.md
+++ b/docs/issues/0095-match-imbalanced-groups-that-should-be-one.md
@@ -1,100 +1,171 @@
 ---
 status: open
 title: Match imbalanced groups that should be one
+milestone: M16
 dependencies: [0068, 0097]
 ---
 
-Repair, after the fact, postings that belong to one economic event but were
-stored in separate unbalanced groups.
+Let a person repair, after the fact, postings that belong to one economic event but
+were stored apart, and record the answer as evidence the engine consumes.
 
 ## Motivation
 
-Grouping is the converter's job and a converter sees one file
-(adr/0021-converters-own-transaction-grouping.md), so several paths leave the
-legs of one event in distinct groups, each balanced by a routed residual:
+0097 derives groups on the server from stored evidence, over the whole dataset
+rather than one upload, so the cases that used to need a person no longer do: two
+legs arriving in two broker logs, and a group cut by a period replace, are both
+joined without anyone being asked.
 
-- Two legs arriving in two broker logs. No converter can see both.
-- A straddling group cut by the period replace in 0094.
+What is left is the half no engine can do. A pair is matched automatically only on
+evidence that identifies the *occurrence*, because a wrong pairing is worse than no
+pairing (adr/0037-transfer-matches-are-links-not-postings.md), and where the
+evidence does not reach that bar the answer is a person's judgement rather than a
+rule. Today there is nowhere to put that judgement, so it reads as an imbalance that
+never resolves, or as a transfer that stays in flight for ever.
 
-The transfer matcher from 0068 already repairs one case of this, and is
-deliberately narrow: it keys on `account_type = 'TRANSFER_CLEARING'`, requires
-the same broker, an exact equal-and-opposite amount and a window of seven days,
-and refuses ambiguity. Everything else stays unmatched, which reads as an
-imbalance that never resolves.
+Which evidence justifies an automatic match is settled and is no longer a question
+for this issue. The engine states it as five rules in a fixed precedence order --
+`Exact`, `Disposal`, `Acquisition`, `CashTrade`, `Deposit` in `server/grouping/` --
+each gated by 0044's *may be* test, each ranking its candidates globally before it
+claims, and each leaving ambiguity unclaimed. See
+adr/0047-grouping-runs-as-precedence-ordered-passes.md and the "Where grouping is
+decided" section of docs/spec/postings.md.
 
 ## Design
 
-Two questions, and the second is the harder one.
+**One evidence shape for both repairs, and the type decides what it means.**
 
-**Which evidence justifies a match.** Where a sufficiently reliable rule exists,
-match automatically as 0068 does. Where it does not, present likely candidates
-and defer to the user for the final call. A wrong pair is worse than no pair, so
-the bar for automatic matching stays where 0068 put it: evidence that identifies
-the occurrence, not merely the amount and a window.
+A hand-made grouping and a hand-made transfer pairing are the same object: a token
+the asserter synthesises, stamped on each named posting with `MATCH_EXACT` and
+`SCOPE_USER`, exactly as adr/0049-a-human-assertion-is-a-correlation.md describes.
+What differs is what the engine concludes from it, and that follows from the
+postings' own type rather than from anything the assertion says:
 
-**Whether a match is a link or a merge, which depends on what is being matched.**
+- **Every named posting must be a transfer.** The assertion pairs the two sides. The
+  grouping engine declines to claim them, so each side keeps its own group and its
+  `TRANSFER_CLEARING` residual, and the transfer matcher writes the link. Merging
+  them would erase the account boundary
+  adr/0022-typed-per-account-cash-flow-boundary.md asks about before it nets a pair
+  or values what is in transit, which is the whole reason 0037 chose a link.
+- **No named posting is a transfer.** The assertion merges them: one group, one
+  residual, routed against the membership that now holds. An `IMBALANCE` residual
+  carries no account boundary -- both halves of a split trade sit in one account and
+  the residual is an artefact of the split -- so a merge is the honest repair.
+- **Anything else is rejected when it is asserted**, and the person is told to
+  correct the declared type and re-upload. That covers a mixed set, and a transfer
+  assertion whose sides sit in one account.
 
-adr/0037-transfer-matches-are-links-not-postings.md chose a link, and its reason
-is specific to transfers: the link records *which account holds the other side*,
-because the portfolio membership test in
-adr/0022-typed-per-account-cash-flow-boundary.md asks whether both accounts are
-members before it nets a pair or values what is in transit. Merging two transfer
-groups would erase the account boundary money-weighted return depends on, which
-is the whole reason the pairing exists.
+No new `Match` operator is needed for this. `MATCH_ACCOUNT` was considered and does
+not fit: it names an account rather than an occurrence, so it cannot say which of
+that account's sides is meant, which is the ambiguity a person is being asked to
+resolve in the first place.
 
-An `IMBALANCE` residual carries no such boundary. Both halves of a split trade
-sit in one account, and the residual is an artefact of the split rather than an
-economic fact, so the right repair is a merge: reassign `group_id` and delete
-both residuals. 0037 calls that unreachable, but that argument is about clearing
-one side of a pair; `check_tx_group_balance()` is `DEFERRABLE INITIALLY
-DEFERRED`, so a merge performed in one transaction is evaluated at COMMIT, where
-the merged group balances.
+**A hand-made transfer link is derived, not stored by hand.** It stops being state
+written once and preserved, and becomes something the matcher rebuilds from the
+correlations on every cycle, like `POINTER` and `REFERENCE`. It has to: `applyChanges`
+in server/db/postgres/grouping_apply.go runs `deleteTouchedMatchesSQL` over every
+group a posting left and every group the engine created, and nothing rebuilds a
+`MANUAL` row, so a link written by hand is destroyed by any genuine repartition of
+either side. A cycle that agrees with the stored partition still churns nothing, so
+this is a gap in what 0049 assumed rather than a contradiction of 0047.
 
-Amend 0037 to say it is scoped to transfers and why, rather than leaving it
-reading as a rule about matching in general.
+## What lands
 
-## Relationship to 0097
+- `SCOPE_USER` in `type.v1.Scope` (proto/type/v1/type.proto), in the
+  `tx_correlations.scope` CHECK (server/migrations/001_initial.sql, amended in
+  place), and as `db.ScopeUser`.
+- A user assertion's comparability set is this user's whole dataset, so its
+  `within` key is the user and its reach widens past broker as well as account.
+- A rule above `Exact`, at precedence 1100. Distinct rather than folded into
+  `Exact` because its precedence over a source-stated token has to be stated rather
+  than emerge from key sort order (0047: precedence is data on the rule), because
+  its reach is unbounded where `Exact`'s is not, and because it declines a transfer
+  assertion instead of claiming it.
+- A pass in server/transfermatch/match.go above the pointer pass, matching two
+  sides whose groups share a `SCOPE_USER` token and writing `method = 'MANUAL'`. It
+  bypasses the same-broker, equal-amount and seven-day gates deliberately: those
+  reject precisely the cross-broker, fee-differing, slow transfer a person is being
+  asked about. Direction follows the existing convention, `from` being the side
+  holding the positive `TRANSFER_CLEARING` residual.
+- An API to create and delete an assertion, enforcing the rejections above and one
+  more: it refuses to stamp a token on a posting that already carries a `SCOPE_USER`
+  one. That is a correctness rule, not tidiness. `State.Claim` is all-or-nothing and
+  the exact rule iterates its keys in sorted order, so two overlapping user tokens
+  do not union -- whichever sorts first takes its postings and the other assertion
+  is discarded in silence. A second assertion overlapping the first is refused at
+  write time, and the person removes the old one.
+- A UI on /admin/imbalance to make and remove an assertion from both the imbalance
+  view and the transfers view. The imbalance view aggregates balances today and
+  says outright that drilling into the groups behind one is not implemented, so the
+  drill-down is part of this.
+- The destruction rule and its warning, below.
+- docs/spec/postings.md: `SCOPE_USER` in the correlation scope table, the assertion
+  rule under "Where grouping is decided", and the destruction rule under
+  "Deletion".
 
-0097 derives groups on the server from stored evidence, over the whole dataset rather
-than one upload. That takes most of the first bullet above with it: two legs in two
-broker logs, and a group cut by a period replace, are both cases the engine joins
-without anyone being asked. What is left here is the half 0097 cannot do -- the pair
-whose evidence does not identify the occurrence, where the answer is a person's
-judgement rather than a rule.
+## An assertion is destroyed when its postings change
 
-## Recording the human answer
+Two guarantees, and deliberately no more:
 
-A hand-made grouping -- the merge repair above, not a transfer match -- is recorded as
-a correlation on the postings it joins: a synthesised token, `MATCH_EXACT`, and
-`SCOPE_USER`, which the grouping engine claims through its highest-precedence pass like
-any other exact match. adr/0049-a-human-assertion-is-a-correlation.md settles this. What
-lands here is the writer: the `SCOPE_USER` value in the vocabulary, the API and UI that
-create and remove an assertion, and the warning shown before a re-upload that would
-destroy one.
+1. A person is warned before an import commits that would modify a posting
+   carrying a user-asserted correlation.
+2. When such a posting is modified, that correlation and every other user-asserted
+   correlation sharing its token are deleted.
 
-A hand-made transfer match stays a link keyed on group ids, for the reason
-adr/0037-transfer-matches-are-links-not-postings.md gives, and survives on the engine
-writing only the groups it disagrees with.
+So the assertion is never partly alive, and the person re-asserts if they still want
+it. That is the price of not building the alternative, which is a resolution step
+with no good answer whenever it fails -- 0049 sets out why a fuzzy re-anchoring
+re-applies a person's judgement to rows they never saw.
 
-## A manual match whose target stops making sense
+Deleting by token also means an assertion never has to record how many postings it
+named: `idx_tx_correlations_token` already indexes the lookup that finds its
+siblings.
 
-Distinct from the id churn adr/0037-transfer-matches-are-links-not-postings.md now records, and not fixed by anchoring a match to
-something durable. A later upload can leave the group a manual match names in a state
-where the match no longer means anything, with the same id throughout: the group's
-residual changes commodity or sign, or it loses the clearing leg the match was made
-against, because the re-uploaded rows genuinely differ from the ones the person looked
-at.
+**Ordering is what preserves the archive round trip.** The replace path collects the
+tokens carried by the postings it is about to delete, deletes the postings, deletes
+the correlations that survive elsewhere carrying those tokens, and only then inserts
+the incoming postings with their own correlations. So the deletion reaches what
+pre-dated the write and nothing the write itself supplied, and an archive that
+carries a whole assertion re-creates it, as adr/0043-grouping-does-not-travel-in-the-archive.md
+and 0049 both promise.
 
-So a match can be anchored perfectly and still be stale. Settle what happens: whether
-it survives on the assumption the judgement still holds, is dropped as unsupported, or
-is kept and flagged for review. The last is probably right -- a person's answer is
-expensive to obtain and discarding it silently is worse than showing it with a caveat
--- but the condition that triggers the flag has to be stated, and it is not simply "the
-group is imbalanced", because an unmatched transfer is imbalanced by construction.
+**The warning is a client-side preflight.** Nothing in the ingestion path gates a
+commit today: `UpsertTxs` queues a job and returns a `job_id`, and `JobStatus` has no
+state a user acknowledges. The precedent to follow is `CountIgnoredTxs`, a read-only
+count the client calls before the mutating call to raise a confirm dialog. So a
+read-only RPC takes the window's broker and period, plus any `SCOPE_USER` tokens the
+payload itself carries, and returns the assertions that would be destroyed together
+with how many postings *outside* the window lose a correlation -- that last number
+being the part a person will not expect. The upload modal calls it after the
+client-side parse and before the upload. The server does not block: an import from
+cron or the CLI has nobody to ask.
+
+## Non-goals
+
+**A person cannot record a negative.** An exact-token claim is a must-link, so an
+assertion can only ever add. There is no way to say "these two are not one event",
+which means a pairing the engine derives wrongly cannot be repaired by hand and a
+link it wrote cannot be broken -- it is re-derived on the next cycle from the same
+evidence. Known gap, not an oversight.
+
+**An assertion cannot be overridden by evidence that arrives later.** A person
+answers in the absence of evidence, and a later upload can supply some -- a source
+stating a grouping of its own that overlaps theirs. Precedence settles it in the
+person's favour, and `State.Claim` being all-or-nothing means the source's claim is
+then refused whole rather than partly honoured: its other members fall to the weaker
+rules. Nothing reports that this happened.
+
+## Suggested split
+
+Three increments rather than one change:
+
+1. Vocabulary and engine -- `SCOPE_USER`, the assertion rule, the matcher's pass,
+   and the destruction rule in the replace path.
+2. API -- create and delete, the preflight count, and a drill-down listing the
+   postings behind a residual balance.
+3. UI -- selection and the two actions on both views of /admin/imbalance, and the
+   confirm dialog in the upload modal.
 
 ## Relationship to 0091
 
-0091 covers hand-pairing transfers the matcher left alone and breaking pairs it
-got wrong, on the transfers view of `/admin/imbalance`. This is that generalised
-past transfers, with a different repair for the non-transfer case. Decide whether
-0095 subsumes 0091 or sits on top of it before either is picked up.
+0091 is subsumed. Its create half is the transfer case above, sharing one writer
+with the non-transfer repair; its unmatch half is the non-goal above.

--- a/docs/issues/milestones.md
+++ b/docs/issues/milestones.md
@@ -15,6 +15,7 @@
 - **M13** - Automated broker transaction import via a browser extension.
 - **M14** - Complete the archive: system and user archives carry everything a rebuild needs, and the transaction CSV is retired.
 - **M15** - The server owns transaction grouping: converters emit evidence and the server derives groups across the whole dataset rather than within one upload.
+- **M16** - A person can repair a grouping or a transfer pairing the engine cannot derive.
 
 ## Unscheduled
 


### PR DESCRIPTION
Documentation only. Both issues predate 0097 and 0098: 0095 opened on grouping being the converter's job and posed "which evidence justifies a match" as an open question, and 0091 rested on the matcher only ever inserting -- which stopped being true when the regroup began dropping the matches naming a group it repartitions.

## Decisions recorded

**A manual assertion is not preserved across a change to its postings.** Two guarantees replace it: a person is warned before an import commits that would modify a posting carrying a user-asserted correlation, and when such a posting is modified that correlation and every other user-asserted correlation sharing its token are deleted. The person re-asserts. Deleting by token removes the partial survivor entirely, so nothing has to record an assertion's arity, judge a fragment, or flag it as stale -- which is most of what 0095 was left holding.

**One evidence shape for both repairs; the type decides the interpretation.** A hand-made grouping and a hand-made transfer pairing are the same object -- a synthesised token with `MATCH_EXACT` and `SCOPE_USER` on each named posting. Where every named posting must be a transfer the assertion pairs the two groups, preserving the account boundary 0022 depends on; where none is, it merges. A mixed set is rejected when it is asserted. No new `Match` operator is needed.

**A `MANUAL` transfer link becomes derived.** It was not durable in the first place: `applyChanges` drops every `transfer_matches` row naming a group a posting left or the engine created, and nothing rebuilt a `MANUAL` one. The matcher now rebuilds it from the correlations like `POINTER` and `REFERENCE`.

**Recording a negative is out of scope**, so a pairing the engine derives wrongly cannot be repaired by hand. Stated as a non-goal rather than left implicit.

## Changes

- `docs/issues/0095-*.md` rewritten; gains milestone M16 and a suggested three-way split.
- `docs/issues/0091-*.md` closed as subsumed.
- `docs/adr/0049-*.md` amended: the destruction rule and its ordering, and a reversal -- a manual transfer match is not a different object after all.
- `docs/adr/0037-*.md` amended: a `MANUAL` match is derived too, and "the matcher only ever inserts" no longer holds.
- `docs/adr/0048-*.md` amended: `SCOPE_USER`'s reach, and why `MATCH_ACCOUNT` does not serve a hand-made pairing.
- `docs/issues/milestones.md`: M16.

🤖 Generated with [Claude Code](https://claude.com/claude-code)