### PR TITLE
Carry holding declarations in the user archive (0076)

### DIFF
--- a/client/app/archive/page.tsx
+++ b/client/app/archive/page.tsx
@@ -23,7 +23,8 @@ const IMPORT_NOTE = (
   <>
     The parts are applied in order on the server, so an import finishes whether or not this page
     stays open. Importing ignored asset classes replaces the rules you have now and removes the
-    transactions they cover.
+    transactions they cover. Importing holding declarations restates the ones the file names and
+    leaves the rest alone -- a declaration missing from a file is not a declaration you deleted.
   </>
 );
 
@@ -117,12 +118,14 @@ export default function UserArchivePage() {
   // What an import changes is spread across the user's own pages, so once it is
   // done everything it could have touched is dropped rather than guessing which
   // part landed. Ignored asset classes delete transactions, which move holdings,
-  // so those go too.
+  // so those go too, and a restored declaration writes the pad posting that
+  // opens its holding.
   const terminalJobId = job.data && !running ? jobId : null;
   useEffect(() => {
     if (terminalJobId === null) return;
     queryClient.invalidateQueries({ queryKey: qk.displayCurrency() });
     queryClient.invalidateQueries({ queryKey: qk.ignoredAssetClasses() });
+    queryClient.invalidateQueries({ queryKey: qk.holdingDeclarations() });
     queryClient.invalidateQueries({ queryKey: qk.holdings() });
     queryClient.invalidateQueries({ queryKey: qk.txs() });
   }, [terminalJobId, queryClient]);

--- a/client/lib/archive/assemble.test.ts
+++ b/client/lib/archive/assemble.test.ts
@@ -292,6 +292,62 @@ describe("assembleUserArchive", () => {
     expect(doc.txs?.windows).toHaveLength(0);
     expect(marshalUser(doc)).toContain('"txs":{}');
   });
+
+  // Declarations arrive a statement at a time -- one account read at one date --
+  // so the assembler accumulates them as it does transaction windows.
+  it("accumulates declaration statements across the stream", () => {
+    const doc = assembleUserArchive(
+      userStream(
+        { item: { case: "envelope", value: USER_ENVELOPE } },
+        { item: { case: "partBegin", value: { part: ArchivePart.DECLARATIONS } } },
+        {
+          item: {
+            case: "declarationStatement",
+            value: {
+              broker: 1,
+              account: "Z1",
+              asOfDate: "2024-01-31",
+              declarations: [
+                { instrument: { type: 11, value: "AAPL", domain: "XNAS" }, declaredQty: "100" },
+                { instrument: { type: 11, value: "MSFT", domain: "XNAS" }, declaredQty: "50" },
+              ],
+            },
+          },
+        },
+        {
+          item: {
+            case: "declarationStatement",
+            value: {
+              broker: 1,
+              account: "Z1",
+              asOfDate: "2024-02-29",
+              declarations: [
+                { instrument: { type: 11, value: "AAPL", domain: "XNAS" }, declaredQty: "120" },
+              ],
+            },
+          },
+        },
+      ),
+    );
+    expect(doc.declarations?.statements).toHaveLength(2);
+    expect(doc.declarations?.statements[0].asOfDate).toBe("2024-01-31");
+    expect(doc.declarations?.statements[0].declarations).toHaveLength(2);
+    expect(doc.declarations?.statements[1].asOfDate).toBe("2024-02-29");
+  });
+
+  // A declarations part asked for over no declarations is present and empty,
+  // the same statement the marker makes for every other part.
+  it("keeps an empty declarations part present", () => {
+    const doc = assembleUserArchive(
+      userStream(
+        { item: { case: "envelope", value: USER_ENVELOPE } },
+        { item: { case: "partBegin", value: { part: ArchivePart.DECLARATIONS } } },
+      ),
+    );
+    expect(doc.declarations).toBeDefined();
+    expect(doc.declarations?.statements).toHaveLength(0);
+    expect(marshalUser(doc)).toContain('"declarations":{}');
+  });
 });
 
 describe("userPartCounts", () => {
@@ -329,6 +385,42 @@ describe("userPartCounts", () => {
       }),
     ]);
     expect(userPartCounts(doc)).toEqual([{ label: "postings", count: 3 }]);
+  });
+
+  // Declarations rather than statements, for the same reason.
+  it("counts declarations for the declarations part", () => {
+    const doc = assembleUserArchive([
+      create(ExportUserArchiveResponseSchema, { item: { case: "envelope", value: { ...ENVELOPE, kind: 2 } } }),
+      create(ExportUserArchiveResponseSchema, {
+        item: { case: "partBegin", value: { part: ArchivePart.DECLARATIONS } },
+      }),
+      create(ExportUserArchiveResponseSchema, {
+        item: {
+          case: "declarationStatement",
+          value: {
+            broker: 1,
+            account: "Z1",
+            asOfDate: "2024-01-31",
+            declarations: [
+              { instrument: { type: 11, value: "AAPL", domain: "XNAS" }, declaredQty: "100" },
+              { instrument: { type: 11, value: "MSFT", domain: "XNAS" }, declaredQty: "50" },
+            ],
+          },
+        },
+      }),
+      create(ExportUserArchiveResponseSchema, {
+        item: {
+          case: "declarationStatement",
+          value: {
+            broker: 1,
+            account: "Z2",
+            asOfDate: "2024-01-31",
+            declarations: [{ instrument: { type: 11, value: "AAPL", domain: "XNAS" }, declaredQty: "7" }],
+          },
+        },
+      }),
+    ]);
+    expect(userPartCounts(doc)).toEqual([{ label: "holding declarations", count: 3 }]);
   });
 
   // A part present and empty is present with nothing in it, which is a

--- a/client/lib/archive/assemble.ts
+++ b/client/lib/archive/assemble.ts
@@ -1,6 +1,7 @@
 import { create } from "@bufbuild/protobuf";
 import { ArchivePart } from "@/gen/archive/v1/common_pb";
 import { CorporateEventPartSchema } from "@/gen/archive/v1/corporate_events_pb";
+import { DeclarationPartSchema } from "@/gen/archive/v1/declarations_pb";
 import { FetchBlockPartSchema } from "@/gen/archive/v1/fetch_blocks_pb";
 import { InflationPartSchema } from "@/gen/archive/v1/inflation_pb";
 import { InstrumentPartSchema } from "@/gen/archive/v1/instruments_pb";
@@ -105,6 +106,9 @@ export function assembleUserArchive(items: ExportUserArchiveResponse[]): UserArc
           case ArchivePart.TXS:
             doc.txs ??= create(TxPartSchema, {});
             break;
+          case ArchivePart.DECLARATIONS:
+            doc.declarations ??= create(DeclarationPartSchema, {});
+            break;
         }
         break;
       case "preferences":
@@ -113,6 +117,10 @@ export function assembleUserArchive(items: ExportUserArchiveResponse[]): UserArc
       case "txWindow":
         doc.txs ??= create(TxPartSchema, {});
         doc.txs.windows.push(item.item.value);
+        break;
+      case "declarationStatement":
+        doc.declarations ??= create(DeclarationPartSchema, {});
+        doc.declarations.statements.push(item.item.value);
         break;
     }
   }
@@ -173,6 +181,14 @@ export function userPartCounts(archive: UserArchive): { label: string; count: nu
     // import job counts.
     const postings = archive.txs.windows.reduce((n, w) => n + w.postings.length, 0);
     out.push({ label: "postings", count: postings });
+  }
+  if (archive.declarations) {
+    // Declarations rather than statements, for the same reason.
+    const declarations = archive.declarations.statements.reduce(
+      (n, s) => n + s.declarations.length,
+      0,
+    );
+    out.push({ label: "holding declarations", count: declarations });
   }
   return out;
 }

--- a/client/lib/archive/parts.ts
+++ b/client/lib/archive/parts.ts
@@ -74,6 +74,12 @@ export const USER_ARCHIVE_PART_OPTIONS: ArchivePartOption[] = [
     note: "Every posting, grouped as the broker converter grouped it. Nothing can rebuild the grouping, so it travels with them.",
     defaultSelected: true,
   },
+  {
+    part: ArchivePart.DECLARATIONS,
+    label: "Holding declarations",
+    note: "What you stated you held, and when. Nothing can refetch a declaration, and a rebuild without them loses every opening balance and every checkpoint.",
+    defaultSelected: true,
+  },
 ];
 
 /** Display names for the parts a job reports against. */
@@ -87,4 +93,5 @@ export const ARCHIVE_PART_LABELS: Record<number, string> = {
   [ArchivePart.PLUGIN_CONFIG]: "Plugin config",
   [ArchivePart.PREFERENCES]: "Preferences",
   [ArchivePart.TXS]: "Transactions",
+  [ArchivePart.DECLARATIONS]: "Holding declarations",
 };

--- a/client/lib/archive/tx-document.test.ts
+++ b/client/lib/archive/tx-document.test.ts
@@ -59,6 +59,30 @@ describe("readTxDocument", () => {
     expect(errors[0]!.message).toContain("more than transactions");
   });
 
+  // Declarations are the other user part, and a broker upload has nowhere to
+  // put them: they restate holdings rather than replacing a period.
+  it("refuses a document that carries declarations", () => {
+    const { window, errors } = readTxDocument(
+      doc({
+        declarations: {
+          statements: [
+            {
+              broker: Broker.FIDELITY,
+              account: "Z1",
+              asOfDate: "2024-01-31",
+              declarations: [
+                { instrument: { type: 11, value: "AAPL", domain: "XNAS" }, declaredQty: "100" },
+              ],
+            },
+          ],
+        },
+      }),
+    );
+
+    expect(window).toBeUndefined();
+    expect(errors[0]!.message).toContain("more than transactions");
+  });
+
   it("reports a file that is not an archive as a parse error rather than throwing", () => {
     const { window, errors } = readTxDocument("date,type\n2024-01-01,BUYSTOCK");
 

--- a/docs/issues/0076-declaration-archive-import-export.md
+++ b/docs/issues/0076-declaration-archive-import-export.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Carry holding declarations in the user archive
 milestone: M14
 dependencies: [0078]

--- a/docs/issues/0104-attach-an-instrument-to-an-unresolved-row.md
+++ b/docs/issues/0104-attach-an-instrument-to-an-unresolved-row.md
@@ -1,0 +1,26 @@
+---
+status: open
+title: Let a user attach an instrument to a row an import could not resolve
+milestone: M16
+---
+
+Give a user a way to find an instrument and attach it to a row the system could
+not identify, from the surface that reports the failure.
+
+## Motivation
+
+An identifier the system cannot take back is a dead end for the user today. A
+transaction lands on a BROKER_DESCRIPTION placeholder and an identification
+error; a declaration in a user archive is rejected outright, because a statement
+about a holding the system cannot name has nothing to pad and nothing to check
+(0076). Either way the only repair is to edit the file by hand and import it
+again, and the file is often not the thing that is wrong -- the identifier is
+real and the instrument is present, and the resolution path simply cannot get
+from one to the other.
+
+The user can already find the instrument: the declaration form searches them.
+What is missing is the attachment -- searching from the error and saying "this
+one", so the row resolves and the surface that reported it closes.
+
+M16 is where a person repairs what the engine cannot derive, and this is the
+same shape as the grouping and transfer-pairing repairs.

--- a/docs/spec/archive-format.md
+++ b/docs/spec/archive-format.md
@@ -668,6 +668,33 @@ follows from the declaration dates for its holding -- the earliest pads, the res
 are checked -- so a stored copy could only ever disagree with them. See
 `docs/adr/0030-declarations-are-padded-then-asserted.md`.
 
+**A declaration that fails to identify is rejected as a row.** This is the one
+part whose instrument resolution is a database lookup and never a creation.
+Prices and corporate events resolve an unknown instrument through the identifier
+plugins because their rows are worth having either way, and a transaction that
+identifies nothing still lands, on a placeholder built from its description --
+the event happened. A declaration is a statement about a holding, so an
+instrument the system cannot name leaves nothing for it to pad and nothing to
+check it against. The row is rejected and the rest of the file lands, which is
+what a rejected row does everywhere in this format. A row failing here is a
+defect rather than a user error: the user picked the instrument in the UI, and
+the export writes an identifier this instance holds.
+
+**A declaration dated before the portfolio start date is rejected too.** Nothing
+before the first transaction can be padded to or checked against, so the
+recalculation deletes such declarations; writing one and removing it moments
+later would report a success the user cannot see the result of. A user with no
+transactions at all has no start date, and the whole part fails rather than every
+row in it -- the file is fine and the instance is not ready for it. Restoring
+transactions before declarations is what avoids both, and is why they are in that
+order.
+
+**The pads are settled once, after the part.** A declaration carries no pad --
+the pad is derived -- and which declaration pads a holding depends on the others
+in it, so the unit of recalculation is the holding rather than the row. The
+import writes the declarations and the recalculation that follows every ingestion
+settles every affected holding's opening balance from the set as it now stands.
+
 ## Producing and consuming a document
 
 One endpoint each way, and one page: `/admin/archive`. Neither the export nor the

--- a/e2e/fixtures/user-archive-declarations.sql
+++ b/e2e/fixtures/user-archive-declarations.sql
@@ -1,0 +1,26 @@
+-- Holding declarations for the user archive round trip: one statement covering
+-- two holdings, and a second statement at a later date for one of them.
+--
+-- Layered on user-archive-txs.sql, which seeds the instruments and the
+-- transactions. A declaration needs both: it is padded from and checked against
+-- the transactions, and the portfolio start date those transactions set is what
+-- an as_of_date has to fall on or after.
+--
+-- The dates sit after the seeded trades (2024-01-15 to 2024-01-17) so nothing is
+-- pruned, and the second statement makes the export cut two statements from one
+-- account rather than one.
+--
+-- share_count_basis is left to the table's trigger on the first two rows, which
+-- defaults it to as_of_date and is what an absent basis in the file means. The
+-- third states one, so the export has a row that has to write it out.
+
+INSERT INTO holding_declarations (user_id, broker, account, instrument_id, declared_qty, as_of_date)
+VALUES
+  ('e2e00000-0000-0000-0000-000000000001', 'FIDELITY', 'ACC-1', 'e2e00000-0000-0000-0000-000000000401', 8, '2024-01-31'),
+  ('e2e00000-0000-0000-0000-000000000001', 'FIDELITY', 'ACC-1', 'e2e00000-0000-0000-0000-000000000402', 15, '2024-01-31')
+ON CONFLICT DO NOTHING;
+
+INSERT INTO holding_declarations (user_id, broker, account, instrument_id, declared_qty, as_of_date, share_count_basis)
+VALUES
+  ('e2e00000-0000-0000-0000-000000000001', 'FIDELITY', 'ACC-1', 'e2e00000-0000-0000-0000-000000000401', 8, '2024-02-29', '2024-03-31')
+ON CONFLICT DO NOTHING;

--- a/e2e/tests/user-archive-roundtrip.spec.ts
+++ b/e2e/tests/user-archive-roundtrip.spec.ts
@@ -353,8 +353,14 @@ test.describe("user archive page", () => {
     );
     await page.locator("[data-testid='start-archive-import']").click();
 
+    // The page shows the most recent import job, so the part is named as well
+    // as counted: without that this would pass against the transaction job the
+    // previous test left behind.
     const parts = page.locator("[data-testid='job-parts']");
     await expect(parts).toBeVisible({ timeout: TIMEOUT_SLOW });
+    await expect(parts).toContainText("Holding declarations", {
+      timeout: TIMEOUT_SLOW,
+    });
     await expect(parts.getByText("Done")).toHaveCount(1, {
       timeout: TIMEOUT_SLOW,
     });

--- a/e2e/tests/user-archive-roundtrip.spec.ts
+++ b/e2e/tests/user-archive-roundtrip.spec.ts
@@ -71,10 +71,11 @@ test.describe("user archive page", () => {
 
     const preferences = page.getByLabel(/Preferences/);
     await expect(preferences).toBeChecked();
-    // Both parts are on by default, which is what a rebuild wants. This test is
+    // Every part is on by default, which is what a rebuild wants. This test is
     // about the settings, so it asks for them alone and the assertions below
     // can be exact about what the document holds.
     await page.getByLabel(/Transactions/).uncheck();
+    await page.getByLabel(/Holding declarations/).uncheck();
 
     const downloadPromise = page.waitForEvent("download");
     await page.locator("[data-testid='export-archive']").click();
@@ -100,6 +101,7 @@ test.describe("user archive page", () => {
     expect(doc.instruments).toBeUndefined();
     expect(doc.prices).toBeUndefined();
     expect(doc.txs).toBeUndefined();
+    expect(doc.declarations).toBeUndefined();
 
     // Put both settings back to what they were, so what lands afterwards came
     // from the file rather than from what was already there.
@@ -152,6 +154,7 @@ test.describe("user archive page", () => {
     await page.goto("/archive");
 
     await page.getByLabel(/Preferences/).uncheck();
+    await page.getByLabel(/Holding declarations/).uncheck();
     await expect(page.getByLabel(/Transactions/)).toBeChecked();
 
     const downloadPromise = page.waitForEvent("download");
@@ -280,6 +283,130 @@ test.describe("user archive page", () => {
       [TEST_USER_ID],
     )) as unknown[];
     expect(unbalanced).toHaveLength(0);
+  });
+
+  test("exports the user's declarations and imports them back", async ({
+    context,
+    page,
+  }) => {
+    await seedFixture("user-archive-declarations.sql");
+    await injectSession(context, sessionId);
+    await page.goto("/archive");
+
+    await page.getByLabel(/Preferences/).uncheck();
+    await page.getByLabel(/Transactions/).uncheck();
+    await expect(page.getByLabel(/Holding declarations/)).toBeChecked();
+
+    const downloadPromise = page.waitForEvent("download");
+    await page.locator("[data-testid='export-archive']").click();
+    const exported = path.join(tmpdir(), "user-archive-declarations-e2e.json");
+    await (await downloadPromise).saveAs(exported);
+    const doc = JSON.parse(await readFile(exported, "utf8"));
+
+    // The group is the statement -- one account read at one date -- so two
+    // holdings declared on the same day travel as one statement and the later
+    // restatement of one of them cuts a second.
+    expect(doc.declarations.statements).toHaveLength(2);
+    const [january, february] = doc.declarations.statements;
+    expect(january.broker).toBe("FIDELITY");
+    expect(january.account).toBe("ACC-1");
+    expect(january.as_of_date).toBe("2024-01-31");
+    expect(january.declarations).toHaveLength(2);
+
+    // Named by identifier and never by id, and by the one bestIdentifierJoin
+    // picks: MIC_TICKER outranks the ISIN the same instrument also carries.
+    expect(january.declarations[0].instrument).toEqual({
+      type: "MIC_TICKER",
+      value: "AMZN",
+    });
+    // Decimals are strings, never JSON numbers.
+    expect(january.declarations[0].declared_qty).toBe("8");
+    // A basis equal to the statement's own date is what an absent one already
+    // means, so it is not written.
+    expect(january.declarations[0].share_count_basis).toBeUndefined();
+    // And one that differs is.
+    expect(february.declarations[0].share_count_basis).toBe("2024-03-31");
+
+    // Neither the pad/assert discriminator nor the check against the computed
+    // holding travels: both are derived from the declarations and the postings,
+    // and are recomputed by whatever instance reads the file.
+    expect(january.declarations[0].kind).toBeUndefined();
+    expect(january.declarations[0].computed_qty).toBeUndefined();
+
+    // Restated so that what lands afterwards came from the file rather than
+    // from what was already there. The rows are left in place rather than
+    // deleted, which is what makes this an upsert rather than an insert: a
+    // re-import collides on the unique key at every unchanged row.
+    await rawQuery(
+      `UPDATE holding_declarations SET declared_qty = 999 WHERE user_id = $1`,
+      [TEST_USER_ID],
+    );
+
+    await page.locator("[data-testid='choose-archive-file']").click();
+    await page
+      .locator("input[aria-label='Choose archive file']")
+      .setInputFiles(exported);
+    // Declarations rather than statements, so the preview and the job's own
+    // total agree.
+    await expect(page.locator("[data-testid='archive-import']")).toContainText(
+      "Carries 3 holding declarations",
+    );
+    await page.locator("[data-testid='start-archive-import']").click();
+
+    const parts = page.locator("[data-testid='job-parts']");
+    await expect(parts).toBeVisible({ timeout: TIMEOUT_SLOW });
+    await expect(parts.getByText("Done")).toHaveCount(1, {
+      timeout: TIMEOUT_SLOW,
+    });
+    await expect(parts).toContainText("3 / 3");
+
+    // Three rows, not six: the import restated the ones already there rather
+    // than colliding on the unique key or writing duplicates.
+    const restored = (await rawQuery(
+      `SELECT broker, account, declared_qty, as_of_date::text, share_count_basis::text
+       FROM holding_declarations WHERE user_id = $1 ORDER BY as_of_date, declared_qty`,
+      [TEST_USER_ID],
+    )) as {
+      broker: string;
+      account: string;
+      declared_qty: string;
+      as_of_date: string;
+      share_count_basis: string;
+    }[];
+    expect(restored).toHaveLength(3);
+    expect(restored.map((r) => Number(r.declared_qty)).sort((a, b) => a - b)).toEqual([
+      8, 8, 15,
+    ]);
+    // The basis the file did not state is the statement's own date, applied by
+    // the table's trigger, and the one it did state is used as stated.
+    const stated = restored.find((r) => r.as_of_date === "2024-02-29");
+    expect(stated?.share_count_basis).toBe("2024-03-31");
+    const defaulted = restored.filter((r) => r.as_of_date === "2024-01-31");
+    expect(defaulted.every((r) => r.share_count_basis === "2024-01-31")).toBe(
+      true,
+    );
+
+    // The earliest declaration for each holding is its pad, and the recalc the
+    // import earns is what writes it. A declaration carries no pad, so without
+    // that pass the restored rows would say what the user holds and nothing
+    // would make it true.
+    //
+    // The USER leg alone: a pad is written with the equal and opposite EQUITY
+    // counterparty that makes its group balance, so counting both would count
+    // each pad twice.
+    const pads = (await rawQuery(
+      `SELECT instrument_id::text, quantity FROM txs
+       WHERE user_id = $1 AND synthetic_purpose = 'INITIALIZE' AND account_type = 'USER'
+       ORDER BY instrument_id`,
+      [TEST_USER_ID],
+    )) as { instrument_id: string; quantity: string }[];
+    // One per holding, not one per declaration: AMZN has two declarations and
+    // the earliest of them is the one that pads.
+    expect(pads).toHaveLength(2);
+    // The seeded trades already account for both declared balances exactly, so
+    // each pad is zero. That is the declaration agreeing with the data rather
+    // than being superseded by it, and the record stays.
+    expect(pads.every((p) => Number(p.quantity) === 0)).toBe(true);
   });
 
   test("refuses a file that is not a user archive", async ({

--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -5,6 +5,7 @@ package portfoliodb.api.v1;
 import "archive/v1/archive.proto";
 import "archive/v1/common.proto";
 import "archive/v1/corporate_events.proto";
+import "archive/v1/declarations.proto";
 import "archive/v1/fetch_blocks.proto";
 import "archive/v1/inflation.proto";
 import "archive/v1/instruments.proto";
@@ -705,7 +706,8 @@ message ExportUserArchiveResponse {
     portfoliodb.archive.v1.PreferencePart preferences = 3;
     // One window per broker, each carrying its own groups.
     portfoliodb.archive.v1.TxWindow tx_window = 4;
-    // 5 is the declaration statement.
+    // One statement per account and date, each carrying its declarations.
+    portfoliodb.archive.v1.Statement declaration_statement = 5;
   }
 }
 

--- a/server/archiveimport/declarations.go
+++ b/server/archiveimport/declarations.go
@@ -1,0 +1,164 @@
+package archiveimport
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/identifier"
+	"github.com/leedenison/portfoliodb/server/service/identification"
+	"github.com/shopspring/decimal"
+)
+
+// declarationDateLayout is the date form the archive states.
+const declarationDateLayout = "2006-01-02"
+
+// DeclarationPart restores a user's holding declarations and reports through
+// rep. It returns how many declarations were written.
+//
+// Import is an upsert on (user, broker, account, instrument, as_of_date). The
+// unique key means a re-import collides on every unchanged row, and the
+// AlreadyExists the declaration API answers with -- right for a user filling in
+// a form -- would fail the restore this exists for. A row whose quantity has
+// changed restates the declaration; a row identical to what is stored changes
+// nothing.
+//
+// Absence is not deletion, and this is the one place the archive deliberately
+// differs from the transaction part. A declaration missing from the file is left
+// alone: a file assembled from one statement covers one account and one date,
+// and treating everything outside it as retracted would delete the user's other
+// checkpoints. Deleting one stays an explicit action.
+//
+// The pads are not written here. Which declaration pads a holding depends on the
+// others in it, so the unit of recalculation is the holding rather than the
+// declaration, and the caller settles every one of them from the set as it
+// stands once the whole part has landed. See
+// docs/adr/0030-declarations-are-padded-then-asserted.md.
+func DeclarationPart(ctx context.Context, database db.DB, userID string, part *archivev1.DeclarationPart, rep *PartReporter) (int32, error) {
+	statements := part.GetStatements()
+	// The part's unit is a declaration rather than a statement, which is what a
+	// reader watching the job expects to see move.
+	total := 0
+	for _, st := range statements {
+		total += len(st.GetDeclarations())
+	}
+	rep.Total(ctx, total)
+	if total == 0 {
+		return 0, nil
+	}
+
+	// A declaration is padded from and checked against the transactions, so a
+	// portfolio with none has nothing to anchor one to. That is the precondition
+	// the create RPC states, and it fails the part rather than every row in it:
+	// the file is fine and the instance is not ready for it.
+	startDate, err := database.GetPortfolioStartDate(ctx, userID)
+	if err != nil {
+		return 0, fmt.Errorf("get portfolio start date: %w", err)
+	}
+	if startDate == nil {
+		return 0, fmt.Errorf("no transactions exist; import transactions before declarations")
+	}
+	startDay := startDate.Truncate(24 * time.Hour)
+
+	var written int32
+	// Row indices run across the whole part rather than restarting per
+	// statement, so a problem points at a declaration in the document.
+	row := 0
+	for _, st := range statements {
+		broker := db.BrokerToStr(st.GetBroker())
+		asOfDate, dateErr := time.Parse(declarationDateLayout, st.GetAsOfDate())
+		for _, d := range st.GetDeclarations() {
+			idx := row
+			row++
+			rep.Advance(ctx, 1)
+
+			if broker == "" {
+				rep.Errf(idx, "broker", fmt.Sprintf("unknown broker %q", st.GetBroker()))
+				continue
+			}
+			if dateErr != nil {
+				rep.Errf(idx, "as_of_date", fmt.Sprintf("%q is not a date: %v", st.GetAsOfDate(), dateErr))
+				continue
+			}
+			// Rejected here rather than left to the recalculation, which deletes
+			// the declarations the start date has moved past. Writing it would
+			// report success and then take it away again with nothing to show
+			// the user for it.
+			if asOfDate.Before(startDay) {
+				rep.Errf(idx, "as_of_date", fmt.Sprintf("%s is before the portfolio start date (%s)",
+					st.GetAsOfDate(), startDay.Format(declarationDateLayout)))
+				continue
+			}
+			qty, err := decimal.NewFromString(d.GetDeclaredQty())
+			if err != nil {
+				rep.Errf(idx, "declared_qty", fmt.Sprintf("%q is not a decimal: %v", d.GetDeclaredQty(), err))
+				continue
+			}
+			basis := asOfDate
+			if d.ShareCountBasis != nil {
+				basis, err = time.Parse(declarationDateLayout, d.GetShareCountBasis())
+				if err != nil {
+					rep.Errf(idx, "share_count_basis", fmt.Sprintf("%q is not a date: %v", d.GetShareCountBasis(), err))
+					continue
+				}
+			}
+			instrumentID, err := findDeclaredInstrument(ctx, database, d.GetInstrument(), idx, rep)
+			if err != nil {
+				return written, fmt.Errorf("resolve instrument: %w", err)
+			}
+			if instrumentID == "" {
+				continue
+			}
+
+			if err := database.UpsertHoldingDeclaration(ctx, userID, broker, st.GetAccount(),
+				instrumentID, qty.String(), asOfDate, basis); err != nil {
+				return written, fmt.Errorf("upsert holding declaration: %w", err)
+			}
+			written++
+		}
+	}
+	return written, nil
+}
+
+// findDeclaredInstrument maps a declaration's instrument reference to an
+// instrument this instance already has, reporting a miss against the row.
+//
+// It resolves against the database alone and never creates an instrument, which
+// is what makes failing loudly possible at all: the transaction path cannot
+// fail, because an unresolved posting lands on a placeholder instrument built
+// from its description. A declaration has no such fallback to offer. It is a
+// statement about a holding the system cannot name -- there is nothing for it to
+// pad and nothing to check it against -- so the row is rejected and the rest of
+// the file lands.
+//
+// A row failing here is a defect rather than a user error: the instrument was
+// picked in the UI when the declaration was made, and the export writes whichever
+// identifier bestIdentifierJoin ranks highest. ResolveByHintsDBOnly rather than a
+// bare lookup is what keeps the two ends in step -- it normalises OCC to the
+// compact form the column stores, and falls back to (type, value) where the file
+// states no domain.
+//
+// It returns "" when the row has nothing to attach itself to, and an error only
+// where the lookup itself failed.
+func findDeclaredInstrument(ctx context.Context, database db.DB, ref *archivev1.InstrumentRef, idx int, rep *PartReporter) (string, error) {
+	if ref.GetValue() == "" {
+		rep.Errf(idx, "instrument", "declaration names no instrument")
+		return "", nil
+	}
+	hint := identifier.Identifier{
+		Type:   ref.GetType().String(),
+		Domain: ref.GetDomain(),
+		Value:  ref.GetValue(),
+	}
+	ids, err := identification.ResolveIDsByHintsDBOnly(ctx, database, []identifier.Identifier{hint})
+	if err != nil {
+		return "", err
+	}
+	if len(ids) == 0 {
+		rep.Errf(idx, "instrument", fmt.Sprintf("%s %s is not an instrument this instance has", ref.GetType(), ref.GetValue()))
+		return "", nil
+	}
+	return ids[0], nil
+}

--- a/server/archiveimport/declarations_test.go
+++ b/server/archiveimport/declarations_test.go
@@ -1,0 +1,259 @@
+package archiveimport
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/proto"
+
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
+	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
+	"github.com/leedenison/portfoliodb/server/db/mock"
+)
+
+// startDay is the portfolio start date every test below shares. A declaration
+// is padded from and checked against the transactions, so the part reads it
+// once and rejects anything the history no longer reaches.
+const startDay = "2020-01-01"
+
+func day(t *testing.T, s string) time.Time {
+	t.Helper()
+	d, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return d
+}
+
+// expectStartDate stubs the one read every run makes before any row.
+func expectStartDate(t *testing.T, database *mock.MockDB) {
+	t.Helper()
+	start := day(t, startDay)
+	database.EXPECT().GetPortfolioStartDate(gomock.Any(), "user-1").Return(&start, nil)
+}
+
+func decl(value, qty string, basis *string) *archivev1.Declaration {
+	return &archivev1.Declaration{
+		Instrument:      &archivev1.InstrumentRef{Type: typev1.IdentifierType_MIC_TICKER, Value: value, Domain: "XNAS"},
+		DeclaredQty:     qty,
+		ShareCountBasis: basis,
+	}
+}
+
+func statement(account, asOf string, decls ...*archivev1.Declaration) *archivev1.Statement {
+	return &archivev1.Statement{
+		Broker:       typev1.Broker_FIDELITY,
+		Account:      account,
+		AsOfDate:     asOf,
+		Declarations: decls,
+	}
+}
+
+func declarationPart(sts ...*archivev1.Statement) *archivev1.DeclarationPart {
+	return &archivev1.DeclarationPart{Statements: sts}
+}
+
+// expectResolve stubs the DB-only lookup for one identifier value.
+func expectResolve(database *mock.MockDB, value, instrumentID string) {
+	database.EXPECT().
+		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", value).
+		Return(instrumentID, nil)
+}
+
+func applyDeclarations(t *testing.T, database *mock.MockDB, rep *PartReporter, part *archivev1.DeclarationPart) int32 {
+	t.Helper()
+	n, err := DeclarationPart(context.Background(), database, "user-1", part, rep)
+	if err != nil {
+		t.Fatalf("DeclarationPart: %v", err)
+	}
+	return n
+}
+
+// Every declaration of every statement is written, with the statement's broker,
+// account and date carried down onto each of its rows.
+func TestDeclarationPart_WritesEveryRow(t *testing.T) {
+	database, rep := newPartTest(t)
+	expectStartDate(t, database)
+	expectResolve(database, "AAPL", "inst-a")
+	expectResolve(database, "MSFT", "inst-m")
+	database.EXPECT().
+		UpsertHoldingDeclaration(gomock.Any(), "user-1", "FIDELITY", "Z1", "inst-a", "100",
+			day(t, "2024-01-31"), day(t, "2024-01-31")).
+		Return(nil)
+	database.EXPECT().
+		UpsertHoldingDeclaration(gomock.Any(), "user-1", "FIDELITY", "Z1", "inst-m", "50",
+			day(t, "2024-01-31"), day(t, "2024-01-31")).
+		Return(nil)
+
+	n := applyDeclarations(t, database, rep, declarationPart(
+		statement("Z1", "2024-01-31", decl("AAPL", "100", nil), decl("MSFT", "50", nil)),
+	))
+	if n != 2 {
+		t.Fatalf("wrote %d declarations, want 2", n)
+	}
+	if rep.ErrCount() != 0 {
+		t.Fatalf("reported %d row errors, want none: %v", rep.ErrCount(), rep.Errors())
+	}
+}
+
+// A quantity read off a record of the statement's date is in the share count
+// current then, so an absent basis is that date. A basis the file states is
+// used as stated.
+func TestDeclarationPart_DefaultsShareCountBasisToTheStatementDate(t *testing.T) {
+	database, rep := newPartTest(t)
+	expectStartDate(t, database)
+	expectResolve(database, "AAPL", "inst-a")
+	database.EXPECT().
+		UpsertHoldingDeclaration(gomock.Any(), "user-1", "FIDELITY", "Z1", "inst-a", "100",
+			day(t, "2024-01-31"), day(t, "2026-08-13")).
+		Return(nil)
+
+	applyDeclarations(t, database, rep, declarationPart(
+		statement("Z1", "2024-01-31", decl("AAPL", "100", proto.String("2026-08-13"))),
+	))
+}
+
+// A declaration the system cannot name has nothing to pad and nothing to check,
+// so the row is rejected. Its siblings still land: a rejected row does not fail
+// the part.
+func TestDeclarationPart_RejectsAnUnresolvableInstrument(t *testing.T) {
+	database, rep := newPartTest(t)
+	expectStartDate(t, database)
+	expectResolve(database, "GONE", "")
+	expectResolve(database, "MSFT", "inst-m")
+	database.EXPECT().
+		UpsertHoldingDeclaration(gomock.Any(), "user-1", "FIDELITY", "Z1", "inst-m", "50",
+			day(t, "2024-01-31"), day(t, "2024-01-31")).
+		Return(nil)
+
+	n := applyDeclarations(t, database, rep, declarationPart(
+		statement("Z1", "2024-01-31", decl("GONE", "100", nil), decl("MSFT", "50", nil)),
+	))
+	if n != 1 {
+		t.Fatalf("wrote %d declarations, want the resolvable one", n)
+	}
+	if rep.ErrCount() != 1 {
+		t.Fatalf("reported %d row errors, want 1: %v", rep.ErrCount(), rep.Errors())
+	}
+	if got := rep.Errors()[0].GetField(); got != "instrument" {
+		t.Fatalf("row error field = %q, want instrument", got)
+	}
+}
+
+// A declaration the start date has moved past would be written and then deleted
+// by the recalculation, so it is rejected here where the user is told about it.
+func TestDeclarationPart_RejectsADateBeforeThePortfolioStart(t *testing.T) {
+	database, rep := newPartTest(t)
+	expectStartDate(t, database)
+
+	n := applyDeclarations(t, database, rep, declarationPart(
+		statement("Z1", "2019-12-31", decl("AAPL", "100", nil)),
+	))
+	if n != 0 {
+		t.Fatalf("wrote %d declarations, want none", n)
+	}
+	if rep.ErrCount() != 1 || rep.Errors()[0].GetField() != "as_of_date" {
+		t.Fatalf("reported %v, want one as_of_date error", rep.Errors())
+	}
+}
+
+// Row indices run across the whole part rather than restarting per statement,
+// so a problem points at a declaration in the document.
+func TestDeclarationPart_RowIndicesRunAcrossTheWholePart(t *testing.T) {
+	database, rep := newPartTest(t)
+	expectStartDate(t, database)
+	expectResolve(database, "AAPL", "inst-a")
+	expectResolve(database, "GONE", "")
+	database.EXPECT().
+		UpsertHoldingDeclaration(gomock.Any(), "user-1", "FIDELITY", "Z1", "inst-a", "100",
+			gomock.Any(), gomock.Any()).
+		Return(nil)
+
+	applyDeclarations(t, database, rep, declarationPart(
+		statement("Z1", "2024-01-31", decl("AAPL", "100", nil)),
+		statement("Z2", "2024-01-31", decl("GONE", "5", nil)),
+	))
+	if rep.ErrCount() != 1 {
+		t.Fatalf("reported %d row errors, want 1", rep.ErrCount())
+	}
+	if got := rep.Errors()[0].GetRowIndex(); got != 1 {
+		t.Fatalf("row index = %d, want 1", got)
+	}
+}
+
+// A quantity that will not parse is a row error rather than a part failure.
+func TestDeclarationPart_RejectsAQuantityThatWillNotParse(t *testing.T) {
+	database, rep := newPartTest(t)
+	expectStartDate(t, database)
+
+	applyDeclarations(t, database, rep, declarationPart(
+		statement("Z1", "2024-01-31", decl("AAPL", "not a number", nil)),
+	))
+	if rep.ErrCount() != 1 || rep.Errors()[0].GetField() != "declared_qty" {
+		t.Fatalf("reported %v, want one declared_qty error", rep.Errors())
+	}
+}
+
+// Absence is not deletion, which is where this part differs from the
+// transaction one. A file assembled from one statement covers one account and
+// one date, and treating everything outside it as retracted would delete the
+// user's other checkpoints -- so nothing is listed and nothing is deleted. The
+// mock is strict, so any such call would fail this test.
+func TestDeclarationPart_LeavesWhatTheFileDoesNotNameAlone(t *testing.T) {
+	database, rep := newPartTest(t)
+	expectStartDate(t, database)
+	expectResolve(database, "AAPL", "inst-a")
+	database.EXPECT().
+		UpsertHoldingDeclaration(gomock.Any(), "user-1", "FIDELITY", "Z1", "inst-a", "100",
+			gomock.Any(), gomock.Any()).
+		Return(nil)
+
+	applyDeclarations(t, database, rep, declarationPart(
+		statement("Z1", "2024-01-31", decl("AAPL", "100", nil)),
+	))
+}
+
+// A part holding nothing succeeds having done nothing, which is what a present
+// but empty section means. It does not even read the start date.
+func TestDeclarationPart_EmptyPartDoesNothing(t *testing.T) {
+	database, rep := newPartTest(t)
+
+	n := applyDeclarations(t, database, rep, declarationPart())
+	if n != 0 {
+		t.Fatalf("wrote %d declarations, want none", n)
+	}
+}
+
+// A portfolio with no transactions has no start date to anchor a pad to. The
+// file is fine and the instance is not ready for it, so the part fails rather
+// than every row in it.
+func TestDeclarationPart_FailsWhenThereAreNoTransactions(t *testing.T) {
+	database, rep := newPartTest(t)
+	database.EXPECT().GetPortfolioStartDate(gomock.Any(), "user-1").Return(nil, nil)
+
+	_, err := DeclarationPart(context.Background(), database, "user-1",
+		declarationPart(statement("Z1", "2024-01-31", decl("AAPL", "100", nil))), rep)
+	if err == nil {
+		t.Fatal("DeclarationPart succeeded, want a part failure")
+	}
+}
+
+// A write that does not land fails the part: what failed is not a row.
+func TestDeclarationPart_AWriteFailureFailsThePart(t *testing.T) {
+	database, rep := newPartTest(t)
+	expectStartDate(t, database)
+	expectResolve(database, "AAPL", "inst-a")
+	database.EXPECT().
+		UpsertHoldingDeclaration(gomock.Any(), "user-1", "FIDELITY", "Z1", "inst-a", "100",
+			gomock.Any(), gomock.Any()).
+		Return(errors.New("disk on fire"))
+
+	_, err := DeclarationPart(context.Background(), database, "user-1",
+		declarationPart(statement("Z1", "2024-01-31", decl("AAPL", "100", nil))), rep)
+	if err == nil {
+		t.Fatal("DeclarationPart succeeded, want the write failure to fail the part")
+	}
+}

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -1155,13 +1155,51 @@ type InitializeTx struct {
 	ShareCountBasis time.Time
 }
 
+// ExportDeclaration is one stored declaration with the best identifier of the
+// instrument it names, ready to be cut into statements.
+//
+// Neither the pad/assert discriminator nor the check against the computed
+// holding is here. Both are derived from the declarations and the postings, and
+// an archive carries inputs rather than what is derived from them. See
+// docs/adr/0032-archive-preserves-inputs-not-derived-state.md.
+type ExportDeclaration struct {
+	Broker  string
+	Account string
+	// The instrument's best identifier, or all three empty for an instrument
+	// carrying none. Chosen by bestIdentifierJoin so that every export naming
+	// one identifier per instrument agrees which one.
+	IdentifierType   string
+	IdentifierValue  string
+	IdentifierDomain string
+	DeclaredQty      decimal.Decimal
+	AsOfDate         time.Time
+	// The share count the declared quantity is denominated in, or nil when it is
+	// the declaration's own as_of_date. The column is NOT NULL and the insert
+	// trigger defaults it to that date, so only a value that differs from it
+	// says anything worth writing to a file.
+	ShareCountBasis *time.Time
+}
+
 // HoldingDeclarationDB provides holding declaration CRUD and INITIALIZE tx helpers.
 type HoldingDeclarationDB interface {
 	CreateHoldingDeclaration(ctx context.Context, userID, broker, account, instrumentID, declaredQty string, asOfDate, shareCountBasis time.Time) (*HoldingDeclarationRow, error)
 	UpdateHoldingDeclaration(ctx context.Context, id, declaredQty string, asOfDate, shareCountBasis time.Time) (*HoldingDeclarationRow, error)
+	// UpsertHoldingDeclaration restates the declaration for a holding at a date,
+	// or creates it where there is none. It is what an archive import writes
+	// through: re-importing an exported file collides on the unique key at every
+	// unchanged row, and the AlreadyExists the create path answers with -- right
+	// for a user filling in a form -- would fail the restore.
+	//
+	// A zero shareCountBasis leaves the column NULL on insert so the table's
+	// trigger applies the as_of_date default, keeping that rule in one place.
+	UpsertHoldingDeclaration(ctx context.Context, userID, broker, account, instrumentID, declaredQty string, asOfDate, shareCountBasis time.Time) error
 	DeleteHoldingDeclaration(ctx context.Context, id string) error
 	GetHoldingDeclaration(ctx context.Context, id string) (*HoldingDeclarationRow, error)
 	ListHoldingDeclarations(ctx context.Context, userID string) ([]*HoldingDeclarationRow, error)
+	// ListHoldingDeclarationsForExport reads one user's declarations in archive
+	// order -- by broker, then account, then date -- so a writer can cut them
+	// into statements in one pass.
+	ListHoldingDeclarationsForExport(ctx context.Context, userID string) ([]ExportDeclaration, error)
 	// GetPortfolioStartDate returns the earliest real tx timestamp for the user, or nil if none exist.
 	GetPortfolioStartDate(ctx context.Context, userID string) (*time.Time, error)
 	// ComputeRunningBalance sums the real (non-synthetic) txs for the given holding

--- a/server/db/postgres/declarations.go
+++ b/server/db/postgres/declarations.go
@@ -232,6 +232,104 @@ func (p *Postgres) ListHoldingDeclarations(ctx context.Context, userID string) (
 	return out, nil
 }
 
+// exportDeclaration is the scan target for ListHoldingDeclarationsForExport.
+type exportDeclaration struct {
+	Broker           string          `db:"broker"`
+	Account          string          `db:"account"`
+	IdentifierType   string          `db:"identifier_type"`
+	IdentifierValue  string          `db:"value"`
+	IdentifierDomain string          `db:"domain"`
+	DeclaredQty      decimal.Decimal `db:"declared_qty"`
+	AsOfDate         time.Time       `db:"as_of_date"`
+	ShareCountBasis  *time.Time      `db:"share_count_basis"`
+}
+
+// ListHoldingDeclarationsForExport implements db.HoldingDeclarationDB.
+//
+// The identifier join is a LEFT JOIN so an instrument carrying no identifier
+// still comes back, and the writer can say so rather than the row simply not
+// appearing: a declaration silently missing from an export is the one failure
+// mode a file the user diffs by hand cannot show them.
+// bestIdentifierJoinOn rather than a hand-written lateral so this export agrees
+// with every other one about which identifier is best.
+//
+// Neither declarationVerify nor declarationKind is here. The check and the
+// pad/assert discriminator are derived from the declaration set and the
+// postings, and are recomputed by whatever instance reads the file.
+func (p *Postgres) ListHoldingDeclarationsForExport(ctx context.Context, userID string) ([]db.ExportDeclaration, error) {
+	userUUID, err := uuid.Parse(userID)
+	if err != nil {
+		return nil, fmt.Errorf("invalid user id: %w", err)
+	}
+	var rows []exportDeclaration
+	err = p.q.SelectContext(ctx, &rows, `
+		SELECT d.broker, d.account,
+			COALESCE(best_id.identifier_type, '') AS identifier_type,
+			COALESCE(best_id.value, '') AS value,
+			COALESCE(best_id.domain, '') AS domain,
+			d.declared_qty, d.as_of_date,
+			-- A basis equal to the declaration's own date is the as-traded
+			-- convention and says nothing a reader cannot infer. The column is
+			-- NOT NULL and the insert trigger defaults it to that date, so
+			-- selecting it raw would stamp a redundant date onto every row.
+			CASE WHEN d.share_count_basis = d.as_of_date THEN NULL
+				ELSE d.share_count_basis END AS share_count_basis
+		FROM holding_declarations d
+		`+bestIdentifierJoinOn("LEFT JOIN", "d.instrument_id", "best_id")+`
+		WHERE d.user_id = $1
+		ORDER BY d.broker, d.account, d.as_of_date, d.instrument_id
+	`, userUUID)
+	if err != nil {
+		return nil, fmt.Errorf("list holding declarations for export: %w", err)
+	}
+	out := make([]db.ExportDeclaration, len(rows))
+	for i, r := range rows {
+		out[i] = db.ExportDeclaration{
+			Broker:           r.Broker,
+			Account:          r.Account,
+			IdentifierType:   r.IdentifierType,
+			IdentifierValue:  r.IdentifierValue,
+			IdentifierDomain: r.IdentifierDomain,
+			DeclaredQty:      r.DeclaredQty,
+			AsOfDate:         r.AsOfDate,
+			ShareCountBasis:  r.ShareCountBasis,
+		}
+	}
+	return out, nil
+}
+
+// UpsertHoldingDeclaration implements db.HoldingDeclarationDB.
+//
+// The BEFORE INSERT trigger fills a NULL share_count_basis from as_of_date, and
+// it runs before the conflict is detected, so EXCLUDED carries the defaulted
+// value on the update branch too and the two branches agree on the denomination.
+func (p *Postgres) UpsertHoldingDeclaration(ctx context.Context, userID, broker, account, instrumentID, declaredQty string, asOfDate, shareCountBasis time.Time) error {
+	userUUID, err := uuid.Parse(userID)
+	if err != nil {
+		return fmt.Errorf("invalid user id: %w", err)
+	}
+	instUUID, err := uuid.Parse(instrumentID)
+	if err != nil {
+		return fmt.Errorf("invalid instrument id: %w", err)
+	}
+	var basis *time.Time
+	if !shareCountBasis.IsZero() {
+		basis = &shareCountBasis
+	}
+	_, err = p.q.ExecContext(ctx, `
+		INSERT INTO holding_declarations (user_id, broker, account, instrument_id, declared_qty, as_of_date, share_count_basis)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		ON CONFLICT (user_id, broker, account, instrument_id, as_of_date)
+		DO UPDATE SET declared_qty = EXCLUDED.declared_qty,
+		              share_count_basis = EXCLUDED.share_count_basis,
+		              updated_at = now()
+	`, userUUID, broker, account, instUUID, declaredQty, asOfDate, basis)
+	if err != nil {
+		return fmt.Errorf("upsert holding declaration: %w", err)
+	}
+	return nil
+}
+
 // GetPortfolioStartDate implements db.HoldingDeclarationDB.
 func (p *Postgres) GetPortfolioStartDate(ctx context.Context, userID string) (*time.Time, error) {
 	userUUID, err := uuid.Parse(userID)

--- a/server/db/postgres/declarations_test.go
+++ b/server/db/postgres/declarations_test.go
@@ -794,3 +794,144 @@ func TestUpsertInitializeTx_DenominatesThePad(t *testing.T) {
 	}
 	assertPadBasis(basis)
 }
+
+// A re-imported file collides on the unique key at every unchanged row, so the
+// archive path upserts where the create path answers AlreadyExists. Applying the
+// same file twice writes what it says and no more.
+func TestUpsertHoldingDeclaration_RestatesRatherThanColliding(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|decl-upsert", "U", "u@u.com")
+	instID, _ := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "AAPL", Canonical: false}}, "", nil, nil, nil)
+
+	asOf := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+	if err := p.UpsertHoldingDeclaration(ctx, userID, "IBKR", "acct1", instID, "100", asOf, asOf); err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	// The same row again changes nothing and must not be an error.
+	if err := p.UpsertHoldingDeclaration(ctx, userID, "IBKR", "acct1", instID, "100", asOf, asOf); err != nil {
+		t.Fatalf("re-import: %v", err)
+	}
+	// A changed quantity restates the declaration in place.
+	if err := p.UpsertHoldingDeclaration(ctx, userID, "IBKR", "acct1", instID, "120", asOf, asOf); err != nil {
+		t.Fatalf("restate: %v", err)
+	}
+
+	rows, err := p.ListHoldingDeclarations(ctx, userID)
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("stored %d declarations, want 1", len(rows))
+	}
+	if rows[0].DeclaredQty != "120" {
+		t.Fatalf("declared_qty = %s, want 120", rows[0].DeclaredQty)
+	}
+}
+
+// A zero basis leaves the column NULL so the table's trigger applies the
+// as_of_date default, on the conflict branch as well as the insert: the trigger
+// runs before the conflict is detected, so EXCLUDED carries the defaulted value.
+func TestUpsertHoldingDeclaration_LetsTheTriggerDefaultTheBasis(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|decl-basis", "U", "u@u.com")
+	instID, _ := p.EnsureInstrument(ctx, "", "", "", "", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "AAPL", Canonical: false}}, "", nil, nil, nil)
+
+	asOf := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+	other := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+	// Stated first, so the update branch has something to overwrite.
+	if err := p.UpsertHoldingDeclaration(ctx, userID, "IBKR", "acct1", instID, "100", asOf, other); err != nil {
+		t.Fatalf("first upsert: %v", err)
+	}
+	if err := p.UpsertHoldingDeclaration(ctx, userID, "IBKR", "acct1", instID, "100", asOf, time.Time{}); err != nil {
+		t.Fatalf("second upsert: %v", err)
+	}
+
+	rows, _ := p.ListHoldingDeclarations(ctx, userID)
+	if len(rows) != 1 {
+		t.Fatalf("stored %d declarations, want 1", len(rows))
+	}
+	if !rows[0].ShareCountBasis.Equal(asOf) {
+		t.Fatalf("share_count_basis = %s, want the as_of_date default %s",
+			rows[0].ShareCountBasis.Format("2006-01-02"), asOf.Format("2006-01-02"))
+	}
+}
+
+// The export names an instrument by the identifier bestIdentifierJoin ranks
+// highest, so this export agrees with every other one about which one it is.
+// It also drops a basis equal to the declaration's own date, which is what an
+// absent one already means.
+func TestListHoldingDeclarationsForExport_UsesTheBestIdentifier(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|decl-export", "U", "u@u.com")
+	instID, _ := p.EnsureInstrument(ctx, "STOCK", "XNAS", "USD", "Apple", "", "", []db.IdentifierInput{
+		{Type: "BROKER_DESCRIPTION", Domain: "IBKR", Value: "APPLE INC", Canonical: false},
+		{Type: "ISIN", Value: "US0378331005", Canonical: true},
+		{Type: "MIC_TICKER", Domain: "XNAS", Value: "AAPL", Canonical: true},
+	}, "", nil, nil, nil)
+
+	asOf := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+	basis := time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)
+	if err := p.UpsertHoldingDeclaration(ctx, userID, "IBKR", "acct1", instID, "100", asOf, asOf); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+	later := time.Date(2025, 7, 1, 0, 0, 0, 0, time.UTC)
+	if err := p.UpsertHoldingDeclaration(ctx, userID, "IBKR", "acct1", instID, "120", later, basis); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	rows, err := p.ListHoldingDeclarationsForExport(ctx, userID)
+	if err != nil {
+		t.Fatalf("list for export: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("read %d rows, want 2", len(rows))
+	}
+	// MIC_TICKER outranks ISIN, which outranks BROKER_DESCRIPTION.
+	if rows[0].IdentifierType != "MIC_TICKER" || rows[0].IdentifierValue != "AAPL" || rows[0].IdentifierDomain != "XNAS" {
+		t.Fatalf("identifier = %s %s %s, want MIC_TICKER AAPL XNAS",
+			rows[0].IdentifierType, rows[0].IdentifierValue, rows[0].IdentifierDomain)
+	}
+	if rows[0].ShareCountBasis != nil {
+		t.Fatalf("share_count_basis = %v, want nil where it equals as_of_date", rows[0].ShareCountBasis)
+	}
+	if rows[1].ShareCountBasis == nil || !rows[1].ShareCountBasis.Equal(basis) {
+		t.Fatalf("share_count_basis = %v, want %s", rows[1].ShareCountBasis, basis.Format("2006-01-02"))
+	}
+	if rows[0].DeclaredQty.String() != "100" {
+		t.Fatalf("declared_qty = %s, want 100", rows[0].DeclaredQty)
+	}
+}
+
+// An instrument carrying no identifier still comes back, so the writer can say
+// so rather than the row simply not appearing: a declaration silently missing
+// from an export is the one failure a file the user diffs by hand cannot show.
+func TestListHoldingDeclarationsForExport_KeepsAnUnidentifiedInstrument(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	userID, _ := p.GetOrCreateUser(ctx, "sub|decl-noid", "U", "u@u.com")
+	var instID string
+	if err := p.q.QueryRowxContext(ctx, `
+		INSERT INTO instruments (asset_class) VALUES ('STOCK') RETURNING id::text
+	`).Scan(&instID); err != nil {
+		t.Fatalf("insert instrument: %v", err)
+	}
+
+	asOf := time.Date(2025, 6, 1, 0, 0, 0, 0, time.UTC)
+	if err := p.UpsertHoldingDeclaration(ctx, userID, "IBKR", "acct1", instID, "100", asOf, asOf); err != nil {
+		t.Fatalf("upsert: %v", err)
+	}
+
+	rows, err := p.ListHoldingDeclarationsForExport(ctx, userID)
+	if err != nil {
+		t.Fatalf("list for export: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("read %d rows, want the unidentified one to survive", len(rows))
+	}
+	if rows[0].IdentifierValue != "" {
+		t.Fatalf("identifier value = %q, want empty", rows[0].IdentifierValue)
+	}
+}

--- a/server/migrations/001_initial.sql
+++ b/server/migrations/001_initial.sql
@@ -308,7 +308,7 @@ CREATE TABLE ingestion_job_parts (
   part            TEXT NOT NULL CHECK (part IN ('INSTRUMENTS', 'PRICES', 'CORPORATE_EVENTS',
                                                 'INFLATION_INDICES', 'FETCH_BLOCKS',
                                                 'UNHANDLED_EVENTS', 'PLUGIN_CONFIG',
-                                                'PREFERENCES', 'TXS')),
+                                                'PREFERENCES', 'TXS', 'DECLARATIONS')),
   status          TEXT NOT NULL CHECK (status IN ('PENDING', 'RUNNING', 'SUCCESS', 'FAILED')),
   total_count     INT NOT NULL DEFAULT 0,
   processed_count INT NOT NULL DEFAULT 0,

--- a/server/service/api/archive.go
+++ b/server/service/api/archive.go
@@ -169,6 +169,7 @@ var (
 	userPartOrder = []archivev1.ArchivePart{
 		archivev1.ArchivePart_PREFERENCES,
 		archivev1.ArchivePart_TXS,
+		archivev1.ArchivePart_DECLARATIONS,
 	}
 )
 

--- a/server/service/api/export_user_archive_test.go
+++ b/server/service/api/export_user_archive_test.go
@@ -53,6 +53,9 @@ func (e *exportUserStreamMock) shape() []string {
 			out = append(out, "preferences")
 		case m.GetTxWindow() != nil:
 			out = append(out, "tx_window:"+m.GetTxWindow().GetBroker().String())
+		case m.GetDeclarationStatement() != nil:
+			st := m.GetDeclarationStatement()
+			out = append(out, "statement:"+st.GetAccount()+"@"+st.GetAsOfDate())
 		}
 	}
 	return out

--- a/server/service/api/export_user_declarations_test.go
+++ b/server/service/api/export_user_declarations_test.go
@@ -1,0 +1,176 @@
+package api
+
+import (
+	"testing"
+	"time"
+
+	"github.com/shopspring/decimal"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
+	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
+	dbpkg "github.com/leedenison/portfoliodb/server/db"
+)
+
+func declDate(t *testing.T, s string) time.Time {
+	t.Helper()
+	d, err := time.Parse("2006-01-02", s)
+	if err != nil {
+		t.Fatalf("parse %q: %v", s, err)
+	}
+	return d
+}
+
+// exportDecl builds one stored export row. basis is written only where it
+// differs from asOf, which is what the query itself does.
+func exportDecl(t *testing.T, broker, account, value, qty, asOf, basis string) dbpkg.ExportDeclaration {
+	t.Helper()
+	row := dbpkg.ExportDeclaration{
+		Broker:           broker,
+		Account:          account,
+		IdentifierType:   "MIC_TICKER",
+		IdentifierValue:  value,
+		IdentifierDomain: "XNAS",
+		DeclaredQty:      decimal.RequireFromString(qty),
+		AsOfDate:         declDate(t, asOf),
+	}
+	if basis != "" {
+		b := declDate(t, basis)
+		row.ShareCountBasis = &b
+	}
+	return row
+}
+
+// exportDeclarations runs a declarations-only export over the given stored rows.
+func exportDeclarations(t *testing.T, rows []dbpkg.ExportDeclaration) *exportUserStreamMock {
+	t.Helper()
+	srv, mockDB := newAPIServerWithMock(t)
+	mockDB.EXPECT().ListHoldingDeclarationsForExport(gomock.Any(), "user-1").Return(rows, nil)
+	stream := &exportUserStreamMock{ctx: authCtx("user-1", "sub|1")}
+	if err := srv.ExportUserArchive(&apiv1.ExportUserArchiveRequest{
+		Parts: []archivev1.ArchivePart{archivev1.ArchivePart_DECLARATIONS},
+	}, stream); err != nil {
+		t.Fatalf("ExportUserArchive: %v", err)
+	}
+	return stream
+}
+
+// statements collects the statements the stream carried.
+func (e *exportUserStreamMock) statements() []*archivev1.Statement {
+	var out []*archivev1.Statement
+	for _, m := range e.sent {
+		if v := m.GetDeclarationStatement(); v != nil {
+			out = append(out, v)
+		}
+	}
+	return out
+}
+
+// The group is the statement -- one account read at one date -- so a run of
+// rows sharing those becomes one message and a change in either cuts a new one.
+func TestExportUserArchive_CutsStatementsOnAccountAndDate(t *testing.T) {
+	stream := exportDeclarations(t, []dbpkg.ExportDeclaration{
+		exportDecl(t, "FIDELITY", "Z1", "AAPL", "100", "2024-01-31", ""),
+		exportDecl(t, "FIDELITY", "Z1", "MSFT", "50", "2024-01-31", ""),
+		exportDecl(t, "FIDELITY", "Z1", "AAPL", "120", "2024-02-29", ""),
+		exportDecl(t, "FIDELITY", "Z2", "AAPL", "7", "2024-02-29", ""),
+	})
+
+	want := []string{
+		"envelope", "begin:DECLARATIONS",
+		"statement:Z1@2024-01-31", "statement:Z1@2024-02-29", "statement:Z2@2024-02-29",
+	}
+	got := stream.shape()
+	if len(got) != len(want) {
+		t.Fatalf("stream shape = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("stream shape = %v, want %v", got, want)
+		}
+	}
+	first := stream.statements()[0]
+	if n := len(first.GetDeclarations()); n != 2 {
+		t.Fatalf("first statement carries %d declarations, want 2", n)
+	}
+	if first.GetBroker() != typev1.Broker_FIDELITY {
+		t.Fatalf("first statement broker = %v, want FIDELITY", first.GetBroker())
+	}
+}
+
+// A basis equal to the statement's own date is what an absent one already
+// means, so writing it would stamp a redundant date onto every row.
+func TestExportUserArchive_WritesShareCountBasisOnlyWhenItDiffers(t *testing.T) {
+	stream := exportDeclarations(t, []dbpkg.ExportDeclaration{
+		exportDecl(t, "FIDELITY", "Z1", "AAPL", "100", "2024-01-31", ""),
+		exportDecl(t, "FIDELITY", "Z1", "MSFT", "50", "2024-01-31", "2026-08-13"),
+	})
+
+	decls := stream.statements()[0].GetDeclarations()
+	if decls[0].ShareCountBasis != nil {
+		t.Fatalf("share_count_basis = %q, want absent", decls[0].GetShareCountBasis())
+	}
+	if got := decls[1].GetShareCountBasis(); got != "2026-08-13" {
+		t.Fatalf("share_count_basis = %q, want 2026-08-13", got)
+	}
+}
+
+// A row this build cannot name in a file would fail validation on the way back
+// in and take its whole statement with it, so it is dropped instead. A
+// statement left with nothing is not sent at all.
+func TestExportUserArchive_SkipsDeclarationsItCannotName(t *testing.T) {
+	noIdentifier := exportDecl(t, "FIDELITY", "Z1", "AAPL", "100", "2024-01-31", "")
+	noIdentifier.IdentifierType, noIdentifier.IdentifierValue, noIdentifier.IdentifierDomain = "", "", ""
+	unknownBroker := exportDecl(t, "NOT_A_BROKER", "Z9", "MSFT", "5", "2024-01-31", "")
+
+	stream := exportDeclarations(t, []dbpkg.ExportDeclaration{
+		noIdentifier,
+		unknownBroker,
+		exportDecl(t, "FIDELITY", "Z1", "MSFT", "50", "2024-01-31", ""),
+	})
+
+	sts := stream.statements()
+	if len(sts) != 1 {
+		t.Fatalf("sent %d statements, want 1", len(sts))
+	}
+	decls := sts[0].GetDeclarations()
+	if len(decls) != 1 || decls[0].GetInstrument().GetValue() != "MSFT" {
+		t.Fatalf("statement carries %v, want the one nameable declaration", decls)
+	}
+}
+
+// A part asked for and holding nothing is still present and empty: the
+// part_begin marker is what creates the container.
+func TestExportUserArchive_DeclarationsPartPresentWhenEmpty(t *testing.T) {
+	stream := exportDeclarations(t, nil)
+	got := stream.shape()
+	if len(got) != 2 || got[1] != "begin:DECLARATIONS" {
+		t.Fatalf("stream shape = %v, want the marker and no statements", got)
+	}
+}
+
+// The period scopes the transaction part alone. A declaration is dated by the
+// date it speaks about rather than by a period of activity, and dropping the
+// checkpoints outside an exported window would lose the pads the oldest
+// holdings open from.
+func TestExportUserArchive_PeriodDoesNotScopeDeclarations(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	rows := []dbpkg.ExportDeclaration{
+		exportDecl(t, "FIDELITY", "Z1", "AAPL", "100", "2019-01-31", ""),
+	}
+	// Called with the user alone: no bounds are passed through.
+	mockDB.EXPECT().ListHoldingDeclarationsForExport(gomock.Any(), "user-1").Return(rows, nil)
+	stream := &exportUserStreamMock{ctx: authCtx("user-1", "sub|1")}
+	if err := srv.ExportUserArchive(&apiv1.ExportUserArchiveRequest{
+		Parts:        []archivev1.ArchivePart{archivev1.ArchivePart_DECLARATIONS},
+		PeriodFrom:   timestamppb.New(declDate(t, "2024-01-01")),
+		PeriodBefore: timestamppb.New(declDate(t, "2025-01-01")),
+	}, stream); err != nil {
+		t.Fatalf("ExportUserArchive: %v", err)
+	}
+	if n := len(stream.statements()); n != 1 {
+		t.Fatalf("sent %d statements, want the out-of-period one to survive", n)
+	}
+}

--- a/server/service/api/user_archive.go
+++ b/server/service/api/user_archive.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log"
+	"time"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -12,6 +13,7 @@ import (
 
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
 	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
+	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
 	"github.com/leedenison/portfoliodb/server/archive"
 	"github.com/leedenison/portfoliodb/server/auth"
 	"github.com/leedenison/portfoliodb/server/db"
@@ -78,6 +80,9 @@ func presentUserParts(a *archivev1.UserArchive) []archivev1.ArchivePart {
 	if a.GetTxs() != nil {
 		parts = append(parts, archivev1.ArchivePart_TXS)
 	}
+	if a.GetDeclarations() != nil {
+		parts = append(parts, archivev1.ArchivePart_DECLARATIONS)
+	}
 	return parts
 }
 
@@ -128,6 +133,8 @@ func (s *Server) ExportUserArchive(req *apiv1.ExportUserArchiveRequest, stream a
 			partErr = s.sendPreferencePart(ctx, u.ID, stream)
 		case archivev1.ArchivePart_TXS:
 			partErr = s.sendTxPart(ctx, u.ID, from, before, stream)
+		case archivev1.ArchivePart_DECLARATIONS:
+			partErr = s.sendDeclarationPart(ctx, u.ID, stream)
 		}
 		if partErr != nil {
 			return partErr
@@ -219,4 +226,97 @@ func (s *Server) sendTxPart(ctx context.Context, userID string, from, before *ti
 		}
 	}
 	return nil
+}
+
+// sendDeclarationPart streams one statement per account and date, each nesting
+// the holdings declared at it.
+//
+// A declaration is the user's own statement about a holding: unlike a
+// transaction nothing can refetch it from a broker, and unlike a price nothing
+// can refetch it from anywhere, so it travels or it is lost.
+//
+// The requested period is not applied. It scopes the transaction part alone, as
+// ExportUserArchiveRequest says: a declaration is dated, but by the date it
+// speaks about rather than by a period of activity, and a rebuild that dropped
+// the checkpoints outside the exported window would silently drop the pads its
+// oldest holdings open from.
+//
+// What is not written: the pad/assert discriminator, which follows from the
+// declaration dates and could only ever disagree with them, and the check
+// against the computed holding, which is recomputed from the postings on read.
+func (s *Server) sendDeclarationPart(ctx context.Context, userID string, stream apiv1.ApiService_ExportUserArchiveServer) error {
+	rows, err := s.db.ListHoldingDeclarationsForExport(ctx, userID)
+	if err != nil {
+		return status.Error(codes.Internal, err.Error())
+	}
+	for _, st := range declarationStatements(rows) {
+		if err := stream.Send(&apiv1.ExportUserArchiveResponse{
+			Item: &apiv1.ExportUserArchiveResponse_DeclarationStatement{DeclarationStatement: st},
+		}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// declarationStatements cuts export rows into statements. The rows arrive
+// ordered by broker, account and date, so a statement is a run and one pass
+// makes them.
+//
+// A row this build cannot name in a file is dropped with a log line rather than
+// written as something an importer would refuse: an UNSPECIFIED broker and an
+// empty identifier both fail validation on the way back in, and either would
+// take the whole statement down with it. A statement left with no declarations
+// is not sent at all, for the same reason.
+func declarationStatements(rows []db.ExportDeclaration) []*archivev1.Statement {
+	var out []*archivev1.Statement
+	var cur *archivev1.Statement
+	var curBroker, curAccount string
+	var curDate time.Time
+	// A statement is emitted once it is complete, so that one left empty by the
+	// skips below never reaches the stream.
+	closeStatement := func() {
+		if cur != nil && len(cur.GetDeclarations()) > 0 {
+			out = append(out, cur)
+		}
+		cur = nil
+	}
+	for _, r := range rows {
+		broker := db.StrToBroker(r.Broker)
+		if broker == 0 {
+			log.Printf("user archive export: skipping declaration (broker %q, account %q): not a known broker", r.Broker, r.Account)
+			continue
+		}
+		idType := identifierTypeFromString(r.IdentifierType)
+		if r.IdentifierValue == "" || idType == typev1.IdentifierType_IDENTIFIER_TYPE_UNSPECIFIED {
+			log.Printf("user archive export: skipping declaration (broker %q, account %q, as of %s): its instrument has no identifier this build can name it by",
+				r.Broker, r.Account, r.AsOfDate.Format("2006-01-02"))
+			continue
+		}
+		if cur == nil || r.Broker != curBroker || r.Account != curAccount || !r.AsOfDate.Equal(curDate) {
+			closeStatement()
+			cur = &archivev1.Statement{
+				Broker:   broker,
+				Account:  r.Account,
+				AsOfDate: r.AsOfDate.Format("2006-01-02"),
+			}
+			curBroker, curAccount, curDate = r.Broker, r.Account, r.AsOfDate
+		}
+		d := &archivev1.Declaration{
+			Instrument: &archivev1.InstrumentRef{
+				Type:   idType,
+				Value:  r.IdentifierValue,
+				Domain: r.IdentifierDomain,
+			},
+			DeclaredQty: r.DeclaredQty.String(),
+		}
+		// Written only where it differs from the statement's own date, which is
+		// what an absent one already means.
+		if r.ShareCountBasis != nil {
+			d.ShareCountBasis = proto.String(r.ShareCountBasis.Format("2006-01-02"))
+		}
+		cur.Declarations = append(cur.Declarations, d)
+	}
+	closeStatement()
+	return out
 }

--- a/server/service/ingestion/user_import.go
+++ b/server/service/ingestion/user_import.go
@@ -18,6 +18,11 @@ import (
 type userImportResult struct {
 	displayCurrencySet bool
 	txsStored          bool
+	// declarationsStored says whether any declaration landed. A restored
+	// declaration is only half of what it means until its holding's pad is
+	// settled from it, and which declaration pads a holding depends on the
+	// others, so the recalc runs once for the whole import rather than per row.
+	declarationsStored bool
 	// userID is whose archive this was, for the recalc a stored posting earns.
 	userID string
 }
@@ -80,6 +85,10 @@ func processUserImport(ctx context.Context, deps ingestDeps, j *JobRequest) user
 			var stored bool
 			stored, partErr = importTxPart(ctx, deps, detail.UserID, j.JobID, a.GetTxs(), rep)
 			out.txsStored = out.txsStored || stored
+		case archivev1.ArchivePart_DECLARATIONS:
+			var written int32
+			written, partErr = archiveimport.DeclarationPart(ctx, database, detail.UserID, a.GetDeclarations(), rep)
+			out.declarationsStored = out.declarationsStored || written > 0
 		default:
 			partErr = errUnknownPart
 		}

--- a/server/service/ingestion/user_import_test.go
+++ b/server/service/ingestion/user_import_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"go.uber.org/mock/gomock"
 	"google.golang.org/protobuf/proto"
@@ -165,18 +166,19 @@ func TestProcessUserImport_ResetsPartialProgressOnRerun(t *testing.T) {
 	processUserImport(context.Background(), ingestDeps{DB: database}, j)
 }
 
-// A part row this build cannot apply means a job written by a later build. It
-// fails that part rather than the whole import.
+// A part row this build has no arm for -- a part from a later build, or one
+// belonging to the other archive -- fails that part rather than the whole
+// import.
 func TestProcessUserImport_UnknownPartFailsOnlyItself(t *testing.T) {
 	database := userImportMock(t)
 	j := &JobRequest{JobID: "job-ua-6", JobType: db.JobTypeUserArchive}
 	database.EXPECT().LoadJobPayload(gomock.Any(), j.JobID).Return(userArchivePayload(t), nil)
 	database.EXPECT().GetJob(gomock.Any(), j.JobID).Return(&db.JobDetail{
-		UserID: "user-7", Parts: partRows(archivev1.ArchivePart_DECLARATIONS),
+		UserID: "user-7", Parts: partRows(archivev1.ArchivePart_INSTRUMENTS),
 	}, nil).AnyTimes()
 	database.EXPECT().SetJobPartStatus(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
 	database.EXPECT().
-		SetJobPartFailed(gomock.Any(), j.JobID, archivev1.ArchivePart_DECLARATIONS, errUnknownPart.Error()).
+		SetJobPartFailed(gomock.Any(), j.JobID, archivev1.ArchivePart_INSTRUMENTS, errUnknownPart.Error()).
 		Return(nil)
 
 	processUserImport(context.Background(), ingestDeps{DB: database}, j)
@@ -271,5 +273,65 @@ func TestProcessJob_UserArchive_NudgesThePriceFetcherOnlyForACurrency(t *testing
 				}
 			}
 		})
+	}
+}
+
+// declarationArchivePayload is a document stating one declaration, which is
+// enough to watch the part run.
+func declarationArchivePayload(t *testing.T) []byte {
+	t.Helper()
+	b, err := proto.Marshal(&archivev1.UserArchive{
+		Envelope: &archivev1.Envelope{
+			FormatVersion: 1,
+			ExportedAt:    timestamppb.Now(),
+			Kind:          archivev1.ArchiveKind_USER,
+		},
+		Declarations: &archivev1.DeclarationPart{
+			Statements: []*archivev1.Statement{{
+				Broker:   typev1.Broker_FIDELITY,
+				Account:  "Z1",
+				AsOfDate: "2024-01-31",
+				Declarations: []*archivev1.Declaration{{
+					Instrument: &archivev1.InstrumentRef{
+						Type:   typev1.IdentifierType_MIC_TICKER,
+						Value:  "AAPL",
+						Domain: "XNAS",
+					},
+					DeclaredQty: "100",
+				}},
+			}},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return b
+}
+
+// The declarations part dispatches, and a declaration that landed is what earns
+// the recalculation: a declaration carries no pad, and the pad is what makes the
+// declared quantity true.
+func TestProcessUserImport_DeclarationsPartStoresAndEarnsTheRecalc(t *testing.T) {
+	database := userImportMock(t)
+	j := &JobRequest{JobID: "job-ua-8", JobType: db.JobTypeUserArchive}
+	database.EXPECT().LoadJobPayload(gomock.Any(), j.JobID).Return(declarationArchivePayload(t), nil)
+	database.EXPECT().GetJob(gomock.Any(), j.JobID).Return(&db.JobDetail{
+		UserID: "user-7", Parts: partRows(archivev1.ArchivePart_DECLARATIONS),
+	}, nil).AnyTimes()
+	database.EXPECT().SetJobPartStatus(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+
+	start := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	database.EXPECT().GetPortfolioStartDate(gomock.Any(), "user-7").Return(&start, nil)
+	database.EXPECT().
+		FindInstrumentByIdentifier(gomock.Any(), "MIC_TICKER", "XNAS", "AAPL").
+		Return("inst-a", nil)
+	database.EXPECT().
+		UpsertHoldingDeclaration(gomock.Any(), "user-7", "FIDELITY", "Z1", "inst-a", "100",
+			gomock.Any(), gomock.Any()).
+		Return(nil)
+
+	res := processUserImport(context.Background(), ingestDeps{DB: database}, j)
+	if !res.declarationsStored {
+		t.Fatal("declarationsStored = false, want the stored declaration to earn the recalc")
 	}
 }

--- a/server/service/ingestion/worker.go
+++ b/server/service/ingestion/worker.go
@@ -144,14 +144,22 @@ func processJob(ctx context.Context, opts WorkerOptions, j *JobRequest) {
 		// chance at a side whose counterpart was already stored. A restored
 		// display currency opens FX gaps of its own, so either alone is reason
 		// enough to nudge the price fetcher.
+		//
+		// Restored declarations earn the recalc for their own sake rather than
+		// the postings': a declaration carries no pad, and the pad is what makes
+		// the declared quantity true. They earn the price fetch too, because the
+		// holding a pad opens may have no postings of its own and therefore no
+		// prices ever fetched for it.
 		if res.txsStored {
-			if err := recalcAfterIngestion(ctx, opts.DB, res.userID); err != nil {
-				log.Printf("user archive job %s: recalc INITIALIZE txs: %v", j.JobID, err)
-			}
 			pluginutil.Trigger(opts.TransferMatchTrigger)
 			pluginutil.Trigger(opts.GroupingTrigger)
 		}
-		if res.displayCurrencySet || res.txsStored {
+		if res.txsStored || res.declarationsStored {
+			if err := recalcAfterIngestion(ctx, opts.DB, res.userID); err != nil {
+				log.Printf("user archive job %s: recalc INITIALIZE txs: %v", j.JobID, err)
+			}
+		}
+		if res.displayCurrencySet || res.txsStored || res.declarationsStored {
 			pluginutil.Trigger(opts.PriceTrigger)
 		}
 	default:


### PR DESCRIPTION
Closes 0076.

A holding declaration is the user's own statement about a holding. Nothing can
refetch it from a broker and nothing can refetch it from anywhere else, so a
rebuild loses every pad and every assertion. This carries them.

The format landed with 0078 and `docs/spec/archive-format.md` already described
it; what was missing was the plumbing -- the `ExportUserArchiveResponse` item,
the export query and writer, the `archiveimport` reader, the worker wiring and
one menu row.

## Decisions the issue left open

**An unresolved declaration is rejected as a row error.** Resolution here is a
database lookup that never creates an instrument, which is what makes failing
loudly possible at all: the transaction path cannot fail, because an unresolved
posting lands on a placeholder built from its description. A declaration has no
such fallback -- an instrument the system cannot name leaves nothing to pad and
nothing to check it against. The lookup is
`identification.ResolveIDsByHintsDBOnly` rather than a bare
`FindInstrumentByIdentifier`, so an OCC identifier `bestIdentifierJoin` picked
resolves against the compact form the column stores, and a ticker exported with
no domain still finds its instrument. That is the gap the issue flags: a row
failing here is a defect rather than user error.

**A declaration dated before the portfolio start date is rejected too**, rather
than written and then deleted by `pruneBeforeStart` moments later with only a
log line to show for it.

## Notes for review

**Import is an upsert** on `(user, broker, account, instrument, as_of_date)`, so
re-importing an exported file restates rather than answering `ALREADY_EXISTS`.
Absence is not deletion: a declaration missing from a file is left alone.

**The pads are not written per row.** Which declaration pads a holding depends on
the others in it, so the unit of recalculation is the holding. The import writes
the declaration rows and a stored declaration earns the `RecalcAllInitializeTxs`
pass the worker already runs after an ingestion, once for the whole import.

**A migration is modified in place.** `ingestion_job_parts.part` has a CHECK
constraint spelling the `ArchivePart` enum, and `DECLARATIONS` was not in it, so
creating the job failed before the import started. Nothing below the API could
catch it -- the check lives in the schema and every test above the db layer mocks
the database. The e2e round trip is what found it.

## Verification

`make check`, `make test` and `make e2e-test` all pass (47 e2e specs). New
coverage: 8 reader tests in `server/archiveimport/declarations_test.go`, 5 writer
tests in `server/service/api/export_user_declarations_test.go`, 4 db integration
tests against real Postgres, client assembler and counter tests, and an e2e
declarations round trip that exports through the UI, restates the stored rows,
imports the file back and checks both the declarations and the pads the recalc
wrote.

Also opens 0104, the follow-up the rejection decision earns: rejecting a row
leaves the user with an error and a file to edit by hand, and the same dead end
exists for a transaction on a placeholder instrument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
