### PR TITLE
Schedule the issues left after M15

### DIFF
--- a/docs/issues/0017-filter-instrument-export.md
+++ b/docs/issues/0017-filter-instrument-export.md
@@ -1,8 +1,0 @@
----
-status: open
-title: Filter instrument export by broker and exchange
-milestone: M06
-dependencies: [0016]
----
-
-Filter instrument export by broker and exchange.

--- a/docs/issues/0017-instrument-export-filters-ui.md
+++ b/docs/issues/0017-instrument-export-filters-ui.md
@@ -1,0 +1,33 @@
+---
+status: open
+title: Surface the instrument export filters in the UI
+milestone: M17
+dependencies: [0016]
+---
+
+Let an admin narrow the instruments part of a system export from the archive page,
+using the filters the server already applies.
+
+## Motivation
+
+`ExportSystemArchiveRequest` carries `exchange` and `asset_classes`, and both reach
+the query: `ListInstrumentsForExport(ctx, exchangeFilter, assetClasses)` in
+server/db/postgres/instruments.go, called from server/service/api/archive.go. No
+caller sets them. `exportSystemArchive` in client/lib/portfolio-api.ts takes only
+`parts`, and client/app/admin/archive/page.tsx offers the part menu and nothing
+else, so an export of the instruments part is always every instrument.
+
+## Scope
+
+Client only. Pass the two filters through `exportSystemArchive`, and put the
+controls on the archive page next to the part menu, shown only when INSTRUMENTS is
+selected -- the server ignores them otherwise and the UI should say so by not
+offering them.
+
+## Broker is not one of the filters
+
+This issue originally asked to filter by broker and exchange. An archived instrument
+has no broker: it is reference data shared across users, and the broker only ever
+described where a description came from, back when instruments were exported as
+their own JSON. Asset class is the second axis in its place and is already on the
+request. There is nothing to build for broker and nothing to store it in.

--- a/docs/issues/0025-identity-csv-cli.md
+++ b/docs/issues/0025-identity-csv-cli.md
@@ -1,7 +1,12 @@
 ---
-status: open
+status: closed
 title: Create CLI for importing / exporting instrument identities to and from CSV
 milestone: M06
 ---
 
-Create CLI for importing / exporting instrument identities to and from CSV.
+Obsolete. The archive format replaced the identity CSV, so there is no file for
+this CLI to read or write (docs/spec/archive-format.md).
+
+Instrument identities travel in the instruments part of the system archive, which
+0079 exposes as an admin page and the export RPC streams. Nothing is left that only
+a CLI could do.

--- a/docs/issues/0034-security-hardening-review.md
+++ b/docs/issues/0034-security-hardening-review.md
@@ -1,6 +1,7 @@
 ---
 status: open
 title: Security review: credentials, CORS, and session configuration
+milestone: M17
 ---
 
 Security review: move DB credentials out of Dockerfile/docker-compose into env vars; make Envoy CORS origins configurable; make session TTL and cookie attributes configurable via env vars.

--- a/docs/issues/0035-configurable-ssr-api-base-url.md
+++ b/docs/issues/0035-configurable-ssr-api-base-url.md
@@ -1,6 +1,7 @@
 ---
 status: open
 title: Make frontend SSR API base URL configurable via env var
+milestone: M17
 ---
 
 Make frontend SSR API base URL configurable via env var instead of hard-coded localhost:8080 fallback.

--- a/docs/issues/0044-lot-identity-disposal-matching.md
+++ b/docs/issues/0044-lot-identity-disposal-matching.md
@@ -1,6 +1,7 @@
 ---
 status: open
 title: Lot identity and disposal matching
+milestone: M19
 ---
 
 Give acquisitions a lot identity and make disposals reference the lots they

--- a/docs/issues/0045-realised-gains-cost-basis-methods.md
+++ b/docs/issues/0045-realised-gains-cost-basis-methods.md
@@ -1,6 +1,7 @@
 ---
 status: open
 title: Realised gains and cost basis methods
+milestone: M19
 dependencies: [0044]
 ---
 

--- a/docs/issues/0050-corporate-event-daily-scheduler.md
+++ b/docs/issues/0050-corporate-event-daily-scheduler.md
@@ -1,6 +1,7 @@
 ---
 status: open
 title: Daily corporate-event scheduler and blanket split recompute
+milestone: M17
 ---
 
 Add the daily scheduler specified in docs/spec/corporate-events.md so newly

--- a/docs/issues/0066-alerting-system.md
+++ b/docs/issues/0066-alerting-system.md
@@ -1,6 +1,7 @@
 ---
 status: open
 title: General alerting system for data problems needing review
+milestone: M18
 ---
 
 A single mechanism for raising, listing, and resolving alerts about data that needs

--- a/docs/issues/0075-declared-cost-basis-on-a-pad.md
+++ b/docs/issues/0075-declared-cost-basis-on-a-pad.md
@@ -1,6 +1,7 @@
 ---
 status: open
 title: Declare a cost basis alongside a pad
+milestone: M19
 dependencies: [0044]
 ---
 

--- a/docs/issues/0088-bulk-declaration-entry-at-inception.md
+++ b/docs/issues/0088-bulk-declaration-entry-at-inception.md
@@ -1,6 +1,7 @@
 ---
 status: open
 title: Bulk entry of holding declarations at inception
+milestone: M19
 ---
 
 Let a user enter a whole account's opening balances in one pass rather than one

--- a/docs/issues/0099-single-source-for-an-instruments-exchange.md
+++ b/docs/issues/0099-single-source-for-an-instruments-exchange.md
@@ -1,6 +1,7 @@
 ---
 status: open
 title: Single source for an instrument's exchange
+milestone: M17
 ---
 
 An instrument's exchange is stored in two places that can disagree. Make one of

--- a/docs/issues/0103-analyze-after-bulk-writes.md
+++ b/docs/issues/0103-analyze-after-bulk-writes.md
@@ -1,6 +1,7 @@
 ---
 status: open
 title: Keep planner statistics current across bulk writes
+milestone: M17
 ---
 
 Decide and implement when PortfolioDB refreshes planner statistics, so a query

--- a/docs/issues/milestones.md
+++ b/docs/issues/milestones.md
@@ -16,6 +16,9 @@
 - **M14** - Complete the archive: system and user archives carry everything a rebuild needs, and the transaction CSV is retired.
 - **M15** - The server owns transaction grouping: converters emit evidence and the server derives groups across the whole dataset rather than within one upload.
 - **M16** - A person can repair a grouping or a transfer pairing the engine cannot derive.
+- **M17** - Operational correctness: scheduled corporate-event recompute, single-sourced instrument data, current planner statistics, and configurable deployment.
+- **M18** - One place that says what needs a person's attention, replacing the per-problem admin cards.
+- **M19** - Lots, cost basis and realised gains.
 
 ## Unscheduled
 


### PR DESCRIPTION
M15 is closed and M14 has two issues left ([0080](../blob/main/docs/issues/0080-consolidated-user-export-import-page.md), [0089](../blob/main/docs/issues/0089-portfolio-definition-export.md)), so the unmilestoned backlog needs homes. This assigns them and resolves two stale stubs. Documentation only.

## Three new milestones

- **M17, operational correctness** -- 0050 (corporate-event scheduler), 0099 (instrument exchange single-sourcing), 0103 (planner statistics), 0034 and 0035 (deployment configuration). Small and independent. 0050 is a live defect -- a future-dated split never becomes effective -- and can be pulled ahead of anything.
- **M18, alerting** -- 0066 alone, because it replaces the per-problem admin cards rather than adding one. Its value rose with 0095's curtailment: assertions are now destroyed silently on import, and nothing reports when a source's grouping is refused in a person's favour.
- **M19, lots, cost basis and realised gains** -- 0044 to 0075 and 0088 to 0045. This is the chain standing between here and the unscheduled return metrics. The two declaration issues join it rather than staying with the archive work, because a pad with no basis is what lot identity exposes.

Left unscheduled deliberately: 0046 (large refactor, no consumer asking), 0049 (needs a modelling decision before it is schedulable), 0071 and 0073 (independent, good filler).

## 0025 closed

The archive replaced the identity CSV, so the CLI has no file to read or write. Identities travel in the instruments part of the system archive.

## 0017 rewritten

Its two clauses had diverged. The exchange filter is implemented end to end -- `ExportSystemArchiveRequest.exchange` reaches `ListInstrumentsForExport` -- and picked up an asset-class filter along the way; only the client never sends either, so what is left is a client-only change to surface both on the admin archive page.

The broker filter is dropped, with the reason recorded in the issue. An archived instrument has no broker: it is shared reference data, and the broker only described where a description came from back when instruments were exported as their own JSON. Asset class is the second axis in its place.

Renaming the file to match the new title follows the issue-tracker skill, which derives the slug from the title; the number is unchanged.

## Standing order

M14 (0080 then 0089), M16 (0104 then 0095), M17, M18, M19. 0104 goes before 0095 within M16: it is smaller, independent of the correlation machinery, and its repair target includes the declarations 0076 now rejects outright.

🤖 Generated with [Claude Code](https://claude.com/claude-code)