### PR TITLE
Share the archive page machinery, and close 0080 (0080)

### DIFF
--- a/client/app/admin/archive/page.tsx
+++ b/client/app/admin/archive/page.tsx
@@ -1,112 +1,41 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { ErrorAlert } from "@/app/components/error-alert";
-import { useAuthedQuery } from "@/hooks/use-authed-query";
-import { errorMessage } from "@/lib/errors";
 import { qk } from "@/lib/query-keys";
-import { exportSystemArchive, getJob, importSystemArchive, listJobs } from "@/lib/portfolio-api";
+import { exportSystemArchive, importSystemArchive } from "@/lib/portfolio-api";
 import { marshalSystem, unmarshalSystem } from "@/lib/archive/codec";
 import { assembleSystemArchive, systemPartCounts } from "@/lib/archive/assemble";
 import { SYSTEM_ARCHIVE_PART_OPTIONS } from "@/lib/archive/parts";
 import { ArchivePart } from "@/gen/archive/v1/common_pb";
-import { JobStatus } from "@/gen/api/v1/api_pb";
+import { ExportArchivePanel } from "@/app/components/archive/export-panel";
 import { ImportArchivePanel } from "@/app/components/archive/import-panel";
-import { JobPartsTable } from "@/app/components/archive/job-parts";
+import { ArchiveJobSection } from "@/app/components/archive/job-parts";
+import { useArchiveJob } from "@/hooks/use-archive-job";
 
 const SYSTEM_ARCHIVE_JOB_TYPE = "system_archive";
 
 export default function ArchivePage() {
   const queryClient = useQueryClient();
-  const [selected, setSelected] = useState<Set<ArchivePart>>(
-    () => new Set(SYSTEM_ARCHIVE_PART_OPTIONS.filter((o) => o.defaultSelected).map((o) => o.part)),
-  );
-  const [exporting, setExporting] = useState(false);
-  const [exportError, setExportError] = useState<string | null>(null);
-  const [startedJobId, setStartedJobId] = useState<string | null>(null);
-
-  // An import keeps running whether or not this page is open, so the job to
-  // watch is looked up rather than remembered: closing the tab and coming back
-  // must show the run that is still going.
-  const recent = useAuthedQuery({
-    queryKey: qk.jobs(),
-    queryFn: () => listJobs(null, SYSTEM_ARCHIVE_JOB_TYPE),
-  });
-  const jobId = startedJobId ?? recent.data?.jobs[0]?.id ?? null;
-
-  const job = useAuthedQuery({
-    queryKey: qk.job(jobId ?? ""),
-    queryFn: () => getJob(jobId!),
-    enabled: jobId !== null,
-    // Polling stops at a terminal status rather than running forever behind an
-    // idle page.
-    refetchInterval: (query) => {
-      const s = query.state.data?.status;
-      return s === JobStatus.SUCCESS || s === JobStatus.FAILED ? false : 2000;
-    },
-  });
-
-  const running =
-    job.data !== undefined &&
-    job.data.status !== JobStatus.SUCCESS &&
-    job.data.status !== JobStatus.FAILED;
-
-  function toggle(part: ArchivePart) {
-    setSelected((prev) => {
-      const next = new Set(prev);
-      if (next.has(part)) {
-        next.delete(part);
-      } else {
-        next.add(part);
-      }
-      return next;
-    });
-  }
-
-  const parts = useMemo(
-    () => SYSTEM_ARCHIVE_PART_OPTIONS.filter((o) => selected.has(o.part)).map((o) => o.part),
-    [selected],
-  );
-
-  async function handleExport() {
-    setExporting(true);
-    setExportError(null);
-    try {
-      const items = [];
-      for await (const item of exportSystemArchive(parts)) {
-        items.push(item);
-      }
-      const json = marshalSystem(assembleSystemArchive(items));
-      const blob = new Blob([json], { type: "application/json" });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = "system-archive.json";
-      a.click();
-      URL.revokeObjectURL(url);
-    } catch (e) {
-      setExportError(errorMessage(e, "Export failed"));
-    } finally {
-      setExporting(false);
-    }
-  }
-
-  function handleImportStarted(id: string) {
-    setStartedJobId(id);
-    queryClient.invalidateQueries({ queryKey: qk.jobs() });
-  }
 
   // What an import changes is spread across the admin section, so once it is
   // done everything it could have touched is dropped rather than guessing which
-  // part landed. Keyed on the terminal status so it runs once per finished job.
-  const terminalJobId = job.data && !running ? jobId : null;
-  useEffect(() => {
-    if (terminalJobId === null) return;
+  // part landed.
+  const onFinished = useCallback(() => {
     queryClient.invalidateQueries({ queryKey: qk.instruments() });
     queryClient.invalidateQueries({ queryKey: qk.prices() });
     queryClient.invalidateQueries({ queryKey: qk.corporateEventSplits() });
-  }, [terminalJobId, queryClient]);
+  }, [queryClient]);
+
+  const { job, running, start } = useArchiveJob(SYSTEM_ARCHIVE_JOB_TYPE, onFinished);
+
+  async function build(parts: ArchivePart[]): Promise<string> {
+    const items = [];
+    for await (const item of exportSystemArchive(parts)) {
+      items.push(item);
+    }
+    return marshalSystem(assembleSystemArchive(items));
+  }
 
   return (
     <div className="space-y-5">
@@ -118,68 +47,22 @@ export default function ArchivePage() {
         </p>
       </div>
 
-      <section className="rounded-lg border border-border bg-surface p-4" data-testid="archive-export">
-        <h2 className="font-display text-base font-semibold text-text-primary">Export</h2>
-        <p className="mt-1 text-sm text-text-muted">
-          A part left unticked is absent from the file. A part ticked but holding nothing is written
-          empty, which records that the export included it and there was nothing.
-        </p>
-        <ul className="mt-3 space-y-2">
-          {SYSTEM_ARCHIVE_PART_OPTIONS.map((opt) => {
-            const id = `part-${opt.part}`;
-            return (
-              <li key={id} className="flex items-start gap-2.5">
-                <input
-                  id={id}
-                  type="checkbox"
-                  className="mt-0.5 h-4 w-4 shrink-0 accent-primary"
-                  checked={selected.has(opt.part)}
-                  onChange={() => toggle(opt.part)}
-                />
-                <label htmlFor={id}>
-                  <span className="text-sm font-medium text-text-primary">{opt.label}</span>
-                  <span className="block text-xs text-text-muted">{opt.note}</span>
-                </label>
-              </li>
-            );
-          })}
-        </ul>
-        {exportError && (
-          <div className="mt-3">
-            <ErrorAlert>{exportError}</ErrorAlert>
-          </div>
-        )}
-        <button
-          type="button"
-          onClick={handleExport}
-          disabled={exporting || parts.length === 0}
-          data-testid="export-archive"
-          className="mt-4 rounded-md border border-border bg-surface px-3 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-primary-light/15 disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          {exporting ? "Exporting…" : "Export archive"}
-        </button>
-      </section>
+      <ExportArchivePanel
+        options={SYSTEM_ARCHIVE_PART_OPTIONS}
+        build={build}
+        filename="system-archive.json"
+      />
 
       <ImportArchivePanel
         running={running}
-        onStarted={handleImportStarted}
+        onStarted={start}
         parse={unmarshalSystem}
         counts={systemPartCounts}
         submit={importSystemArchive}
         note="The parts are applied in order on the server, so an import finishes whether or not this page stays open. To import one kind of data, upload an archive carrying only that part."
       />
 
-      {job.data && (
-        <section className="rounded-lg border border-border bg-surface p-4" data-testid="archive-job">
-          <h2 className="font-display text-base font-semibold text-text-primary">Last import</h2>
-          <p className="mt-1 text-sm text-text-muted">
-            {running
-              ? "Running. This continues whether or not this page is open."
-              : "Finished."}
-          </p>
-          <JobPartsTable job={job.data} />
-        </section>
-      )}
+      {job && <ArchiveJobSection job={job} running={running} />}
     </div>
   );
 }

--- a/client/app/archive/page.tsx
+++ b/client/app/archive/page.tsx
@@ -1,21 +1,19 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { AppShell } from "@/app/components/app-shell";
-import { ErrorAlert } from "@/app/components/error-alert";
+import { ExportArchivePanel } from "@/app/components/archive/export-panel";
 import { ImportArchivePanel } from "@/app/components/archive/import-panel";
-import { JobPartsTable } from "@/app/components/archive/job-parts";
+import { ArchiveJobSection } from "@/app/components/archive/job-parts";
 import { useAuth } from "@/contexts/auth-context";
-import { useAuthedQuery } from "@/hooks/use-authed-query";
-import { errorMessage } from "@/lib/errors";
+import { useArchiveJob } from "@/hooks/use-archive-job";
 import { qk } from "@/lib/query-keys";
-import { exportUserArchive, getJob, importUserArchive, listJobs } from "@/lib/portfolio-api";
+import { exportUserArchive, importUserArchive } from "@/lib/portfolio-api";
 import { marshalUser, unmarshalUser } from "@/lib/archive/codec";
 import { assembleUserArchive, userPartCounts } from "@/lib/archive/assemble";
 import { USER_ARCHIVE_PART_OPTIONS } from "@/lib/archive/parts";
 import { ArchivePart } from "@/gen/archive/v1/common_pb";
-import { JobStatus } from "@/gen/api/v1/api_pb";
 
 const USER_ARCHIVE_JOB_TYPE = "user_archive";
 
@@ -40,95 +38,29 @@ const IMPORT_NOTE = (
 export default function UserArchivePage() {
   const { state } = useAuth();
   const queryClient = useQueryClient();
-  const [selected, setSelected] = useState<Set<ArchivePart>>(
-    () => new Set(USER_ARCHIVE_PART_OPTIONS.filter((o) => o.defaultSelected).map((o) => o.part)),
-  );
-  const [exporting, setExporting] = useState(false);
-  const [exportError, setExportError] = useState<string | null>(null);
-  const [startedJobId, setStartedJobId] = useState<string | null>(null);
-
-  // An import keeps running whether or not this page is open, so the job to
-  // watch is looked up rather than remembered.
-  const recent = useAuthedQuery({
-    queryKey: qk.jobs(),
-    queryFn: () => listJobs(null, USER_ARCHIVE_JOB_TYPE),
-  });
-  const jobId = startedJobId ?? recent.data?.jobs[0]?.id ?? null;
-
-  const job = useAuthedQuery({
-    queryKey: qk.job(jobId ?? ""),
-    queryFn: () => getJob(jobId!),
-    enabled: jobId !== null,
-    refetchInterval: (query) => {
-      const s = query.state.data?.status;
-      return s === JobStatus.SUCCESS || s === JobStatus.FAILED ? false : 2000;
-    },
-  });
-
-  const running =
-    job.data !== undefined &&
-    job.data.status !== JobStatus.SUCCESS &&
-    job.data.status !== JobStatus.FAILED;
-
-  function toggle(part: ArchivePart) {
-    setSelected((prev) => {
-      const next = new Set(prev);
-      if (next.has(part)) {
-        next.delete(part);
-      } else {
-        next.add(part);
-      }
-      return next;
-    });
-  }
-
-  const parts = useMemo(
-    () => USER_ARCHIVE_PART_OPTIONS.filter((o) => selected.has(o.part)).map((o) => o.part),
-    [selected],
-  );
-
-  async function handleExport() {
-    setExporting(true);
-    setExportError(null);
-    try {
-      const items = [];
-      for await (const item of exportUserArchive(parts)) {
-        items.push(item);
-      }
-      const json = marshalUser(assembleUserArchive(items));
-      const blob = new Blob([json], { type: "application/json" });
-      const url = URL.createObjectURL(blob);
-      const a = document.createElement("a");
-      a.href = url;
-      a.download = "user-archive.json";
-      a.click();
-      URL.revokeObjectURL(url);
-    } catch (e) {
-      setExportError(errorMessage(e, "Export failed"));
-    } finally {
-      setExporting(false);
-    }
-  }
-
-  function handleImportStarted(id: string) {
-    setStartedJobId(id);
-    queryClient.invalidateQueries({ queryKey: qk.jobs() });
-  }
 
   // What an import changes is spread across the user's own pages, so once it is
   // done everything it could have touched is dropped rather than guessing which
   // part landed. Ignored asset classes delete transactions, which move holdings,
   // so those go too, and a restored declaration writes the pad posting that
   // opens its holding.
-  const terminalJobId = job.data && !running ? jobId : null;
-  useEffect(() => {
-    if (terminalJobId === null) return;
+  const onFinished = useCallback(() => {
     queryClient.invalidateQueries({ queryKey: qk.displayCurrency() });
     queryClient.invalidateQueries({ queryKey: qk.ignoredAssetClasses() });
     queryClient.invalidateQueries({ queryKey: qk.holdingDeclarations() });
     queryClient.invalidateQueries({ queryKey: qk.holdings() });
     queryClient.invalidateQueries({ queryKey: qk.txs() });
-  }, [terminalJobId, queryClient]);
+  }, [queryClient]);
+
+  const { job, running, start } = useArchiveJob(USER_ARCHIVE_JOB_TYPE, onFinished);
+
+  async function build(parts: ArchivePart[]): Promise<string> {
+    const items = [];
+    for await (const item of exportUserArchive(parts)) {
+      items.push(item);
+    }
+    return marshalUser(assembleUserArchive(items));
+  }
 
   return (
     <AppShell>
@@ -154,70 +86,22 @@ export default function UserArchivePage() {
               </p>
             </div>
 
-            <section className="rounded-lg border border-border bg-surface p-4" data-testid="archive-export">
-              <h2 className="font-display text-base font-semibold text-text-primary">Export</h2>
-              <p className="mt-1 text-sm text-text-muted">
-                A part left unticked is absent from the file. A part ticked but holding nothing is
-                written empty, which records that the export included it and there was nothing.
-              </p>
-              <ul className="mt-3 space-y-2">
-                {USER_ARCHIVE_PART_OPTIONS.map((opt) => {
-                  const id = `part-${opt.part}`;
-                  return (
-                    <li key={id} className="flex items-start gap-2.5">
-                      <input
-                        id={id}
-                        type="checkbox"
-                        className="mt-0.5 h-4 w-4 shrink-0 accent-primary"
-                        checked={selected.has(opt.part)}
-                        onChange={() => toggle(opt.part)}
-                      />
-                      <label htmlFor={id}>
-                        <span className="text-sm font-medium text-text-primary">{opt.label}</span>
-                        <span className="block text-xs text-text-muted">{opt.note}</span>
-                      </label>
-                    </li>
-                  );
-                })}
-              </ul>
-              {exportError && (
-                <div className="mt-3">
-                  <ErrorAlert>{exportError}</ErrorAlert>
-                </div>
-              )}
-              <button
-                type="button"
-                onClick={handleExport}
-                disabled={exporting || parts.length === 0}
-                data-testid="export-archive"
-                className="mt-4 rounded-md border border-border bg-surface px-3 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-primary-light/15 disabled:cursor-not-allowed disabled:opacity-50"
-              >
-                {exporting ? "Exporting…" : "Export archive"}
-              </button>
-            </section>
+            <ExportArchivePanel
+              options={USER_ARCHIVE_PART_OPTIONS}
+              build={build}
+              filename="user-archive.json"
+            />
 
             <ImportArchivePanel
               running={running}
-              onStarted={handleImportStarted}
+              onStarted={start}
               parse={unmarshalUser}
               counts={userPartCounts}
               submit={importUserArchive}
               note={IMPORT_NOTE}
             />
 
-            {job.data && (
-              <section className="rounded-lg border border-border bg-surface p-4" data-testid="archive-job">
-                <h2 className="font-display text-base font-semibold text-text-primary">
-                  Last import
-                </h2>
-                <p className="mt-1 text-sm text-text-muted">
-                  {running
-                    ? "Running. This continues whether or not this page is open."
-                    : "Finished."}
-                </p>
-                <JobPartsTable job={job.data} />
-              </section>
-            )}
+            {job && <ArchiveJobSection job={job} running={running} />}
           </div>
         )}
       </div>

--- a/client/app/components/archive/export-panel.test.tsx
+++ b/client/app/components/archive/export-panel.test.tsx
@@ -1,0 +1,94 @@
+import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { ArchivePart } from "@/gen/archive/v1/common_pb";
+import type { ArchivePartOption } from "@/lib/archive/parts";
+import { ExportArchivePanel } from "./export-panel";
+
+const OPTIONS: ArchivePartOption[] = [
+  {
+    part: ArchivePart.PREFERENCES,
+    label: "Preferences",
+    note: "Display currency, and the asset classes ignored on import.",
+    defaultSelected: true,
+  },
+  {
+    part: ArchivePart.TXS,
+    label: "Transactions",
+    note: "Every posting.",
+    defaultSelected: true,
+  },
+  {
+    part: ArchivePart.DECLARATIONS,
+    label: "Holding declarations",
+    note: "What you stated you held, and when.",
+    defaultSelected: false,
+  },
+];
+
+function renderPanel(build = vi.fn().mockResolvedValue("{}")) {
+  render(<ExportArchivePanel options={OPTIONS} build={build} filename="archive.json" />);
+  return build;
+}
+
+describe("ExportArchivePanel", () => {
+  it("starts with the parts the menu says are selected by default", () => {
+    renderPanel();
+    expect(screen.getByLabelText(/Preferences/)).toBeChecked();
+    expect(screen.getByLabelText(/Transactions/)).toBeChecked();
+    // Plugin config is why this is a per-part decision rather than a blanket
+    // one: a part can be offered without being asked for by default.
+    expect(screen.getByLabelText(/Holding declarations/)).not.toBeChecked();
+  });
+
+  it("asks for the ticked parts in menu order, not tick order", async () => {
+    const build = renderPanel();
+
+    // Ticked last, and still exported in the order the menu states it, which is
+    // restore order.
+    fireEvent.click(screen.getByLabelText(/Holding declarations/));
+    fireEvent.click(screen.getByLabelText(/Preferences/));
+    fireEvent.click(screen.getByLabelText(/Preferences/));
+    fireEvent.click(screen.getByTestId("export-archive"));
+
+    await waitFor(() => expect(build).toHaveBeenCalledTimes(1));
+    expect(build).toHaveBeenCalledWith([
+      ArchivePart.PREFERENCES,
+      ArchivePart.TXS,
+      ArchivePart.DECLARATIONS,
+    ]);
+  });
+
+  it("leaves an unticked part out of the request", async () => {
+    const build = renderPanel();
+
+    fireEvent.click(screen.getByLabelText(/Transactions/));
+    fireEvent.click(screen.getByTestId("export-archive"));
+
+    // Absent from the request rather than requested and dropped: what the file
+    // does not carry is what was not asked for.
+    await waitFor(() => expect(build).toHaveBeenCalledWith([ArchivePart.PREFERENCES]));
+  });
+
+  it("cannot export nothing", () => {
+    const build = renderPanel();
+
+    fireEvent.click(screen.getByLabelText(/Preferences/));
+    fireEvent.click(screen.getByLabelText(/Transactions/));
+
+    expect(screen.getByTestId("export-archive")).toBeDisabled();
+    fireEvent.click(screen.getByTestId("export-archive"));
+    expect(build).not.toHaveBeenCalled();
+  });
+
+  it("says so when the export fails, and stays usable", async () => {
+    const build = renderPanel(vi.fn().mockRejectedValue(new Error("stream broke")));
+
+    fireEvent.click(screen.getByTestId("export-archive"));
+
+    expect(await screen.findByText("stream broke")).toBeInTheDocument();
+    // The button comes back rather than being left saying "Exporting...", so a
+    // failed export can be retried without reloading the page.
+    await waitFor(() => expect(screen.getByTestId("export-archive")).toBeEnabled());
+    expect(build).toHaveBeenCalledTimes(1);
+  });
+});

--- a/client/app/components/archive/export-panel.tsx
+++ b/client/app/components/archive/export-panel.tsx
@@ -1,0 +1,119 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { ErrorAlert } from "@/app/components/error-alert";
+import { errorMessage } from "@/lib/errors";
+import type { ArchivePartOption } from "@/lib/archive/parts";
+import { ArchivePart } from "@/gen/archive/v1/common_pb";
+
+/**
+ * Choose what an archive carries, and download it.
+ *
+ * Which parts a menu offers differs between the two archives; what a menu means
+ * does not, which is why both pages share this. A part left unticked is absent
+ * from the file, and a part ticked but holding nothing is written empty, which
+ * records that the export included it and there was nothing.
+ *
+ * `build` returns the document text, so the streaming, assembly and marshalling
+ * of one kind of archive stay with the page that knows which kind it is. That is
+ * the split ImportArchivePanel already makes with parse and submit.
+ */
+export function ExportArchivePanel({
+  options,
+  build,
+  filename,
+}: {
+  /** The parts on offer, in restore order. */
+  options: ArchivePartOption[];
+  /** Produce the document text for the parts asked for. */
+  build: (parts: ArchivePart[]) => Promise<string>;
+  /** What the downloaded file is called. */
+  filename: string;
+}) {
+  const [selected, setSelected] = useState<Set<ArchivePart>>(
+    () => new Set(options.filter((o) => o.defaultSelected).map((o) => o.part)),
+  );
+  const [exporting, setExporting] = useState(false);
+  const [exportError, setExportError] = useState<string | null>(null);
+
+  function toggle(part: ArchivePart) {
+    setSelected((prev) => {
+      const next = new Set(prev);
+      if (next.has(part)) {
+        next.delete(part);
+      } else {
+        next.add(part);
+      }
+      return next;
+    });
+  }
+
+  // Menu order rather than the order the boxes were ticked in.
+  const parts = useMemo(
+    () => options.filter((o) => selected.has(o.part)).map((o) => o.part),
+    [options, selected],
+  );
+
+  async function handleExport() {
+    setExporting(true);
+    setExportError(null);
+    try {
+      const json = await build(parts);
+      const blob = new Blob([json], { type: "application/json" });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement("a");
+      a.href = url;
+      a.download = filename;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch (e) {
+      setExportError(errorMessage(e, "Export failed"));
+    } finally {
+      setExporting(false);
+    }
+  }
+
+  return (
+    <section className="rounded-lg border border-border bg-surface p-4" data-testid="archive-export">
+      <h2 className="font-display text-base font-semibold text-text-primary">Export</h2>
+      <p className="mt-1 text-sm text-text-muted">
+        A part left unticked is absent from the file. A part ticked but holding nothing is written
+        empty, which records that the export included it and there was nothing.
+      </p>
+      <ul className="mt-3 space-y-2">
+        {options.map((opt) => {
+          const id = `part-${opt.part}`;
+          return (
+            <li key={id} className="flex items-start gap-2.5">
+              <input
+                id={id}
+                type="checkbox"
+                className="mt-0.5 h-4 w-4 shrink-0 accent-primary"
+                checked={selected.has(opt.part)}
+                onChange={() => toggle(opt.part)}
+              />
+              <label htmlFor={id}>
+                <span className="text-sm font-medium text-text-primary">{opt.label}</span>
+                <span className="block text-xs text-text-muted">{opt.note}</span>
+              </label>
+            </li>
+          );
+        })}
+      </ul>
+      {exportError && (
+        <div className="mt-3">
+          <ErrorAlert>{exportError}</ErrorAlert>
+        </div>
+      )}
+      <button
+        type="button"
+        onClick={handleExport}
+        disabled={exporting || parts.length === 0}
+        data-testid="export-archive"
+        className="mt-4 rounded-md border border-border bg-surface px-3 py-1.5 text-xs font-medium text-text-primary transition-colors hover:bg-primary-light/15 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        {exporting ? "Exporting…" : "Export archive"}
+      </button>
+    </section>
+  );
+}

--- a/client/app/components/archive/job-parts.tsx
+++ b/client/app/components/archive/job-parts.tsx
@@ -12,6 +12,31 @@ const STATUS_LABELS: Record<number, string> = {
 };
 
 /**
+ * The last import a page knows about, and how far it has got.
+ *
+ * Whether the run is still going is as much a part of the result as the counts
+ * are: an import is applied on the server, so a page showing one it did not
+ * start is the normal case rather than the odd one.
+ */
+export function ArchiveJobSection({
+  job,
+  running,
+}: {
+  job: GetJobResult;
+  running: boolean;
+}) {
+  return (
+    <section className="rounded-lg border border-border bg-surface p-4" data-testid="archive-job">
+      <h2 className="font-display text-base font-semibold text-text-primary">Last import</h2>
+      <p className="mt-1 text-sm text-text-muted">
+        {running ? "Running. This continues whether or not this page is open." : "Finished."}
+      </p>
+      <JobPartsTable job={job} />
+    </section>
+  );
+}
+
+/**
  * The per-part results of one import.
  *
  * A part with validation errors has still succeeded: what failed is a row. So

--- a/client/hooks/use-archive-job.test.tsx
+++ b/client/hooks/use-archive-job.test.tsx
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { queryWrapper } from "@/test-utils";
+import { JobStatus } from "@/gen/api/v1/api_pb";
+import type { GetJobResult, JobSummary, ListJobsResult } from "@/lib/portfolio-api";
+import { getJob, listJobs } from "@/lib/portfolio-api";
+import { useArchiveJob } from "./use-archive-job";
+
+// The session gate on useAuthedQuery: authenticated, so the queries run.
+vi.mock("@/contexts/auth-context", () => ({
+  useAuth: () => ({ state: { status: "authenticated" } }),
+}));
+
+vi.mock("@/lib/portfolio-api", () => ({
+  listJobs: vi.fn(),
+  getJob: vi.fn(),
+}));
+
+const mockListJobs = vi.mocked(listJobs);
+const mockGetJob = vi.mocked(getJob);
+
+function summary(id: string): JobSummary {
+  return {
+    id,
+    jobType: "user_archive",
+    filename: "user-archive.json",
+    broker: "",
+    status: JobStatus.SUCCESS,
+    validationErrorCount: 0,
+    identificationErrorCount: 0,
+  };
+}
+
+function listing(...ids: string[]): ListJobsResult {
+  return { jobs: ids.map(summary), nextPageToken: null, totalCount: ids.length };
+}
+
+function job(status: JobStatus): GetJobResult {
+  return {
+    status,
+    validationErrors: [],
+    identificationErrors: [],
+    totalCount: 0,
+    processedCount: 0,
+    parts: [],
+  };
+}
+
+describe("useArchiveJob", () => {
+  beforeEach(() => {
+    mockListJobs.mockReset();
+    mockGetJob.mockReset();
+  });
+
+  it("watches the most recent job of its own type when none was started here", async () => {
+    mockListJobs.mockResolvedValue(listing("newest", "older"));
+    mockGetJob.mockResolvedValue(job(JobStatus.SUCCESS));
+
+    const { result } = renderHook(() => useArchiveJob("user_archive", () => {}), {
+      wrapper: queryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.job).toBeDefined());
+    // The listing is asked for by type, so the admin page and the user page do
+    // not adopt each other's imports.
+    expect(mockListJobs).toHaveBeenCalledWith(null, "user_archive");
+    expect(mockGetJob).toHaveBeenCalledWith("newest");
+    expect(result.current.running).toBe(false);
+  });
+
+  it("watches the job it started instead of the one it found", async () => {
+    mockListJobs.mockResolvedValue(listing("found"));
+    mockGetJob.mockResolvedValue(job(JobStatus.RUNNING));
+
+    const { result } = renderHook(() => useArchiveJob("user_archive", () => {}), {
+      wrapper: queryWrapper(),
+    });
+    await waitFor(() => expect(result.current.job).toBeDefined());
+
+    act(() => result.current.start("started"));
+
+    await waitFor(() => expect(mockGetJob).toHaveBeenCalledWith("started"));
+    // A job that has not reached a terminal status is still running, which is
+    // what stops a second import being queued over it.
+    await waitFor(() => expect(result.current.running).toBe(true));
+  });
+
+  it("reports a failed job as finished rather than running", async () => {
+    mockListJobs.mockResolvedValue(listing("failed"));
+    mockGetJob.mockResolvedValue(job(JobStatus.FAILED));
+
+    const { result } = renderHook(() => useArchiveJob("user_archive", () => {}), {
+      wrapper: queryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.job).toBeDefined());
+    expect(result.current.running).toBe(false);
+  });
+
+  it("calls onFinished once per finished job, not once per render", async () => {
+    mockListJobs.mockResolvedValue(listing("done"));
+    mockGetJob.mockResolvedValue(job(JobStatus.SUCCESS));
+
+    const onFinished = vi.fn();
+    // A fresh arrow each render, as a page passing an inline callback gives it.
+    const { result, rerender } = renderHook(
+      () => useArchiveJob("user_archive", () => onFinished()),
+      { wrapper: queryWrapper() },
+    );
+
+    await waitFor(() => expect(onFinished).toHaveBeenCalledTimes(1));
+    rerender();
+    rerender();
+    // Dropping every cached query the import could have touched is not free, so
+    // it happens when a job finishes and not whenever the page re-renders.
+    expect(onFinished).toHaveBeenCalledTimes(1);
+    expect(result.current.running).toBe(false);
+  });
+
+  it("does not call onFinished while the job is still running", async () => {
+    mockListJobs.mockResolvedValue(listing("running"));
+    mockGetJob.mockResolvedValue(job(JobStatus.RUNNING));
+
+    const onFinished = vi.fn();
+    const { result } = renderHook(() => useArchiveJob("user_archive", onFinished), {
+      wrapper: queryWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.running).toBe(true));
+    expect(onFinished).not.toHaveBeenCalled();
+  });
+});

--- a/client/hooks/use-archive-job.ts
+++ b/client/hooks/use-archive-job.ts
@@ -1,0 +1,77 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { useQueryClient } from "@tanstack/react-query";
+import { useAuthedQuery } from "@/hooks/use-authed-query";
+import { qk } from "@/lib/query-keys";
+import { getJob, listJobs, type GetJobResult } from "@/lib/portfolio-api";
+import { JobStatus } from "@/gen/api/v1/api_pb";
+
+/**
+ * The import job an archive page watches.
+ *
+ * An import is applied on the server, so it keeps running whether or not the
+ * page is open and the job to watch is looked up rather than remembered:
+ * closing the tab and coming back must show the run that is still going.
+ * Polling stops at a terminal status rather than running forever behind an idle
+ * page.
+ *
+ * Both archive pages share this because the sequence is the behaviour rather
+ * than the decoration; only the job type they ask for and what they drop
+ * afterwards differ. `onFinished` fires once per finished job, and each page
+ * passes its own because the cached queries an import invalidates are the ones
+ * its own section reads.
+ */
+export function useArchiveJob(
+  jobType: string,
+  onFinished: () => void,
+): {
+  job: GetJobResult | undefined;
+  running: boolean;
+  start: (jobId: string) => void;
+} {
+  const queryClient = useQueryClient();
+  const [startedJobId, setStartedJobId] = useState<string | null>(null);
+
+  const recent = useAuthedQuery({
+    queryKey: qk.jobs(),
+    queryFn: () => listJobs(null, jobType),
+  });
+  const jobId = startedJobId ?? recent.data?.jobs[0]?.id ?? null;
+
+  const job = useAuthedQuery({
+    queryKey: qk.job(jobId ?? ""),
+    queryFn: () => getJob(jobId!),
+    enabled: jobId !== null,
+    refetchInterval: (query) => {
+      const s = query.state.data?.status;
+      return s === JobStatus.SUCCESS || s === JobStatus.FAILED ? false : 2000;
+    },
+  });
+
+  const running =
+    job.data !== undefined &&
+    job.data.status !== JobStatus.SUCCESS &&
+    job.data.status !== JobStatus.FAILED;
+
+  // Held in a ref so that a caller passing an inline function does not make
+  // every render look like another finished job.
+  const finished = useRef(onFinished);
+  useEffect(() => {
+    finished.current = onFinished;
+  }, [onFinished]);
+
+  // Keyed on the terminal status so it runs once per finished job.
+  const terminalJobId = job.data && !running ? jobId : null;
+  useEffect(() => {
+    if (terminalJobId === null) return;
+    finished.current();
+  }, [terminalJobId]);
+
+  function start(id: string) {
+    setStartedJobId(id);
+    queryClient.invalidateQueries({ queryKey: qk.jobs() });
+  }
+
+  return { job: job.data, running, start };
+}

--- a/client/vitest.setup.ts
+++ b/client/vitest.setup.ts
@@ -1,1 +1,8 @@
 import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+// Vitest globals are off, so testing-library's own auto-cleanup never
+// registers. Without this a component rendered by one test is still mounted
+// during the next, and a query that should find one element finds two.
+afterEach(cleanup);

--- a/docs/issues/0080-consolidated-user-export-import-page.md
+++ b/docs/issues/0080-consolidated-user-export-import-page.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Consolidated user export and import page
 milestone: M14
 dependencies: [0078]
@@ -46,3 +46,41 @@ export menu and import panel, the per-part results table and the IA entry all
 landed under 0085, which needed them to carry its own part. What remains here is
 the transactions and holding declarations rows in the include menu, once 0077 and
 0076 land the parts behind them.
+
+Closed. The include menu arrived before this issue did: 0076 and 0077 each
+brought their own row along with the part behind it, so all three parts were
+already on the page and enabled. What closed the issue was what a *consolidated*
+page claims and nothing had shown -- that the parts compose.
+
+The whole archive now round trips as one file. Every earlier test unticked the
+other two parts and proved one alone, which says nothing about what happens when
+they travel together, and that is where the pads, the restore order and the
+synthetic postings meet. Two things fell out of writing it.
+
+The declarations part succeeding is the only ordering guarantee a round trip can
+show. A declaration dated before the portfolio start date is rejected, and a user
+whose transactions have just been deleted has no start date at all, so the part
+would have failed whole had it been applied before them. Preferences-first is not
+observable and was not manufactured: an instance cannot hold postings its own
+ignored asset class rules cover, so no self-consistent export carries both.
+
+The transaction part must carry six postings where the table holds ten. The pads
+a restored declaration earns are synthetic, and a part leaking into another would
+show up as a pad about to be re-imported as a real transaction.
+
+The two archive pages had also written the same machinery twice -- the include
+menu, the export and download, the job lookup and poll, the results card. They
+now share an `ExportArchivePanel`, a `useArchiveJob` hook and an
+`ArchiveJobSection`, on the split `ImportArchivePanel` already made: what a menu
+means is common, and which archive is being built is not.
+
+The information architecture claimed the transaction and declaration parts were
+still to come, and described the upload modal as the thing that converts a
+broker's own file. Since 0084 that modal also accepts a transactions document in
+the archive schema, so the distinction that survives is scope rather than format:
+one file covering one period, replacing that period, against a whole archive
+restored part by part.
+
+The export period the RPC accepts still has no control on the page. Nothing asked
+for one, and 0094 settled the semantics without a UI, so it stays out rather than
+arriving unasked.


### PR DESCRIPTION
Stacked on #424 -- merge that first.

The two archive pages had written the same thing twice: the include menu and its
selection state, the export and the download, the job lookup and its poll, and
the results card. Only the import panel and the parts table were shared. This
extracts the rest, on the split `ImportArchivePanel` already made -- what a menu
means is common to both archives, and which archive is being built is not.

- **`ExportArchivePanel`** owns the menu, the selection and the download, and
  takes a `build` callback returning the document text, so the streaming,
  assembly and marshalling of one kind of archive stay with the page that knows
  which kind it is.
- **`useArchiveJob`** owns the lookup, the poll that stops at a terminal status
  and the `running` derivation, and calls `onFinished` once per finished job --
  held in a ref, so a page passing an inline callback does not make every render
  look like another job finishing.
- **`ArchiveJobSection`** is the card around the parts table.

283 lines out, 120 in. No behaviour changes, and the test ids say so: both
archive suites and the whole archive round trip from #424 address the pages
through them.

Adding the first component test turned up a hole in the client test setup.
Vitest globals are off, so testing-library's own auto-cleanup never registered
and a component rendered by one test was still mounted during the next. Fixed in
`vitest.setup.ts` rather than per file.

**0080 is closed.** The include menu it asked for arrived before it did -- 0076
and 0077 each brought their own row with the part behind it -- so what closed it
was what a consolidated page claims and nothing had shown: that the parts
compose. The closing note records that, and that the export period the RPC
accepts still has no control on the page, deliberately.

`make client-test`: 236 passed. `make client-typecheck` and `make
lint-ts-client`: clean. `make e2e-test` against the rebuilt client: 48 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)