### PR TITLE
Defer portfolio definitions out of M14

### DIFF
--- a/docs/issues/0089-portfolio-definition-export.md
+++ b/docs/issues/0089-portfolio-definition-export.md
@@ -1,7 +1,6 @@
 ---
 status: open
 title: Export and import portfolio definitions
-milestone: M14
 dependencies: [0078, 0080]
 ---
 
@@ -34,5 +33,19 @@ unscheduled list, widen the same seam: a portfolio would then reference data the
 exporting user does not own, and the archive boundary in
 adr/0033-system-and-user-archives-are-separate.md would need an answer for it.
 
-Settle once both archives exist and the identifier translation has been exercised
-by transactions and declarations.
+## Why it is deferred rather than scheduled
+
+The general idea is agreed -- a portfolio definition is user-owned data and a
+rebuild should not lose it. What is not agreed is the definition itself. The
+filter model it would serialise is the current one rather than a settled one, and
+committing it to an archive format fixes it before it is ready: shared portfolios
+and tag-based definitions both sit in the unscheduled list and both change what a
+definition is.
+
+So the archive is completed without it, and a user rebuilding an instance writes
+their portfolios again by hand. That is a handful of filter rows entered once,
+against a format that would otherwise have to be migrated when the definition
+settles.
+
+Take it up once the portfolio definition is pinned down, and once the identifier
+translation above has been exercised by transactions and declarations.

--- a/docs/issues/milestones.md
+++ b/docs/issues/milestones.md
@@ -13,7 +13,7 @@
 - **M11** - Allow users to set a display currency.
 - **M12** - Move transactions to grouped double-entry postings with exact decimal amounts and an enforced balance constraint.
 - **M13** - Automated broker transaction import via a browser extension.
-- **M14** - Complete the archive: system and user archives carry everything a rebuild needs, and the transaction CSV is retired.
+- **M14** - Complete the archive: system and user archives carry everything a rebuild needs apart from portfolio definitions, and the transaction CSV is retired.
 - **M15** - The server owns transaction grouping: converters emit evidence and the server derives groups across the whole dataset rather than within one upload.
 - **M16** - A person can repair a grouping or a transfer pairing the engine cannot derive.
 - **M17** - Operational correctness: scheduled corporate-event recompute, single-sourced instrument data, current planner statistics, and configurable deployment.
@@ -26,6 +26,7 @@
 - Corporate events fetched for known instruments and adjustments applied to user transactions idempotently.
 - Portfolio performance comparison to indices.
 - Portfolio definition based on tagged instruments.
+- Carrying portfolio definitions in the user archive, once the definition is settled.
 - Portfolio sharing between users and aggregates that combine portfolios (including shared portfolios).
 - Transaction importer for IBKR.
 - Transaction importer for SCHB.

--- a/docs/spec/archive-format.md
+++ b/docs/spec/archive-format.md
@@ -19,10 +19,10 @@ difference decides what it carries.
 
 It carries two kinds of thing:
 
-- **Irreplaceable data.** Transactions, holding declarations,
-  portfolios, preferences, plugin configuration, fetch-block reasons, the
-  corporate events an admin was asked to judge and the calls made on them, and
-  hand-recovered prices no provider still serves. Nothing can reconstruct these.
+- **Irreplaceable data.** Transactions, holding declarations, preferences,
+  plugin configuration, fetch-block reasons, the corporate events an admin was
+  asked to judge and the calls made on them, and hand-recovered prices no
+  provider still serves. Nothing can reconstruct these.
 - **Data that is expensive to reacquire.** Instruments and their identifiers,
   provider identifiers, prices with their coverage, corporate events with their
   coverage, and inflation indices. These are refetchable in principle, at the
@@ -41,6 +41,15 @@ the evidence a posting carries rather than being told it
 postings and the importing instance groups them. The evidence itself -- a
 posting's `correlations` -- is irreplaceable data and stays, since a rebuild that
 had only the answer could never derive it again.
+
+Portfolio definitions are the one piece of irreplaceable data the archive does
+not carry, and their absence is a deliberate omission rather than a claim that
+they are recomputable. A definition is a set of filters whose shape is not
+settled -- tag-based definitions and portfolios shared between users would both
+change what one is -- and writing the current shape into the format would fix it
+before the question is answered. A user rebuilding an instance enters their
+portfolios again, which is a handful of filter rows against a format that would
+otherwise have to be migrated.
 
 Full reasoning: `docs/adr/0032-archive-preserves-inputs-not-derived-state.md`.
 


### PR DESCRIPTION
A portfolio definition is a set of filters whose shape is not settled -- tag-based definitions and portfolios shared between users would both change what one is -- and writing the current shape into the archive format fixes it before the question is answered. A user rebuilding an instance enters their portfolios again instead: a handful of filter rows, against a format that would otherwise have to be migrated once the definition settles.

So [0089](../blob/main/docs/issues/0089-portfolio-definition-export.md) loses its milestone and gains a section saying why it is deferred rather than merely late. With 0080 closed by #425, that completes M14.

## The spec was promising something the format never offered

`docs/spec/archive-format.md` listed portfolios among the irreplaceable data an archive carries. Nothing implemented it and `ArchivePart` has no value for them, so the sentence was a plan read as a description. It is dropped from that list and replaced by a paragraph saying the omission is deliberate -- otherwise a reader meets the gap later and takes it for a claim that a definition is recomputable, which is the one thing it is not.

`adr/0032-archive-preserves-inputs-not-derived-state.md` is left alone. It classifies portfolios as tier 1, irreplaceable, and that stays true; what changed is scheduling, not the tiering decision it records.

M14's own description now says the archive carries everything a rebuild needs apart from portfolio definitions, and the unscheduled list carries the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)