### PR TITLE
Test the twenty API RPCs that nothing called

### DIFF
--- a/server/service/api/corporate_events_admin_test.go
+++ b/server/service/api/corporate_events_admin_test.go
@@ -1,0 +1,140 @@
+package api
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/testutil"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+)
+
+// The admin RPCs over the unhandled corporate event queue: what is in it, how much
+// of it there is, and marking one dealt with.
+
+// A page of events, with the instrument name looked up per event for display and
+// the ex-date written as a plain date rather than an instant.
+func TestListUnhandledCorporateEvents(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	exDate := time.Date(2025, 6, 2, 0, 0, 0, 0, time.UTC)
+	created := time.Date(2025, 6, 1, 9, 30, 0, 0, time.UTC)
+	name := "APPLE INC"
+	mockDB.EXPECT().ListUnhandledCorporateEvents(gomock.Any(), false, int32(50), "").Return(
+		[]db.UnhandledCorporateEvent{{
+			ID: "e1", InstrumentID: "i1", EventType: "SPINOFF",
+			ExDate: &exDate, Detail: "unsupported", Data: []byte(`{"a":1}`),
+			Resolved: false, CreatedAt: created,
+		}}, int32(1), "next", nil)
+	mockDB.EXPECT().GetInstrument(gomock.Any(), "i1").Return(&db.InstrumentRow{ID: "i1", Name: &name}, nil)
+
+	resp, err := srv.ListUnhandledCorporateEvents(adminCtx("admin-1", "sub|admin"), &apiv1.ListUnhandledCorporateEventsRequest{})
+	if err != nil {
+		t.Fatalf("ListUnhandledCorporateEvents: %v", err)
+	}
+	if resp.GetTotalCount() != 1 || resp.GetNextPageToken() != "next" {
+		t.Errorf("page: got total=%d token=%q, want 1 and \"next\"", resp.GetTotalCount(), resp.GetNextPageToken())
+	}
+	if len(resp.GetEvents()) != 1 {
+		t.Fatalf("events: got %d, want 1", len(resp.GetEvents()))
+	}
+	e := resp.GetEvents()[0]
+	if e.GetId() != "e1" || e.GetEventType() != "SPINOFF" || e.GetExDate() != "2025-06-02" {
+		t.Errorf("event: got %+v", e)
+	}
+	if e.GetInstrumentName() != name {
+		t.Errorf("instrument name: got %q, want %q", e.GetInstrumentName(), name)
+	}
+	if e.GetData() != `{"a":1}` {
+		t.Errorf("data: got %q", e.GetData())
+	}
+}
+
+// An unset page_size is a default rather than a page of nothing.
+func TestListUnhandledCorporateEvents_DefaultsPageSize(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	mockDB.EXPECT().ListUnhandledCorporateEvents(gomock.Any(), true, int32(50), "tok").Return(nil, int32(0), "", nil)
+
+	_, err := srv.ListUnhandledCorporateEvents(adminCtx("admin-1", "sub|admin"), &apiv1.ListUnhandledCorporateEventsRequest{
+		IncludeResolved: true, PageToken: "tok",
+	})
+	if err != nil {
+		t.Fatalf("ListUnhandledCorporateEvents: %v", err)
+	}
+}
+
+func TestListUnhandledCorporateEvents_StoreError(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	mockDB.EXPECT().ListUnhandledCorporateEvents(gomock.Any(), false, int32(50), "").Return(nil, int32(0), "", errors.New("boom"))
+
+	_, err := srv.ListUnhandledCorporateEvents(adminCtx("admin-1", "sub|admin"), &apiv1.ListUnhandledCorporateEventsRequest{})
+	testutil.RequireGRPCCode(t, err, codes.Internal)
+}
+
+func TestCountUnhandledCorporateEvents(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	mockDB.EXPECT().CountUnhandledCorporateEvents(gomock.Any()).Return(int32(7), nil)
+
+	resp, err := srv.CountUnhandledCorporateEvents(adminCtx("admin-1", "sub|admin"), &apiv1.CountUnhandledCorporateEventsRequest{})
+	if err != nil {
+		t.Fatalf("CountUnhandledCorporateEvents: %v", err)
+	}
+	if resp.GetCount() != 7 {
+		t.Errorf("count: got %d, want 7", resp.GetCount())
+	}
+}
+
+func TestCountUnhandledCorporateEvents_StoreError(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	mockDB.EXPECT().CountUnhandledCorporateEvents(gomock.Any()).Return(int32(0), errors.New("boom"))
+
+	_, err := srv.CountUnhandledCorporateEvents(adminCtx("admin-1", "sub|admin"), &apiv1.CountUnhandledCorporateEventsRequest{})
+	testutil.RequireGRPCCode(t, err, codes.Internal)
+}
+
+func TestResolveUnhandledCorporateEvent(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	mockDB.EXPECT().ResolveUnhandledCorporateEvent(gomock.Any(), "e1").Return(nil)
+
+	_, err := srv.ResolveUnhandledCorporateEvent(adminCtx("admin-1", "sub|admin"), &apiv1.ResolveUnhandledCorporateEventRequest{Id: "e1"})
+	if err != nil {
+		t.Fatalf("ResolveUnhandledCorporateEvent: %v", err)
+	}
+}
+
+// Resolving nothing in particular would mark whichever row the store guessed at, so
+// the id is required before it is asked.
+func TestResolveUnhandledCorporateEvent_MissingID(t *testing.T) {
+	srv, _ := newAPIServerWithMock(t)
+	_, err := srv.ResolveUnhandledCorporateEvent(adminCtx("admin-1", "sub|admin"), &apiv1.ResolveUnhandledCorporateEventRequest{})
+	testutil.RequireGRPCCode(t, err, codes.InvalidArgument)
+}
+
+func TestCorporateEventQueue_AdminOnly(t *testing.T) {
+	srv, _ := newAPIServerWithMock(t)
+	ctx := authCtx("user-1", "sub|1")
+	tests := []struct {
+		name string
+		call func() error
+	}{
+		{"ListUnhandledCorporateEvents", func() error {
+			_, err := srv.ListUnhandledCorporateEvents(ctx, &apiv1.ListUnhandledCorporateEventsRequest{})
+			return err
+		}},
+		{"CountUnhandledCorporateEvents", func() error {
+			_, err := srv.CountUnhandledCorporateEvents(ctx, &apiv1.CountUnhandledCorporateEventsRequest{})
+			return err
+		}},
+		{"ResolveUnhandledCorporateEvent", func() error {
+			_, err := srv.ResolveUnhandledCorporateEvent(ctx, &apiv1.ResolveUnhandledCorporateEventRequest{Id: "e1"})
+			return err
+		}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			testutil.RequireGRPCCode(t, tc.call(), codes.PermissionDenied)
+		})
+	}
+}

--- a/server/service/api/ignored_asset_classes_test.go
+++ b/server/service/api/ignored_asset_classes_test.go
@@ -1,0 +1,122 @@
+package api
+
+import (
+	"errors"
+	"testing"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/testutil"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+)
+
+// rule is the wire shape of one ignore rule.
+func rule(broker, account string, class typev1.AssetClass) *apiv1.IgnoredAssetClassRule {
+	return &apiv1.IgnoredAssetClassRule{Broker: broker, Account: account, AssetClass: class}
+}
+
+// An empty account means every account of that broker, so it survives the round
+// trip rather than being filled in with something.
+func TestGetIgnoredAssetClasses(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	mockDB.EXPECT().ListIgnoredAssetClasses(gomock.Any(), "user-1").Return([]db.IgnoredAssetClass{
+		{Broker: "IBKR", Account: "U1000001", AssetClass: "OPTION"},
+		{Broker: "FIDELITY", Account: "", AssetClass: "CASH"},
+	}, nil)
+
+	resp, err := srv.GetIgnoredAssetClasses(authCtx("user-1", "sub|1"), &apiv1.GetIgnoredAssetClassesRequest{})
+	if err != nil {
+		t.Fatalf("GetIgnoredAssetClasses: %v", err)
+	}
+	want := []*apiv1.IgnoredAssetClassRule{
+		rule("IBKR", "U1000001", typev1.AssetClass_OPTION),
+		rule("FIDELITY", "", typev1.AssetClass_CASH),
+	}
+	got := resp.GetRules()
+	if len(got) != len(want) {
+		t.Fatalf("rules: got %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i].GetBroker() != want[i].GetBroker() ||
+			got[i].GetAccount() != want[i].GetAccount() ||
+			got[i].GetAssetClass() != want[i].GetAssetClass() {
+			t.Errorf("rule %d: got %v, want %v", i, got[i], want[i])
+		}
+	}
+}
+
+func TestGetIgnoredAssetClasses_StoreError(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	mockDB.EXPECT().ListIgnoredAssetClasses(gomock.Any(), "user-1").Return(nil, errors.New("boom"))
+
+	_, err := srv.GetIgnoredAssetClasses(authCtx("user-1", "sub|1"), &apiv1.GetIgnoredAssetClassesRequest{})
+	testutil.RequireGRPCCode(t, err, codes.Internal)
+}
+
+// Set replaces the whole set, so what reaches the store is the request and nothing
+// merged into it.
+func TestSetIgnoredAssetClasses(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	mockDB.EXPECT().SetIgnoredAssetClasses(gomock.Any(), "user-1", []db.IgnoredAssetClass{
+		{Broker: "IBKR", Account: "U1000001", AssetClass: "OPTION"},
+	}).Return(nil)
+
+	_, err := srv.SetIgnoredAssetClasses(authCtx("user-1", "sub|1"), &apiv1.SetIgnoredAssetClassesRequest{
+		Rules: []*apiv1.IgnoredAssetClassRule{rule("IBKR", "U1000001", typev1.AssetClass_OPTION)},
+	})
+	if err != nil {
+		t.Fatalf("SetIgnoredAssetClasses: %v", err)
+	}
+}
+
+// An empty set is a valid instruction -- it clears the rules -- rather than a
+// request with something missing from it.
+func TestSetIgnoredAssetClasses_ClearsWithNoRules(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	mockDB.EXPECT().SetIgnoredAssetClasses(gomock.Any(), "user-1", []db.IgnoredAssetClass{}).Return(nil)
+
+	_, err := srv.SetIgnoredAssetClasses(authCtx("user-1", "sub|1"), &apiv1.SetIgnoredAssetClassesRequest{})
+	if err != nil {
+		t.Fatalf("SetIgnoredAssetClasses: %v", err)
+	}
+}
+
+// A rule naming no broker is rejected before the store is asked, because a rule
+// that matched every broker is not what an unset field means.
+func TestSetIgnoredAssetClasses_RejectsRuleWithNoBroker(t *testing.T) {
+	srv, _ := newAPIServerWithMock(t)
+	_, err := srv.SetIgnoredAssetClasses(authCtx("user-1", "sub|1"), &apiv1.SetIgnoredAssetClassesRequest{
+		Rules: []*apiv1.IgnoredAssetClassRule{rule("", "", typev1.AssetClass_OPTION)},
+	})
+	testutil.RequireGRPCCode(t, err, codes.InvalidArgument)
+}
+
+// Count answers the question the confirmation dialog asks before a set: how much
+// would this destroy. Declarations are counted separately from transactions,
+// because they are a separate thing to lose.
+func TestCountIgnoredTxs(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	mockDB.EXPECT().CountIgnoredTxs(gomock.Any(), "user-1", []db.IgnoredAssetClass{
+		{Broker: "IBKR", Account: "", AssetClass: "OPTION"},
+	}).Return(int32(12), int32(3), nil)
+
+	resp, err := srv.CountIgnoredTxs(authCtx("user-1", "sub|1"), &apiv1.CountIgnoredTxsRequest{
+		Rules: []*apiv1.IgnoredAssetClassRule{rule("IBKR", "", typev1.AssetClass_OPTION)},
+	})
+	if err != nil {
+		t.Fatalf("CountIgnoredTxs: %v", err)
+	}
+	if resp.GetTxCount() != 12 || resp.GetDeclarationCount() != 3 {
+		t.Errorf("counts: got txs=%d declarations=%d, want 12 and 3", resp.GetTxCount(), resp.GetDeclarationCount())
+	}
+}
+
+func TestCountIgnoredTxs_StoreError(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	mockDB.EXPECT().CountIgnoredTxs(gomock.Any(), "user-1", gomock.Any()).Return(int32(0), int32(0), errors.New("boom"))
+
+	_, err := srv.CountIgnoredTxs(authCtx("user-1", "sub|1"), &apiv1.CountIgnoredTxsRequest{})
+	testutil.RequireGRPCCode(t, err, codes.Internal)
+}

--- a/server/service/api/inflation_test.go
+++ b/server/service/api/inflation_test.go
@@ -1,0 +1,93 @@
+package api
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/testutil"
+	"github.com/shopspring/decimal"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/genproto/googleapis/type/date"
+	"google.golang.org/grpc/codes"
+)
+
+// A month is a date rather than an instant on the wire, and the index keeps its
+// full precision: it is a divisor in every real-terms figure, so a value rounded
+// here would move them all.
+func TestListInflationIndices(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	month := time.Date(2025, 3, 1, 0, 0, 0, 0, time.UTC)
+	mockDB.EXPECT().
+		ListInflationIndices(gomock.Any(), "GBP", gomock.Any(), gomock.Any(), 30, "").
+		Return([]db.InflationIndex{{
+			Currency: "GBP", Month: month,
+			IndexValue: decimal.RequireFromString("134.567"), BaseYear: 2015, DataProvider: "ons",
+		}}, "next", 1, nil)
+
+	resp, err := srv.ListInflationIndices(adminCtx("admin-1", "sub|admin"), &apiv1.ListInflationIndicesRequest{
+		Currency:   "GBP",
+		DateFrom:   &date.Date{Year: 2025, Month: 1, Day: 1},
+		DateBefore: &date.Date{Year: 2025, Month: 4, Day: 1},
+	})
+	if err != nil {
+		t.Fatalf("ListInflationIndices: %v", err)
+	}
+	if resp.GetTotalCount() != 1 || resp.GetNextPageToken() != "next" {
+		t.Errorf("page: got total=%d token=%q, want 1 and \"next\"", resp.GetTotalCount(), resp.GetNextPageToken())
+	}
+	if len(resp.GetIndices()) != 1 {
+		t.Fatalf("indices: got %d, want 1", len(resp.GetIndices()))
+	}
+	i := resp.GetIndices()[0]
+	if i.GetCurrency() != "GBP" || i.GetMonth() != "2025-03-01" || i.GetIndexValue() != "134.567" ||
+		i.GetBaseYear() != 2015 || i.GetDataProvider() != "ons" {
+		t.Errorf("index: got %+v", i)
+	}
+}
+
+// An unset page size is a default, and one larger than the cap is the cap: a page
+// is bounded by what the server will serve rather than by what a caller asks for.
+func TestListInflationIndices_PageSizeBounds(t *testing.T) {
+	tests := []struct {
+		name     string
+		asked    int32
+		expected int
+	}{
+		{"unset takes the default", 0, 30},
+		{"negative takes the default", -1, 30},
+		{"under the cap is honoured", 10, 10},
+		{"over the cap is capped", 500, 100},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv, mockDB := newAPIServerWithMock(t)
+			mockDB.EXPECT().
+				ListInflationIndices(gomock.Any(), "", gomock.Any(), gomock.Any(), tt.expected, "").
+				Return(nil, "", 0, nil)
+
+			_, err := srv.ListInflationIndices(adminCtx("admin-1", "sub|admin"), &apiv1.ListInflationIndicesRequest{PageSize: tt.asked})
+			if err != nil {
+				t.Fatalf("ListInflationIndices: %v", err)
+			}
+		})
+	}
+}
+
+func TestListInflationIndices_StoreError(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	mockDB.EXPECT().
+		ListInflationIndices(gomock.Any(), "", gomock.Any(), gomock.Any(), 30, "").
+		Return(nil, "", 0, errors.New("boom"))
+
+	_, err := srv.ListInflationIndices(adminCtx("admin-1", "sub|admin"), &apiv1.ListInflationIndicesRequest{})
+	testutil.RequireGRPCCode(t, err, codes.Internal)
+}
+
+func TestListInflationIndices_AdminOnly(t *testing.T) {
+	srv, _ := newAPIServerWithMock(t)
+	_, err := srv.ListInflationIndices(authCtx("user-1", "sub|1"), &apiv1.ListInflationIndicesRequest{})
+	testutil.RequireGRPCCode(t, err, codes.PermissionDenied)
+}

--- a/server/service/api/plugin_categories_test.go
+++ b/server/service/api/plugin_categories_test.go
@@ -1,0 +1,336 @@
+package api
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"testing"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/testutil"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+)
+
+// The five plugin categories are one shape repeated: list reads ListPluginConfigs
+// for its own category and maps the rows out, update writes UpdatePluginConfig for
+// its own category and maps the row back. Only price was tested, and the other four
+// were the copies -- which is how they came to have no coverage at all.
+//
+// A table rather than five sets of near-identical tests, because the thing worth
+// asserting is that they are the same shape, and because a sixth category should be
+// one line here rather than another copy. What is particular to a category is the
+// constant it passes, which is exactly what these check.
+//
+// pluginView is what the five response types have in common, so one set of
+// assertions can read all of them.
+type pluginView struct {
+	id         string
+	enabled    bool
+	precedence int32
+	configJSON string
+	display    string
+}
+
+// pluginOpts is the optional half of an update request. Every field is a pointer
+// on the wire because leaving one out means "do not change it", which is not the
+// same as setting it to zero, and it is the half a copied method can drop without
+// failing to compile.
+type pluginOpts struct {
+	enabledV    *bool
+	precedenceV *int32
+	configV     *string
+}
+
+func (o *pluginOpts) enabled() *bool {
+	if o == nil {
+		return nil
+	}
+	return o.enabledV
+}
+
+func (o *pluginOpts) precedence() *int32 {
+	if o == nil {
+		return nil
+	}
+	return o.precedenceV
+}
+
+func (o *pluginOpts) configJSON() *string {
+	if o == nil {
+		return nil
+	}
+	return o.configV
+}
+
+type pluginCategory struct {
+	name     string
+	category string
+	list     func(*Server, context.Context) ([]pluginView, error)
+	update   func(*Server, context.Context, string, *pluginOpts) (pluginView, error)
+}
+
+var pluginCategories = []pluginCategory{
+	{
+		name: "identifier", category: db.PluginCategoryIdentifier,
+		list: func(s *Server, ctx context.Context) ([]pluginView, error) {
+			r, err := s.ListIdentifierPlugins(ctx, &apiv1.ListIdentifierPluginsRequest{})
+			if err != nil {
+				return nil, err
+			}
+			out := make([]pluginView, 0, len(r.GetPlugins()))
+			for _, p := range r.GetPlugins() {
+				out = append(out, pluginView{p.GetPluginId(), p.GetEnabled(), p.GetPrecedence(), p.GetConfigJson(), p.GetDisplayName()})
+			}
+			return out, nil
+		},
+		update: func(s *Server, ctx context.Context, id string, o *pluginOpts) (pluginView, error) {
+			r, err := s.UpdateIdentifierPlugin(ctx, &apiv1.UpdateIdentifierPluginRequest{PluginId: id, Enabled: o.enabled(), Precedence: o.precedence(), ConfigJson: o.configJSON()})
+			if err != nil {
+				return pluginView{}, err
+			}
+			p := r.GetPlugin()
+			return pluginView{p.GetPluginId(), p.GetEnabled(), p.GetPrecedence(), p.GetConfigJson(), p.GetDisplayName()}, nil
+		},
+	},
+	{
+		name: "description", category: db.PluginCategoryDescription,
+		list: func(s *Server, ctx context.Context) ([]pluginView, error) {
+			r, err := s.ListDescriptionPlugins(ctx, &apiv1.ListDescriptionPluginsRequest{})
+			if err != nil {
+				return nil, err
+			}
+			out := make([]pluginView, 0, len(r.GetPlugins()))
+			for _, p := range r.GetPlugins() {
+				out = append(out, pluginView{p.GetPluginId(), p.GetEnabled(), p.GetPrecedence(), p.GetConfigJson(), p.GetDisplayName()})
+			}
+			return out, nil
+		},
+		update: func(s *Server, ctx context.Context, id string, o *pluginOpts) (pluginView, error) {
+			r, err := s.UpdateDescriptionPlugin(ctx, &apiv1.UpdateDescriptionPluginRequest{PluginId: id, Enabled: o.enabled(), Precedence: o.precedence(), ConfigJson: o.configJSON()})
+			if err != nil {
+				return pluginView{}, err
+			}
+			p := r.GetPlugin()
+			return pluginView{p.GetPluginId(), p.GetEnabled(), p.GetPrecedence(), p.GetConfigJson(), p.GetDisplayName()}, nil
+		},
+	},
+	{
+		name: "price", category: db.PluginCategoryPrice,
+		list: func(s *Server, ctx context.Context) ([]pluginView, error) {
+			r, err := s.ListPricePlugins(ctx, &apiv1.ListPricePluginsRequest{})
+			if err != nil {
+				return nil, err
+			}
+			out := make([]pluginView, 0, len(r.GetPlugins()))
+			for _, p := range r.GetPlugins() {
+				out = append(out, pluginView{p.GetPluginId(), p.GetEnabled(), p.GetPrecedence(), p.GetConfigJson(), p.GetDisplayName()})
+			}
+			return out, nil
+		},
+		update: func(s *Server, ctx context.Context, id string, o *pluginOpts) (pluginView, error) {
+			r, err := s.UpdatePricePlugin(ctx, &apiv1.UpdatePricePluginRequest{PluginId: id, Enabled: o.enabled(), Precedence: o.precedence(), ConfigJson: o.configJSON()})
+			if err != nil {
+				return pluginView{}, err
+			}
+			p := r.GetPlugin()
+			return pluginView{p.GetPluginId(), p.GetEnabled(), p.GetPrecedence(), p.GetConfigJson(), p.GetDisplayName()}, nil
+		},
+	},
+	{
+		name: "inflation", category: db.PluginCategoryInflation,
+		list: func(s *Server, ctx context.Context) ([]pluginView, error) {
+			r, err := s.ListInflationPlugins(ctx, &apiv1.ListInflationPluginsRequest{})
+			if err != nil {
+				return nil, err
+			}
+			out := make([]pluginView, 0, len(r.GetPlugins()))
+			for _, p := range r.GetPlugins() {
+				out = append(out, pluginView{p.GetPluginId(), p.GetEnabled(), p.GetPrecedence(), p.GetConfigJson(), p.GetDisplayName()})
+			}
+			return out, nil
+		},
+		update: func(s *Server, ctx context.Context, id string, o *pluginOpts) (pluginView, error) {
+			r, err := s.UpdateInflationPlugin(ctx, &apiv1.UpdateInflationPluginRequest{PluginId: id, Enabled: o.enabled(), Precedence: o.precedence(), ConfigJson: o.configJSON()})
+			if err != nil {
+				return pluginView{}, err
+			}
+			p := r.GetPlugin()
+			return pluginView{p.GetPluginId(), p.GetEnabled(), p.GetPrecedence(), p.GetConfigJson(), p.GetDisplayName()}, nil
+		},
+	},
+	{
+		name: "corporate_event", category: db.PluginCategoryCorporateEvent,
+		list: func(s *Server, ctx context.Context) ([]pluginView, error) {
+			r, err := s.ListCorporateEventPlugins(ctx, &apiv1.ListCorporateEventPluginsRequest{})
+			if err != nil {
+				return nil, err
+			}
+			out := make([]pluginView, 0, len(r.GetPlugins()))
+			for _, p := range r.GetPlugins() {
+				out = append(out, pluginView{p.GetPluginId(), p.GetEnabled(), p.GetPrecedence(), p.GetConfigJson(), p.GetDisplayName()})
+			}
+			return out, nil
+		},
+		update: func(s *Server, ctx context.Context, id string, o *pluginOpts) (pluginView, error) {
+			r, err := s.UpdateCorporateEventPlugin(ctx, &apiv1.UpdateCorporateEventPluginRequest{PluginId: id, Enabled: o.enabled(), Precedence: o.precedence(), ConfigJson: o.configJSON()})
+			if err != nil {
+				return pluginView{}, err
+			}
+			p := r.GetPlugin()
+			return pluginView{p.GetPluginId(), p.GetEnabled(), p.GetPrecedence(), p.GetConfigJson(), p.GetDisplayName()}, nil
+		},
+	},
+}
+
+// Each list reads its own category and nobody else's. The expectation names the
+// category, so a method that passed a neighbour's constant -- the mistake a set of
+// copies invites -- fails on the unexpected call.
+func TestListPlugins_ReadsItsOwnCategory(t *testing.T) {
+	for _, c := range pluginCategories {
+		t.Run(c.name, func(t *testing.T) {
+			srv, mockDB := newAPIServerWithMock(t)
+			mockDB.EXPECT().ListPluginConfigs(gomock.Any(), c.category).Return([]db.PluginConfigRowFull{
+				{PluginID: "one", Enabled: true, Precedence: 10, Config: []byte(`{"key":"val"}`)},
+			}, nil)
+
+			got, err := c.list(srv, adminCtx("admin-1", "sub|admin"))
+			if err != nil {
+				t.Fatalf("list: %v", err)
+			}
+			want := []pluginView{{id: "one", enabled: true, precedence: 10, configJSON: `{"key":"val"}`, display: "one"}}
+			if len(got) != 1 || got[0] != want[0] {
+				t.Errorf("plugins: got %+v, want %+v", got, want)
+			}
+		})
+	}
+}
+
+// An empty category returns no plugins rather than failing, which is the state an
+// instance with a category disabled is in.
+func TestListPlugins_EmptyCategory(t *testing.T) {
+	for _, c := range pluginCategories {
+		t.Run(c.name, func(t *testing.T) {
+			srv, mockDB := newAPIServerWithMock(t)
+			mockDB.EXPECT().ListPluginConfigs(gomock.Any(), c.category).Return(nil, nil)
+
+			got, err := c.list(srv, adminCtx("admin-1", "sub|admin"))
+			if err != nil {
+				t.Fatalf("list: %v", err)
+			}
+			if len(got) != 0 {
+				t.Errorf("plugins: got %+v, want none", got)
+			}
+		})
+	}
+}
+
+// A store error is Internal rather than a partial response.
+func TestListPlugins_StoreError(t *testing.T) {
+	for _, c := range pluginCategories {
+		t.Run(c.name, func(t *testing.T) {
+			srv, mockDB := newAPIServerWithMock(t)
+			mockDB.EXPECT().ListPluginConfigs(gomock.Any(), c.category).Return(nil, errors.New("boom"))
+
+			_, err := c.list(srv, adminCtx("admin-1", "sub|admin"))
+			testutil.RequireGRPCCode(t, err, codes.Internal)
+		})
+	}
+}
+
+// Update writes to its own category too, and hands back the row the store returned
+// rather than the request it was given.
+func TestUpdatePlugin_WritesItsOwnCategory(t *testing.T) {
+	for _, c := range pluginCategories {
+		t.Run(c.name, func(t *testing.T) {
+			srv, mockDB := newAPIServerWithMock(t)
+			mockDB.EXPECT().
+				UpdatePluginConfig(gomock.Any(), c.category, "one", nil, nil, nil, gomock.Any()).
+				Return(&db.PluginConfigRowFull{PluginID: "one", Enabled: false, Precedence: 20, Config: []byte(`{"k":1}`)}, nil)
+
+			got, err := c.update(srv, adminCtx("admin-1", "sub|admin"), "one", nil)
+			if err != nil {
+				t.Fatalf("update: %v", err)
+			}
+			want := pluginView{id: "one", enabled: false, precedence: 20, configJSON: `{"k":1}`, display: "one"}
+			if got != want {
+				t.Errorf("plugin: got %+v, want %+v", got, want)
+			}
+		})
+	}
+}
+
+// A plugin the category does not have is NotFound, not Internal: the store says so
+// with ErrNoRows and every category has to translate it.
+func TestUpdatePlugin_NotFound(t *testing.T) {
+	for _, c := range pluginCategories {
+		t.Run(c.name, func(t *testing.T) {
+			srv, mockDB := newAPIServerWithMock(t)
+			mockDB.EXPECT().
+				UpdatePluginConfig(gomock.Any(), c.category, "missing", gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+				Return(nil, sql.ErrNoRows)
+
+			_, err := c.update(srv, adminCtx("admin-1", "sub|admin"), "missing", nil)
+			testutil.RequireGRPCCode(t, err, codes.NotFound)
+		})
+	}
+}
+
+// A signed-in user who is not an admin is refused. Distinct from the unauthenticated
+// case in server_test.go, which the service descriptor drives: this is the other half
+// of the guard, and it is the half a category copied without RequireAdmin would fail.
+func TestPlugins_AdminOnly(t *testing.T) {
+	for _, c := range pluginCategories {
+		t.Run(c.name+"/list", func(t *testing.T) {
+			srv, _ := newAPIServerWithMock(t)
+			_, err := c.list(srv, authCtx("user-1", "sub|1"))
+			testutil.RequireGRPCCode(t, err, codes.PermissionDenied)
+		})
+		t.Run(c.name+"/update", func(t *testing.T) {
+			srv, _ := newAPIServerWithMock(t)
+			_, err := c.update(srv, authCtx("user-1", "sub|1"), "one", nil)
+			testutil.RequireGRPCCode(t, err, codes.PermissionDenied)
+		})
+	}
+}
+
+// An empty plugin_id is rejected before the store is asked anything.
+func TestUpdatePlugin_MissingPluginID(t *testing.T) {
+	for _, c := range pluginCategories {
+		t.Run(c.name, func(t *testing.T) {
+			srv, _ := newAPIServerWithMock(t)
+			_, err := c.update(srv, adminCtx("admin-1", "sub|admin"), "", nil)
+			testutil.RequireGRPCCode(t, err, codes.InvalidArgument)
+		})
+	}
+}
+
+// Each optional field reaches the store as the value the request carried, and a
+// field left out reaches it as nil.
+//
+// The expectation names all three rather than accepting anything, because these are
+// three pointers marshalled by hand in five copies of the same method, and a copy
+// that dropped one would still compile and still return a plausible response.
+func TestUpdatePlugin_CarriesTheOptionalFields(t *testing.T) {
+	for _, c := range pluginCategories {
+		t.Run(c.name, func(t *testing.T) {
+			srv, mockDB := newAPIServerWithMock(t)
+			enabled, precedence, config := true, int32(42), `{"key":"val"}`
+			wantEnabled, wantPrecedence := true, 42
+			mockDB.EXPECT().
+				UpdatePluginConfig(gomock.Any(), c.category, "one", &wantEnabled, &wantPrecedence, []byte(config), gomock.Any()).
+				Return(&db.PluginConfigRowFull{PluginID: "one", Enabled: true, Precedence: 42, Config: []byte(config)}, nil)
+
+			got, err := c.update(srv, adminCtx("admin-1", "sub|admin"), "one",
+				&pluginOpts{enabledV: &enabled, precedenceV: &precedence, configV: &config})
+			if err != nil {
+				t.Fatalf("update: %v", err)
+			}
+			want := pluginView{id: "one", enabled: true, precedence: 42, configJSON: config, display: "one"}
+			if got != want {
+				t.Errorf("plugin: got %+v, want %+v", got, want)
+			}
+		})
+	}
+}

--- a/server/service/api/price_fetch_blocks_test.go
+++ b/server/service/api/price_fetch_blocks_test.go
@@ -1,0 +1,130 @@
+package api
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/testutil"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+)
+
+// A block names an instrument by id, which means nothing to whoever has to decide
+// whether to clear it, so the list resolves a name for each one.
+func TestListPriceFetchBlocks(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	blocked := time.Date(2025, 5, 4, 8, 0, 0, 0, time.UTC)
+	name := "APPLE INC"
+	mockDB.EXPECT().ListPriceFetchBlocks(gomock.Any()).Return([]db.PriceFetchBlock{
+		{InstrumentID: "i1", PluginID: "eodhd", Reason: "not found", FirstBlockedAt: blocked},
+	}, nil)
+	mockDB.EXPECT().ListInstrumentsByIDs(gomock.Any(), []string{"i1"}).Return([]*db.InstrumentRow{
+		{ID: "i1", Name: &name},
+	}, nil)
+
+	resp, err := srv.ListPriceFetchBlocks(adminCtx("admin-1", "sub|admin"), &apiv1.ListPriceFetchBlocksRequest{})
+	if err != nil {
+		t.Fatalf("ListPriceFetchBlocks: %v", err)
+	}
+	if len(resp.GetBlocks()) != 1 {
+		t.Fatalf("blocks: got %d, want 1", len(resp.GetBlocks()))
+	}
+	b := resp.GetBlocks()[0]
+	if b.GetInstrumentId() != "i1" || b.GetPluginId() != "eodhd" || b.GetReason() != "not found" {
+		t.Errorf("block: got %+v", b)
+	}
+	if b.GetInstrumentDisplayName() != name {
+		t.Errorf("instrument name: got %q, want %q", b.GetInstrumentDisplayName(), name)
+	}
+	if !b.GetFirstBlockedAt().AsTime().Equal(blocked) {
+		t.Errorf("first blocked at: got %v, want %v", b.GetFirstBlockedAt().AsTime(), blocked)
+	}
+}
+
+// An instrument with no name of its own falls back to its id, so a block is always
+// identifiable even where resolution never got far enough to name it.
+func TestListPriceFetchBlocks_UnnamedInstrumentFallsBackToItsID(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	mockDB.EXPECT().ListPriceFetchBlocks(gomock.Any()).Return([]db.PriceFetchBlock{
+		{InstrumentID: "i1", PluginID: "eodhd"},
+	}, nil)
+	mockDB.EXPECT().ListInstrumentsByIDs(gomock.Any(), []string{"i1"}).Return(nil, nil)
+
+	resp, err := srv.ListPriceFetchBlocks(adminCtx("admin-1", "sub|admin"), &apiv1.ListPriceFetchBlocksRequest{})
+	if err != nil {
+		t.Fatalf("ListPriceFetchBlocks: %v", err)
+	}
+	if got := resp.GetBlocks()[0].GetInstrumentDisplayName(); got != "i1" {
+		t.Errorf("instrument name: got %q, want the id", got)
+	}
+}
+
+// Nothing blocked is an empty list, and the instrument lookup is not made at all --
+// there is nothing to look up, and asking for none would be a query per empty page.
+func TestListPriceFetchBlocks_Empty(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	mockDB.EXPECT().ListPriceFetchBlocks(gomock.Any()).Return(nil, nil)
+
+	resp, err := srv.ListPriceFetchBlocks(adminCtx("admin-1", "sub|admin"), &apiv1.ListPriceFetchBlocksRequest{})
+	if err != nil {
+		t.Fatalf("ListPriceFetchBlocks: %v", err)
+	}
+	if len(resp.GetBlocks()) != 0 {
+		t.Errorf("blocks: got %d, want none", len(resp.GetBlocks()))
+	}
+}
+
+func TestListPriceFetchBlocks_StoreError(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	mockDB.EXPECT().ListPriceFetchBlocks(gomock.Any()).Return(nil, errors.New("boom"))
+
+	_, err := srv.ListPriceFetchBlocks(adminCtx("admin-1", "sub|admin"), &apiv1.ListPriceFetchBlocksRequest{})
+	testutil.RequireGRPCCode(t, err, codes.Internal)
+}
+
+func TestDeletePriceFetchBlock(t *testing.T) {
+	srv, mockDB := newAPIServerWithMock(t)
+	mockDB.EXPECT().DeletePriceFetchBlock(gomock.Any(), "i1", "eodhd").Return(nil)
+
+	_, err := srv.DeletePriceFetchBlock(adminCtx("admin-1", "sub|admin"), &apiv1.DeletePriceFetchBlockRequest{
+		InstrumentId: "i1", PluginId: "eodhd",
+	})
+	if err != nil {
+		t.Fatalf("DeletePriceFetchBlock: %v", err)
+	}
+}
+
+// A block is one pair, so half of one names a set rather than a row.
+func TestDeletePriceFetchBlock_NeedsBothHalvesOfThePair(t *testing.T) {
+	tests := []struct {
+		name string
+		req  *apiv1.DeletePriceFetchBlockRequest
+	}{
+		{"no instrument", &apiv1.DeletePriceFetchBlockRequest{PluginId: "eodhd"}},
+		{"no plugin", &apiv1.DeletePriceFetchBlockRequest{InstrumentId: "i1"}},
+		{"neither", &apiv1.DeletePriceFetchBlockRequest{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv, _ := newAPIServerWithMock(t)
+			_, err := srv.DeletePriceFetchBlock(adminCtx("admin-1", "sub|admin"), tt.req)
+			testutil.RequireGRPCCode(t, err, codes.InvalidArgument)
+		})
+	}
+}
+
+func TestPriceFetchBlocks_AdminOnly(t *testing.T) {
+	srv, _ := newAPIServerWithMock(t)
+	ctx := authCtx("user-1", "sub|1")
+	t.Run("ListPriceFetchBlocks", func(t *testing.T) {
+		_, err := srv.ListPriceFetchBlocks(ctx, &apiv1.ListPriceFetchBlocksRequest{})
+		testutil.RequireGRPCCode(t, err, codes.PermissionDenied)
+	})
+	t.Run("DeletePriceFetchBlock", func(t *testing.T) {
+		_, err := srv.DeletePriceFetchBlock(ctx, &apiv1.DeletePriceFetchBlockRequest{InstrumentId: "i1", PluginId: "eodhd"})
+		testutil.RequireGRPCCode(t, err, codes.PermissionDenied)
+	})
+}

--- a/server/service/api/triggers_test.go
+++ b/server/service/api/triggers_test.go
@@ -1,0 +1,132 @@
+package api
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	"github.com/leedenison/portfoliodb/server/db/mock"
+	"github.com/leedenison/portfoliodb/server/testutil"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+)
+
+// The trigger RPCs nudge a worker to run a cycle now rather than at its cadence.
+// Each is the same three properties: it sends when a channel is wired, it returns
+// rather than panicking when one is not, and it never blocks -- a worker already
+// running has a full buffer, and an admin asking twice must not hang the request.
+//
+// TriggerPriceFetch has these three tested in plugins_test.go. The inflation and
+// corporate-event ones are the copies, and had none.
+type triggerRPC struct {
+	name string
+	// server builds a server with this trigger wired to ch, and nothing else.
+	server func(ch chan struct{}) *Server
+	call   func(*Server, context.Context) error
+}
+
+var triggerRPCs = []triggerRPC{
+	{
+		name:   "TriggerInflationFetch",
+		server: func(ch chan struct{}) *Server { return NewServer(ServerConfig{InflationTrigger: ch}) },
+		call: func(s *Server, ctx context.Context) error {
+			_, err := s.TriggerInflationFetch(ctx, &apiv1.TriggerInflationFetchRequest{})
+			return err
+		},
+	},
+	{
+		name:   "TriggerCorporateEventFetch",
+		server: func(ch chan struct{}) *Server { return NewServer(ServerConfig{CorporateEventTrigger: ch}) },
+		call: func(s *Server, ctx context.Context) error {
+			_, err := s.TriggerCorporateEventFetch(ctx, &apiv1.TriggerCorporateEventFetchRequest{})
+			return err
+		},
+	},
+}
+
+func TestTriggers_Send(t *testing.T) {
+	for _, tr := range triggerRPCs {
+		t.Run(tr.name, func(t *testing.T) {
+			ch := make(chan struct{}, 1)
+			if err := tr.call(tr.server(ch), adminCtx("admin-1", "sub|admin")); err != nil {
+				t.Fatalf("%s: %v", tr.name, err)
+			}
+			select {
+			case <-ch:
+			default:
+				t.Errorf("%s: nothing was sent on the trigger", tr.name)
+			}
+		})
+	}
+}
+
+// An instance running without that worker has no channel, and the RPC succeeds
+// having done nothing rather than failing on a nil send.
+func TestTriggers_NilChannel(t *testing.T) {
+	for _, tr := range triggerRPCs {
+		t.Run(tr.name, func(t *testing.T) {
+			if err := tr.call(tr.server(nil), adminCtx("admin-1", "sub|admin")); err != nil {
+				t.Errorf("%s with no trigger wired: %v", tr.name, err)
+			}
+		})
+	}
+}
+
+// The buffer is already full, which is what a worker mid-cycle looks like. The send
+// is dropped and the call returns, because the pending run will pick up whatever
+// this one would have.
+func TestTriggers_NonBlocking(t *testing.T) {
+	for _, tr := range triggerRPCs {
+		t.Run(tr.name, func(t *testing.T) {
+			ch := make(chan struct{}, 1)
+			ch <- struct{}{}
+			done := make(chan error, 1)
+			go func() { done <- tr.call(tr.server(ch), adminCtx("admin-1", "sub|admin")) }()
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Errorf("%s: %v", tr.name, err)
+				}
+			case <-time.After(time.Second):
+				t.Errorf("%s blocked on a full trigger", tr.name)
+			}
+		})
+	}
+}
+
+func TestTriggers_AdminOnly(t *testing.T) {
+	for _, tr := range triggerRPCs {
+		t.Run(tr.name, func(t *testing.T) {
+			ch := make(chan struct{}, 1)
+			err := tr.call(tr.server(ch), authCtx("user-1", "sub|1"))
+			testutil.RequireGRPCCode(t, err, codes.PermissionDenied)
+			if len(ch) != 0 {
+				t.Errorf("%s sent on the trigger despite refusing the caller", tr.name)
+			}
+		})
+	}
+}
+
+// ListTelemetryCounters reads Redis, and an instance with none configured reports
+// no counters rather than failing. That is the whole of what can be checked here:
+// the scan and decode want a Redis to scan, which this package has no fake for.
+func TestListTelemetryCounters_NoRedis(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(func() { ctrl.Finish() })
+	srv := NewServer(ServerConfig{DB: mock.NewMockDB(ctrl)})
+
+	resp, err := srv.ListTelemetryCounters(adminCtx("admin-1", "sub|admin"), &apiv1.ListTelemetryCountersRequest{})
+	if err != nil {
+		t.Fatalf("ListTelemetryCounters: %v", err)
+	}
+	if len(resp.GetCounters()) != 0 {
+		t.Errorf("counters: got %d, want none", len(resp.GetCounters()))
+	}
+}
+
+func TestListTelemetryCounters_AdminOnly(t *testing.T) {
+	srv, _ := newAPIServerWithMock(t)
+	_, err := srv.ListTelemetryCounters(authCtx("user-1", "sub|1"), &apiv1.ListTelemetryCountersRequest{})
+	testutil.RequireGRPCCode(t, err, codes.PermissionDenied)
+}


### PR DESCRIPTION
Second of two. Stacked on #429, which makes the auth guarantee total; this one
adds the behaviour those 20 RPCs never had.

They were not a random twenty. The plugin RPCs for identifier, description,
inflation and corporate events are structural copies of the price ones somebody
had tested, and the copies are what nobody wrote a second set of tests for.

## The five categories as a table

`plugin_categories_test.go` covers all five with one entry each, adapting the
per-category request and response types to what they have in common, so every
assertion runs against all five and a sixth category is one entry rather than
another copy.

What differs between them is the constant each passes, so that is what the
expectations name:

- `ListPluginConfigs(any, <category>)` -- a method reading its neighbour's
  category fails on the unexpected call rather than returning a plausible list of
  the wrong thing.
- `UpdatePluginConfig(any, <category>, id, enabled, precedence, config, ...)` with
  the optional fields named rather than accepted as anything. They are three
  pointers marshalled by hand in five places, and a copy that dropped one would
  still compile and still return a plausible response.

Also covered per category: empty result, store error to `Internal`, `ErrNoRows`
to `NotFound`, missing `plugin_id` to `InvalidArgument`, and `PermissionDenied`
for a signed-in non-admin.

## The rest

- **Triggers** (`triggers_test.go`) -- the two get the three properties the price
  one is already held to: sends when a channel is wired, does not fail when none
  is, does not block when the worker is mid-cycle. Plus: refusing a caller does
  not send.
- **Ignored asset classes**, **unhandled corporate events**, **price fetch
  blocks**, **inflation indices** -- success path, store error, and the arguments
  each refuses. Some behaviour worth having pinned: an empty rule set is a valid
  instruction to clear rather than a malformed request; a block on an unnamed
  instrument falls back to its id; page sizes default and cap.
- **`ListTelemetryCounters`** -- guard and no-Redis case only. The scan and decode
  want a Redis to scan and this package has no fake; adding a dependency for one
  RPC was not worth it. Flagging it rather than hiding it.

`PermissionDenied` is asserted separately from #429's unauthenticated table
because a signed-in non-admin is a different question from no user at all.

## Verification

All twenty go from 0%:

```
ListUnhandledCorporateEvents   100.0     ListPriceFetchBlocks        96.7
CountUnhandledCorporateEvents  100.0     DeletePriceFetchBlock       85.7
ResolveUnhandledCorporateEvent  85.7     ListIdentifierPlugins       93.3
GetIgnoredAssetClasses         100.0     UpdateIdentifierPlugin      92.3
SetIgnoredAssetClasses          88.9     ListDescriptionPlugins      93.3
CountIgnoredTxs                 90.0     UpdateDescriptionPlugin     92.3
ListInflationIndices           100.0     ListInflationPlugins        93.3
TriggerInflationFetch          100.0     UpdateInflationPlugin       92.3
TriggerCorporateEventFetch     100.0     ListCorporateEventPlugins   93.3
ListTelemetryCounters           77.8     UpdateCorporateEventPlugin  92.3
```

What is left uncovered is the display-name branches (they want a plugin registry
wired) and telemetry's Redis path.

Mutation-checked: pointing `ListIdentifierPlugins` at the description category
fails.

```
--- FAIL: TestListPlugins_ReadsItsOwnCategory/identifier
    missing call(s) to MockDB.ListPluginConfigs(is anything, is equal to identifier (string))
```

Reverted. `make server-test` and `make lint-go` clean. No production code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
