### PR TITLE
Test the session store, and read the cookie with net/http

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -138,8 +138,11 @@ server-test: $(STAMP_DIR)/generate
 client-test: $(STAMP_DIR)/generate
 	HOST_UID=$$(id -u) HOST_GID=$$(id -g) $(COMPOSE_DEV) run --rm client npm run test:run
 
+# Tests that need real infrastructure: the database abstraction layer against
+# postgres, and the session store against redis. Both are skipped by a plain
+# server-test, which has neither.
 db-test: $(STAMP_DIR)/generate
-	@rc=0; $(COMPOSE_TEST_TESTER) go test -v ./server/db/postgres/... || rc=$$?; $(COMPOSE_TEST) down; exit $$rc
+	@rc=0; $(COMPOSE_TEST_TESTER) go test -v ./server/db/postgres/... ./server/auth/session/... || rc=$$?; $(COMPOSE_TEST) down; exit $$rc
 
 integration-test: $(STAMP_DIR)/generate
 	$(COMPOSE_TOOLS) go test -tags integration -v ./server/plugins/...

--- a/docker/docker-compose.test.yml
+++ b/docker/docker-compose.test.yml
@@ -38,10 +38,15 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      redis:
+        condition: service_healthy
     environment:
       GOCACHE: /app/.cache/go-build
       GOMODCACHE: /app/.gomodcache
       TEST_DATABASE_URL: postgres://portfoliodb:portfoliodb@postgres:5432/portfoliodb_test?sslmode=disable
+      # The session store keeps its sessions here. Unset outside this harness, which
+      # is what leaves its tests skipped in a run that has no Redis to talk to.
+      TEST_REDIS_URL: redis://redis:6379/0
       # Opt-in performance tests. Passed through from the host with no default so
       # that `BENCH_BALANCE=1 make db-test` reaches the container, and an unset one
       # leaves the test skipped.

--- a/server/auth/session/redis_test.go
+++ b/server/auth/session/redis_test.go
@@ -1,0 +1,309 @@
+// The session store against a real Redis.
+//
+// Real rather than faked, for the same reason the database abstraction layer is
+// tested against a real postgres: what this package does is almost entirely what
+// Redis does with it -- a TTL that expires, a key that is gone after a delete, a
+// value that round-trips as JSON -- and a fake would be a second implementation of
+// exactly the part under test.
+//
+// Skipped without TEST_REDIS_URL, so `make server-test` passes over it and
+// `make db-test` runs it against the redis in the test stack.
+package session
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// testStore returns a store on a key prefix of its own, so tests cannot see each
+// other's sessions and a leftover key from a previous run cannot be mistaken for one
+// of these.
+func testStore(t *testing.T, extendTTL time.Duration) *RedisStore {
+	t.Helper()
+	url := os.Getenv("TEST_REDIS_URL")
+	if url == "" {
+		t.Skip("TEST_REDIS_URL not set (run via make db-test)")
+	}
+	opts, err := redis.ParseURL(url)
+	if err != nil {
+		t.Fatalf("parse TEST_REDIS_URL: %v", err)
+	}
+	client := redis.NewClient(opts)
+	t.Cleanup(func() { _ = client.Close() })
+	if err := client.Ping(context.Background()).Err(); err != nil {
+		t.Fatalf("ping redis: %v", err)
+	}
+	prefix := "test:" + t.Name() + ":"
+	t.Cleanup(func() {
+		keys, err := client.Keys(context.Background(), prefix+"*").Result()
+		if err == nil && len(keys) > 0 {
+			_ = client.Del(context.Background(), keys...).Err()
+		}
+	})
+	return NewRedisStore(client, prefix, extendTTL)
+}
+
+func userSession() *Data {
+	return &Data{
+		Kind: SessionKindUser, UserID: "user-1", Email: "u@example.com",
+		GoogleSub: "sub|1", Role: "admin",
+	}
+}
+
+// A created session comes back with everything it was given, and with the three
+// times the store stamps on it.
+func TestRedisStore_CreateAndGet(t *testing.T) {
+	store := testStore(t, 0)
+	ctx := context.Background()
+	before := time.Now()
+
+	id, err := store.Create(ctx, userSession(), time.Hour)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if id == "" {
+		t.Fatal("Create returned no session id")
+	}
+
+	got, err := store.Get(ctx, id, 0)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got == nil {
+		t.Fatal("Get returned nothing for a session just created")
+	}
+	if got.UserID != "user-1" || got.Email != "u@example.com" ||
+		got.GoogleSub != "sub|1" || got.Role != "admin" || got.Kind != SessionKindUser {
+		t.Errorf("session: got %+v", got)
+	}
+	if got.CreatedAt.Before(before) {
+		t.Errorf("created at: got %v, want no earlier than %v", got.CreatedAt, before)
+	}
+	if !got.LastSeenAt.Equal(got.CreatedAt) {
+		t.Errorf("last seen at: got %v, want the creation time %v", got.LastSeenAt, got.CreatedAt)
+	}
+	if want := got.CreatedAt.Add(time.Hour); !got.ExpiresAt.Equal(want) {
+		t.Errorf("expires at: got %v, want %v", got.ExpiresAt, want)
+	}
+}
+
+// Two sessions never share an id, which is the whole of what makes the id worth
+// holding: it is the only thing a caller presents.
+func TestRedisStore_CreateIssuesDistinctIDs(t *testing.T) {
+	store := testStore(t, 0)
+	ctx := context.Background()
+	seen := map[string]bool{}
+	for range 20 {
+		id, err := store.Create(ctx, userSession(), time.Hour)
+		if err != nil {
+			t.Fatalf("Create: %v", err)
+		}
+		if seen[id] {
+			t.Fatalf("Create issued %q twice", id)
+		}
+		seen[id] = true
+	}
+}
+
+// An id nobody was given is not a session, and says so by returning nothing rather
+// than by failing: a stale cookie is an ordinary thing for a request to carry.
+func TestRedisStore_GetUnknownID(t *testing.T) {
+	store := testStore(t, 0)
+	got, err := store.Get(context.Background(), "no-such-session", 0)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != nil {
+		t.Errorf("session: got %+v, want nothing", got)
+	}
+}
+
+// The key carries the TTL the session was created with, so Redis drops it even if
+// nothing ever asks for it again.
+func TestRedisStore_CreateSetsTheTTL(t *testing.T) {
+	store := testStore(t, 0)
+	ctx := context.Background()
+	id, err := store.Create(ctx, userSession(), time.Hour)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	ttl, err := store.client.TTL(ctx, store.key(id)).Result()
+	if err != nil {
+		t.Fatalf("TTL: %v", err)
+	}
+	if ttl <= 0 || ttl > time.Hour {
+		t.Errorf("ttl: got %v, want a positive value no greater than an hour", ttl)
+	}
+}
+
+// An expired session is gone whichever way it went: the key may have been dropped by
+// Redis, or the stored ExpiresAt may have passed while the key survived. The second
+// is what the check inside Get is for, and it is reachable because the sliding
+// extension writes an expiry the key's TTL does not have to agree with.
+func TestRedisStore_ExpiredSessionIsGone(t *testing.T) {
+	store := testStore(t, 0)
+	ctx := context.Background()
+	id, err := store.Create(ctx, userSession(), 50*time.Millisecond)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	time.Sleep(100 * time.Millisecond)
+
+	got, err := store.Get(ctx, id, 0)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != nil {
+		t.Errorf("session: got %+v, want nothing once it has expired", got)
+	}
+}
+
+// A user session in use is extended, which is what keeps somebody working from being
+// logged out on a fixed schedule.
+func TestRedisStore_GetSlidesAUserSession(t *testing.T) {
+	store := testStore(t, 0)
+	ctx := context.Background()
+	id, err := store.Create(ctx, userSession(), time.Hour)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	created, err := store.Get(ctx, id, 0)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	got, err := store.Get(ctx, id, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("Get with sliding: %v", err)
+	}
+	if !got.ExpiresAt.After(created.ExpiresAt) {
+		t.Errorf("expires at: got %v, want later than the original %v", got.ExpiresAt, created.ExpiresAt)
+	}
+	// And it is the stored session that moved, not just the copy returned.
+	again, err := store.Get(ctx, id, 0)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if !again.ExpiresAt.After(created.ExpiresAt) {
+		t.Errorf("stored expires at: got %v, want the extension to have been written", again.ExpiresAt)
+	}
+	ttl, err := store.client.TTL(ctx, store.key(id)).Result()
+	if err != nil {
+		t.Fatalf("TTL: %v", err)
+	}
+	if ttl <= time.Hour {
+		t.Errorf("ttl: got %v, want the key's own expiry extended past the original hour", ttl)
+	}
+}
+
+// A window shorter than what the session already has does not shorten it. Sliding is
+// there to extend a session in use, and a short window arriving late must not cut one
+// that was created with a longer life.
+func TestRedisStore_GetDoesNotShortenASession(t *testing.T) {
+	store := testStore(t, 0)
+	ctx := context.Background()
+	id, err := store.Create(ctx, userSession(), 24*time.Hour)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	created, err := store.Get(ctx, id, 0)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	got, err := store.Get(ctx, id, time.Minute)
+	if err != nil {
+		t.Fatalf("Get with a short window: %v", err)
+	}
+	if !got.ExpiresAt.Equal(created.ExpiresAt) {
+		t.Errorf("expires at: got %v, want it left at %v", got.ExpiresAt, created.ExpiresAt)
+	}
+}
+
+// A machine session is not extended by use. A service account holds a token for as
+// long as it was issued for, and sliding it would make the lifetime unbounded.
+func TestRedisStore_GetDoesNotSlideAMachineSession(t *testing.T) {
+	store := testStore(t, 0)
+	ctx := context.Background()
+	id, err := store.Create(ctx, &Data{Kind: SessionKindServiceAccount, ServiceAccountID: "svc-1"}, time.Hour)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	created, err := store.Get(ctx, id, 0)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+
+	got, err := store.Get(ctx, id, 24*time.Hour)
+	if err != nil {
+		t.Fatalf("Get with sliding: %v", err)
+	}
+	if !got.ExpiresAt.Equal(created.ExpiresAt) {
+		t.Errorf("expires at: got %v, want a machine session left at %v", got.ExpiresAt, created.ExpiresAt)
+	}
+	if got.ServiceAccountID != "svc-1" {
+		t.Errorf("service account: got %q, want svc-1", got.ServiceAccountID)
+	}
+}
+
+// Delete ends the session, which is what logging out relies on.
+func TestRedisStore_Delete(t *testing.T) {
+	store := testStore(t, 0)
+	ctx := context.Background()
+	id, err := store.Create(ctx, userSession(), time.Hour)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := store.Delete(ctx, id); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	got, err := store.Get(ctx, id, 0)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if got != nil {
+		t.Errorf("session: got %+v, want nothing after a delete", got)
+	}
+}
+
+// Deleting a session that is not there is not an error. A logout arriving twice, or
+// after the session has already expired, is ordinary.
+func TestRedisStore_DeleteUnknownID(t *testing.T) {
+	store := testStore(t, 0)
+	if err := store.Delete(context.Background(), "no-such-session"); err != nil {
+		t.Errorf("Delete of an unknown session: %v", err)
+	}
+}
+
+// The key prefix keeps sessions apart from everything else in the same Redis, and
+// there is a default because an instance that names none still must not collide with
+// the telemetry counters beside it.
+func TestNewRedisStore_KeyPrefix(t *testing.T) {
+	url := os.Getenv("TEST_REDIS_URL")
+	if url == "" {
+		t.Skip("TEST_REDIS_URL not set (run via make db-test)")
+	}
+	tests := []struct {
+		name  string
+		given string
+		want  string
+	}{
+		{"a prefix of its own", "myapp:sess:", "myapp:sess:abc"},
+		{"none given takes the default", "", "portfoliodb:session:abc"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			store := NewRedisStore(nil, tt.given, time.Hour)
+			if got := store.key("abc"); got != tt.want {
+				t.Errorf("key: got %q, want %q", got, tt.want)
+			}
+			if store.extendTTL != time.Hour {
+				t.Errorf("extend ttl: got %v, want an hour", store.extendTTL)
+			}
+		})
+	}
+}

--- a/server/service/auth/cookie_test.go
+++ b/server/service/auth/cookie_test.go
@@ -1,0 +1,211 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"google.golang.org/grpc/metadata"
+)
+
+// What the session id is read out of, which is the one piece of an authenticated
+// request that an attacker writes in full.
+//
+// The parsing behind SessionIDFromContext is hand-rolled -- readCookies, and with it
+// splitCookie, indexByte and trimSpace, which are strings.Split, strings.IndexByte
+// and a partial strings.TrimSpace. Nothing exercised any of it. These tests go
+// through the exported entry point rather than at the four helpers, because that is
+// what the interceptor calls and the helpers are an implementation of it.
+//
+// Where the hand-rolled parser and net/http disagree is recorded below, in
+// TestSessionIDFromContext_DivergesFromNetHTTP. Those cases are written as
+// what the code does today rather than what it ought to do, so that replacing the
+// parser shows up as a diff in the expectations rather than as silence.
+
+// ctxWithMetadata returns a context carrying the given incoming metadata pairs.
+func ctxWithMetadata(kv ...string) context.Context {
+	return metadata.NewIncomingContext(context.Background(), metadata.Pairs(kv...))
+}
+
+func TestSessionIDFromContext(t *testing.T) {
+	const name = "portfoliodb_session"
+	tests := []struct {
+		name string
+		ctx  context.Context
+		want string
+	}{
+		{
+			name: "the cookie on its own",
+			ctx:  ctxWithMetadata("cookie", name+"=abc123"),
+			want: "abc123",
+		},
+		{
+			name: "picked out from among others",
+			ctx:  ctxWithMetadata("cookie", "theme=dark; "+name+"=abc123; lang=en"),
+			want: "abc123",
+		},
+		{
+			name: "a cookie of another name is not it",
+			ctx:  ctxWithMetadata("cookie", "other=abc123"),
+			want: "",
+		},
+		{
+			// The name is compared exactly, so a differently-cased cookie is a
+			// different cookie rather than the same one.
+			name: "the name is case sensitive",
+			ctx:  ctxWithMetadata("cookie", "PORTFOLIODB_SESSION=abc123"),
+			want: "",
+		},
+		{
+			name: "surrounding whitespace is not part of it",
+			ctx:  ctxWithMetadata("cookie", "  "+name+"  =  abc123  "),
+			want: "abc123",
+		},
+		{
+			name: "a value holding an equals sign keeps it",
+			ctx:  ctxWithMetadata("cookie", name+"=a=b=c"),
+			want: "a=b=c",
+		},
+		{
+			// The first wins. Nothing in the format says which of two cookies of
+			// one name is meant, and taking the later one would let an attacker
+			// who can append a cookie displace the real session.
+			name: "the first of two of the same name wins",
+			ctx:  ctxWithMetadata("cookie", name+"=first; "+name+"=second"),
+			want: "first",
+		},
+		{
+			name: "an empty value is empty rather than absent",
+			ctx:  ctxWithMetadata("cookie", name+"="),
+			want: "",
+		},
+		{
+			name: "a bare name with no value is skipped",
+			ctx:  ctxWithMetadata("cookie", name),
+			want: "",
+		},
+		{
+			name: "stray semicolons are not cookies",
+			ctx:  ctxWithMetadata("cookie", ";;"+name+"=abc123;;"),
+			want: "abc123",
+		},
+		{
+			name: "an empty header yields nothing",
+			ctx:  ctxWithMetadata("cookie", ""),
+			want: "",
+		},
+		{
+			// Two Cookie headers rather than one, which is what a client sending
+			// them separately produces.
+			name: "a second cookie header is read too",
+			ctx: metadata.NewIncomingContext(context.Background(), metadata.MD{
+				"cookie": []string{"theme=dark", name + "=abc123"},
+			}),
+			want: "abc123",
+		},
+		{
+			// The machine path: a service account holds a bearer token rather than
+			// a cookie, and the same lookup answers for both.
+			name: "a bearer token stands in for the cookie",
+			ctx:  ctxWithMetadata("authorization", "Bearer machine-token"),
+			want: "machine-token",
+		},
+		{
+			name: "the cookie is preferred over a bearer token",
+			ctx: metadata.NewIncomingContext(context.Background(), metadata.MD{
+				"cookie":        []string{name + "=abc123"},
+				"authorization": []string{"Bearer machine-token"},
+			}),
+			want: "abc123",
+		},
+		{
+			// Only the Bearer scheme. Basic credentials are not a session id, and
+			// treating the whole header as one would look up whatever was there.
+			name: "another authorization scheme is not a session",
+			ctx:  ctxWithMetadata("authorization", "Basic dXNlcjpwYXNz"),
+			want: "",
+		},
+		{
+			name: "no metadata at all yields nothing",
+			ctx:  context.Background(),
+			want: "",
+		},
+		{
+			name: "metadata with neither header yields nothing",
+			ctx:  ctxWithMetadata("user-agent", "curl"),
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SessionIDFromContext(tt.ctx, name); got != tt.want {
+				t.Errorf("session id: got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+// Where the hand-rolled parser and net/http disagree about the same header.
+//
+// A value reaching here goes on to be a Redis key and to be echoed back in a
+// GetSession response. Neither can be injected into by a value of any shape -- the
+// Redis protocol is length-prefixed and the response is protobuf -- so none of these
+// is a hole today. What they are is a wider set of accepted values than any browser
+// will ever send, on the one input an attacker writes in full.
+//
+// net/http is already imported by this file's subject, and its own parser is what
+// readCookies, splitCookie, indexByte and trimSpace are a partial reimplementation
+// of. The stdlib column is what (&http.Request{Header: ...}).Cookies() gives for the
+// same header, so it is both the record of the difference and the check that the
+// difference is still there. Every case in the test above agrees between the two;
+// these are the whole of the disagreement.
+func TestSessionIDFromContext_DivergesFromNetHTTP(t *testing.T) {
+	const name = "portfoliodb_session"
+	tests := []struct {
+		name   string
+		value  string
+		want   string // what readCookies yields
+		stdlib string // what net/http yields for the same header
+	}{
+		{name: "a carriage return", value: "a\rb", want: "a\rb", stdlib: ""},
+		{name: "a newline", value: "a\nb", want: "a\nb", stdlib: ""},
+		{name: "a NUL", value: "a\x00b", want: "a\x00b", stdlib: ""},
+		{name: "a backslash", value: `a\b`, want: `a\b`, stdlib: ""},
+		{name: "a DEL", value: "\x7f", want: "\x7f", stdlib: ""},
+		{
+			// A tab inside the value survives; one at either end is trimmed off,
+			// which is trimSpace rather than anything the format asks for.
+			name: "an interior tab", value: "a\tb", want: "a\tb", stdlib: "",
+		},
+		{
+			// The one difference that is not about accepting more: net/http reads
+			// the quotes as delimiters and this reads them as part of the value, so
+			// a quoted session id here matches no stored session.
+			name: "surrounding quotes", value: `"abc"`, want: `"abc"`, stdlib: "abc",
+		},
+		{
+			// trimSpace takes the space off; net/http keeps it, so the two look up
+			// different sessions for one header.
+			name: "a leading space", value: " abc", want: "abc", stdlib: " abc",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			header := name + "=" + tt.value
+			if got := SessionIDFromContext(ctxWithMetadata("cookie", header), name); got != tt.want {
+				t.Errorf("session id: got %q, want %q", got, tt.want)
+			}
+			std := ""
+			req := &http.Request{Header: http.Header{"Cookie": []string{header}}}
+			for _, c := range req.Cookies() {
+				if c.Name == name {
+					std = c.Value
+					break
+				}
+			}
+			if std != tt.stdlib {
+				t.Errorf("net/http now yields %q for %q, not %q; this test is out of date", std, header, tt.stdlib)
+			}
+		})
+	}
+}

--- a/server/service/auth/cookie_test.go
+++ b/server/service/auth/cookie_test.go
@@ -2,7 +2,6 @@ package auth
 
 import (
 	"context"
-	"net/http"
 	"testing"
 
 	"google.golang.org/grpc/metadata"
@@ -11,16 +10,11 @@ import (
 // What the session id is read out of, which is the one piece of an authenticated
 // request that an attacker writes in full.
 //
-// The parsing behind SessionIDFromContext is hand-rolled -- readCookies, and with it
-// splitCookie, indexByte and trimSpace, which are strings.Split, strings.IndexByte
-// and a partial strings.TrimSpace. Nothing exercised any of it. These tests go
-// through the exported entry point rather than at the four helpers, because that is
-// what the interceptor calls and the helpers are an implementation of it.
-//
-// Where the hand-rolled parser and net/http disagree is recorded below, in
-// TestSessionIDFromContext_DivergesFromNetHTTP. Those cases are written as
-// what the code does today rather than what it ought to do, so that replacing the
-// parser shows up as a diff in the expectations rather than as silence.
+// The parsing is net/http's. It was hand-rolled -- readCookies, and with it
+// splitCookie, indexByte and trimSpace, which were strings.Split, strings.IndexByte
+// and a partial strings.TrimSpace -- and none of it was exercised. The tests below
+// go through the exported entry point rather than at whatever is under it, because
+// that is what the interceptor calls.
 
 // ctxWithMetadata returns a context carrying the given incoming metadata pairs.
 func ctxWithMetadata(kv ...string) context.Context {
@@ -57,14 +51,25 @@ func TestSessionIDFromContext(t *testing.T) {
 			want: "",
 		},
 		{
-			name: "surrounding whitespace is not part of it",
-			ctx:  ctxWithMetadata("cookie", "  "+name+"  =  abc123  "),
-			want: "abc123",
+			// Space around the name is not part of the name, which is what lets the
+			// usual "a=1; b=2" spacing work at all. Space after the equals is part
+			// of the value, because nothing says it is not and trimming it would
+			// make two different headers name one session.
+			name: "space around the name is not part of it, space in the value is",
+			ctx:  ctxWithMetadata("cookie", "  "+name+"  =  abc123"),
+			want: "  abc123",
 		},
 		{
 			name: "a value holding an equals sign keeps it",
 			ctx:  ctxWithMetadata("cookie", name+"=a=b=c"),
 			want: "a=b=c",
+		},
+		{
+			// A semicolon is the separator, so it ends the value rather than being
+			// part of it. A session id cannot contain one, so nothing is lost.
+			name: "a semicolon ends the value",
+			ctx:  ctxWithMetadata("cookie", name+"=abc;123"),
+			want: "abc",
 		},
 		{
 			// The first wins. Nothing in the format says which of two cookies of
@@ -73,6 +78,13 @@ func TestSessionIDFromContext(t *testing.T) {
 			name: "the first of two of the same name wins",
 			ctx:  ctxWithMetadata("cookie", name+"=first; "+name+"=second"),
 			want: "first",
+		},
+		{
+			// Quotes delimit the value rather than being part of it, so this names
+			// the same session as the unquoted form.
+			name: "a quoted value is unwrapped",
+			ctx:  ctxWithMetadata("cookie", name+`="abc123"`),
+			want: "abc123",
 		},
 		{
 			name: "an empty value is empty rather than absent",
@@ -145,66 +157,62 @@ func TestSessionIDFromContext(t *testing.T) {
 	}
 }
 
-// Where the hand-rolled parser and net/http disagree about the same header.
+// A value no browser will ever have sent names no session.
 //
-// A value reaching here goes on to be a Redis key and to be echoed back in a
-// GetSession response. Neither can be injected into by a value of any shape -- the
-// Redis protocol is length-prefixed and the response is protobuf -- so none of these
-// is a hole today. What they are is a wider set of accepted values than any browser
-// will ever send, on the one input an attacker writes in full.
+// Each of these was accepted verbatim by the parser this replaced, and each is now
+// dropped. None of them was a hole -- the value goes on to be a Redis key, whose
+// protocol is length-prefixed, and to be echoed into a protobuf response, so there
+// was nothing to inject into. What they are is the difference between accepting
+// what the format permits and accepting whatever arrived, on the one input an
+// attacker writes in full.
 //
-// net/http is already imported by this file's subject, and its own parser is what
-// readCookies, splitCookie, indexByte and trimSpace are a partial reimplementation
-// of. The stdlib column is what (&http.Request{Header: ...}).Cookies() gives for the
-// same header, so it is both the record of the difference and the check that the
-// difference is still there. Every case in the test above agrees between the two;
-// these are the whole of the disagreement.
-func TestSessionIDFromContext_DivergesFromNetHTTP(t *testing.T) {
+// A dropped cookie falls through to the bearer token and then to nothing, so the
+// request is unauthenticated rather than authenticated as somebody. That is the
+// property here: none of these returns a session id.
+func TestSessionIDFromContext_RejectsWhatNoBrowserSends(t *testing.T) {
 	const name = "portfoliodb_session"
 	tests := []struct {
-		name   string
-		value  string
-		want   string // what readCookies yields
-		stdlib string // what net/http yields for the same header
+		name  string
+		value string
 	}{
-		{name: "a carriage return", value: "a\rb", want: "a\rb", stdlib: ""},
-		{name: "a newline", value: "a\nb", want: "a\nb", stdlib: ""},
-		{name: "a NUL", value: "a\x00b", want: "a\x00b", stdlib: ""},
-		{name: "a backslash", value: `a\b`, want: `a\b`, stdlib: ""},
-		{name: "a DEL", value: "\x7f", want: "\x7f", stdlib: ""},
-		{
-			// A tab inside the value survives; one at either end is trimmed off,
-			// which is trimSpace rather than anything the format asks for.
-			name: "an interior tab", value: "a\tb", want: "a\tb", stdlib: "",
-		},
-		{
-			// The one difference that is not about accepting more: net/http reads
-			// the quotes as delimiters and this reads them as part of the value, so
-			// a quoted session id here matches no stored session.
-			name: "surrounding quotes", value: `"abc"`, want: `"abc"`, stdlib: "abc",
-		},
-		{
-			// trimSpace takes the space off; net/http keeps it, so the two look up
-			// different sessions for one header.
-			name: "a leading space", value: " abc", want: "abc", stdlib: " abc",
-		},
+		{name: "a carriage return", value: "a\rb"},
+		{name: "a newline", value: "a\nb"},
+		{name: "a NUL", value: "a\x00b"},
+		{name: "a backslash", value: `a\b`},
+		{name: "a DEL", value: "\x7f"},
+		{name: "an interior tab", value: "a\tb"},
+		{name: "an interior quote", value: `a"b`},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			header := name + "=" + tt.value
-			if got := SessionIDFromContext(ctxWithMetadata("cookie", header), name); got != tt.want {
-				t.Errorf("session id: got %q, want %q", got, tt.want)
+			ctx := ctxWithMetadata("cookie", name+"="+tt.value)
+			if got := SessionIDFromContext(ctx, name); got != "" {
+				t.Errorf("session id: got %q, want nothing for a value the format does not permit", got)
 			}
-			std := ""
-			req := &http.Request{Header: http.Header{"Cookie": []string{header}}}
-			for _, c := range req.Cookies() {
-				if c.Name == name {
-					std = c.Value
-					break
-				}
-			}
-			if std != tt.stdlib {
-				t.Errorf("net/http now yields %q for %q, not %q; this test is out of date", std, header, tt.stdlib)
+		})
+	}
+}
+
+// One bad cookie does not take the session down with it.
+//
+// This is why the parsing goes through a request rather than through
+// http.ParseCookie, which rejects the whole header when any part of it is
+// malformed: a cookie set by something else entirely would then log the user out.
+func TestSessionIDFromContext_SurvivesAMalformedNeighbour(t *testing.T) {
+	const name = "portfoliodb_session"
+	tests := []struct {
+		name   string
+		header string
+	}{
+		{"a neighbour with a control character", "junk=a\x00b; " + name + "=abc123"},
+		{"a neighbour with no value", "junk; " + name + "=abc123"},
+		{"a neighbour with no name", "=junk; " + name + "=abc123"},
+		{"a trailing semicolon", name + "=abc123; "},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := SessionIDFromContext(ctxWithMetadata("cookie", tt.header), name); got != "abc123" {
+				t.Errorf("session id: got %q, want abc123", got)
 			}
 		})
 	}

--- a/server/service/auth/server.go
+++ b/server/service/auth/server.go
@@ -260,13 +260,20 @@ func getSessionIDFromContext(ctx context.Context, cookieName string) string {
 	if !ok {
 		return ""
 	}
-	vals := md.Get("cookie")
-	for _, v := range vals {
-		cookies := readCookies(v, cookieName)
-		for _, c := range cookies {
-			if c.Name == cookieName {
-				return c.Value
-			}
+	// net/http's own parser, reached through a request because that is the only
+	// shape it is exposed in. Nothing here is served over HTTP; the Cookie headers
+	// arrive as gRPC metadata and this borrows the parsing rather than repeating
+	// it. http.ParseCookie is the direct call but rejects the whole header when any
+	// one cookie in it is malformed, which would let an unrelated cookie take the
+	// session down with it.
+	//
+	// It is stricter than a parser written for this: a value carrying a control
+	// character, a backslash or a quote is not one a browser will have sent, and it
+	// is dropped rather than looked up. See the tests for what that excludes.
+	if vals := md.Get("cookie"); len(vals) > 0 {
+		req := &http.Request{Header: http.Header{"Cookie": vals}}
+		if c, err := req.Cookie(cookieName); err == nil {
+			return c.Value
 		}
 	}
 	for _, v := range md.Get("authorization") {
@@ -275,56 +282,4 @@ func getSessionIDFromContext(ctx context.Context, cookieName string) string {
 		}
 	}
 	return ""
-}
-
-// Minimal cookie parsing for "name=value" in Cookie header.
-func readCookies(header, filter string) []*http.Cookie {
-	var out []*http.Cookie
-	for _, part := range splitCookie(header) {
-		eq := indexByte(part, '=')
-		if eq < 0 {
-			continue
-		}
-		name := trimSpace(part[:eq])
-		value := trimSpace(part[eq+1:])
-		if filter != "" && name != filter {
-			continue
-		}
-		out = append(out, &http.Cookie{Name: name, Value: value})
-	}
-	return out
-}
-
-func splitCookie(s string) []string {
-	var parts []string
-	start := 0
-	for i := 0; i < len(s); i++ {
-		if s[i] == ';' {
-			parts = append(parts, trimSpace(s[start:i]))
-			start = i + 1
-		}
-	}
-	if start < len(s) {
-		parts = append(parts, trimSpace(s[start:]))
-	}
-	return parts
-}
-
-func indexByte(s string, b byte) int {
-	for i := 0; i < len(s); i++ {
-		if s[i] == b {
-			return i
-		}
-	}
-	return -1
-}
-
-func trimSpace(s string) string {
-	for len(s) > 0 && (s[0] == ' ' || s[0] == '\t') {
-		s = s[1:]
-	}
-	for len(s) > 0 && (s[len(s)-1] == ' ' || s[len(s)-1] == '\t') {
-		s = s[:len(s)-1]
-	}
-	return s
 }

--- a/server/service/auth/session_rpc_test.go
+++ b/server/service/auth/session_rpc_test.go
@@ -1,0 +1,197 @@
+package auth
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	authv1 "github.com/leedenison/portfoliodb/proto/auth/v1"
+	authpkg "github.com/leedenison/portfoliodb/server/auth"
+	"github.com/leedenison/portfoliodb/server/auth/session"
+	"github.com/leedenison/portfoliodb/server/testutil"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
+)
+
+// The two RPCs either side of a session's life: reading who the caller is, and
+// ending it. Both read the cookie, and Logout writes one.
+
+// sessionServer returns a server with the given cookie config and a store, plus the
+// transport stream its Set-Cookie headers land in.
+func sessionServer(t *testing.T, cookie CookieConfig) (*Server, *stubSessionStore, *stubServerTransportStream) {
+	t.Helper()
+	store := newStubSessionStore()
+	s := NewServer(nil, store, &stubUserDB{userID: "user-1"}, &stubSvcAcctDB{}, nil,
+		cookie, 30*24*time.Hour, 72*time.Hour, time.Hour, "")
+	return s, store, &stubServerTransportStream{}
+}
+
+// withSession returns a context carrying the cookie and the transport stream, as an
+// authenticated request has.
+func withSession(stream *stubServerTransportStream, cookieName, sessionID string) context.Context {
+	ctx := grpc.NewContextWithServerTransportStream(context.Background(), stream)
+	if sessionID == "" {
+		return ctx
+	}
+	return metadata.NewIncomingContext(ctx, metadata.Pairs("cookie", cookieName+"="+sessionID))
+}
+
+// setCookie returns the single Set-Cookie header the call sent.
+func setCookie(t *testing.T, stream *stubServerTransportStream) string {
+	t.Helper()
+	got := stream.headers.Get("set-cookie")
+	if len(got) != 1 {
+		t.Fatalf("set-cookie headers: got %d (%v), want 1", len(got), got)
+	}
+	return got[0]
+}
+
+// GetSession answers from the user the interceptor put in the context, which is the
+// only thing that says the session was valid. It reads the id back off the cookie
+// rather than holding one, so the answer names the session it was asked about.
+func TestGetSession(t *testing.T) {
+	cookie := CookieConfig{Name: "portfoliodb_session", Path: "/"}
+	s, _, stream := sessionServer(t, cookie)
+	ctx := withSession(stream, cookie.Name, "sess-1")
+	ctx = authpkg.WithUser(ctx, &authpkg.User{
+		ID: "user-1", Email: "u@example.com", Name: "U", Role: "admin",
+	})
+
+	resp, err := s.GetSession(ctx, &authv1.GetSessionRequest{})
+	if err != nil {
+		t.Fatalf("GetSession: %v", err)
+	}
+	if got := resp.GetUser(); got.GetId() != "user-1" || got.GetEmail() != "u@example.com" ||
+		got.GetName() != "U" || got.GetRole() != "admin" {
+		t.Errorf("user: got %+v", got)
+	}
+	if !resp.GetUserExists() {
+		t.Error("user_exists: got false, want true -- a session implies the user is there")
+	}
+	if got := resp.GetSession().GetSessionId(); got != "sess-1" {
+		t.Errorf("session id: got %q, want the one the cookie carried", got)
+	}
+}
+
+// No user in the context means the interceptor did not accept the request, whatever
+// the caller sent. A cookie naming a session that does not exist reaches here the
+// same way one naming nothing does.
+func TestGetSession_Unauthenticated(t *testing.T) {
+	cookie := CookieConfig{Name: "portfoliodb_session", Path: "/"}
+	s, _, stream := sessionServer(t, cookie)
+	tests := []struct {
+		name string
+		ctx  context.Context
+	}{
+		{"no user and no cookie", withSession(stream, cookie.Name, "")},
+		{"a cookie the interceptor did not accept", withSession(stream, cookie.Name, "sess-1")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := s.GetSession(tt.ctx, &authv1.GetSessionRequest{})
+			testutil.RequireGRPCCode(t, err, codes.Unauthenticated)
+		})
+	}
+}
+
+// Logout destroys the session and tells the browser to drop the cookie.
+func TestLogout(t *testing.T) {
+	cookie := CookieConfig{Name: "portfoliodb_session", Path: "/"}
+	s, store, stream := sessionServer(t, cookie)
+	store.sessions["sess-1"] = &session.Data{Kind: session.SessionKindUser, UserID: "user-1"}
+
+	if _, err := s.Logout(withSession(stream, cookie.Name, "sess-1"), &authv1.LogoutRequest{}); err != nil {
+		t.Fatalf("Logout: %v", err)
+	}
+	if _, still := store.sessions["sess-1"]; still {
+		t.Error("the session survived logout")
+	}
+	if got := setCookie(t, stream); !strings.Contains(got, "Max-Age=0") {
+		t.Errorf("set-cookie: got %q, want it to clear the cookie", got)
+	}
+}
+
+// A logout with no session still clears the cookie. The cookie is the thing the
+// browser holds, so a request that arrives without a usable one is exactly when
+// clearing it matters.
+func TestLogout_NoSession(t *testing.T) {
+	cookie := CookieConfig{Name: "portfoliodb_session", Path: "/"}
+	s, _, stream := sessionServer(t, cookie)
+
+	if _, err := s.Logout(withSession(stream, cookie.Name, ""), &authv1.LogoutRequest{}); err != nil {
+		t.Fatalf("Logout: %v", err)
+	}
+	if got := setCookie(t, stream); !strings.Contains(got, "Max-Age=0") {
+		t.Errorf("set-cookie: got %q, want it to clear the cookie", got)
+	}
+}
+
+// failingDeleteStore is a store whose Delete always fails, for the case where the
+// session cannot be destroyed.
+type failingDeleteStore struct{ *stubSessionStore }
+
+func (failingDeleteStore) Delete(context.Context, string) error {
+	return errors.New("redis unavailable")
+}
+
+// A store that cannot delete does not leave the caller logged in at the browser. The
+// session may outlive the request, but the cookie is cleared and the error is not
+// returned -- there is nothing the user can do about it and refusing would leave
+// them holding a cookie they asked to be rid of.
+func TestLogout_StoreFailureStillClearsTheCookie(t *testing.T) {
+	cookie := CookieConfig{Name: "portfoliodb_session", Path: "/"}
+	store := newStubSessionStore()
+	s := NewServer(nil, failingDeleteStore{store}, &stubUserDB{}, &stubSvcAcctDB{}, nil,
+		cookie, time.Hour, time.Hour, time.Hour, "")
+	stream := &stubServerTransportStream{}
+
+	if _, err := s.Logout(withSession(stream, cookie.Name, "sess-1"), &authv1.LogoutRequest{}); err != nil {
+		t.Fatalf("Logout: %v", err)
+	}
+	if got := setCookie(t, stream); !strings.Contains(got, "Max-Age=0") {
+		t.Errorf("set-cookie: got %q, want it to clear the cookie", got)
+	}
+}
+
+// The cleared cookie has to match the one that was set closely enough for the
+// browser to replace it rather than add a second: same name and path. It carries no
+// value and expires at once, and stays HttpOnly so the clearing is not itself
+// scriptable.
+func TestClearSessionCookie(t *testing.T) {
+	tests := []struct {
+		name   string
+		cookie CookieConfig
+		want   string
+	}{
+		{
+			name:   "the ordinary one",
+			cookie: CookieConfig{Name: "portfoliodb_session", Path: "/"},
+			want:   "portfoliodb_session=; Path=/; Max-Age=0; HttpOnly",
+		},
+		{
+			// Secure is carried over, because a cookie set with it is a different
+			// cookie from one set without and would not be replaced.
+			name:   "a secure one",
+			cookie: CookieConfig{Name: "portfoliodb_session", Path: "/", Secure: true},
+			want:   "portfoliodb_session=; Path=/; Max-Age=0; HttpOnly; Secure",
+		},
+		{
+			name:   "a scoped path",
+			cookie: CookieConfig{Name: "sid", Path: "/app"},
+			want:   "sid=; Path=/app; Max-Age=0; HttpOnly",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			stream := &stubServerTransportStream{}
+			ctx := grpc.NewContextWithServerTransportStream(context.Background(), stream)
+			clearSessionCookie(ctx, tt.cookie)
+			if got := setCookie(t, stream); got != tt.want {
+				t.Errorf("set-cookie:\n got %q\nwant %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Covers the three groups with no tests, and replaces the hand-rolled cookie parser
with the one `net/http` already provides.

Two commits, in that order deliberately: the tests were written against the old
parser first, so the swap shows up as a diff in their expectations rather than as
silence.

## The cookie parsing

`readCookies`, `splitCookie`, `indexByte` and `trimSpace` were `strings.Split`,
`strings.IndexByte`, a partial `strings.TrimSpace` and a mini
`http.Request.Cookies()` -- a reimplementation of a parser this file already
imported, on the one input an authenticated request lets an attacker write in
full. All four are gone.

It goes through a request rather than through `http.ParseCookie`, which rejects the
whole header when any one cookie in it is malformed: a cookie set by something else
entirely would then log the user out. Through a request it is per-cookie, as the
old code was. `TestSessionIDFromContext_SurvivesAMalformedNeighbour` pins that.

**What changes for a caller**, which the first commit's tests predicted case for
case:

| header | before | after |
| --- | --- | --- |
| `sid=a\rb`, `a\nb`, `a\x00b`, `a\b`, `\x7f`, `a\tb` | accepted verbatim | dropped |
| `sid="abc"` | `"abc"` | `abc` |
| `sid= abc` | `abc` | `" abc"` |

No browser sends any of those. Nothing a browser does send parses differently --
the whole legitimate corpus was identical between the two parsers before the swap.

**None of it was a hole.** A session id becomes a Redis key, whose protocol is
length-prefixed, and is echoed into a protobuf response. There was nothing to
inject into either way. What it was is a wider accepted set than the format
permits, kept by code nobody had tested.

Tested through `SessionIDFromContext` rather than at the internals, because that is
what the interceptor calls. Beyond the ordinary shapes: the first of two cookies of
one name wins, so somebody who can append a cookie cannot displace the session; the
name is compared exactly; a bearer token stands in on the machine path and the
cookie wins where both are present; `Basic` credentials are not a session id.

## The session store

Tested against a real Redis, for the reason the database abstraction layer is
tested against a real postgres: what the store does is almost entirely what Redis
does with it -- a TTL that expires, a key gone after a delete, a value that
round-trips as JSON -- and a fake would reimplement the part under test.

The test stack already ran a `redis` service that nothing used, so this wires the
tester to it (`TEST_REDIS_URL`, `depends_on`) and adds the package to `db-test`.
Without that variable the tests skip, so `make server-test` passes over them.

The sliding window is the part worth pinning: a session in use is extended, a
shorter window arriving later does not cut one already longer, and a machine
session is not slid at all -- sliding it would make a service account's lifetime
unbounded.

## Coverage

```
NewRedisStore   100.0     GetSession              100.0
key             100.0     Logout                  100.0
Create           81.8     clearSessionCookie      100.0
Get              81.8     SessionIDFromContext    100.0
Delete          100.0     getSessionIDFromContext 100.0
```

All were 0%. What is left on `Create`/`Get` is the JSON-marshal and Redis-error
branches, which need a broken client rather than a broken input. `readCookies` and
friends were at 100% after the first commit and no longer exist after the second.

`make server-test`, `make db-test`, `make lint-go`, `make vet`, `make fmt-check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
