### PR TITLE
Test the client libraries the converters rest on

### DIFF
--- a/client/hooks/use-authed-query.test.tsx
+++ b/client/hooks/use-authed-query.test.tsx
@@ -1,0 +1,121 @@
+/**
+ * The gate that keeps a query from firing before the session is known.
+ *
+ * Firing one in that window gets a 401, which the transport turns into a
+ * session-lost redirect -- so the bug this prevents is not a failed request but a
+ * user bounced to the sign-in page on every reload. That makes the loading state,
+ * rather than the authenticated one, the case worth pinning.
+ */
+
+import React from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useAuthedQuery } from "./use-authed-query";
+
+type AuthState =
+  | { status: "loading" }
+  | { status: "unauthenticated" }
+  | { status: "authenticated"; user: unknown; email: string; role: string };
+
+// The hook reads state.status off the auth context and nothing else, so the
+// context is mocked rather than driven through AuthProvider's getSession call.
+const authState = vi.hoisted(() => ({ current: { status: "loading" } as AuthState }));
+vi.mock("@/contexts/auth-context", () => ({
+  useAuth: () => ({ state: authState.current }),
+}));
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+/** Renders the hook against a query function that records whether it ran. */
+function renderQuery(state: AuthState, enabled?: boolean) {
+  authState.current = state;
+  const queryFn = vi.fn().mockResolvedValue("data");
+  const view = renderHook(
+    () => useAuthedQuery({ queryKey: ["thing"], queryFn, ...(enabled === undefined ? {} : { enabled }) }),
+    { wrapper }
+  );
+  return { queryFn, ...view };
+}
+
+describe("useAuthedQuery", () => {
+  it("does not fetch while the session is still loading", async () => {
+    const { queryFn, result } = renderQuery({ status: "loading" });
+    // Nothing to wait for, so give the query a chance to fire if it were going to.
+    await Promise.resolve();
+    expect(queryFn).not.toHaveBeenCalled();
+    expect(result.current.fetchStatus).toBe("idle");
+  });
+
+  it("does not fetch when the session is known to be absent", async () => {
+    const { queryFn } = renderQuery({ status: "unauthenticated" });
+    await Promise.resolve();
+    expect(queryFn).not.toHaveBeenCalled();
+  });
+
+  it("fetches once the session is good", async () => {
+    const { queryFn, result } = renderQuery({
+      status: "authenticated",
+      user: {},
+      email: "u@example.com",
+      role: "user",
+    });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(queryFn).toHaveBeenCalled();
+    expect(result.current.data).toBe("data");
+  });
+
+  it("fetches when the caller says enabled and the session is good", async () => {
+    const { queryFn, result } = renderQuery(
+      { status: "authenticated", user: {}, email: "u@example.com", role: "user" },
+      true
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(queryFn).toHaveBeenCalled();
+  });
+
+  it("does not fetch when the caller says disabled, session or no session", async () => {
+    // The caller's own enabled is combined with the gate rather than replaced by
+    // it: a query waiting on an id it does not have yet must stay waiting.
+    const { queryFn } = renderQuery(
+      { status: "authenticated", user: {}, email: "u@example.com", role: "user" },
+      false
+    );
+    await Promise.resolve();
+    expect(queryFn).not.toHaveBeenCalled();
+  });
+
+  it("starts fetching when the session arrives", async () => {
+    const { queryFn, result, rerender } = renderQuery({ status: "loading" });
+    await Promise.resolve();
+    expect(queryFn).not.toHaveBeenCalled();
+
+    authState.current = { status: "authenticated", user: {}, email: "u@example.com", role: "user" };
+    rerender();
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(queryFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("keys the query on what the caller gave and nothing else", async () => {
+    // The user is deliberately not part of the key: sign-out drops the cached
+    // queries instead, so keys stay readable and a signed-out cache holds nothing.
+    const client = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+    authState.current = { status: "authenticated", user: {}, email: "u@example.com", role: "user" };
+    const { result } = renderHook(
+      () => useAuthedQuery({ queryKey: ["thing", 7], queryFn: () => Promise.resolve("data") }),
+      {
+        wrapper: ({ children }: { children: React.ReactNode }) => (
+          <QueryClientProvider client={client}>{children}</QueryClientProvider>
+        ),
+      }
+    );
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+    expect(client.getQueryData(["thing", 7])).toBe("data");
+  });
+});

--- a/client/lib/archive/parts.test.ts
+++ b/client/lib/archive/parts.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import { ArchivePart, ArchivePartSchema } from "@/gen/archive/v1/common_pb";
+import {
+  ARCHIVE_PART_LABELS,
+  SYSTEM_ARCHIVE_PART_OPTIONS,
+  USER_ARCHIVE_PART_OPTIONS,
+  type ArchivePartOption,
+} from "./parts";
+
+/**
+ * The export menu is written out by hand against a vocabulary that is not, so what
+ * is worth asserting is that the two have not drifted: a part added to the proto
+ * and left out here cannot be exported and reports its progress under no name.
+ */
+const declared = ArchivePartSchema.values.filter((v) => v.number !== 0);
+const menus: [string, ArchivePartOption[]][] = [
+  ["system", SYSTEM_ARCHIVE_PART_OPTIONS],
+  ["user", USER_ARCHIVE_PART_OPTIONS],
+];
+
+describe("the export menus", () => {
+  it("cover every part the proto declares, between them and without overlap", () => {
+    const offered = menus.flatMap(([, m]) => m.map((o) => o.part));
+    expect([...offered].sort()).toEqual(declared.map((v) => v.number).sort());
+  });
+
+  it.each(menus)("gives every %s part a label and a note", (_name, menu) => {
+    for (const o of menu) {
+      expect(o.label).not.toBe("");
+      expect(o.note).not.toBe("");
+    }
+  });
+
+  it.each(menus)("lists no part twice in the %s menu", (_name, menu) => {
+    expect(new Set(menu.map((o) => o.part)).size).toBe(menu.length);
+  });
+
+  it("names every part a job can report against", () => {
+    // A job reports progress per part, so a part with no entry here shows the
+    // user a blank row rather than what it was working on.
+    for (const v of declared) {
+      expect(ARCHIVE_PART_LABELS[v.number]).toBeTruthy();
+    }
+  });
+
+  it("labels each part the same way in the menu and in a job's progress", () => {
+    for (const [, menu] of menus) {
+      for (const o of menu) {
+        expect(ARCHIVE_PART_LABELS[o.part]).toBe(o.label);
+      }
+    }
+  });
+});
+
+describe("what is selected by default", () => {
+  it("selects everything except plugin config", () => {
+    // Plugin config carries live API keys, which makes the archive a secret and
+    // changes where it can safely be kept. It is the one thing somebody has to
+    // ask for rather than opt out of, so this is the assertion worth having:
+    // adding a part that defaults off, or flipping this one on, both fail here.
+    const off = menus.flatMap(([, m]) => m.filter((o) => !o.defaultSelected).map((o) => o.part));
+    expect(off).toEqual([ArchivePart.PLUGIN_CONFIG]);
+  });
+
+  it("says in the plugin config note that it makes the file a secret", () => {
+    const opt = SYSTEM_ARCHIVE_PART_OPTIONS.find((o) => o.part === ArchivePart.PLUGIN_CONFIG)!;
+    expect(opt.note).toMatch(/secret/i);
+  });
+});
+
+describe("the notes", () => {
+  it("says the grouping is derived on import rather than carried", () => {
+    // It is not carried. The postings are flat under the window and the importing
+    // instance derives the partition from the evidence they hold, so a note
+    // promising that grouping is preserved describes a format that was replaced.
+    // See docs/adr/0043-grouping-does-not-travel-in-the-archive.md.
+    const txs = USER_ARCHIVE_PART_OPTIONS.find((o) => o.part === ArchivePart.TXS)!;
+    expect(txs.note).toMatch(/derived again on import/i);
+    expect(txs.note).not.toMatch(/travels with|so it travels|grouping is preserved/i);
+  });
+});

--- a/client/lib/archive/parts.ts
+++ b/client/lib/archive/parts.ts
@@ -71,7 +71,7 @@ export const USER_ARCHIVE_PART_OPTIONS: ArchivePartOption[] = [
   {
     part: ArchivePart.TXS,
     label: "Transactions",
-    note: "Every posting, grouped as the broker converter grouped it. Nothing can rebuild the grouping, so it travels with them.",
+    note: "Every posting the brokers reported, with the evidence that says which of them are legs of one event. The grouping itself is derived again on import.",
     defaultSelected: true,
   },
   {

--- a/client/lib/asset-class.test.ts
+++ b/client/lib/asset-class.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { AssetClass, AssetClassSchema } from "@/gen/type/v1/type_pb";
+import {
+  ALL_ASSET_CLASSES,
+  ASSET_CLASS_LABELS,
+  DEFAULT_ASSET_CLASSES,
+  IGNORABLE_ASSET_CLASSES,
+  assetClassFromStr,
+  assetClassToStr,
+} from "./asset-class";
+
+/** Every asset class the proto defines except UNSPECIFIED. */
+const declared = AssetClassSchema.values.filter((v) => v.number !== 0);
+
+describe("the asset class lists", () => {
+  // The lists are written out by hand, so what matters is that they have not
+  // fallen behind the vocabulary they are drawn from. A class added to the proto
+  // and left out of ALL_ASSET_CLASSES is one the UI silently cannot show.
+  it("covers every class the proto declares, and only those", () => {
+    expect([...ALL_ASSET_CLASSES].sort()).toEqual(declared.map((v) => v.number).sort());
+  });
+
+  it("has a label for every class, including UNSPECIFIED", () => {
+    for (const v of AssetClassSchema.values) {
+      expect(ASSET_CLASS_LABELS).toHaveProperty(String(v.number));
+    }
+    // UNSPECIFIED renders as nothing rather than as the word: it is the absence of
+    // a class, and a filter row reading "Unspecified" would invite selecting it.
+    expect(ASSET_CLASS_LABELS[AssetClass.ASSET_CLASS_UNSPECIFIED]).toBe("");
+    for (const c of ALL_ASSET_CLASSES) {
+      expect(ASSET_CLASS_LABELS[c]).not.toBe("");
+    }
+  });
+
+  it("draws the ignorable and default sets from the full list", () => {
+    for (const c of IGNORABLE_ASSET_CLASSES) {
+      expect(ALL_ASSET_CLASSES).toContain(c);
+    }
+    for (const c of DEFAULT_ASSET_CLASSES) {
+      expect(ALL_ASSET_CLASSES).toContain(c);
+    }
+  });
+
+  it("leaves ETF and FX out of the ignorable set", () => {
+    // Ignoring a class deletes the transactions in it, so the set is the ones with
+    // tx type mappings rather than everything on offer.
+    expect(IGNORABLE_ASSET_CLASSES).not.toContain(AssetClass.ETF);
+    expect(IGNORABLE_ASSET_CLASSES).not.toContain(AssetClass.FX);
+  });
+});
+
+describe("assetClassFromStr", () => {
+  it("round-trips every class through its stored name", () => {
+    // The stored vocabulary is the enum value names, so this is the whole of the
+    // conversion in both directions.
+    for (const v of declared) {
+      expect(assetClassFromStr(v.name)).toBe(v.number);
+      expect(assetClassToStr(v.number)).toBe(v.name);
+    }
+  });
+
+  it.each([
+    ["an unknown name", "NOT_A_CLASS"],
+    ["an empty string", ""],
+    ["the wrong case", "stock"],
+    ["a numeric string, which the reverse mapping would answer with a name", "1"],
+    ["a property inherited from Object", "toString"],
+    ["the prototype", "__proto__"],
+  ])("maps %s to UNSPECIFIED", (_name, input) => {
+    // The lookup is on a plain object, so anything already on it -- a numeric key
+    // from the enum's own reverse mapping, or something off Object.prototype --
+    // has to be rejected by the typeof guard rather than returned as a class.
+    expect(assetClassFromStr(input)).toBe(AssetClass.ASSET_CLASS_UNSPECIFIED);
+  });
+});
+
+describe("assetClassToStr", () => {
+  it("maps UNSPECIFIED to the empty string", () => {
+    // Absent rather than a class named "unspecified", which is what the column
+    // holds when a source states nothing.
+    expect(assetClassToStr(AssetClass.ASSET_CLASS_UNSPECIFIED)).toBe("");
+  });
+
+  it("maps a value outside the vocabulary to the empty string", () => {
+    expect(assetClassToStr(9999 as AssetClass)).toBe("");
+  });
+});

--- a/client/lib/csv/converters/registry.test.ts
+++ b/client/lib/csv/converters/registry.test.ts
@@ -1,0 +1,122 @@
+/**
+ * The registry itself, with entries this file puts in it.
+ *
+ * index.test.ts asserts the real registry ends up populated, which is the thing
+ * that silently breaks when a converter is split into a pure module and a
+ * registering one. This is the other half: what the lookups do, and what they do
+ * for a broker nobody registered. Vitest gives each test file its own module
+ * graph, so importing the registry here rather than the barrel gets an empty one
+ * with no converters registered into it.
+ */
+
+import { beforeAll, describe, expect, it } from "vitest";
+import { Broker } from "@/gen/type/v1/type_pb";
+import type { StandardParseResult } from "@/lib/csv/parse-result";
+import {
+  getBrokerEntry,
+  getBrokerLabel,
+  getBrokerOptionsForUpload,
+  getFormatsForBroker,
+  getSourcePrefix,
+  register,
+} from "./registry";
+
+const convert = (): StandardParseResult => ({
+  postings: [],
+  periodFrom: new Date(0),
+  periodBefore: new Date(0),
+  errors: [],
+});
+
+beforeAll(() => {
+  register({
+    broker: Broker.FIDELITY,
+    label: "Convertible",
+    sourcePrefix: "Conv",
+    formats: [
+      { id: "csv", label: "CSV", convert },
+      { id: "ofx", label: "OFX", accept: ".ofx,.qfx", convert },
+    ],
+  });
+  // A broker the app knows about but cannot read a file for. This is the real
+  // shape of SCHB, which has an entry and no converter -- see
+  // docs/issues/0073-schwab-client-converter.md.
+  register({
+    broker: Broker.SCHB,
+    label: "Unconvertible",
+    sourcePrefix: "Unconv",
+    formats: [{ id: "someday", label: "Someday" }],
+  });
+});
+
+describe("getBrokerOptionsForUpload", () => {
+  it("offers a broker that can convert something", () => {
+    expect(getBrokerOptionsForUpload()).toContainEqual({
+      value: Broker.FIDELITY,
+      label: "Convertible",
+    });
+  });
+
+  it("leaves out a broker with no converter", () => {
+    // The dropdown is what a user picks before choosing a file, so a broker whose
+    // formats all lack a convert function would offer a path that dead-ends.
+    expect(getBrokerOptionsForUpload().map((o) => o.value)).not.toContain(Broker.SCHB);
+  });
+});
+
+describe("getFormatsForBroker", () => {
+  it("puts the archive document ahead of the broker's own formats", () => {
+    // Every broker can be handed an archive document, whether or not it has a
+    // converter, because the file is read rather than converted.
+    expect(getFormatsForBroker(Broker.FIDELITY).map((f) => f.id)).toEqual(["archive", "csv", "ofx"]);
+  });
+
+  it("gives the archive entry no converter and a .json accept", () => {
+    const archive = getFormatsForBroker(Broker.FIDELITY)[0];
+    expect(archive.convert).toBeUndefined();
+    expect(archive.accept).toBe(".json");
+  });
+
+  it("keeps each format's own accept", () => {
+    const ofx = getFormatsForBroker(Broker.FIDELITY).find((f) => f.id === "ofx");
+    expect(ofx?.accept).toBe(".ofx,.qfx");
+  });
+
+  it("offers the archive document even where nothing can be converted", () => {
+    expect(getFormatsForBroker(Broker.SCHB).map((f) => f.id)).toEqual(["archive", "someday"]);
+  });
+
+  it("returns nothing for a broker nobody registered", () => {
+    expect(getFormatsForBroker(Broker.IBKR)).toEqual([]);
+  });
+});
+
+describe("the lookups for a broker nobody registered", () => {
+  // Each falls back rather than throwing: these are read while rendering, and a
+  // broker can reach the UI from stored data before its converter exists.
+  it("has no entry", () => {
+    expect(getBrokerEntry(Broker.IBKR)).toBeUndefined();
+  });
+
+  it("labels it with a dash rather than the enum number", () => {
+    expect(getBrokerLabel(Broker.IBKR)).toBe("—");
+  });
+
+  it("gives it a source prefix that names nothing", () => {
+    // The prefix is part of the source string an instrument resolves against, so
+    // a placeholder is better than an empty one: it cannot collide with a real
+    // broker's and it is legible in stored data.
+    expect(getSourcePrefix(Broker.IBKR)).toBe("unknown");
+  });
+});
+
+describe("the lookups for a registered broker", () => {
+  it("returns the entry it was given", () => {
+    expect(getBrokerEntry(Broker.FIDELITY)?.label).toBe("Convertible");
+  });
+
+  it("returns its label and source prefix", () => {
+    expect(getBrokerLabel(Broker.FIDELITY)).toBe("Convertible");
+    expect(getSourcePrefix(Broker.FIDELITY)).toBe("Conv");
+  });
+});

--- a/client/lib/decimal.test.ts
+++ b/client/lib/decimal.test.ts
@@ -1,0 +1,113 @@
+/**
+ * The numeric boundary every converter's exactness rests on.
+ *
+ * A converter derives counter-legs and splits netted totals, so its postings have
+ * to sum back to the figures they came from. That holds only if the values never
+ * pass through a float64 -- which is what parseDecimal is for, and what makes the
+ * regex in front of big.js load-bearing rather than defensive.
+ */
+import { describe, expect, it } from "vitest";
+import { Big, DECIMAL_RE, decimalFromNumber, parseDecimal } from "./decimal";
+
+describe("parseDecimal", () => {
+  it.each([
+    ["an integer", "42", "42"],
+    ["a negative integer", "-42", "-42"],
+    ["a fraction", "3.14", "3.14"],
+    ["a negative fraction", "-0.005", "-0.005"],
+    ["zero", "0", "0"],
+    ["negative zero", "-0", "0"],
+    ["a leading zero", "007", "7"],
+    ["trailing zeros, which are kept", "1.500", "1.5"],
+  ])("parses %s", (_name, input, want) => {
+    expect(parseDecimal(input)?.toString()).toBe(want);
+  });
+
+  it("keeps precision a float64 would lose", () => {
+    // The whole point: 0.1 + 0.2 is 0.30000000000000004 as numbers.
+    expect(parseDecimal("0.1")!.plus(parseDecimal("0.2")!).toString()).toBe("0.3");
+    // And a value with more significant digits than a float64 holds survives.
+    const long = "9007199254740993.0000000001";
+    expect(parseDecimal(long)!.toString()).toBe(long);
+  });
+
+  it("trims surrounding whitespace", () => {
+    // A CSV cell arrives padded and the value in it is still a number.
+    expect(parseDecimal("  1.25\t")?.toString()).toBe("1.25");
+  });
+
+  it.each([
+    ["undefined", undefined],
+    ["null", null],
+    ["an empty string", ""],
+    ["whitespace only", "   "],
+    ["a word", "abc"],
+    ["a currency symbol", "$1.00"],
+    ["thousands separators", "1,000"],
+    ["a trailing percent", "50%"],
+    ["a bare decimal point", "."],
+    ["a leading decimal point", ".5"],
+    ["a trailing decimal point", "1."],
+    ["two decimal points", "1.2.3"],
+    ["a stray minus", "-"],
+    ["a trailing minus", "1-"],
+    ["parenthesised negative", "(1.00)"],
+    ["a leading plus", "+1"],
+    ["Infinity", "Infinity"],
+    ["NaN", "NaN"],
+  ])("rejects %s", (_name, input) => {
+    expect(parseDecimal(input)).toBeUndefined();
+  });
+
+  it("rejects exponent notation, which big.js would accept but the wire format does not", () => {
+    // Narrower than big.js on purpose: the shape is not in the protovalidate
+    // pattern the API's decimal strings carry, so accepting it here would let a
+    // value through that the server will reject.
+    expect(() => new Big("1e3")).not.toThrow();
+    expect(parseDecimal("1e3")).toBeUndefined();
+  });
+
+  it("returns undefined rather than throwing, so one bad cell is one bad row", () => {
+    // big.js throws on a malformed value. The format is checked before
+    // constructing so that a bad cell produces a row-level parse error instead of
+    // taking the whole file down.
+    expect(() => parseDecimal("not a number")).not.toThrow();
+  });
+});
+
+describe("DECIMAL_RE", () => {
+  // The pattern is shared with the wire format, so it is worth stating that it is
+  // anchored: an unanchored one would accept "1.0abc" and every guard built on it
+  // would let the trailing rubbish through.
+  it.each(["1.0abc", "abc1.0", "1.0\n2.0"])("does not match %j", (s) => {
+    expect(DECIMAL_RE.test(s)).toBe(false);
+  });
+});
+
+describe("decimalFromNumber", () => {
+  it.each([
+    ["an integer", 42, "42"],
+    ["a negative", -1.5, "-1.5"],
+    ["zero", 0, "0"],
+  ])("parses %s", (_name, input, want) => {
+    expect(decimalFromNumber(input)?.toString()).toBe(want);
+  });
+
+  it("stops the loss where it is rather than compounding it", () => {
+    // Whatever the float64 lost is already lost. Stringifying first is what makes
+    // this 0.1 rather than its binary expansion, which is what the value would
+    // become if it were handed to big.js as a number.
+    expect(decimalFromNumber(0.1)?.toString()).toBe("0.1");
+    expect(decimalFromNumber(0.1)!.plus(decimalFromNumber(0.2)!).toString()).toBe("0.3");
+  });
+
+  it.each([
+    ["undefined", undefined],
+    ["null", null],
+    ["NaN", NaN],
+    ["Infinity", Infinity],
+    ["-Infinity", -Infinity],
+  ])("rejects %s", (_name, input) => {
+    expect(decimalFromNumber(input)).toBeUndefined();
+  });
+});

--- a/client/lib/format.test.ts
+++ b/client/lib/format.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+import { formatCurrency, formatCurrencyCompact } from "./format";
+
+/**
+ * Rendering money. Both take an explicit locale from nowhere -- Intl uses the
+ * runtime's -- so these assert the shape rather than the exact separators, which
+ * are the runtime's to choose and would make the tests about the test machine.
+ */
+
+describe("formatCurrency", () => {
+  it("renders a numeric string without going through a float", () => {
+    // The reason a string is accepted at all: an exact balance carries more
+    // significant digits than a float64 holds, and Intl formats the string
+    // directly. The value is 2^53 + 1 with cents on it, so a number would have
+    // rounded it before it got here -- the last assertion says so. The group
+    // separators are the runtime's, hence the strip.
+    const exact = "9007199254740993.45";
+    const digits = formatCurrency(exact, "USD").replace(/[^\d.]/g, "");
+    expect(digits).toBe("9007199254740993.45");
+    expect(Number(exact).toString()).not.toBe(exact);
+  });
+
+  it("always shows two decimal places", () => {
+    // Money is written to the cent whether or not the value has one, so a column
+    // of figures lines up.
+    for (const v of [1, 1.5, 1.005, 0]) {
+      expect(formatCurrency(v, "USD")).toMatch(/\d[.,]\d\d(\D|$)/);
+    }
+  });
+
+  it("renders the currency it was given rather than the runtime's", () => {
+    expect(formatCurrency(1, "GBP")).toMatch(/£|GBP/);
+    expect(formatCurrency(1, "JPY")).toMatch(/¥|JPY/);
+  });
+
+  it("defaults to USD", () => {
+    expect(formatCurrency(1)).toBe(formatCurrency(1, "USD"));
+  });
+
+  it("keeps the sign on a negative", () => {
+    expect(formatCurrency(-1234.56, "USD")).toMatch(/-|\(/);
+  });
+
+  it("renders zero rather than nothing", () => {
+    expect(formatCurrency(0, "USD")).toMatch(/0/);
+  });
+});
+
+describe("formatCurrencyCompact", () => {
+  it.each([
+    [1_200_000, /1\.2\s*M/],
+    [45_300, /45\.3\s*K/],
+    [1_500_000_000, /1\.5\s*B/],
+  ])("abbreviates %d", (value, want) => {
+    expect(formatCurrencyCompact(value, "USD")).toMatch(want);
+  });
+
+  it("leaves a small value unabbreviated", () => {
+    expect(formatCurrencyCompact(42, "USD")).toMatch(/42/);
+  });
+
+  it("keeps at most one decimal place", () => {
+    // The point of compact notation is a figure that fits in a tile.
+    expect(formatCurrencyCompact(1_234_567, "USD")).not.toMatch(/\d[.,]\d\d/);
+  });
+
+  it("keeps the sign on a negative", () => {
+    expect(formatCurrencyCompact(-1_200_000, "USD")).toMatch(/-|\(/);
+  });
+
+  it("defaults to USD", () => {
+    expect(formatCurrencyCompact(1_200_000)).toBe(formatCurrencyCompact(1_200_000, "USD"));
+  });
+});

--- a/client/lib/identifiers.test.ts
+++ b/client/lib/identifiers.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from "vitest";
+import { IdentifierTypeSchema } from "@/gen/type/v1/type_pb";
+import { VALID_IDENTIFIER_TYPES } from "./identifiers";
+
+/**
+ * The set an import parser checks a hint against. It is derived from the proto
+ * rather than written out, so what is worth asserting is that the derivation says
+ * what it means to: every name the vocabulary defines, and nothing that is not one.
+ */
+describe("VALID_IDENTIFIER_TYPES", () => {
+  it("holds every identifier type the proto declares", () => {
+    const declared = IdentifierTypeSchema.values.filter((v) => v.number !== 0).map((v) => v.name);
+    expect([...VALID_IDENTIFIER_TYPES].sort()).toEqual(declared.sort());
+    expect(VALID_IDENTIFIER_TYPES.size).toBe(declared.length);
+  });
+
+  it("holds the ones the parsers actually emit", () => {
+    // Named rather than counted, so that a rename in the proto fails here with the
+    // old name in hand instead of only moving a total.
+    for (const t of ["ISIN", "CUSIP", "OCC", "CURRENCY", "MIC_TICKER", "BROKER_DESCRIPTION"]) {
+      expect(VALID_IDENTIFIER_TYPES.has(t)).toBe(true);
+    }
+  });
+
+  it("excludes the unspecified value", () => {
+    // A hint of no type is the absence of a hint. Admitting it would let a row
+    // carrying nothing pass a check meant to establish that it carried something.
+    const unspecified = IdentifierTypeSchema.values.find((v) => v.number === 0)!;
+    expect(VALID_IDENTIFIER_TYPES.has(unspecified.name)).toBe(false);
+  });
+
+  it.each(["", "ticker", "NOT_A_TYPE", "0"])("does not hold %j", (s) => {
+    expect(VALID_IDENTIFIER_TYPES.has(s)).toBe(false);
+  });
+});


### PR DESCRIPTION
The seven libs you named. 340 client tests now, up from 235; 26 test files, up
from 22.

## parseDecimal first

It is the numeric boundary the rest rests on. A converter derives counter-legs and
splits netted totals, so its postings have to sum back to the figures they came
from, and that holds only while the values stay out of a float64.

The regex in front of big.js is load-bearing rather than defensive, so the tests
say what it excludes and why: `1e3` parses fine in big.js and is in the wire
format's protovalidate pattern nowhere, so accepting it here would let a value
through that the server then rejects. Also pinned: it returns `undefined` rather
than throwing, which is what makes one bad cell one bad row instead of a file that
fails to parse; and `decimalFromNumber` stringifies first, which is what makes
`0.1` parse as `0.1` rather than as its binary expansion.

## Three lists, tested for drift

`asset-class.ts`, `archive/parts.ts` and `identifiers.ts` are written out by hand
against vocabularies that are not. So the tests are about drift:

- every asset class the proto declares is in the display list and has a non-empty
  label, and the ignorable and default sets are drawn from it
- every archive part is in exactly one export menu, and is labelled the same way
  there as in a job's progress
- the identifier set is every declared name and nothing else

A value added to a proto and left out of one of these is *invisible* in the UI
rather than broken, which is exactly the kind of thing that survives review.

`assetClassFromStr` also gets the cases its lookup shape invites: a numeric string
(the enum's own reverse mapping would answer with a name) and `__proto__` both have
to be rejected by the `typeof` guard rather than returned as a class.

## One thing that had gone stale

The transactions note in the export menu told the user their postings travel
**"grouped as the broker converter grouped it. Nothing can rebuild the grouping,
so it travels with them."**

Both halves were true once and neither is now — the archive carries postings flat
and the importing instance derives the partition from the correlations they hold
(ADR 0043, and `archive-format.md`: "Grouping does not travel"). This is
user-visible text on the export screen, so it is corrected here and a test pins it.

## The other two

`registry.ts` gets the half `index.test.ts` does not reach. That file asserts the
real registry ends up populated; this one imports the registry module directly —
vitest gives each file its own module graph, so it starts empty — and tests what
the lookups do with entries it controls: the fallbacks for a broker nobody
registered (`—`, `unknown`, `[]`), and that a broker whose formats all lack a
`convert` stays out of the upload dropdown while still being offered the archive
document. That is the real shape of SCHB, which has an entry and no reader yet.

`use-authed-query.ts` is tested at the loading state rather than the authenticated
one. A query firing before the session is known gets a 401, which the transport
turns into a session-lost redirect — so the bug it prevents is not a failed request
but a user bounced to the sign-in page on every reload. Also pinned: the caller's
own `enabled` is combined with the gate rather than replaced by it, and the user is
not part of the query key.

## Not done

The 46 `.tsx` files. You flagged `app/admin/prices/page.tsx` — 11 changes in four
weeks with nothing exercising it — and I have not touched it; these were the libs
you said to pick up first. Worth saying that page-level tests want a different
setup from anything here (a router, the query client, and the auth context all
mocked per test), which is a piece of harness rather than more of the same.

`make client-test`, `make lint-ts-client`, `make client-typecheck` and
`make extension-test` clean. One production line changed, the note above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
