### PR TITLE
Open two issues on identifying instruments from a description

### DIFF
--- a/docs/issues/0105-measure-openai-description-accuracy.md
+++ b/docs/issues/0105-measure-openai-description-accuracy.md
@@ -1,0 +1,89 @@
+---
+status: open
+title: Measure the OpenAI description plugin's accuracy and decide whether to keep it
+---
+
+Measure how often the OpenAI description plugin identifies the right instrument,
+against ground truth taken from broker files that carry an identifier, and decide
+whether the plugin is worth its cost.
+
+## Motivation
+
+The plugin is a paid, per-upload call on the hot path of ingestion, and nothing
+measures whether its answers are right. The integration test at
+server/plugins/openai/description/integration_test.go asserts only the identifier
+*type* each id came back as -- `MIC_TICKER` or `OCC` -- and never the value, so a
+confidently wrong ticker passes. There is no accuracy harness, no golden set and no
+scoring code anywhere in the repository.
+
+The plugin returns no confidence, so there is no threshold to tune: the outcome is
+keep, drop, or narrow it to the cases it wins.
+
+Ground truth is now available. The extension reads the Fidelity JSON, which pairs a
+description with an ISIN on the same row, and the IBKR QFX exports pair a security
+name with a `UNIQUEID`. Both are the same broker descriptions the plugin is asked to
+interpret, with the answer attached.
+
+## What is being measured
+
+The plugin does not return an ISIN. server/plugins/openai/description/plugin.go emits
+`OCC` for an option and `MIC_TICKER` for everything else, with an empty `domain` and
+so no exchange -- the prompt in client.go asks for exactly those two. A ground truth
+of ISINs therefore cannot be compared to plugin output directly.
+
+Measure end to end instead: does description -> extracted ticker -> identifier
+plugins -> instrument land on the same instrument the known ISIN or CUSIP resolves
+to. Comparing the intermediate ticker alone would need the exchange the plugin never
+returns, which is the ambiguity 0106 is about rather than a property of the plugin.
+
+## Scope
+
+**Report the reached population, not just the hit rate.** `extractDescHints` in
+server/service/ingestion/worker.go extracts a description only when it misses
+`FindInstrumentBySourceDescription` and at least one posting sharing that description
+arrived with no identifier hints. Path A in server/service/ingestion/resolve.go then
+bypasses description plugins entirely whenever the converter supplied hints. Since
+0107, client/lib/csv/converters/fidelity-csv.ts supplies a `MIC_TICKER` hint for every
+security whose description ends in a ticker, so what reaches the plugin on that path
+is roughly the unlisted funds -- the rows with no ticker to take. A plugin that is
+accurate over a dozen rows is a different proposition from one carrying the whole CSV
+path, and the decision needs both numbers.
+
+**The cheap baseline is already in the tree, and the plugin only sees what it
+missed.** `tickerOf` in the Fidelity converter takes the ticker from the trailing
+parenthetical of a description, anchored to the end so that `ISHARES PHYSICAL GOLD ETC
+USD (GBP) ACC (SGLN)` yields `SGLN` and not `GBP`. IBKR's `SECNAME` leads with the
+ticker instead -- `AMD ADVANCED MICRO DEVICES` -- so the equivalent baseline there is
+a leading token. Where such a rule fires, the converter has already hinted and the
+plugin is never called; so on live data the plugin's population is precisely the
+residue the free rule could not take, and a measurement must not credit it with the
+rows the rule already got. Run the baselines over the whole ground-truth set to size
+that residue, then score the plugin on the residue alone.
+
+That residue is also the hardest case. An unlisted fund is named `M&G European Index
+Tracker`, with no symbol anywhere in it, so the plugin is being asked for the case
+where there is nothing to extract and something has to be known. Report it as its own
+bucket rather than blended into one hit rate. The existing token counters
+(`instruments.description.openai.ticker_extraction.prompt_tokens` and its siblings)
+make the price per resolution measurable, so state accuracy and cost together.
+
+**Ground truth sources.** The Fidelity JSON export gives the cleanest pairing:
+extension/src/brokers/fidelity-json.ts reads `assetName` alongside `isin` and `sedol`
+from one row, and its `isValidIsin` check-digit helper is what separates real ISINs
+from the cash pseudo-ISINs Fidelity emits. The IBKR QFX exports pair `SECNAME` with a
+`UNIQUEID` and `UNIQUEIDTYPE` (client/lib/ofx/parser.ts); in practice these skew
+heavily to CUSIP and CONID with only a handful of true ISINs, so IBKR mainly
+contributes description-to-CUSIP pairs, plus description-to-OCC through the SECLIST
+ticker path in client/lib/csv/converters/ibkr-ofx.ts.
+
+## Deliverable
+
+A one-off measurement, not a committed harness. Build the pair set and the comparison
+under `local/`, run it once, and record here the reached-population count, the
+accuracy against the baseline, the cost per resolution and the decision that follows.
+If the plugin is kept, a repeatable harness can be its own issue.
+
+The broker exports the pairs come from carry a real account number, in their contents
+and in their filenames, and stay in `local/`. Nothing derived from them is committed
+and no account or filename is named. Descriptions, tickers, ISINs and CUSIPs are
+reference data and are fine to record.

--- a/docs/issues/0106-share-a-broker-description-map.md
+++ b/docs/issues/0106-share-a-broker-description-map.md
@@ -1,0 +1,92 @@
+---
+status: open
+title: Evaluate the archive ergonomics of sharing a broker-description map
+---
+
+Evaluate whether an admin can export the broker-description mappings that definitive
+identification produced, and import them into an instance whose users have only CSV
+to import from.
+
+## Motivation
+
+The Fidelity CSV names no venue and no ISIN. 0107 settled what the download actually
+carries: a security is named `ISSUER, SECURITY DESCRIPTION (TICKER)` and that trailing
+parenthetical is the whole of what the file says about the listing, so
+client/lib/csv/converters/fidelity-csv.ts emits a `MIC_TICKER` with no domain rather
+than guess a venue the source never named. The currency does not come from the file
+either -- it comes from a dropdown the user picks in fidelity.tsx. An unlisted fund
+ends in no ticker and offers no hint at all, leaving the description to resolve it
+alone.
+
+A bare ticker is not unique across venues, so this is how a CSV upload lands on the
+wrong listing of the right company -- a silent error rather than a failed import.
+
+A user running the extension does not have this problem.
+extension/src/brokers/fidelity-json.ts reads the JSON behind the same export and
+keeps the ISIN the CSV discards, so their descriptions resolve definitively. An
+instance where those users import is therefore accumulating the mappings a
+CSV-only instance is guessing at.
+
+Moving them is an admin operation and should stay one. `INSTRUMENTS` is a
+system-archive part and both `ExportSystemArchive` and `ImportSystemArchive` are
+admin-only (proto/api/v1/api.proto), which is the right shape: an identifier is
+instance-global, so importing a map rebinds those descriptions for everyone on the
+instance, and that is a decision an admin takes rather than something a user does to
+their own account. The question is not who is allowed to do it but whether the
+archive makes doing it practical.
+
+The mapping is not a thing of its own today. It is a row in `instrument_identifiers`
+with `identifier_type = BROKER_DESCRIPTION`, `domain = source` and `value =
+description` (server/db/postgres/instruments.go,
+`FindInstrumentBySourceDescription`), and it travels in an archive as one more entry
+in `Instrument.identifiers` (proto/archive/v1/common.proto and instruments.proto). So
+there is no map to export -- only whole instrument records that happen to carry one.
+
+## Scope
+
+Five questions, each with an obstacle already visible in the code.
+
+**Is the mapping recorded at all on the source instance?** Path A in
+server/service/ingestion/resolve.go deliberately persists no `BROKER_DESCRIPTION`
+identifier when the client supplies identifier hints, keeping the resolution only in
+the batch's in-memory cache. The extension always supplies an ISIN, so the imports
+best placed to build the map are the ones that skip building it. Since 0107 the CSV
+supplies a ticker hint for every listed security too, so on both sides the only rows
+that leave a stored mapping behind are the ones nothing could hint -- the unlisted
+funds. That is close to the inverse of what a shared map wants to carry, and
+everything below is moot if it holds.
+
+**Can an export be scoped to the mappings?** `ExportSystemArchiveRequest` filters on
+`exchange` and `asset_classes` alone, and `ListInstrumentsForExport` has no filter on
+identifier type, on `canonical`, or on the domain that holds the source. A map is
+therefore a full instrument export. 0017 surfaces the two filters that do exist, and
+is the neighbour if a source filter is wanted.
+
+**Does importing one behave sensibly?** Two hazards worth confirming. The payload
+dedupe key in server/archiveimport/instruments.go is type and value with the domain
+excluded, while the database uniqueness is over type, domain and value -- so the same
+description arriving under two sources reads as a duplicate and the second instrument
+is rejected, which a mapping-heavy file makes the ordinary case rather than the rare
+one. And `MergeInstrumentFromArchive` inserts identifiers with `ON CONFLICT DO
+NOTHING`, so a description already bound to a different instrument is silently
+ignored and nothing says it was.
+
+**Can an admin tell what a map would change before importing it?** The effect is
+instance-wide and the archive import is asynchronous, so the admin's judgement rests
+on what the job reports. Worth settling what they can see: which descriptions the file
+would newly bind, which it would leave alone because they are already bound, and
+whether that is visible before the import rather than only after. 0104 is the same
+decision taken one row at a time, with the instrument in front of the person making
+it.
+
+**What does exporting one disclose?** A broker-description identifier exists only
+because someone uploaded a file containing it, so a set of them names the instruments
+those users traded and the sources they traded them under. That leaves the instance
+with the export, which is a thing to weigh rather than a blocker.
+
+## Deliverable
+
+A judgement recorded here: either the archive is close enough and the gap is an export
+filter plus a better import report, or a description-to-instrument map is its own
+artifact and needs specifying as one. Either way the work that follows gets its own
+issues.


### PR DESCRIPTION
Two issues for future consideration. Both ask a question rather than propose an
implementation, and both end in a decision recorded on the issue. Neither is
scheduled, so neither carries a milestone and `milestones.md` is unchanged.

## 0105 -- measure the OpenAI description plugin

Nothing checks the plugin's answers today. `integration_test.go` asserts the
identifier *type* each id came back as and never the value, so a confidently wrong
ticker passes.

Two things shape what the measurement has to be:

- **It does not return an ISIN.** The prompt asks for a ticker or an OCC symbol, so
  ISIN ground truth cannot be compared to its output directly. The measurement runs
  end to end instead, against the instrument a known ISIN resolves to.
- **The free rule is already in the tree, and the plugin only sees what it missed.**
  Extraction runs only for a description that misses the database *and* arrives with
  no converter hint, and since 0107 the Fidelity CSV hints every security whose
  description ends in a ticker. So the live population is the residue -- largely the
  unlisted funds, which are also the hardest case, since `M&G European Index Tracker`
  has no symbol in it at all. Scoring the plugin over the whole ground-truth set would
  credit it with rows it never saw.

Ground truth comes from the Fidelity JSON the extension reads, which pairs a
description with an ISIN on one row, and from the IBKR QFX exports, which pair
`SECNAME` with a `UNIQUEID`.

Deliverable is a one-off measurement run from `local/`, with the finding recorded on
the issue. Nothing is committed.

## 0106 -- archive ergonomics of sharing a broker-description map

The Fidelity download names no venue and no ISIN, so a CSV upload identifies a
security by the ticker in its trailing parentheses, and a bare ticker is not unique
across venues -- which is how an import lands on the wrong listing of the right
company, silently. A user running the extension has the ISIN and does not have that
problem.

Moving those mappings is an admin operation and stays one: identifiers are
instance-global, so an import rebinds descriptions for everyone on the instance. The
question is not who may do it but whether the archive makes doing it practical.

The first obstacle is upstream of the archive: resolution deliberately stores no
`BROKER_DESCRIPTION` identifier when the client supplies identifier hints. The
extension always supplies an ISIN and, since 0107, the CSV supplies a ticker for every
listed security -- so on both sides the only rows leaving a stored mapping behind are
the ones nothing could hint. That is close to the inverse of what a shared map wants
to carry, and it makes the rest moot if it holds.

Behind it sit an export with no filter for identifier type, canonicality or source, so
a map is a full instrument export; and an import whose payload dedupe key excludes the
domain that the database uniqueness includes, which a mapping-heavy file would trip as
the ordinary case rather than the rare one.

## Notes

- Rebased onto #434, which landed while these were being written and reshaped both.
  The Fidelity paragraphs in each issue describe the converter as it is now.
- Every path and symbol cited in the two issues was checked against the current tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)