### PR TITLE
Cap what a rejected request says about itself

### DIFF
--- a/server/cmd/portfoliodb/main.go
+++ b/server/cmd/portfoliodb/main.go
@@ -54,16 +54,14 @@ import (
 	"github.com/leedenison/portfoliodb/server/service/ingestion"
 	"github.com/leedenison/portfoliodb/server/telemetry"
 	"github.com/leedenison/portfoliodb/server/transfermatch"
+	"github.com/leedenison/portfoliodb/server/validate"
 	"github.com/leedenison/portfoliodb/server/worker"
 	_ "github.com/lib/pq"
 	"github.com/redis/go-redis/v9"
 	"google.golang.org/grpc"
-	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/health"
 	healthpb "google.golang.org/grpc/health/grpc_health_v1"
 	"google.golang.org/grpc/reflection"
-	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 )
 
 // Set via -ldflags at build time.
@@ -319,20 +317,12 @@ func main() {
 	if err != nil {
 		log.Fatalf("protovalidate.New: %v", err)
 	}
-	validateInterceptor := func(ctx context.Context, req interface{}, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (interface{}, error) {
-		if msg, ok := req.(proto.Message); ok {
-			if err := validator.Validate(msg); err != nil {
-				return nil, status.Errorf(codes.InvalidArgument, "%v", err)
-			}
-		}
-		return handler(ctx, req)
-	}
 	svc := grpc.NewServer(
 		grpc.MaxRecvMsgSize(32<<20),
 		grpc.ChainUnaryInterceptor(
 			logger.UnaryErrorInterceptor(serverLogger),
 			auth.UnaryInterceptor(interceptorConfig),
-			validateInterceptor,
+			validate.UnaryInterceptor(validator),
 		),
 		grpc.ChainStreamInterceptor(
 			logger.StreamErrorInterceptor(serverLogger),

--- a/server/validate/interceptor.go
+++ b/server/validate/interceptor.go
@@ -1,0 +1,97 @@
+// Package validate applies the protovalidate rules a request's proto carries,
+// and keeps what it reports about a bad request small enough to travel.
+package validate
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"unicode/utf8"
+
+	"buf.build/go/protovalidate"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+// How much of a validation failure an InvalidArgument states.
+//
+// A gRPC status message travels in the response HEADERS frame, and a proxy
+// rejects headers over its own limit rather than forwarding them: Envoy's
+// default is 60 KiB, and what it does on a larger response is reset the stream,
+// so the caller sees a transport failure instead of the error. That turns the
+// clearest answer the server has -- your file is wrong, here is where -- into an
+// opaque 503, and it happens exactly when the answer is most needed.
+//
+// A per-element rule makes the message proportional to the upload rather than to
+// the mistake: an archive of a thousand postings that each miss a required field
+// produces a thousand violations, and there is no size of file for which the
+// thousandth is the one that explains it. So the message names the first few and
+// counts the rest.
+//
+// The byte cap is the backstop for one enormous violation -- a CEL message
+// quoting a long field value -- and is far enough under the header budget to
+// survive grpc-message's percent-encoding, which can treble a non-ASCII byte.
+const (
+	MaxViolations   = 20
+	MaxMessageBytes = 4 << 10
+)
+
+// UnaryInterceptor rejects a request that violates the rules its proto carries,
+// before the handler sees it.
+func UnaryInterceptor(v protovalidate.Validator) grpc.UnaryServerInterceptor {
+	return func(ctx context.Context, req any, _ *grpc.UnaryServerInfo, handler grpc.UnaryHandler) (any, error) {
+		if msg, ok := req.(proto.Message); ok {
+			if err := v.Validate(msg); err != nil {
+				return nil, status.Error(codes.InvalidArgument, Message(err))
+			}
+		}
+		return handler(ctx, req)
+	}
+}
+
+// Message is what a validation failure says on the wire: the same text
+// protovalidate writes, capped at MaxViolations violations and MaxMessageBytes
+// bytes.
+//
+// An error that is not a ValidationError -- a compilation or runtime failure --
+// is passed through under the same byte cap, since it is bounded by the schema
+// rather than by the request but still ends up in the same header.
+func Message(err error) string {
+	var invalid *protovalidate.ValidationError
+	if !errors.As(err, &invalid) {
+		return truncate(err.Error())
+	}
+	shown := invalid.Violations
+	if len(shown) > MaxViolations {
+		shown = shown[:MaxViolations]
+	}
+	if len(invalid.Violations) == 1 {
+		return truncate("validation error: " + shown[0].String())
+	}
+	b := &strings.Builder{}
+	b.WriteString("validation errors:")
+	for _, violation := range shown {
+		b.WriteString("\n - ")
+		b.WriteString(violation.String())
+	}
+	if rest := len(invalid.Violations) - len(shown); rest > 0 {
+		fmt.Fprintf(b, "\n - and %d more", rest)
+	}
+	return truncate(b.String())
+}
+
+// truncate cuts a message to MaxMessageBytes, on a rune boundary so the result
+// is still a valid string, and says that it did.
+func truncate(msg string) string {
+	if len(msg) <= MaxMessageBytes {
+		return msg
+	}
+	cut := msg[:MaxMessageBytes]
+	for len(cut) > 0 && !utf8.ValidString(cut) {
+		cut = cut[:len(cut)-1]
+	}
+	return cut + "... (truncated)"
+}

--- a/server/validate/interceptor_test.go
+++ b/server/validate/interceptor_test.go
@@ -1,0 +1,139 @@
+package validate_test
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"buf.build/go/protovalidate"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
+	ingestionv1 "github.com/leedenison/portfoliodb/proto/ingestion/v1"
+	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
+	"github.com/leedenison/portfoliodb/server/testutil"
+	"github.com/leedenison/portfoliodb/server/validate"
+)
+
+// request is an upsert of n postings, each of which violates one rule: an
+// archive written against an older proto arrives with no declared type, which is
+// the shape that made the message grow with the file.
+func request(n int) *ingestionv1.UpsertTxsRequest {
+	postings := make([]*archivev1.Posting, n)
+	for i := range postings {
+		postings[i] = &archivev1.Posting{
+			Timestamp:             timestamppb.New(time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC)),
+			InstrumentDescription: "GBP",
+			Quantity:              "1",
+		}
+	}
+	return &ingestionv1.UpsertTxsRequest{
+		Window: &archivev1.TxWindow{
+			Broker:       typev1.Broker_FIDELITY,
+			PeriodFrom:   timestamppb.New(time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)),
+			PeriodBefore: timestamppb.New(time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)),
+			Source:       "Fidelity:web:standard",
+			Postings:     postings,
+		},
+	}
+}
+
+func TestUnaryInterceptor(t *testing.T) {
+	validator, err := protovalidate.New()
+	if err != nil {
+		t.Fatalf("protovalidate.New: %v", err)
+	}
+	handler := func(_ context.Context, req any) (any, error) { return req, nil }
+	info := &grpc.UnaryServerInfo{FullMethod: "/portfoliodb.ingestion.v1.IngestionService/UpsertTxs"}
+	interceptor := validate.UnaryInterceptor(validator)
+
+	t.Run("valid request reaches the handler", func(t *testing.T) {
+		req := request(1)
+		req.Window.Postings[0].BrokerTxType = []typev1.TxType{typev1.TxType_TRADE_CASH}
+		got, err := interceptor(context.Background(), req, info, handler)
+		if err != nil {
+			t.Fatalf("interceptor: %v", err)
+		}
+		if got != any(req) {
+			t.Errorf("handler received %v, want the request", got)
+		}
+	})
+
+	cases := []struct {
+		name      string
+		postings  int
+		wantMore  string
+		wantFirst string
+	}{
+		{
+			name:      "one violation is stated in full",
+			postings:  1,
+			wantFirst: "window.postings[0].broker_tx_type",
+		},
+		{
+			name:      "violations up to the cap are all listed",
+			postings:  validate.MaxViolations,
+			wantFirst: "window.postings[0].broker_tx_type",
+		},
+		{
+			name:      "beyond the cap the rest are counted",
+			postings:  validate.MaxViolations + 5,
+			wantFirst: "window.postings[0].broker_tx_type",
+			wantMore:  "and 5 more",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := interceptor(context.Background(), request(tc.postings), info, handler)
+			testutil.RequireGRPCCode(t, err, codes.InvalidArgument)
+			msg := status.Convert(err).Message()
+			if !strings.Contains(msg, tc.wantFirst) {
+				t.Errorf("message %q does not name the first violation %q", msg, tc.wantFirst)
+			}
+			if tc.wantMore != "" && !strings.Contains(msg, tc.wantMore) {
+				t.Errorf("message %q does not count the rest (%q)", msg, tc.wantMore)
+			}
+			if lines := strings.Count(msg, "\n - "); lines > validate.MaxViolations+1 {
+				t.Errorf("message lists %d violations, want at most %d plus the count", lines, validate.MaxViolations)
+			}
+			if len(msg) > validate.MaxMessageBytes+len("... (truncated)") {
+				t.Errorf("message is %d bytes, want at most %d", len(msg), validate.MaxMessageBytes)
+			}
+		})
+	}
+}
+
+// The archive that produced the 503 this cap exists for: every posting of a
+// large upload violating the same rule has to leave a message a proxy will
+// forward.
+func TestMessageStaysUnderTheHeaderBudget(t *testing.T) {
+	validator, err := protovalidate.New()
+	if err != nil {
+		t.Fatalf("protovalidate.New: %v", err)
+	}
+	err = validator.Validate(request(1032))
+	if err == nil {
+		t.Fatal("expected a validation error")
+	}
+	if got, want := len(validate.Message(err)), validate.MaxMessageBytes; got > want {
+		t.Errorf("message is %d bytes, want at most %d", got, want)
+	}
+	if raw := len(err.Error()); raw <= validate.MaxMessageBytes {
+		t.Errorf("uncapped message is %d bytes, so this no longer tests the cap", raw)
+	}
+}
+
+func TestMessagePassesThroughOtherErrors(t *testing.T) {
+	if got := validate.Message(errors.New("boom")); got != "boom" {
+		t.Errorf("Message = %q, want %q", got, "boom")
+	}
+	long := strings.Repeat("x", validate.MaxMessageBytes*2)
+	if got := validate.Message(errors.New(long)); len(got) > validate.MaxMessageBytes+len("... (truncated)") {
+		t.Errorf("Message is %d bytes, want it capped", len(got))
+	}
+}


### PR DESCRIPTION
## What

Uploading an archive written against an older proto returned a **503** instead of an `InvalidArgument`. The file's postings all carried the pre-0098 `type` field, which the client's reader drops as unknown, so every one of 1032 postings arrived violating `broker_tx_type`'s `min_items: 1`.

The validation interceptor put the whole protovalidate error into the gRPC status message -- **80,436 bytes** of it. That message travels in the response HEADERS frame, and Envoy resets a stream whose headers exceed `max_response_headers_kb` (60 KiB by default) rather than forwarding it. The dev proxy's counters recorded exactly that:

```
cluster.portfoliodb_grpc.http2.header_overflow: 1
cluster.portfoliodb_grpc.upstream_rq_rx_reset: 1
cluster.portfoliodb_grpc.upstream_rq_503: 1
```

Nothing appeared in the service log either, since `logger.UnaryErrorInterceptor` only logs 5xx codes and `InvalidArgument` is not one. So the clearest answer the server ever has -- your file is wrong, here is where -- reached the user as an opaque transport failure, and did so exactly when it was most needed.

## Change

The interceptor moves out of `main.go` into `server/validate`, beside the `auth` and `logger` interceptors it is chained with. The message it builds names the first 20 violations and counts the rest, under a 4 KiB byte cap that backstops one enormous violation and stays far enough below the header budget to survive `grpc-message`'s percent-encoding.

A per-element rule makes the message proportional to the request rather than to the mistake, and there is no size of file for which the thousandth violation is the one that explains it. Errors that are not `ValidationError` -- compilation and runtime failures -- pass through under the same byte cap, since they end up in the same header.

## Testing

`make server-test`. The new tests cover the pass-through, the three cap boundaries, and a 1032-posting request asserting both that the capped message fits *and* that the uncapped one would not, so the test cannot quietly stop testing the cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)