### PR TITLE
Scale the rounding tolerance by the precision of the price (0113)

### DIFF
--- a/docs/adr/0026-exact-decimals-bounded-by-closure.md
+++ b/docs/adr/0026-exact-decimals-bounded-by-closure.md
@@ -91,3 +91,33 @@ the floor against double rounding is no longer needed. Also in
 
 The wire encoding that follows from this is recorded separately in
 [0027](0027-decimal-values-cross-the-wire-as-strings.md).
+
+## Amendments
+
+**The inferred tolerance is in place.** "A tolerance survives at ingest" above says
+exactness lets the tolerance be inferred from the scale of the amounts rather than
+fixed as a constant. It is, and it took two terms rather than one, because a group
+holds two figures rounded differently:
+
+```
+tolerance = half a cent + SUM over converted legs of |units| x half the last digit of the price
+```
+
+The example above is the first term: a cash row written to 2dp is out by half a cent
+however large it is. The second is the one that was missing. A price written to 2dp is
+out by half a penny *per unit*, and a group balances on weight, so a holding of 2,676
+units at a printed 7.67 is 10.30 away from the cash row the same statement carries.
+Covering only the first reported every large trade as an imbalance -- 70 of 70 in the
+sample data, which was the whole of one broker's imbalance report.
+
+The scale is floored at 2 decimal places rather than read off the figure, because it
+is not recoverable: Fidelity strips trailing zeros in its own download, so `47.1` and
+`47.11` appear in one instrument's series and a stated scale understates what was
+quoted. That is an assumption about how brokers quote rather than about any row, and a
+source genuinely quoting to 1dp would keep reporting imbalances rather than silently
+absorbing them.
+
+The bound is never below the fixed term, so the inference can only reclassify an
+imbalance as rounding and never the reverse. What it costs is that a small missing leg
+can hide inside a high-quantity trade's bound, since summing per-leg bounds assumes
+every price erred the same way.

--- a/docs/issues/0113-scale-the-rounding-tolerance-by-the-price.md
+++ b/docs/issues/0113-scale-the-rounding-tolerance-by-the-price.md
@@ -1,0 +1,82 @@
+---
+status: closed
+title: Scale the rounding tolerance by the precision of the price
+milestone: M15
+---
+
+Add the price's own rounding to the tolerance that separates `SOURCE_ROUNDING` from
+`IMBALANCE`, so a residual that is only the printed price failing to reproduce the
+cash figure stops reading as a missing leg.
+
+## Motivation
+
+A group balances on weight, and a security leg weighs at `quantity * unit_price`. A
+price printed to 2dp is out by up to half a penny per unit, so a large position is out
+by pounds:
+
+```
+INRG   2676 units, price printed 7.67, cash in 20514.62
+       20514.62 / 2676 = 7.66615      printed as 7.67
+       x 2676 units                   = 10.30      routed to IMBALANCE
+```
+
+The tolerance was a fixed 0.005, which covers only the rounding in the cash figure. So
+every large trade reported as an imbalance: 70 of 70 currency imbalances in the sample
+data, which was the whole of one broker's report.
+
+`residual.go`, `docs/spec/postings.md` and
+adr/0026-exact-decimals-bounded-by-closure.md all named this and deferred it. 0026
+states it as a consequence already accepted -- "the tolerance can be inferred from the
+scale of the amounts rather than fixed as a constant" -- so this is that deferred half
+rather than a new decision.
+
+## Design
+
+```
+tolerance = moneyTolerance + SUM over converted legs of |units| x half the last digit of the price
+```
+
+A leg counts only where its weight was derived by pricing it into the settlement
+currency, which `weight <> quantity` says. A cash leg's price of 1 is exact by
+definition, so a deposit run's tolerance is unchanged. Because
+`weight = quantity * price * contract size`, the term is `|weight| * halfUlp / |price|`
+and needs no join to `instruments` for the multiplier.
+
+The precision is floored at `residual.PriceScaleFloor = 2` rather than read off the
+figure. Fidelity strips trailing zeros in its own download -- the sample writes prices
+at 0, 1 and 2 decimal places, with `47.1` and `47.11` in one instrument's series -- so
+the stated scale understates what was quoted. Reading it off inflates the bound tenfold
+on a 1dp price and a hundredfold on a 0dp one, and reclassifies exactly the same
+groups: largest bound 338.91 as stored against 38.82 floored. A floor rather than a
+fixed precision, so IBKR (6dp) and Schwab (4dp) keep their own.
+
+## Evidence
+
+Over the 70 currency imbalances in the dev database, `residual / bound` reaches 0.970
+and never exceeds 1. The tightest is 32 units at 1067.67 leaving 0.16 against a bound
+of `32 * 0.005 = 0.16` -- the price error saturating its theoretical maximum. Residuals
+crowding a bound they never cross is what a correct error model looks like.
+
+Applying the shipped SQL to that database reclassifies all 70, and leaves all 132
+`TRANSFER_CLEARING` groups untouched.
+
+## Consequences
+
+The change is monotone: the bound is `moneyTolerance` plus a non-negative term, so
+nothing can move from `SOURCE_ROUNDING` to `IMBALANCE`.
+
+What it costs is that summing per-leg bounds is a worst case, assuming every price
+erred the same way, so a small missing leg can hide inside a high-quantity trade's
+bound -- a 30 pound discrepancy on a 6,778-unit position sits within a 34 pound bound.
+
+The grouping engine's `Opts.Money` deliberately does **not** scale. It compares two
+figures the source stated, where no price arithmetic has happened; the balancer
+compares a derived weight against a stated figure. The spec previously tied the two
+together and now says why they differ.
+
+`SplitType` is untouched: a residual left by a period replace is the value of the legs
+that went and can be any size.
+
+The `exports_test.go` goldens do not move. Their `Unbalanced` count comes from an
+independent oracle asking whether a group closes, not from the classifier, and they do
+not inspect account types.

--- a/docs/spec/postings.md
+++ b/docs/spec/postings.md
@@ -382,14 +382,41 @@ carries one residual per commodity however many replaces have reached it.
 
 ### Source rounding
 
-A residual below a **tolerance** -- half a cent for money, `1e-6` otherwise -- takes
-the `SOURCE_ROUNDING` type instead. The tolerance is not a floating-point fudge and
-did not go away when quantities became exact: a broker quoting a price to 4dp and a
-cash amount to 2dp disagrees with itself by a fraction of a cent per trade, and that
-difference is exact and real but is an artefact of how the statement was written
-rather than a leg the converter missed. Inferring the tolerance from the scale of the
-contributing amounts, rather than fixing it, would change which residuals are
-classified this way and has not been done. See
+A residual below a **tolerance** takes the `SOURCE_ROUNDING` type instead. The
+tolerance is not a floating-point fudge and did not go away when quantities became
+exact: a broker quoting a price to one precision and a cash amount to another
+disagrees with itself, and that difference is exact and real but is an artefact of how
+the statement was written rather than a leg the converter missed.
+
+There are two roundings, because there are two figures:
+
+```
+tolerance = half a cent                                         (the cash figure's own rounding)
+          + SUM over converted legs of |units| x half the last digit of the price
+```
+
+A cash amount written to 2dp is out by up to half a cent however large it is. A price
+written to 2dp is out by up to half a penny *per unit*, so a holding of 2,676 units is
+out by 10.30 -- and a group balances on weight, where that lands. A fixed half-cent
+tolerance covers only the first, and so reports every large trade as an imbalance.
+
+A leg contributes only where its weight was derived by pricing it into the settlement
+currency. A cash leg does not: its price of `1` is exact by definition rather than a
+rounded quote, which is what leaves a deposit run's tolerance where it was. A residual
+denominated in a security keeps `1e-6`, since an unpriced leg was never converted.
+
+The price's precision is **assumed, not read**. Fidelity strips trailing zeros in its
+own download -- the sample export writes prices at 0, 1 and 2 decimal places, with
+`47.1` and `47.11` in one instrument's series -- so a stated scale understates what was
+quoted, and reading it off the figure inflates the bound tenfold on a 1dp price. The
+floor is 2 decimal places (`residual.PriceScaleFloor`) and it is a floor rather than a
+fixed precision, so a source quoting finer keeps its own: the sample IBKR statements
+run to 6dp and Schwab to 4dp.
+
+The sum is a worst case, assuming every leg's price erred the same way, so a small
+missing leg can hide inside the bound of a high-quantity trade. That is the cost of
+not reporting the source's own arithmetic as missing data. The bound is never below
+half a cent, so nothing that was rounding becomes an imbalance. See
 adr/0026-exact-decimals-bounded-by-closure.md.
 
 The tolerance decides the **type** of the routed posting, not whether one is written.
@@ -598,10 +625,15 @@ regroup began.
 
 A group the engine assembled is re-routed as a whole group and one a posting left as a
 shortened one, which is the distinction [Source rounding](#source-rounding) turns on.
-The engine pairs money figures that differ by up to the same tolerance the balancer
-rounds at, so a pairing it accepts leaves exactly the difference that reads as the
-source disagreeing with itself; reading that as a missing leg would report every
-correctly paired trade as an imbalance and seed the next cycle from it.
+The engine pairs money figures that differ by up to half a cent, which is the fixed
+half of the tolerance the balancer rounds at and not the whole of it. The two are
+different questions and stay separate: the engine compares two figures the **source
+stated** -- a trade's own total against its cash row -- where no price arithmetic has
+happened and half a cent is the whole of the error, while the balancer compares a
+**derived weight** against a stated figure and so also carries the price's rounding.
+A trade whose stated total matches its cash row exactly can still be 10.30 out by
+weight. Reading either as a missing leg would report correctly paired trades as
+imbalances and seed the next cycle from them.
 
 It runs on an admin RPC, which is how an external cron job gives it a cadence, and
 again when a transaction import commits, so legs that have just landed beside older

--- a/server/db/postgres/residual_balances.go
+++ b/server/db/postgres/residual_balances.go
@@ -21,6 +21,13 @@ import (
 // is the only place that is visible. It is deliberately absent from the dashboard
 // counts below, which ask whether something is wrong.
 //
+// What it measures is the precision of the figures a broker prints rather than the
+// quality of its converter, and since the tolerance came to scale with the price it
+// measures that and little else -- a broker quoting to 2dp leaves a residual
+// proportional to the size of the position, and nothing a converter does changes it.
+// A total that grows here is a statement about the statement, not about this
+// repository. See residual.Tolerance.
+//
 // The commodity is the instrument's name, not its currency: for money the two
 // agree, but a residual left by an unpaired security transfer is a quantity of
 // shares whose instrument currency would render it as money and misstate it.

--- a/server/db/postgres/settle_test.go
+++ b/server/db/postgres/settle_test.go
@@ -390,3 +390,87 @@ func TestSettle_UngroupedPostingsAreSettledSeparately(t *testing.T) {
 	}
 	assertBalanced(t, p, userID)
 }
+
+// priceRoundingSeed stores one trade whose asset leg is priced and whose cash leg is
+// the figure the source stated, so the group is left out by exactly what the printed
+// price fails to reproduce. Returns the routed leg's account type.
+//
+// The weights are the caller's, because that is what the balancer computes and what
+// the residual is a sum of: the asset leg weighs at quantity * price and the cash leg
+// at its own amount, so the gap between them is the whole of what this test is about.
+func priceRoundingSeed(t *testing.T, sub, qty, price, cash string) string {
+	t.Helper()
+	// One group, because the residual this is about is a property of a trade and
+	// its cash leg together. Without a settler each posting is a group of its own
+	// and the whole consideration reads as missing.
+	p := testDBTx(t).WithSettler(oneGroupSettler{})
+	userID, usd := balanceSeed(t, p, sub)
+	ctx := context.Background()
+	inst, err := p.EnsureInstrument(ctx, "STOCK", "", "GBP", "INRG", "", "",
+		[]db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: "F", Value: "INRG", Canonical: false}}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure instrument: %v", err)
+	}
+	at := time.Date(2022, 2, 8, 0, 0, 0, 0, time.UTC)
+	tx := func(desc, quantity string, unitPrice *string) *apiv1.Tx {
+		return &apiv1.Tx{
+			OrderDate: timestamppb.New(at), TradeDate: timestamppb.New(at),
+			InstrumentDescription: desc,
+			BrokerTxType:          []typev1.TxType{typev1.TxType_TRADE_ASSET},
+			ResolvedTxType:        typev1.TxType_TRADE_ASSET,
+			Quantity:              quantity, UnitPrice: unitPrice,
+			Account: "A", SettlementCurrency: "GBP", TradingCurrency: "GBP",
+		}
+	}
+	one := "1"
+	txs := []*apiv1.Tx{tx("INRG", qty, &price), tx("GBP", cash, &one)}
+	weights := []db.Weight{
+		{Amount: decimal.RequireFromString(qty).Mul(decimal.RequireFromString(price)), Commodity: "cur:GBP"},
+		{Amount: decimal.RequireFromString(cash), Commodity: "cur:GBP"},
+	}
+	if err := p.ReplaceTxsInPeriod(ctx, userID, "FIDELITY", "",
+		timestamppb.New(at.Add(-time.Hour)), timestamppb.New(at.Add(time.Hour)),
+		txs, []string{inst, usd}, weights, nil); err != nil {
+		t.Fatalf("store: %v", err)
+	}
+	var acct string
+	if err := p.q.QueryRowContext(ctx, `
+		SELECT account_type FROM txs
+		WHERE user_id = $1 AND synthetic_purpose = 'RESIDUAL'
+	`, userID).Scan(&acct); err != nil {
+		t.Fatalf("read routed posting: %v", err)
+	}
+	return acct
+}
+
+// The residual a printed price leaves is the source disagreeing with itself, and it
+// scales with the position: 2676 units of a price written to 2dp can be out by 13.38,
+// and this one is out by 10.30. A fixed half-cent tolerance called every large trade
+// an imbalance.
+func TestSettle_ScalesTheToleranceByThePrice(t *testing.T) {
+	// 2676 * 7.67 = 20524.92 against a stated cash row of 20514.62.
+	got := priceRoundingSeed(t, "sub|price-rounding", "2676", "7.67", "-20514.62")
+	if got != "SOURCE_ROUNDING" {
+		t.Fatalf("routed to %s, want SOURCE_ROUNDING", got)
+	}
+}
+
+// The bound is a bound. Past what the prices could account for, a residual is still a
+// leg the source did not supply however large the position.
+func TestSettle_StillReportsWhatThePricesCannotExplain(t *testing.T) {
+	// The same trade 100 short of its cash row, which no price rounding reaches.
+	got := priceRoundingSeed(t, "sub|price-rounding-big", "2676", "7.67", "-20424.92")
+	if got != "IMBALANCE" {
+		t.Fatalf("routed to %s, want IMBALANCE", got)
+	}
+}
+
+// A small position at the same price has a small bound, so the tolerance has not
+// simply been loosened: it tracks the units the price was applied to.
+func TestSettle_KeepsASmallPositionsToleranceSmall(t *testing.T) {
+	// 10 * 7.67 = 76.70, a cash row 1.00 short. 10 units can only be out by 0.05.
+	got := priceRoundingSeed(t, "sub|price-rounding-small", "10", "7.67", "-75.70")
+	if got != "IMBALANCE" {
+		t.Fatalf("routed to %s, want IMBALANCE", got)
+	}
+}

--- a/server/db/postgres/txs.go
+++ b/server/db/postgres/txs.go
@@ -750,8 +750,23 @@ const repointGroupTimestampsSQL = `
 // group it balances, so it stays attributable. commodity is the earliest surviving leg
 // weighing in that commodity, which is where a residual in a security takes its
 // instrument and description from.
+//
+// rounding is what the group's own prices could be out by, which the tolerance that
+// classifies the residual is scaled by. A leg converted into the settlement currency
+// weighs at quantity * price * contract size, so a price quoted to n decimal places
+// carries an error of up to half of the last one per unit; weight / price is the
+// units it was applied to, contract size included, which is why no join to
+// instruments is needed for the multiplier. $2 is residual.PriceScaleFloor, passed in
+// so the assumption has one home rather than being spelled here as well.
+//
+// weight <> quantity is what says a leg converted. A cash leg weighs its own
+// quantity, and its price of 1 is exact by definition rather than a rounded quote, so
+// it contributes nothing -- which is what leaves a deposit run's tolerance where it
+// was. A price of zero contributes nothing either: an option expiring worthless
+// converts at zero, so there is no consideration to have rounded.
 const groupResidualsSQL = `
 	SELECT r.group_id, r.weight_commodity, r.residual,
+	       rounding.price_rounding,
 	       types.resolved_tx_types,
 	       first.order_date, first.trade_date, first.broker_tx_type, first.resolved_tx_type, first.broker, first.account,
 	       first.trading_currency, first.settlement_currency,
@@ -763,6 +778,16 @@ const groupResidualsSQL = `
 		GROUP BY group_id, weight_commodity
 		HAVING SUM(weight) <> 0
 	) r
+	JOIN LATERAL (
+		SELECT COALESCE(SUM(
+			abs(t.weight / t.unit_price)
+			* 0.5 * power(10::numeric, -greatest(scale(t.unit_price), $2::int))
+		), 0) AS price_rounding
+		FROM txs t
+		WHERE t.group_id = r.group_id
+		  AND t.unit_price IS NOT NULL AND t.unit_price <> 0
+		  AND t.weight <> t.quantity
+	) rounding ON true
 	JOIN LATERAL (
 		SELECT array_agg(DISTINCT t.resolved_tx_type) AS resolved_tx_types
 		FROM txs t WHERE t.group_id = r.group_id
@@ -823,6 +848,9 @@ type groupResidual struct {
 	// family rule; the first leg's declared set and resolved value are what
 	// the routed counterparty carries.
 	resolvedTypes pq.StringArray
+	// What the group's own prices could be out by, which scales the tolerance the
+	// residual is classified against. Zero for a group that moved only money.
+	priceRounding decimal.Decimal
 	// Both dates of the group's earliest leg, since a routed residual is that
 	// group's own event and belongs on the same days as the legs it balances.
 	orderDate      time.Time
@@ -976,19 +1004,19 @@ func deleteReplacedPostings(ctx context.Context, exec queryable, userUUID uuid.U
 
 // residualRule classifies what a group has left over. The two differ only in whether
 // a difference small enough to be a rounding is read as one.
-type residualRule func(commodity string, amount decimal.Decimal, resolved []typev1.TxType) typev1.AccountType
+type residualRule func(commodity string, amount, priceRounding decimal.Decimal, resolved []typev1.TxType) typev1.AccountType
 
 // wholeSource is the rule for a group holding every leg its source stated. What is
 // left over is the source's own figures failing to reconcile, so a small enough
 // difference is the source disagreeing with itself. See residual.Type.
-func wholeSource(commodity string, amount decimal.Decimal, resolved []typev1.TxType) typev1.AccountType {
-	return residual.Type(commodity, amount, resolved)
+func wholeSource(commodity string, amount, priceRounding decimal.Decimal, resolved []typev1.TxType) typev1.AccountType {
+	return residual.Type(commodity, amount, priceRounding, resolved)
 }
 
 // legsRemoved is the rule for a group something was taken out of. What is left over
 // is the value of the legs that went rather than two figures rounded differently, so
 // it can be any size and a small one is small by coincidence. See residual.SplitType.
-func legsRemoved(_ string, _ decimal.Decimal, resolved []typev1.TxType) typev1.AccountType {
+func legsRemoved(_ string, _, _ decimal.Decimal, resolved []typev1.TxType) typev1.AccountType {
 	return residual.SplitType(resolved)
 }
 
@@ -1074,7 +1102,7 @@ func settle(ctx context.Context, exec queryable, userUUID uuid.UUID, groupIDs []
 // routeResiduals writes the counterparty that balances each group left unbalanced
 // once its boundary legs are in.
 func routeResiduals(ctx context.Context, exec queryable, userUUID uuid.UUID, groupIDs interface{}, rule residualRule) error {
-	rows, err := exec.QueryContext(ctx, groupResidualsSQL, groupIDs)
+	rows, err := exec.QueryContext(ctx, groupResidualsSQL, groupIDs, residual.PriceScaleFloor)
 	if err != nil {
 		return fmt.Errorf("surviving residuals: %w", err)
 	}
@@ -1082,7 +1110,7 @@ func routeResiduals(ctx context.Context, exec queryable, userUUID uuid.UUID, gro
 	var residuals []groupResidual
 	for rows.Next() {
 		var r groupResidual
-		if err := rows.Scan(&r.groupID, &r.commodity, &r.amount, &r.resolvedTypes,
+		if err := rows.Scan(&r.groupID, &r.commodity, &r.amount, &r.priceRounding, &r.resolvedTypes,
 			&r.orderDate, &r.tradeDate, &r.brokerTxTypes, &r.resolvedTxType, &r.broker, &r.account,
 			&r.trading, &r.settlement, &r.description, &r.instrumentID); err != nil {
 			return fmt.Errorf("surviving residuals: %w", err)
@@ -1096,7 +1124,7 @@ func routeResiduals(ctx context.Context, exec queryable, userUUID uuid.UUID, gro
 	byCurrency := map[string]uuid.UUID{}
 	for _, r := range residuals {
 		amount := r.amount.Neg()
-		acctType, err := accountTypeToStr(rule(r.commodity, amount, db.StrsToTxTypes(r.resolvedTypes)))
+		acctType, err := accountTypeToStr(rule(r.commodity, amount, r.priceRounding, db.StrsToTxTypes(r.resolvedTypes)))
 		if err != nil {
 			return err
 		}

--- a/server/residual/residual.go
+++ b/server/residual/residual.go
@@ -47,25 +47,66 @@ const (
 // Quantities are exact decimals now, so this is no longer absorbing arithmetic
 // error -- it is the disagreement between two figures the source rounded
 // differently, which exactness does not remove. Both beancount and ledger keep a
-// tolerance for the same reason. Inferring it from the scale of the contributing
-// amounts, rather than fixing it, is a change to how residuals get classified and
-// is deliberately not made here.
+// tolerance for the same reason.
 var (
 	moneyTolerance     = decimal.RequireFromString("0.005")
 	commodityTolerance = decimal.New(1, -6)
 )
 
+// PriceScaleFloor is the fewest decimal places a source is taken to have quoted a
+// security price to, whatever the scale of the figure it wrote.
+//
+// It has to be assumed, because the precision is not recoverable. Fidelity strips
+// trailing zeros in its own download: the sample export writes prices at 0, 1 and 2
+// decimal places, with 47.1 and 47.11 in one instrument's series, so a price reading
+// 47.1 means 47.10 and its stated scale understates what was quoted. Reading the
+// scale off the figure instead inflates the bound tenfold on a 1dp price and a
+// hundredfold on a 0dp one, which classifies the same residuals while leaving far
+// more room to swallow a leg that really is missing.
+//
+// A floor rather than a fixed precision, so a source that quotes finer keeps its own:
+// the sample IBKR statements run to 6 decimal places and Schwab to 4, and neither is
+// loosened by this.
+//
+// It is a claim about how brokers quote rather than about any row, in the same class
+// as the converter's own calibrated constants. A source that genuinely quoted to 1dp
+// would get a bound ten times tighter than its error and keep reporting imbalances,
+// which fails safe rather than silently.
+const PriceScaleFloor = 2
+
 // Tolerance returns the residual below which a difference in this commodity reads
 // as the source's own rounding rather than as a leg it omitted.
-func Tolerance(commodity string) decimal.Decimal {
-	if strings.HasPrefix(commodity, CurrencyPrefix) {
+//
+// priceRounding is what the group's own prices could be out by: for each leg whose
+// weight was derived by pricing it into the settlement currency, the units it carried
+// times half the last digit the price was quoted to. Zero for a group holding no such
+// leg, which is every group that moved only money.
+//
+// Two roundings, because there are two figures. A cash amount written to 2dp is out
+// by up to half a cent however large it is, which is the fixed term. A price written
+// to 2dp is out by up to half a penny *per unit*, so on 2676 units it is out by
+// 10.30 -- and a group balances on weight, which is where that lands. Covering only
+// the first reports every large trade as an imbalance.
+//
+// The sum is a worst case: it assumes every leg's price erred in the same direction.
+// So a small missing leg can hide inside the bound of a high-quantity trade, which is
+// the cost of not reporting an artefact of the source's own arithmetic as missing
+// data. See docs/adr/0026-exact-decimals-bounded-by-closure.md.
+func Tolerance(commodity string, priceRounding decimal.Decimal) decimal.Decimal {
+	if !strings.HasPrefix(commodity, CurrencyPrefix) {
+		// An unpriced leg was never converted, so no price rounding reaches a
+		// residual denominated in the security itself.
+		return commodityTolerance
+	}
+	if priceRounding.IsNegative() {
 		return moneyTolerance
 	}
-	return commodityTolerance
+	return moneyTolerance.Add(priceRounding)
 }
 
 // Type returns the account type the residual of amount in commodity is routed to,
-// for a group whose postings resolved to the given tx types.
+// for a group whose postings resolved to the given tx types and whose prices could be
+// out by priceRounding.
 //
 // The tolerance decides the account type, not whether the residual is routed at
 // all: suppressing the small ones would leave the group summing to a small
@@ -74,8 +115,8 @@ func Tolerance(commodity string) decimal.Decimal {
 // the one thing already known about them. A sub-tolerance residual on a journal
 // is rounding too, so SOURCE_ROUNDING beats the transfer case rather than the
 // other way round.
-func Type(commodity string, amount decimal.Decimal, resolved []typev1.TxType) typev1.AccountType {
-	if amount.Abs().LessThan(Tolerance(commodity)) {
+func Type(commodity string, amount, priceRounding decimal.Decimal, resolved []typev1.TxType) typev1.AccountType {
+	if amount.Abs().LessThan(Tolerance(commodity, priceRounding)) {
 		return typev1.AccountType_ACCOUNT_TYPE_SOURCE_ROUNDING
 	}
 	return family(resolved)

--- a/server/residual/residual_test.go
+++ b/server/residual/residual_test.go
@@ -12,8 +12,11 @@ func TestType(t *testing.T) {
 		name      string
 		commodity string
 		amount    string
-		resolved  []typev1.TxType
-		want      typev1.AccountType
+		// What the group's prices could be out by. Empty is none, which is what
+		// every case here meant before the tolerance could be scaled.
+		rounding string
+		resolved []typev1.TxType
+		want     typev1.AccountType
 	}{
 		{
 			name:      "missing cash leg",
@@ -116,13 +119,61 @@ func TestType(t *testing.T) {
 			resolved:  []typev1.TxType{typev1.TxType_TRADE_CASH},
 			want:      typev1.AccountType_ACCOUNT_TYPE_IMBALANCE,
 		},
+		// The case this exists for. 2676 units of a price printed to 2dp can be out
+		// by 2676 * 0.005 = 13.38, and the sample export is out by 10.30 -- the
+		// printed price failing to reproduce the cash row rather than a leg the
+		// converter missed.
+		{
+			name:      "a large position at a price rounded to 2dp",
+			commodity: "cur:GBP",
+			amount:    "10.30",
+			rounding:  "13.38",
+			resolved:  []typev1.TxType{typev1.TxType_TRADE_ASSET},
+			want:      typev1.AccountType_ACCOUNT_TYPE_SOURCE_ROUNDING,
+		},
+		// The bound is a bound. A residual past what the prices could account for
+		// is still a leg the source did not supply, however large the position.
+		{
+			name:      "past what the prices could account for",
+			commodity: "cur:GBP",
+			amount:    "13.39",
+			rounding:  "13.38",
+			resolved:  []typev1.TxType{typev1.TxType_TRADE_ASSET},
+			want:      typev1.AccountType_ACCOUNT_TYPE_IMBALANCE,
+		},
+		// A deposit run holds only money, whose price of 1 is exact, so nothing
+		// scales its tolerance and it is still short of the leg that never came.
+		{
+			name:      "a journal, whose money carries no price rounding",
+			commodity: "cur:GBP",
+			amount:    "-5000",
+			rounding:  "0",
+			resolved:  []typev1.TxType{typev1.TxType_TRANSFER},
+			want:      typev1.AccountType_ACCOUNT_TYPE_TRANSFER_CLEARING,
+		},
+		// A residual in the security itself comes from a leg that was never
+		// converted, so no price rounding reaches it whatever the group's other
+		// legs were quoted to.
+		{
+			name:      "a security residual is not scaled by a price",
+			commodity: "inst:abc",
+			amount:    "0.5",
+			rounding:  "13.38",
+			resolved:  []typev1.TxType{typev1.TxType_TRADE_ASSET},
+			want:      typev1.AccountType_ACCOUNT_TYPE_IMBALANCE,
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got := Type(tc.commodity, decimal.RequireFromString(tc.amount), tc.resolved)
+			rounding := decimal.Zero
+			if tc.rounding != "" {
+				rounding = decimal.RequireFromString(tc.rounding)
+			}
+			got := Type(tc.commodity, decimal.RequireFromString(tc.amount), rounding, tc.resolved)
 			if got != tc.want {
-				t.Fatalf("Type(%q, %s) = %v, want %v", tc.commodity, tc.amount, got, tc.want)
+				t.Fatalf("Type(%q, %s, rounding %s) = %v, want %v",
+					tc.commodity, tc.amount, rounding, got, tc.want)
 			}
 		})
 	}
@@ -140,5 +191,21 @@ func TestCommodityAccessors(t *testing.T) {
 	}
 	if _, ok := InstrumentOf("desc:inst:abc"); ok {
 		t.Fatal("InstrumentOf(desc:inst:abc) reported a security")
+	}
+}
+
+// The bound is moneyTolerance plus a non-negative term, so nothing can move from
+// SOURCE_ROUNDING to IMBALANCE however the term is derived. That is what bounds the
+// blast radius of scaling it.
+func TestTolerance_NeverTightensMoney(t *testing.T) {
+	base := Tolerance("cur:GBP", decimal.Zero)
+	for _, r := range []string{"0", "0.0001", "13.38", "1000000"} {
+		if got := Tolerance("cur:GBP", decimal.RequireFromString(r)); got.LessThan(base) {
+			t.Fatalf("Tolerance with rounding %s = %s, below the money tolerance %s", r, got, base)
+		}
+	}
+	// A negative term is a caller mistake rather than a tighter bound.
+	if got := Tolerance("cur:GBP", decimal.RequireFromString("-5")); !got.Equal(base) {
+		t.Fatalf("Tolerance with a negative rounding = %s, want the money tolerance %s", got, base)
 	}
 }


### PR DESCRIPTION
A residual that is only the printed price failing to reproduce the cash figure now classifies as `SOURCE_ROUNDING` rather than `IMBALANCE`.

## Why

A group balances on **weight**, and a security leg weighs at `quantity × unit_price`. A price printed to 2dp is out by up to half a penny *per unit*:

```
INRG   2676 units, price printed 7.67, cash in 20514.62
       20514.62 / 2676 = 7.66615      printed as 7.67
       × 2676 units                   = 10.30      routed to IMBALANCE
```

The tolerance was a fixed `0.005`, covering only the rounding in the cash figure. So every large trade reported as an imbalance — **70 of 70** currency imbalances in the sample data, which was the whole of one broker's report.

`residual.go`, `docs/spec/postings.md` and ADR 0026 all named this and deferred it. 0026 states it as a consequence already accepted — *"the tolerance can be inferred from the scale of the amounts rather than fixed as a constant"* — so this is that deferred half, not a new decision.

## The bound

```
tolerance = moneyTolerance + Σ over converted legs of |units| × half the last digit of the price
```

`weight <> quantity` is what says a leg converted. A cash leg's price of `1` is exact by definition, so a deposit run's tolerance is unchanged. Since `weight = quantity × price × contractSize`, the term is `|weight| × halfUlp / |price|` — no join to `instruments` for the multiplier.

## The precision is assumed, not read

This is the part that changed during implementation. **Fidelity strips trailing zeros in its own download** — the genuine export writes prices at 0dp, 1dp and 2dp, with `47.1` and `47.11` in one instrument's series — so the stated scale understates what was quoted. Reading it off inflates the bound tenfold on a 1dp price and a hundredfold on a 0dp one: largest bound **338.91 as stored** vs **38.82 floored**, reclassifying *exactly the same 70 groups*. That slack buys nothing and is pure room to swallow a real missing leg.

Hence `PriceScaleFloor = 2` — a floor, not a cap, so IBKR (6dp) and Schwab (4dp) keep their own.

## Evidence

Over the 70 imbalances, `residual ÷ bound` reaches **0.970 and never exceeds 1**. The tightest is 32 units at 1067.67 leaving 0.16 against `32 × 0.005 = 0.16` — the price error saturating its theoretical maximum. Residuals crowding a bound they never cross is what a correct error model looks like.

Applying the shipped SQL to the dev database reclassifies all 70 and leaves all 132 `TRANSFER_CLEARING` groups untouched.

## What it costs

Summing per-leg bounds is a worst case assuming every price erred the same way, so a small missing leg can hide inside a high-quantity trade's bound — £30 on a 6,778-unit position sits within £34. Traded against 70 false imbalances today.

The change is **monotone**: the bound is the fixed term plus a non-negative one, so nothing can move from `SOURCE_ROUNDING` to `IMBALANCE`.

## Also

`Opts.Money` deliberately does **not** scale — it compares two figures the source *stated*, where no price arithmetic has happened. The spec tied the two tolerances together and now says why they differ; the INRG case proves it, since the pairing was accepted on equal stated amounts while the weight was 10.30 out.

`exports_test.go` goldens do not move, as predicted — their oracle is independent of the classifier.

## Verification

`make lint`, `make fmt-check` and all five suites pass. Three new DB integration tests, including one confirming a *small* position's bound stays small, so the tolerance tracks units rather than just being loosened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)