### PR TITLE
Design telemetry as run-scoped event rows read by Grafana

### DIFF
--- a/docs/adr/0053-telemetry-is-run-scoped-event-rows.md
+++ b/docs/adr/0053-telemetry-is-run-scoped-event-rows.md
@@ -1,0 +1,94 @@
+# Telemetry is run-scoped event rows, not counters
+
+[0009](0009-telemetry-and-logging.md) made telemetry a set of Redis integers under a
+dotted namespace, discovered by scanning the prefix and rendered by grouping the name
+segments. The naming convention was the whole of the design: nothing recorded what a
+counter counted one of, and nothing related two counters to each other.
+
+That is why the counters cannot be read. `instruments.resolution.totals.description.attempts`
+is incremented once per batch item, `...no_hints` once per batch, and `...plugin_error`
+once per plugin per batch -- three grains sharing one namespace, so no two of them can
+be added, subtracted or divided. Nothing says whether a pair of counters partitions a
+population or overlaps it. And no counter is attributable: having imported a file, there
+is no way to ask what happened during that import, because the numbers are global running
+totals with no notion of when or on whose behalf they moved.
+
+Counters are replaced by event rows in Postgres, read by a Grafana container. One rule
+governs every table:
+
+> One row is one completed unit of work, and carries exactly one outcome drawn from a
+> closed, mutually exclusive vocabulary.
+
+The vocabulary being closed is what makes a chart interpretable without knowing how the
+code branches; the unit of work being nameable is what stops a second grain being smuggled
+into the same table.
+
+## A run is the unit everything hangs off
+
+Work in this system is either an ingestion job or a worker cycle, and identification runs
+under both -- from tx import, from the price worker, from archive declarations, and from
+the corporate events cycle that adjusts option identity across splits. A `job_id` would
+leave that last one parentless and invisible.
+
+So a **run** is one activation of one subsystem, of which a job and a cycle are two kinds.
+Every event row carries a non-nullable `run_id`. This subsumes what would otherwise be a
+separate worker-runs metric: the run table is that chart.
+
+A run row is created before its children, because they reference it, and stamped with its
+outcome when it ends. It is therefore written twice, not once, and a run whose process died
+never receives the second write. `incomplete` is an explicit member of the outcome
+vocabulary rather than a null, so that a killed container reads as a fact rather than a
+hole -- which under the dev stack's pinned `memswap_limit` is a diagnosis, not an edge case.
+
+A job's status is denormalised onto its run rather than joined from `ingestion_jobs`.
+The duplication is accepted because a run's outcome is a historical fact once stamped,
+and because it keeps every panel reading one table regardless of run kind.
+
+An RPC request is deliberately **not** a kind of run. No handler in the service does
+substantial synchronous work -- the trigger RPCs poke a channel and return, the import RPCs
+enqueue a job -- so nothing would populate it today, while the SPA's polling would swamp the
+run table and make the run-kind chart unreadable. `TriggerGrouping` is the illustration:
+it drops the trigger when the channel is full and still answers OK, so the request outcome
+and the work outcome can disagree outright.
+
+## Grains nest; they do not sum
+
+Under a run, per distinct resolution key -- one (source, description, hints) triple, not one
+transaction -- sit description extraction and identification, each with its own plugin calls.
+A cache hit is not an outcome in any of these tables: it is an artefact of deduplication,
+and counting it would make the population transactions rather than descriptions.
+
+Relationships between grains are foreign keys, not arithmetic identities. Asking whether
+buckets sum was forced by Redis having nothing but scalars; a resolution key producing four
+identification attempts (one primary, two for the MIC_TICKER against OPENFIGI_SHARE_CLASS
+mismatch check, one per level of underlying recursion) is then a fact recorded in a `purpose`
+column rather than a discrepancy between two totals.
+
+Each table is exposed through one wide view that flattens its parents in and never fans out
+into its children, because a view spanning two sibling grains duplicates the parent's rows
+and makes counting it silently wrong. Judgements live in the view as computed columns --
+which outcomes count as having reached a plugin, which runs are imports -- and panels
+select on them, so a definition is stated once in reviewed SQL rather than retyped into
+each dashboard.
+
+## Plugins report telemetry; the orchestrator writes it
+
+0009 injected a counter interface into plugins so they would not depend on Redis. That
+stays true in spirit and changes in mechanism, because a single plugin-call row needs facts
+from two parties that never meet. Only the plugin knows its transport outcome, its retries
+and its token usage. Only the orchestrator knows whether that plugin won, was superseded by
+a better hint match, or was discarded as inconsistent with the winner -- decided after every
+plugin has returned, and unknowable to any of them.
+
+So `Identify` and `ExtractBatch` return a telemetry value alongside their result, and the
+orchestrator composes and writes the row. The alternative -- the plugin writing its own row
+and the orchestrator updating it -- is rejected because it makes plugins depend on the
+telemetry backend and drags a database into every plugin test, which is the thing 0009
+existed to prevent. Plugins consequently stop depending on a telemetry interface at all.
+
+## Consequences
+
+The counters half of 0009 is superseded; the logging half stands. The Redis counter
+infrastructure is retained but is left with no defined counters. The admin telemetry page
+and the RPC behind it lose their subject matter, and what becomes of them is settled
+separately.

--- a/docs/issues/0114-plugins-return-telemetry.md
+++ b/docs/issues/0114-plugins-return-telemetry.md
@@ -1,0 +1,21 @@
+---
+status: open
+title: Plugins return telemetry rather than incrementing counters
+milestone: M20
+---
+
+Change `identifier.Plugin.Identify` and `description.Plugin.ExtractBatch` to return a
+telemetry value alongside their result, and drop the injected counter from every plugin.
+
+A plugin-call row needs facts from two parties: the plugin knows its transport outcome,
+its retries and its token usage, while only the orchestrator knows whether that plugin
+won, was superseded by a better hint match, or was discarded as inconsistent with the
+winner -- decided after every plugin has returned. Having the plugin write its own row
+instead would make plugins depend on the telemetry backend and drag a database into
+every plugin test, which is what the injected counter existed to avoid.
+
+Plugins consequently stop importing `server/telemetry` altogether. Touches EODHD
+(identifier, price, corporate events), Massive (identifier, price), OpenAI, OpenFIGI and
+the inflation plugin.
+
+See adr/0053-telemetry-is-run-scoped-event-rows.md and docs/spec/telemetry.md.

--- a/docs/issues/0115-telemetry-schema-and-writer.md
+++ b/docs/issues/0115-telemetry-schema-and-writer.md
@@ -1,0 +1,18 @@
+---
+status: open
+title: Telemetry schema and synchronous writer
+milestone: M20
+---
+
+Add `server/migrations/005_telemetry.sql` creating the `telemetry` schema -- `run`,
+`resolution_key`, `identification_attempt`, `identifier_plugin_call`,
+`description_plugin_call`, one wide view per table, and SELECT-only grants for the
+reading role -- and the writer behind it in `server/db`.
+
+The writer uses its own connection pool and never joins the work's transaction, so a
+rolled-back import still leaves the rows explaining why. Writes are synchronous; a write
+that fails sets `telemetry_incomplete` on the run and is otherwise ignored.
+
+Retention is a delete over `run.started_at` at 360 days, cascading to children.
+
+Column lists and outcome vocabularies are in docs/spec/telemetry.md.

--- a/docs/issues/0116-emit-run-scoped-telemetry.md
+++ b/docs/issues/0116-emit-run-scoped-telemetry.md
@@ -1,0 +1,19 @@
+---
+status: open
+title: Emit run-scoped telemetry from ingestion, identification and the workers
+milestone: M20
+dependencies: [0114, 0115]
+---
+
+Open a run for every ingestion job and every worker cycle, and emit the event rows
+beneath it: one resolution key per distinct (source, description, hints) triple, one
+identification attempt per `ResolveWithPlugins` call, one row per plugin invocation.
+
+A resolution key is not a transaction -- many transactions share one and resolve once --
+so `tx_count` carries the fan-out. `purpose` distinguishes the primary attempt from the
+two the MIC_TICKER against OPENFIGI_SHARE_CLASS mismatch check makes and from underlying
+recursion; those two are currently made with a nil counter and are invisible.
+
+Includes the startup sweep that stamps `incomplete` on runs left without a terminal
+outcome, which is what lets a null outcome mean genuinely in flight. The worker registry
+is unchanged: it keeps live gauges, the run table owns history.

--- a/docs/issues/0117-grafana-container.md
+++ b/docs/issues/0117-grafana-container.md
@@ -1,0 +1,15 @@
+---
+status: open
+title: Grafana container reading the telemetry schema
+milestone: M20
+dependencies: [0115]
+---
+
+Add a Grafana service to the dev stack with its datasource and dashboards provisioned
+from files in the repo, connecting to the `telemetry` schema as the SELECT-only role.
+Bind it to localhost.
+
+Two dashboards over the same tables: one scoped by a run picker, for reading a single
+import during manual testing, and one bucketed over time for drift. Panels select from
+the views and carry no definitions of their own -- `where is_import and reached_plugins`
+rather than a repeated list of excluded outcomes.

--- a/docs/issues/0118-retire-the-redis-counters.md
+++ b/docs/issues/0118-retire-the-redis-counters.md
@@ -1,0 +1,13 @@
+---
+status: open
+title: Retire the Redis counters and the admin telemetry page
+milestone: M20
+dependencies: [0116, 0117]
+---
+
+Remove every defined counter, the `/admin/telemetry` page and the
+`ListTelemetryCounters` RPC behind it. The counter infrastructure in `server/telemetry`
+stays, with no callers, so a counter can be reintroduced without rebuilding it.
+
+Nothing is deleted until the dashboards replacing it are in place, which is what the
+dependencies say.

--- a/docs/issues/milestones.md
+++ b/docs/issues/milestones.md
@@ -19,6 +19,7 @@
 - **M17** - Operational correctness: scheduled corporate-event recompute, single-sourced instrument data, current planner statistics, and configurable deployment.
 - **M18** - One place that says what needs a person's attention, replacing the per-problem admin cards.
 - **M19** - Lots, cost basis and realised gains.
+- **M20** - Telemetry is run-scoped event rows in Postgres read by Grafana, replacing the Redis counters.
 
 ## Unscheduled
 

--- a/docs/spec/telemetry.md
+++ b/docs/spec/telemetry.md
@@ -1,91 +1,187 @@
 # Telemetry
 
-## 1. Counters
+## 1. Events
 
-### Overview
+Telemetry is event rows in a `telemetry` schema in the application database, read
+by a Grafana container through a SELECT-only role. See
+[adr/0053](../adr/0053-telemetry-is-run-scoped-event-rows.md) for why, and for what
+replaced the Redis counters.
 
-- **Storage**: Redis. Use a dedicated key prefix so counters can be discovered and separated from session keys (`portfoliodb:session:`). See **Key naming** below.
-- **Semantics**: Each counter is a Redis key; value is an integer. Increment with `INCR`. No TTL; counters persist until explicitly reset or overwritten.
-- **Discovery**: The admin page must **discover** which counters exist (e.g. `SCAN` or `KEYS` on the counter prefix) and show name + value. No hard-coded list of counter names in the UI.
+One rule governs every table below:
 
-### Key naming
+> One row is one completed unit of work, and carries exactly one outcome drawn from
+> a closed, mutually exclusive vocabulary.
 
-- **Prefix**: `portfoliodb:counters:`
-- **Suffixes**: Human-readable, dot-separated names following the convention `<subsystem>.<subsystem>.<subsystem>.<operation>.<outcome>`. Up to 3 subsystems segments, an optional operation and an outcome.  Full key = prefix + suffix.
-  - **Segment 1 - (n - 2) (subsystem)**: The plugin or server subsystem (e.g. `instruments.resolution.totals`, `instruments.description.openai`, `instruments.identification.openfigi`, `instruments.identification.massive`).
-  - **Segment (n - 1) (operation)**: The specific operation or feature within that subsystem (e.g. `ticker_mapping`, `ticker_search`, `ticker_extraction`, `ticker_metadata`).
-  - **Segment (n) (outcome)**: The specific metric or outcome (e.g. `succeeded`, `failed`, `rate_limit`, `prompt_tokens`).
-- See adr/0009-telemetry-and-logging.md for why counters use this convention.
+Where a row has two outcome columns it is because the unit of work has two sequential
+stages, not because two grains share a row. Counts of one grain are never derived by
+adding counts of another; grains relate by foreign key.
 
-### Admin page
+### Shape
 
-- **Location**: `/admin/telemetry`, linked from the admin sidebar.
-- **Behaviour**: Counters are grouped by their dot-separated name segments into a hierarchical layout:
-  - **Section** (segment 1): Full-width heading for each subsystem. Sections are rendered top-to-bottom.
-  - **Card** (segment 2): Within each section, cards are arranged in a responsive two-column grid.
-  - **Card Heading 1** (segment 3): Within each card are a series of ruled headings separating subsections.
-  - **Card Heading 2** (segment 4): Within each main card heading are a series of indented sub-headings separating subsections.
-  - **Entry** (segment 5): At whatever level we terminate (section, card, card heading 1, card heading 2), leaf counter values are listed with the outcome label and right-aligned numeric value.
-- Counter names and grouping are derived dynamically from the keys discovered in Redis; no hard-coded list of counter names or sections in the UI.
-- **Auth**: Admin-only (same as other admin pages).
+```
+run
+├── resolution_key                     one distinct (source, description, hints)
+│     └── identification_attempt       one ResolveWithPlugins call
+│           └── identifier_plugin_call one plugin invocation
+└── description_plugin_call            one plugin invocation over a batch
+```
 
-### Counters
+`description_plugin_call` hangs off the run rather than off a resolution key: one
+`ExtractBatch` call covers many descriptions at once, so it has no single parent key.
+Identifier plugins are called once per plugin per attempt and do nest. This asymmetry
+is forced by the code and must not be flattened away -- it is what made the counters
+it replaces impossible to add up.
 
-1. **Resolution counters** (server/service/ingestion/resolve.go)
+### run
 
-   - `instruments.resolution.totals.description.extraction_failed` -- description extraction failed; using broker-description-only.
-   - `instruments.resolution.totals.description.plugin_error` -- a description plugin returned an error.
-   - `instruments.resolution.totals.description.no_hints` -- plugins were tried but none returned hints.
-   - `instruments.resolution.totals.description.identifier_mismatch` -- TICKER and OPENFIGI_SHARE_CLASS hints resolved to different instruments.
-   - `instruments.resolution.totals.description.attempts` -- description plugins were invoked for a broker description (increment for each description in a batch).
-   - `instruments.resolution.totals.identify.attempts` -- identifier plugins were invoked for a (source, instrument_description) pair.
+One activation of one subsystem. Created before its children and stamped when it ends.
 
-2. **OpenFIGI outcomes** (server/plugins/openfigi/identifier/openfigi.go)
+| column | notes |
+| --- | --- |
+| `id` | referenced by every event row |
+| `kind` | `tx_import`, `user_archive_import`, `system_archive_import`, `price_job`, `grouping_cycle`, `transfer_match_cycle`, `corporate_event_cycle`, `price_fetch_cycle`, `inflation_cycle` |
+| `job_id` | `ingestion_jobs.id` when the run is a job; null for a cycle |
+| `user_id`, `broker`, `source` | null for cycles |
+| `started_at`, `ended_at` | |
+| `outcome` | `success`, `failed`, `incomplete`; null while in flight |
+| `telemetry_incomplete` | a telemetry write failed, so this run's counts understate |
 
-   - **Mapping**
-     - `instruments.identification.openfigi.mapping.attempts` -- mapping was attempted.
-     - `instruments.identification.openfigi.mapping.succeeded` -- mapping returned at least one result.
-     - `instruments.identification.openfigi.mapping.zero_results` -- mapping returned no results (empty data, no API error).
-     - `instruments.identification.openfigi.mapping.rate_limit` -- HTTP 429.
-     - `instruments.identification.openfigi.mapping.failed` -- any other error (non-200, API error message, etc.).
+`incomplete` means the run died. It is stamped by a sweep at service startup over runs
+with no terminal outcome, which is what lets a null outcome mean genuinely running now.
+`telemetry_incomplete` is unrelated to it: the work may have succeeded while its
+telemetry was lost, and a panel should mark such a run rather than trust its counts.
 
-   - **Search**
-     - `instruments.identification.openfigi.search.attempts` -- search was attempted.
-     - `instruments.identification.openfigi.search.succeeded` -- search returned at least one result.
-     - `instruments.identification.openfigi.search.zero_results` -- search returned no results.
-     - `instruments.identification.openfigi.search.rate_limit` -- HTTP 429.
-     - `instruments.identification.openfigi.search.failed` -- any other error.
+### resolution_key
 
-   **Placement**: In `server/plugins/openfigi/identifier/openfigi.go`, after each `Mapping` and `Search` call, increment the appropriate counter. The plugin receives a **counter interface** (injected by the server); it does not depend on Redis directly.
+One distinct `(source, instrument_description, identifier hints)` triple within a run --
+the thing `cacheKeyWithHints` names. **Not** one transaction: many transactions share a
+key and resolve once. A cache hit is not an outcome, because it is not a resolution;
+`tx_count` records the fan-out instead, so a failure affecting 300 rows can be told from
+one affecting 1.
 
-3. **OpenAI description plugin** (server/plugins/openai/description/plugin.go)
+| column | notes |
+| --- | --- |
+| `run_id`, `source`, `description` | |
+| `tx_count` | transactions sharing this key |
+| `had_identifier_hints`, `security_type_hint`, `instrument_kind` | lets a spike be attributed rather than merely noticed |
+| `extraction_outcome` | stage 1, below |
+| `outcome` | stage 2, below |
+| `mismatch_detected` | MIC_TICKER and OPENFIGI_SHARE_CLASS resolved differently |
+| `instrument_id` | null when unresolved |
 
-   - `instruments.description.openai.ticker_extraction.attempted` -- total ticker extractions attempted across all batches (eg. sum of tickers in all batches).
-   - `instruments.description.openai.ticker_extraction.succeeded` -- total ticker extractions that succeeded across all batches (eg. sum of tickers in all batches).
-   - `instruments.description.openai.ticker_extraction.failed` -- total ticker extractions that failed across all batches (eg. sum of tickers in all batches).
-   - `instruments.description.openai.ticker_extraction.model_not_found` -- model not found error (404 or model_not_found).
-   - `instruments.description.openai.ticker_extraction.quota_exceeded` -- quota exceeded error (429 or insufficient_quota).
-   - `instruments.description.openai.ticker_extraction.prompt_tokens` -- prompt token count (uses IncrBy).
-   - `instruments.description.openai.ticker_extraction.completion_tokens` -- completion token count (uses IncrBy).
-   - `instruments.description.openai.ticker_extraction.total_tokens` -- total token count (uses IncrBy).
+`extraction_outcome`: `hints_found`, `no_hints`, `not_attempted_db_hit`,
+`not_attempted_hints_supplied`, `not_attempted_type_filter`, `not_attempted_no_plugins`.
+The `not_attempted_*` members are where skips live. Extraction is skipped for a
+description already resolved by DB lookup, and for one whose every posting names an
+identifier, because extraction exists to find an identifier and is a paid call.
 
-4. **Massive.com plugin** (server/plugins/massive/client/client.go)
+`outcome`: `db_source_description`, `db_identifier_hints`, `identified`,
+`broker_description_only`, `extraction_failed`, `plugin_timeout`, `plugin_unavailable`,
+`conflicting_hints`. The two `db_*` members are distinct lookups -- by stored
+`(source, description)` and by supplied identifier hints -- and conflating them hides
+which path is carrying an import. The three fallback members mirror the messages the
+resolver already records against a row.
 
-   - `instruments.identification.massive.request.succeeded` -- successful API request.
-   - `instruments.identification.massive.request.failed` -- any error (network, status code, decode).
-   - `instruments.identification.massive.request.rate_limit` -- HTTP 429.
+`mismatch_detected` is a flag rather than an outcome. Resolution continues and succeeds
+using MIC_TICKER, so a mismatch is not a terminal state, and modelling it as one would
+make the outcome column non-exhaustive.
 
-### Counter interface (injected into plugins)
+### identification_attempt
 
-- Plugins must **not** depend on Redis. The server injects a small counter interface so that plugins can report metrics without importing Redis or the telemetry implementation (see adr/0009-telemetry-and-logging.md).
-- **Interface**: A single method, e.g. `Incr(name string)` or `Incr(ctx, name string)`, where `name` is the counter suffix (e.g. `instruments.identification.openfigi.mapping.succeeded`). The implementation (in the server or a shared telemetry package) prepends `portfoliodb:counters:` and calls Redis `INCR`.
-- **Wiring**: When the server constructs or invokes plugins (e.g. identifier registry, ingestion worker), it passes an implementation of this interface. The ingestion worker also receives an implementation (backed by the same Redis client) for `instruments.resolution.totals.identify.attempts`. The OpenFIGI plugin receives the interface and calls it from `openfigi.go` after each Mapping/Search.
+One `ResolveWithPlugins` call. A single resolution key produces several: one `primary`,
+two more when the mismatch check runs, and one per level of underlying recursion.
 
-### API for the admin page
+| column | notes |
+| --- | --- |
+| `resolution_key_id` | |
+| `purpose` | `primary`, `mismatch_check`, `underlying` |
+| `depth` | recursion depth; 0 for the first call |
+| `outcome` | `db_short_circuit`, `no_eligible_plugins`, `identified`, `not_identified`, `plugin_timeout`, `plugin_error` |
+| `security_type_hint`, `asset_class`, `had_identifier_hints` | |
 
-- New gRPC (or HTTP) admin-only method that returns a list of `{ name, value }` by scanning Redis for `portfoliodb:counters:*`. Counter names shown in the UI are the key suffixes (the part after the prefix).
+A plugin filtered out by acceptable kind or security type produces no
+`identifier_plugin_call` row, because no call was made. When that filter removes every
+plugin the attempt records `no_eligible_plugins`.
 
----
+### identifier_plugin_call
+
+One plugin invocation within an attempt.
+
+| column | notes |
+| --- | --- |
+| `identification_attempt_id`, `plugin_id` | |
+| `outcome` | `won`, `superseded`, `discarded_inconsistent`, `not_identified`, `rate_limited`, `timeout`, `error`, `skipped_expired` |
+| `retries`, `duration_ms` | |
+
+The first three are all successes and are decided by the orchestrator after every plugin
+has returned: `superseded` lost to a better hint match despite higher precedence, and
+`discarded_inconsistent` was dropped as contradicting the winner. A plugin cannot know
+either, which is why the plugin returns its transport outcome and the orchestrator
+composes the row.
+
+### description_plugin_call
+
+One plugin invocation over a batch.
+
+| column | notes |
+| --- | --- |
+| `run_id`, `plugin_id` | |
+| `batch_size` | items passed to this plugin, after the type filter |
+| `items_with_hints` | items it returned hints for |
+| `outcome` | `hints_returned`, `no_hints`, `error`, `rate_limited`, `quota_exceeded`, `model_not_found` |
+| `prompt_tokens`, `completion_tokens`, `total_tokens` | null for plugins with no token cost |
+| `duration_ms` | |
+
+Description plugins run in precedence order and each sees only the items its
+predecessors failed on, so `batch_size` is a different population per plugin and rates
+are not comparable between them. Identifier plugins run in parallel and every eligible
+plugin is called, so those rates are comparable. Tokens are columns rather than running
+totals, which is what makes the cost of one import answerable.
+
+### Views
+
+One view per table, each flattening its parents in and never fanning out into its
+children -- a view spanning two sibling grains duplicates the parent's rows and makes
+counting it silently wrong.
+
+Judgements are computed columns on the view; selection belongs to the panel. At least:
+
+- `is_import` -- the run kind is one of the three import kinds.
+- `reached_plugins` -- the attempt outcome is neither `db_short_circuit` nor
+  `no_eligible_plugins`.
+
+`reached_plugins` is the denominator for identification failure rate. Using all attempts
+instead makes the rate fall as the instrument table fills, because more resolutions
+short-circuit in the database, which reads as improving identification when nothing has
+changed. A failure-rate panel filters `purpose = 'primary'` as well, or an import
+carrying more dual-hint descriptions inflates the denominator with mismatch-check
+attempts.
+
+### Writing
+
+Writes are synchronous, through a connection pool separate from the application's, and
+confined to `server/db` as all SQL is. They never join the work's transaction: a failed
+import rolls back, and telemetry riding along would erase the diagnostics for the run
+most worth inspecting. A write that fails sets `telemetry_incomplete` on the run and is
+otherwise ignored -- telemetry never fails the work.
+
+Plugins do not write. `Identify` and `ExtractBatch` return a telemetry value alongside
+their result and the orchestrator composes the row, so no plugin depends on the
+telemetry backend or needs a database to unit test.
+
+### Retention
+
+Plain tables, not hypertables: the volume does not warrant Timescale, and foreign keys
+into a hypertable are an avoidable complication. Children cascade from `run`, so
+retention is a delete over `run.started_at`, at **360 days**. Traffic is low and a
+problem may go unnoticed for a long time, so the window is set to outlast the gap
+between a regression landing and someone looking for it.
+
+The schema, its tables, its views and the SELECT-only grants live in
+`server/migrations/005_telemetry.sql`, separate from the application schema because it is
+a separate scope rather than a later change to the same one. The reading role's password
+is not in the migration: the role is created at container init from compose
+environment.
 
 ## 2. Logger
 


### PR DESCRIPTION
Design only -- no code. Adds an ADR, rewrites the counters half of the telemetry spec, and opens the issues that implement it.

## Why

The Redis counters are not interpretable. `instruments.resolution.totals.description.attempts` is incremented once per batch item, `...no_hints` once per batch and `...plugin_error` once per plugin per batch -- three grains in one namespace, so no two can be added, subtracted or divided. Nothing says whether a pair of counters partitions a population or overlaps it, and nothing is attributable: having imported a file, there is no way to ask what happened during that import.

## What replaces them

Event rows in a `telemetry` schema in the application database, read by a Grafana container through a SELECT-only role. One rule governs every table:

> One row is one completed unit of work, and carries exactly one outcome drawn from a closed, mutually exclusive vocabulary.

Grains relate by foreign key, not by arithmetic. Asking whether buckets sum was forced by Redis having nothing but scalars.

```
run
├── resolution_key                     one distinct (source, description, hints)
│     └── identification_attempt       one ResolveWithPlugins call
│           └── identifier_plugin_call one plugin invocation
└── description_plugin_call            one plugin invocation over a batch
```

Points worth reviewing specifically:

- **A run is the unit everything hangs off**, of which an ingestion job and a worker cycle are two kinds. Keyed on `job_id` instead, the corporate-events cycle's identification work would be parentless and invisible. An RPC request is deliberately not a kind of run -- no handler does substantial synchronous work, and the SPA's polling would swamp the table.
- **Resolution is measured per distinct (source, description, hints) triple, not per transaction.** Many transactions share one and resolve once, so per-transaction the chart is dominated by cache hits and whether a row lands in "db match" or "cache hit" is decided only by which row came first. `tx_count` carries the fan-out so a failure affecting 300 rows is still distinguishable from one affecting 1.
- **`description_plugin_call` hangs off the run, not off a resolution key.** One `ExtractBatch` covers many descriptions. Identifier plugins are called once per plugin per attempt and do nest. Flattening that asymmetry is what made the counters unaddable.
- **`mismatch_detected` is a flag, not an outcome.** Resolution continues and succeeds on MIC_TICKER, so modelling it as terminal would leave the outcome column non-exhaustive.
- **`reached_plugins` is the failure-rate denominator.** Using all attempts makes the rate fall as the instrument table fills, because more resolutions short-circuit in the database -- which reads as improving identification when nothing has changed.
- **Plugins return telemetry rather than incrementing counters.** A plugin-call row needs the plugin's transport outcome and the orchestrator's selection outcome (`won` / `superseded` / `discarded_inconsistent`, decided after every plugin has returned), and neither party can know the other's. Plugins consequently stop depending on the telemetry backend at all, which is a stronger version of what ADR 0009 was reaching for.
- **Telemetry never joins the work's transaction.** A failed import rolls back, and telemetry riding along would erase the diagnostics for the run most worth inspecting.

## Contents

- `docs/adr/0053-telemetry-is-run-scoped-event-rows.md` -- supersedes the counters half of ADR 0009; its logging half stands.
- `docs/spec/telemetry.md` -- section 1 rewritten as the event model (tables, outcome vocabularies, views, write rules, 360-day retention). Section 2 (logger) untouched.
- Issues 0114-0118 under a new milestone M20. 0114 and 0115 are independent; 0118 deletes nothing until the dashboards replacing it exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)