### PR TITLE
Description plugins return telemetry rather than incrementing counters (0114)

### DIFF
--- a/docs/layout.md
+++ b/docs/layout.md
@@ -92,7 +92,7 @@ Go code for the PortfolioDB backend: one main service binary, DB abstraction, an
 - **server/db/**  
   Database abstraction layer. All SQL and Postgres/TimescaleDB access lives here. Rest of the server uses this layer only (no raw SQL elsewhere), so that non-DB code can be unit tested with mocks.
 - **server/identifier/**  
-  Instrument identification plugin API: interface (e.g. `Identify(ctx, config, broker, source, instrument_description, hints...)`), canonical types (Instrument, Identifier with optional domain), and plugin registry. Plugin implementations live under `server/plugins/<datasource>/identifier`. The **server/identifier/description** subpackage defines the description plugin interface (`Extract(...)` returning identifier hints) and registry; config is stored in the **description_plugin_config** table (enabled, precedence, config JSONB).
+  Instrument identification plugin API: interface (e.g. `Identify(ctx, config, broker, source, instrument_description, hints...)`), canonical types (Instrument, Identifier with optional domain), and plugin registry. Plugin implementations live under `server/plugins/<datasource>/identifier`. The **server/identifier/description** subpackage defines the description plugin interface (`ExtractBatch(...)` returning identifier hints and the call's telemetry) and registry; config is stored in the **description_plugin_config** table (enabled, precedence, config JSONB).
 - **server/migrations/**  
   SQL migrations for the Postgres/TimescaleDB datamodel. Industry-standard migrations pattern. Plugin-owned migrations (e.g. reference tables) live in the plugin directory (eg. `server/plugins/<datasource>/identifier/migrations`).
 - **server/plugins/&lt;datasource&gt;/identifier**  

--- a/server/cmd/portfoliodb/main.go
+++ b/server/cmd/portfoliodb/main.go
@@ -224,7 +224,7 @@ func main() {
 		log.Fatalf("ensure identifier plugin configs: %v", err)
 	}
 	descRegistry := description.NewRegistry()
-	descRegistry.Register(openaidesc.PluginID, openaidesc.NewPlugin(counter, logger.WithCategory(serverLogger, "server/plugins/openai"), newDescriptionHTTPClient()))
+	descRegistry.Register(openaidesc.PluginID, openaidesc.NewPlugin(logger.WithCategory(serverLogger, "server/plugins/openai"), newDescriptionHTTPClient()))
 	descRegistry.Register(cashdesc.PluginID, cashdesc.NewPlugin())
 	if err := ensurePluginConfigs(context.Background(), database, db.PluginCategoryDescription, descRegistry.ListIDs(), func(id string) []byte {
 		if p := descRegistry.Get(id); p != nil {

--- a/server/identifier/description/doc.go
+++ b/server/identifier/description/doc.go
@@ -16,18 +16,29 @@
 //
 // # ExtractBatch contract
 //
-// The caller invokes enabled plugins in series by descending precedence. The
-// first plugin that returns at least one hint for any item wins; remaining
-// plugins are not called. Each plugin receives config JSON, broker, source, and
-// a slice of [BatchItem] (one per instrument description to extract).
+// The caller invokes enabled plugins in series by descending precedence. Each
+// plugin sees only the items its predecessors failed to extract hints for, so
+// a later plugin is called with the remainder rather than not at all. Each
+// plugin receives config JSON, broker, source, and a slice of [BatchItem] (one
+// per instrument description to extract).
 //
 // Return values:
-//   - (map[BatchItem.ID][]Identifier, nil) on success. The map is keyed by
-//     [BatchItem.ID]; items with no extractable hints may be absent or have an
-//     empty slice.
-//   - (nil, nil) or an empty map when nothing could be extracted.
-//   - (nil, error) on failure (API error, timeout, etc.). The caller logs the
-//     error, increments a plugin_error counter, and tries the next plugin.
+//   - ([Result] with Hints, nil) on success. Hints is keyed by [BatchItem.ID];
+//     items with no extractable hints may be absent or have an empty slice.
+//   - ([Result] with empty Hints, nil) when nothing could be extracted.
+//   - ([Result], error) on failure (API error, timeout, etc.). The caller logs
+//     the error and tries the next plugin.
+//
+// # Telemetry
+//
+// Set [Result.Telemetry] on every return path, errors included. [Outcome] says
+// how the call went, and [Telemetry.Tokens] carries what the call cost, which
+// is what makes the cost of one import answerable. A failure the plugin
+// absorbs -- returning no hints and no error -- must still be reported as the
+// failure it was, or it is indistinguishable from finding nothing. Leave the
+// batch size and the count of items with hints to the caller: it knows both. A
+// plugin never writes telemetry itself and never depends on the telemetry
+// backend.
 //
 // Returned identifiers must have a Type from [identifier.AllowedIdentifierTypes];
 // the caller filters out invalid types at debug log level.
@@ -37,8 +48,9 @@
 // Description plugins extract hints; they do not produce canonical instrument
 // data. They must not access the database. They support native batching via
 // ExtractBatch (identifier plugins process one item at a time). Description
-// plugins are called in series (first wins); identifier plugins are called
-// concurrently with results merged by precedence.
+// plugins are called in series, each on what the previous ones left
+// unresolved; identifier plugins are called concurrently with results merged
+// by precedence.
 //
 // # Security type filtering
 //

--- a/server/identifier/description/plugin.go
+++ b/server/identifier/description/plugin.go
@@ -6,6 +6,51 @@ import (
 	"github.com/leedenison/portfoliodb/server/identifier"
 )
 
+// Outcome is how one ExtractBatch call went. It is the whole of a description
+// plugin call's outcome: unlike identifier plugins, description plugins run in
+// series and the caller adds nothing to what the plugin reports.
+type Outcome string
+
+const (
+	// OutcomeHintsReturned means the plugin extracted hints for at least one item.
+	OutcomeHintsReturned Outcome = "hints_returned"
+	// OutcomeNoHints means the call succeeded and extracted nothing.
+	OutcomeNoHints Outcome = "no_hints"
+	// OutcomeError covers transport, decoding and API errors.
+	OutcomeError Outcome = "error"
+	// OutcomeRateLimited means the upstream service refused the call as too frequent.
+	OutcomeRateLimited Outcome = "rate_limited"
+	// OutcomeQuotaExceeded means the account has no quota left.
+	OutcomeQuotaExceeded Outcome = "quota_exceeded"
+	// OutcomeModelNotFound means the configured model does not exist.
+	OutcomeModelNotFound Outcome = "model_not_found"
+)
+
+// Usage is the token cost of one call, summed over the chunks a plugin split
+// the batch into. Nil for plugins that cost no tokens, which is what keeps the
+// token columns null rather than zero for them.
+type Usage struct {
+	PromptTokens     int64
+	CompletionTokens int64
+	TotalTokens      int64
+}
+
+// Telemetry is what only the plugin knows about one ExtractBatch call. The
+// batch size and the number of items that came back with hints are the
+// caller's to count.
+type Telemetry struct {
+	Outcome Outcome
+	Tokens  *Usage
+}
+
+// Result is what ExtractBatch returns. Hints is keyed by BatchItem.ID; items
+// with nothing extractable may be absent or carry an empty slice. Telemetry is
+// populated on every path, including the error paths.
+type Result struct {
+	Hints     map[string][]identifier.Identifier
+	Telemetry Telemetry
+}
+
 // BatchItem is one item for batch extraction. ID is a short stable key (e.g. hash) used to match responses.
 type BatchItem struct {
 	ID                    string
@@ -30,8 +75,9 @@ type Plugin interface {
 	AcceptableSecurityTypes() map[string]bool
 
 	// ExtractBatch runs extraction on all items. config is the plugin's JSON config (may be nil).
-	// Result map is keyed by BatchItem.ID. Returns (nil, nil) or empty map when nothing could be extracted; no DB access.
-	ExtractBatch(ctx context.Context, config []byte, broker, source string, items []BatchItem) (map[string][]identifier.Identifier, error)
+	// Returns a Result whose Hints are keyed by BatchItem.ID, empty when nothing could be extracted; no DB access.
+	// Result.Telemetry is set on every path and is the plugin's contribution to the description_plugin_call row the caller writes.
+	ExtractBatch(ctx context.Context, config []byte, broker, source string, items []BatchItem) (Result, error)
 
 	// DefaultConfig returns the plugin's default config JSON. The server calls this on startup when no row exists.
 	DefaultConfig() []byte

--- a/server/plugins/cash/description/plugin.go
+++ b/server/plugins/cash/description/plugin.go
@@ -41,7 +41,7 @@ func (p *Plugin) AcceptableSecurityTypes() map[string]bool {
 }
 
 // ExtractBatch returns one CURRENCY identifier per item when Hints.Currency is set (from tx.trading_currency).
-func (p *Plugin) ExtractBatch(ctx context.Context, config []byte, broker, source string, items []descpkg.BatchItem) (map[string][]identifier.Identifier, error) {
+func (p *Plugin) ExtractBatch(ctx context.Context, config []byte, broker, source string, items []descpkg.BatchItem) (descpkg.Result, error) {
 	out := make(map[string][]identifier.Identifier)
 	for _, item := range items {
 		code := strings.ToUpper(strings.TrimSpace(item.Hints.Currency))
@@ -50,8 +50,9 @@ func (p *Plugin) ExtractBatch(ctx context.Context, config []byte, broker, source
 		}
 		out[item.ID] = []identifier.Identifier{{Type: "CURRENCY", Domain: "", Value: code}}
 	}
+	// Tokens stay nil: the currency comes off the transaction, at no cost.
 	if len(out) == 0 {
-		return nil, nil
+		return descpkg.Result{Telemetry: descpkg.Telemetry{Outcome: descpkg.OutcomeNoHints}}, nil
 	}
-	return out, nil
+	return descpkg.Result{Hints: out, Telemetry: descpkg.Telemetry{Outcome: descpkg.OutcomeHintsReturned}}, nil
 }

--- a/server/plugins/cash/description/plugin_test.go
+++ b/server/plugins/cash/description/plugin_test.go
@@ -14,14 +14,17 @@ func TestPlugin_ExtractBatch_ReturnsCurrency(t *testing.T) {
 	items := []descpkg.BatchItem{
 		{ID: "1", InstrumentDescription: "USD Cash", Hints: identifier.Hints{Currency: "USD", SecurityTypeHint: identifier.SecurityTypeHintCash}},
 	}
-	out, err := p.ExtractBatch(ctx, nil, "IBKR", "IBKR:test", items)
+	res, err := p.ExtractBatch(ctx, nil, "IBKR", "IBKR:test", items)
 	if err != nil {
 		t.Fatalf("ExtractBatch: %v", err)
 	}
-	if out == nil {
-		t.Fatal("expected non-nil map")
+	if res.Telemetry.Outcome != descpkg.OutcomeHintsReturned {
+		t.Errorf("Telemetry.Outcome = %q, want %q", res.Telemetry.Outcome, descpkg.OutcomeHintsReturned)
 	}
-	hints := out["1"]
+	if res.Telemetry.Tokens != nil {
+		t.Errorf("Telemetry.Tokens = %+v, want nil for a plugin with no token cost", res.Telemetry.Tokens)
+	}
+	hints := res.Hints["1"]
 	if len(hints) != 1 {
 		t.Fatalf("expected 1 hint, got %d", len(hints))
 	}
@@ -36,12 +39,12 @@ func TestPlugin_ExtractBatch_NormalizesCurrencyCode(t *testing.T) {
 	items := []descpkg.BatchItem{
 		{ID: "1", Hints: identifier.Hints{Currency: "  usd  ", SecurityTypeHint: identifier.SecurityTypeHintCash}},
 	}
-	out, err := p.ExtractBatch(ctx, nil, "", "", items)
+	res, err := p.ExtractBatch(ctx, nil, "", "", items)
 	if err != nil {
 		t.Fatalf("ExtractBatch: %v", err)
 	}
-	if out["1"][0].Value != "USD" {
-		t.Errorf("Value = %q, want USD", out["1"][0].Value)
+	if res.Hints["1"][0].Value != "USD" {
+		t.Errorf("Value = %q, want USD", res.Hints["1"][0].Value)
 	}
 }
 
@@ -51,12 +54,15 @@ func TestPlugin_ExtractBatch_EmptyCurrency_ReturnsNothing(t *testing.T) {
 	items := []descpkg.BatchItem{
 		{ID: "1", Hints: identifier.Hints{SecurityTypeHint: identifier.SecurityTypeHintCash}},
 	}
-	out, err := p.ExtractBatch(ctx, nil, "", "", items)
+	res, err := p.ExtractBatch(ctx, nil, "", "", items)
 	if err != nil {
 		t.Fatalf("ExtractBatch: %v", err)
 	}
-	if len(out) > 0 {
-		t.Errorf("expected nil or empty map when Currency empty, got %+v", out)
+	if len(res.Hints) > 0 {
+		t.Errorf("expected no hints when Currency empty, got %+v", res.Hints)
+	}
+	if res.Telemetry.Outcome != descpkg.OutcomeNoHints {
+		t.Errorf("Telemetry.Outcome = %q, want %q", res.Telemetry.Outcome, descpkg.OutcomeNoHints)
 	}
 }
 

--- a/server/plugins/openai/description/integration_test.go
+++ b/server/plugins/openai/description/integration_test.go
@@ -63,7 +63,7 @@ func TestIntegration_OpenAI_ExtractBatch(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			_, httpClient := vcr.New(t, tc.cassette, vcr.SanitizeAll, "openai/description")
 
-			p := NewPlugin(nil, nil, httpClient)
+			p := NewPlugin(nil, httpClient)
 			cfg, err := json.Marshal(configJSON{
 				OpenAIAPIKey: apiKey,
 				OpenAIModel:  "gpt-4o-mini",
@@ -72,7 +72,7 @@ func TestIntegration_OpenAI_ExtractBatch(t *testing.T) {
 				t.Fatalf("marshal config: %v", err)
 			}
 
-			out, err := p.ExtractBatch(
+			res, err := p.ExtractBatch(
 				context.Background(),
 				cfg,
 				"test-broker",
@@ -84,7 +84,7 @@ func TestIntegration_OpenAI_ExtractBatch(t *testing.T) {
 			}
 
 			for id, wantType := range tc.wantType {
-				ids, ok := out[id]
+				ids, ok := res.Hints[id]
 				if !ok {
 					t.Errorf("missing result for id %q", id)
 					continue

--- a/server/plugins/openai/description/plugin.go
+++ b/server/plugins/openai/description/plugin.go
@@ -9,23 +9,10 @@ import (
 
 	"github.com/leedenison/portfoliodb/server/identifier"
 	descpkg "github.com/leedenison/portfoliodb/server/identifier/description"
-	"github.com/leedenison/portfoliodb/server/telemetry"
 )
 
 // PluginID is the stable plugin_id for registration and description_plugin_config.
 const PluginID = "openai"
-
-// Counter names (prefixed by telemetry in production).
-const (
-	CounterAttempted        = "instruments.description.openai.ticker_extraction.attempted"
-	CounterSucceeded        = "instruments.description.openai.ticker_extraction.succeeded"
-	CounterFailed           = "instruments.description.openai.ticker_extraction.failed"
-	CounterModelNotFound    = "instruments.description.openai.ticker_extraction.model_not_found"
-	CounterQuotaExceeded    = "instruments.description.openai.ticker_extraction.quota_exceeded"
-	CounterPromptTokens     = "instruments.description.openai.ticker_extraction.prompt_tokens"
-	CounterCompletionTokens = "instruments.description.openai.ticker_extraction.completion_tokens"
-	CounterTotalTokens      = "instruments.description.openai.ticker_extraction.total_tokens"
-)
 
 // configJSON is the shape of the plugin's config from description_plugin_config.config.
 type configJSON struct {
@@ -40,14 +27,13 @@ type configJSON struct {
 type Plugin struct {
 	client     *Client
 	config     configJSON
-	counter    telemetry.CounterIncrementer
 	log        *slog.Logger
 	httpClient *http.Client
 }
 
-// NewPlugin returns a new description plugin. Counter and log are optional (nil for tests); when set, model-not-found and quota-exceeded errors are logged and counted.
-func NewPlugin(counter telemetry.CounterIncrementer, log *slog.Logger, httpClient *http.Client) *Plugin {
-	return &Plugin{counter: counter, log: log, httpClient: httpClient}
+// NewPlugin returns a new description plugin. log is optional (nil for tests); when set, model-not-found and quota-exceeded errors are logged.
+func NewPlugin(log *slog.Logger, httpClient *http.Client) *Plugin {
+	return &Plugin{log: log, httpClient: httpClient}
 }
 
 // DisplayName returns a human-readable name for the plugin.
@@ -89,16 +75,20 @@ func (p *Plugin) AcceptableSecurityTypes() map[string]bool {
 }
 
 // ExtractBatch implements descpkg.Plugin. Chunks items into groups of 50 and calls the API per chunk; merges results keyed by ID.
-func (p *Plugin) ExtractBatch(ctx context.Context, config []byte, broker, source string, items []descpkg.BatchItem) (map[string][]identifier.Identifier, error) {
+// An API failure is absorbed -- no hints and no error, so the caller moves on to the next plugin -- and reported as the outcome it was.
+func (p *Plugin) ExtractBatch(ctx context.Context, config []byte, broker, source string, items []descpkg.BatchItem) (descpkg.Result, error) {
 	var cfg configJSON
 	if len(config) > 0 {
 		if err := json.Unmarshal(config, &cfg); err != nil {
-			return nil, err
+			return result(nil, descpkg.OutcomeError, nil), err
 		}
 	}
 	p.config = cfg
 	if cfg.OpenAIAPIKey == "" {
-		return nil, nil
+		// Enabled but unconfigured: no call was made and none could be. It is
+		// an error rather than an empty answer, or a plugin nobody finished
+		// setting up reads as one that never finds anything.
+		return result(nil, descpkg.OutcomeError, nil), nil
 	}
 	p.client = NewClient(cfg.OpenAIAPIKey, cfg.OpenAIModel, cfg.OpenAIBaseURL, cfg.BatchChunkSize, cfg.MaxCompletionTokens, p.httpClient)
 	clientItems := make([]BatchItemForClient, len(items))
@@ -109,23 +99,15 @@ func (p *Plugin) ExtractBatch(ctx context.Context, config []byte, broker, source
 			TypeHint:    items[i].Hints.SecurityTypeHint,
 		}
 	}
-	if p.counter != nil {
-		p.counter.IncrBy(ctx, CounterAttempted, int64(len(items)))
-	}
 	byID, usage, err := p.client.NormalizeDescriptionsBatch(ctx, clientItems)
 	if err != nil {
-		if p.counter != nil {
-			p.counter.IncrBy(ctx, CounterFailed, int64(len(items)))
-		}
+		outcome := descpkg.OutcomeError
 		for _, item := range items {
-			p.handleOpenAIError(ctx, item.InstrumentDescription, err)
+			if o := p.handleOpenAIError(ctx, item.InstrumentDescription, err); o != descpkg.OutcomeError {
+				outcome = o
+			}
 		}
-		return nil, nil
-	}
-	if p.counter != nil && usage != nil {
-		p.counter.IncrBy(ctx, CounterPromptTokens, usage.PromptTokens)
-		p.counter.IncrBy(ctx, CounterCompletionTokens, usage.CompletionTokens)
-		p.counter.IncrBy(ctx, CounterTotalTokens, usage.TotalTokens)
+		return result(nil, outcome, nil), nil
 	}
 	out := make(map[string][]identifier.Identifier)
 	for id, norm := range byID {
@@ -138,40 +120,58 @@ func (p *Plugin) ExtractBatch(ctx context.Context, config []byte, broker, source
 			out[id] = []identifier.Identifier{{Type: "MIC_TICKER", Domain: "", Value: norm.Ticker}}
 		}
 	}
-	if p.counter != nil {
-		succeeded := int64(len(out))
-		failed := int64(len(items)) - succeeded
-		p.counter.IncrBy(ctx, CounterSucceeded, succeeded)
-		if failed > 0 {
-			p.counter.IncrBy(ctx, CounterFailed, failed)
-		}
+	outcome := descpkg.OutcomeNoHints
+	if len(out) > 0 {
+		outcome = descpkg.OutcomeHintsReturned
 	}
-	return out, nil
+	return result(out, outcome, usage), nil
 }
 
-// handleOpenAIError logs and increments path-specific counters for model-not-found and quota-exceeded errors.
-func (p *Plugin) handleOpenAIError(ctx context.Context, instrumentDescription string, err error) {
-	if p.log == nil && p.counter == nil {
-		return
+// result assembles the extraction and the telemetry for the call. usage may be
+// nil, in which case the call cost no tokens the plugin could observe.
+func result(hints map[string][]identifier.Identifier, outcome descpkg.Outcome, usage *Usage) descpkg.Result {
+	res := descpkg.Result{Hints: hints, Telemetry: descpkg.Telemetry{Outcome: outcome}}
+	if usage != nil {
+		res.Telemetry.Tokens = &descpkg.Usage{
+			PromptTokens:     usage.PromptTokens,
+			CompletionTokens: usage.CompletionTokens,
+			TotalTokens:      usage.TotalTokens,
+		}
 	}
+	return res
+}
+
+// handleOpenAIError logs the errors worth naming and classifies one into the
+// outcome vocabulary. Returns OutcomeError for anything it does not recognise.
+func (p *Plugin) handleOpenAIError(ctx context.Context, instrumentDescription string, err error) descpkg.Outcome {
 	errStr := err.Error()
 	if isOpenAIModelNotFound(errStr) {
 		if p.log != nil {
 			p.log.ErrorContext(ctx, "OpenAI description plugin: model not found", "instrument_description", instrumentDescription, "err", err)
 		}
-		if p.counter != nil {
-			p.counter.Incr(ctx, CounterModelNotFound)
+		return descpkg.OutcomeModelNotFound
+	}
+	if isOpenAIRateLimited(errStr) {
+		if p.log != nil {
+			p.log.ErrorContext(ctx, "OpenAI description plugin: rate limited", "instrument_description", instrumentDescription, "err", err)
 		}
-		return
+		return descpkg.OutcomeRateLimited
 	}
 	if isOpenAIQuotaExceeded(errStr) {
 		if p.log != nil {
 			p.log.ErrorContext(ctx, "OpenAI description plugin: quota exceeded", "instrument_description", instrumentDescription, "err", err)
 		}
-		if p.counter != nil {
-			p.counter.Incr(ctx, CounterQuotaExceeded)
-		}
+		return descpkg.OutcomeQuotaExceeded
 	}
+	return descpkg.OutcomeError
+}
+
+// isOpenAIRateLimited matches the rate limit OpenAI reports with the same 429
+// it uses for an exhausted quota, so it is checked by the body marker and
+// tried before the quota test.
+func isOpenAIRateLimited(errStr string) bool {
+	s := strings.ToLower(errStr)
+	return strings.Contains(s, "rate_limit_exceeded") || strings.Contains(s, "rate limit")
 }
 
 func isOpenAIModelNotFound(errStr string) bool {

--- a/server/plugins/openai/description/plugin_test.go
+++ b/server/plugins/openai/description/plugin_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/leedenison/portfoliodb/server/identifier"
 	descpkg "github.com/leedenison/portfoliodb/server/identifier/description"
-	"github.com/leedenison/portfoliodb/server/telemetry"
 )
 
 func TestIsOpenAIModelNotFound(t *testing.T) {
@@ -52,56 +51,42 @@ func TestIsOpenAIQuotaExceeded(t *testing.T) {
 	}
 }
 
-// recordingCounter records the last counter name passed to Incr.
-type recordingCounter struct {
-	last string
+func TestHandleOpenAIError_Classifies(t *testing.T) {
+	ctx := context.Background()
+	p := NewPlugin(slog.Default(), http.DefaultClient)
+
+	tests := []struct {
+		name string
+		err  string
+		want descpkg.Outcome
+	}{
+		{name: "model not found", err: "openai 404: model not found", want: descpkg.OutcomeModelNotFound},
+		{name: "quota exceeded", err: "openai 429: insufficient_quota", want: descpkg.OutcomeQuotaExceeded},
+		// Both arrive as 429; only the body marker tells them apart.
+		{name: "rate limited", err: "openai 429: rate_limit_exceeded", want: descpkg.OutcomeRateLimited},
+		{name: "other", err: "openai 500: internal server error", want: descpkg.OutcomeError},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := p.handleOpenAIError(ctx, "INRG", &errWithMessage{tc.err})
+			if got != tc.want {
+				t.Errorf("handleOpenAIError(%q) = %q, want %q", tc.err, got, tc.want)
+			}
+		})
+	}
 }
 
-func (r *recordingCounter) Incr(_ context.Context, name string) { r.last = name }
-
-func (r *recordingCounter) IncrBy(_ context.Context, name string, _ int64) { r.last = name }
-
-func TestHandleOpenAIError_IncrementsCounters(t *testing.T) {
-	ctx := context.Background()
-
-	t.Run("model not found", func(t *testing.T) {
-		c := &recordingCounter{}
-		p := NewPlugin(c, slog.Default(), http.DefaultClient)
-		p.handleOpenAIError(ctx, "INRG", &errWithMessage{"openai 404: model not found"})
-		if c.last != CounterModelNotFound {
-			t.Errorf("counter = %q, want %q", c.last, CounterModelNotFound)
-		}
-	})
-
-	t.Run("quota exceeded", func(t *testing.T) {
-		c := &recordingCounter{}
-		p := NewPlugin(c, slog.Default(), http.DefaultClient)
-		p.handleOpenAIError(ctx, "VUSA", &errWithMessage{"openai 429: insufficient_quota"})
-		if c.last != CounterQuotaExceeded {
-			t.Errorf("counter = %q, want %q", c.last, CounterQuotaExceeded)
-		}
-	})
-
-	t.Run("nil counter no panic", func(t *testing.T) {
-		p := NewPlugin(nil, slog.Default(), http.DefaultClient)
-		p.handleOpenAIError(ctx, "X", &errWithMessage{"openai 404: not found"})
-	})
-
-	t.Run("other error no increment", func(t *testing.T) {
-		c := &recordingCounter{}
-		p := NewPlugin(c, slog.Default(), http.DefaultClient)
-		p.handleOpenAIError(ctx, "X", &errWithMessage{"openai 500: internal server error"})
-		if c.last != "" {
-			t.Errorf("unexpected counter increment: %q", c.last)
-		}
-	})
+func TestHandleOpenAIError_NilLogger(t *testing.T) {
+	p := NewPlugin(nil, http.DefaultClient)
+	if got := p.handleOpenAIError(context.Background(), "X", &errWithMessage{"openai 404: not found"}); got != descpkg.OutcomeModelNotFound {
+		t.Errorf("outcome = %q, want %q", got, descpkg.OutcomeModelNotFound)
+	}
 }
 
 type errWithMessage struct{ msg string }
 
 func (e *errWithMessage) Error() string { return e.msg }
-
-var _ telemetry.CounterIncrementer = (*recordingCounter)(nil)
 
 func TestExtractBatch_TypeHintPassedToClient(t *testing.T) {
 	// BatchItemForClient must include TypeHint from Hints.SecurityTypeHint; when server returns OCC, plugin emits OCC identifier.
@@ -136,20 +121,27 @@ func TestExtractBatch_TypeHintPassedToClient(t *testing.T) {
 
 	config := []byte(`{"openai_api_key":"test","openai_base_url":"` + server.URL + `"}`)
 	ctx := context.Background()
-	p := NewPlugin(nil, nil, http.DefaultClient)
+	p := NewPlugin(nil, http.DefaultClient)
 	items := []descpkg.BatchItem{
 		{ID: "ab12", InstrumentDescription: "BRKB 241115P00390000 BRK B 15NOV24 390 P", Hints: identifier.Hints{SecurityTypeHint: identifier.SecurityTypeHintOption}},
 	}
-	out, err := p.ExtractBatch(ctx, config, "IBKR", "IBKR:test:statement", items)
+	res, err := p.ExtractBatch(ctx, config, "IBKR", "IBKR:test:statement", items)
 	if err != nil {
 		t.Fatalf("ExtractBatch: %v", err)
 	}
-	if out == nil {
-		t.Fatal("expected non-nil out")
+	if res.Telemetry.Outcome != descpkg.OutcomeHintsReturned {
+		t.Errorf("Telemetry.Outcome = %q, want %q", res.Telemetry.Outcome, descpkg.OutcomeHintsReturned)
 	}
-	ids, ok := out["ab12"]
+	// The token cost of the call is what makes the cost of one import answerable.
+	if res.Telemetry.Tokens == nil {
+		t.Fatal("Telemetry.Tokens = nil, want the usage the API reported")
+	}
+	if res.Telemetry.Tokens.PromptTokens != 1 || res.Telemetry.Tokens.CompletionTokens != 1 || res.Telemetry.Tokens.TotalTokens != 2 {
+		t.Errorf("Telemetry.Tokens = %+v, want {1 1 2}", *res.Telemetry.Tokens)
+	}
+	ids, ok := res.Hints["ab12"]
 	if !ok || len(ids) != 1 {
-		t.Fatalf("out[ab12] = %v, want one OCC identifier", out)
+		t.Fatalf("Hints[ab12] = %v, want one OCC identifier", res.Hints)
 	}
 	if ids[0].Type != "OCC" || ids[0].Value != "BRKB241115P00390000" {
 		t.Errorf("out[ab12] = %+v, want Type=OCC Value=BRKB241115P00390000", ids[0])
@@ -160,7 +152,7 @@ func TestExtractBatch_TypeHintPassedToClient(t *testing.T) {
 }
 
 func TestPlugin_AcceptableSecurityTypes_IncludesETF(t *testing.T) {
-	p := NewPlugin(nil, nil, nil)
+	p := NewPlugin(nil, nil)
 	types := p.AcceptableSecurityTypes()
 	if !types[identifier.SecurityTypeHintETF] {
 		t.Error("ETF is not acceptable; an ETF arriving with no identifiers gets no description plugin at all")

--- a/server/service/ingestion/resolve.go
+++ b/server/service/ingestion/resolve.go
@@ -150,7 +150,7 @@ func runDescriptionPluginsBatch(ctx context.Context, database db.PluginConfigDB,
 			ingestionLogger().DebugContext(ctx, "description plugin batch skipped (no items with acceptable security type)", "plugin_id", c.PluginID)
 			continue
 		}
-		out, err := p.ExtractBatch(ctx, c.Config, broker, source, filtered)
+		res, err := p.ExtractBatch(ctx, c.Config, broker, source, filtered)
 		if err != nil {
 			if counter != nil {
 				counter.Incr(ctx, "instruments.resolution.totals.description.plugin_error")
@@ -158,6 +158,7 @@ func runDescriptionPluginsBatch(ctx context.Context, database db.PluginConfigDB,
 			ingestionLogger().DebugContext(ctx, "description plugin batch result: error", "plugin_id", c.PluginID, "err", err)
 			continue
 		}
+		out := res.Hints
 		hasAny := false
 		for id, hints := range out {
 			filteredHints := identification.FilterIdentifierHints(ctx, hints, ingestionLogger())

--- a/server/service/ingestion/resolve_test.go
+++ b/server/service/ingestion/resolve_test.go
@@ -592,9 +592,9 @@ func (p *fakeDescPlugin) DisplayName() string                        { return "F
 func (p *fakeDescPlugin) DefaultConfig() []byte                      { return nil }
 func (p *fakeDescPlugin) AcceptableInstrumentKinds() map[string]bool { return p.acceptableKinds }
 func (p *fakeDescPlugin) AcceptableSecurityTypes() map[string]bool   { return p.acceptable }
-func (p *fakeDescPlugin) ExtractBatch(_ context.Context, _ []byte, _, _ string, items []descpkg.BatchItem) (map[string][]identifier.Identifier, error) {
+func (p *fakeDescPlugin) ExtractBatch(_ context.Context, _ []byte, _, _ string, items []descpkg.BatchItem) (descpkg.Result, error) {
 	if p.err != nil {
-		return nil, p.err
+		return descpkg.Result{Telemetry: descpkg.Telemetry{Outcome: descpkg.OutcomeError}}, p.err
 	}
 	out := make(map[string][]identifier.Identifier)
 	for _, item := range items {
@@ -602,7 +602,11 @@ func (p *fakeDescPlugin) ExtractBatch(_ context.Context, _ []byte, _, _ string, 
 			out[item.ID] = hints
 		}
 	}
-	return out, nil
+	outcome := descpkg.OutcomeNoHints
+	if len(out) > 0 {
+		outcome = descpkg.OutcomeHintsReturned
+	}
+	return descpkg.Result{Hints: out, Telemetry: descpkg.Telemetry{Outcome: outcome}}, nil
 }
 
 // TestRunDescriptionPluginsBatch_MultiplePlugins_DifferentSecurityTypes verifies


### PR DESCRIPTION
Second of three for [0114](docs/issues/0114-plugins-return-telemetry.md). **Depends on #446** and is based on its branch.

`ExtractBatch` returns `description.Result` -- the hints and the plugin's telemetry for the call -- and the OpenAI plugin's injected counter and its eight exported counter names go with it.

The OpenAI plugin absorbs an API failure, returning no hints and no error so the caller moves on to the next plugin. That left the caller unable to tell a call that failed from one that found nothing, which is the distinction the outcome now carries. Token usage comes back as `Telemetry.Tokens` rather than being added into running totals, which is what makes the cost of one import answerable, and stays nil for a plugin that costs no tokens.

Two classification changes:

* a rate limit is separated from an exhausted quota. OpenAI reports both with 429 and only the body marker separates them, so the marker is tested before the quota check -- a bare 429 still lands where it did.
* an enabled but unconfigured plugin reports an error rather than an empty answer, or it reads as one that never finds anything.

The batch size and the count of items that came back with hints stay with the caller, which knows both. The caller's own resolution counters are untouched; 0118 retires them.

Also corrects two stale claims in the plugin author docs: a later description plugin is called with what its predecessors left unresolved rather than not called at all (there is a regression test for this), and the interface is `ExtractBatch` rather than `Extract`.

## Testing

`make fmt-check vet lint-go`, `make server-test` and `make integration-test` all pass; VCR cassettes are unchanged. The OpenAI `recordingCounter` is replaced by a table-driven test over the outcome classification and an assertion on the token usage the API reported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)