### PR TITLE
Retire the injected counter from the price and corporate-event plugins (0114)

### DIFF
--- a/docs/issues/0114-plugins-return-telemetry.md
+++ b/docs/issues/0114-plugins-return-telemetry.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Plugins return telemetry rather than incrementing counters
 milestone: M20
 ---

--- a/server/cmd/portfoliodb/main.go
+++ b/server/cmd/portfoliodb/main.go
@@ -235,8 +235,8 @@ func main() {
 		log.Fatalf("ensure description plugin configs: %v", err)
 	}
 	priceRegistry := pricefetcher.NewRegistry()
-	priceRegistry.Register(massiveprice.PluginID, massiveprice.NewPlugin(counter, logger.WithCategory(serverLogger, "server/plugins/massive/price"), pluginHTTPClient))
-	priceRegistry.Register(eodhdprice.PluginID, eodhdprice.NewPlugin(counter, logger.WithCategory(serverLogger, "server/plugins/eodhd/price"), pluginHTTPClient, exchMap))
+	priceRegistry.Register(massiveprice.PluginID, massiveprice.NewPlugin(logger.WithCategory(serverLogger, "server/plugins/massive/price"), pluginHTTPClient))
+	priceRegistry.Register(eodhdprice.PluginID, eodhdprice.NewPlugin(logger.WithCategory(serverLogger, "server/plugins/eodhd/price"), pluginHTTPClient, exchMap))
 	if err := ensurePluginConfigs(context.Background(), database, db.PluginCategoryPrice, priceRegistry.ListIDs(), func(id string) []byte {
 		if p := priceRegistry.Get(id); p != nil {
 			return p.DefaultConfig()
@@ -256,8 +256,8 @@ func main() {
 		log.Fatalf("ensure inflation plugin configs: %v", err)
 	}
 	corporateEventRegistry := corporateevents.NewRegistry()
-	corporateEventRegistry.Register(massivece.PluginID, massivece.NewPlugin(counter, logger.WithCategory(serverLogger, "server/plugins/massive/corporateevents"), pluginHTTPClient))
-	corporateEventRegistry.Register(eodhdce.PluginID, eodhdce.NewPlugin(counter, logger.WithCategory(serverLogger, "server/plugins/eodhd/corporateevents"), pluginHTTPClient, exchMap))
+	corporateEventRegistry.Register(massivece.PluginID, massivece.NewPlugin(logger.WithCategory(serverLogger, "server/plugins/massive/corporateevents"), pluginHTTPClient))
+	corporateEventRegistry.Register(eodhdce.PluginID, eodhdce.NewPlugin(logger.WithCategory(serverLogger, "server/plugins/eodhd/corporateevents"), pluginHTTPClient, exchMap))
 	if err := ensurePluginConfigs(context.Background(), database, db.PluginCategoryCorporateEvent, corporateEventRegistry.ListIDs(), func(id string) []byte {
 		if p := corporateEventRegistry.Get(id); p != nil {
 			return p.DefaultConfig()

--- a/server/plugins/eodhd/corporateevents/integration_test.go
+++ b/server/plugins/eodhd/corporateevents/integration_test.go
@@ -88,7 +88,7 @@ func TestIntegration_EODHD_FetchEvents(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			_, httpClient := vcr.New(t, tc.cassette, vcr.SanitizeAll, "eodhd/corporateevents")
 
-			p := NewPlugin(nil, nil, httpClient, exchangemap.New())
+			p := NewPlugin(nil, httpClient, exchangemap.New())
 			cfg, err := json.Marshal(configJSON{EODHDAPIKey: apiKey})
 			if err != nil {
 				t.Fatalf("marshal config: %v", err)

--- a/server/plugins/eodhd/corporateevents/plugin.go
+++ b/server/plugins/eodhd/corporateevents/plugin.go
@@ -26,7 +26,6 @@ import (
 	"github.com/leedenison/portfoliodb/server/db"
 	"github.com/leedenison/portfoliodb/server/plugins/eodhd/client"
 	"github.com/leedenison/portfoliodb/server/plugins/eodhd/exchangemap"
-	"github.com/leedenison/portfoliodb/server/telemetry"
 )
 
 // PluginID is the stable plugin_id for registration and plugin_config.
@@ -41,7 +40,6 @@ type configJSON struct {
 // Plugin implements corporateevents.Plugin using the EODHD splits and
 // dividends APIs.
 type Plugin struct {
-	counter    telemetry.CounterIncrementer
 	log        *slog.Logger
 	httpClient *http.Client
 	exchMap    *exchangemap.ExchangeMap
@@ -51,9 +49,9 @@ type Plugin struct {
 	lastConfig string
 }
 
-// NewPlugin returns a plugin. counter, log and exchMap are optional.
-func NewPlugin(counter telemetry.CounterIncrementer, log *slog.Logger, httpClient *http.Client, exchMap *exchangemap.ExchangeMap) *Plugin {
-	return &Plugin{counter: counter, log: log, httpClient: httpClient, exchMap: exchMap}
+// NewPlugin returns a plugin. log and exchMap are optional.
+func NewPlugin(log *slog.Logger, httpClient *http.Client, exchMap *exchangemap.ExchangeMap) *Plugin {
+	return &Plugin{log: log, httpClient: httpClient, exchMap: exchMap}
 }
 
 func (p *Plugin) DisplayName() string { return "EODHD" }
@@ -99,12 +97,10 @@ func (p *Plugin) FetchEvents(ctx context.Context, config []byte, identifiers []c
 	toStr := beforeInclusive.Format("2006-01-02")
 
 	splits, err := c.Splits(ctx, symbol, fromStr, toStr)
-	p.reportOutcome(ctx, err)
 	if err != nil {
 		return nil, p.translateError(err, symbol)
 	}
 	dividends, err := c.Dividends(ctx, symbol, fromStr, toStr)
-	p.reportOutcome(ctx, err)
 	if err != nil {
 		return nil, p.translateError(err, symbol)
 	}
@@ -284,27 +280,6 @@ func normalizeFrequency(period string) string {
 
 func formatFloat(f float64) string {
 	return strconv.FormatFloat(f, 'f', -1, 64)
-}
-
-const (
-	counterSucceeded = "corporate_events.fetch.eodhd.request.succeeded"
-	counterFailed    = "corporate_events.fetch.eodhd.request.failed"
-	counterRateLimit = "corporate_events.fetch.eodhd.request.rate_limit"
-)
-
-func (p *Plugin) reportOutcome(ctx context.Context, err error) {
-	if p.counter == nil {
-		return
-	}
-	var rl *client.ErrRateLimit
-	switch {
-	case err == nil:
-		p.counter.Incr(ctx, counterSucceeded)
-	case errors.As(err, &rl):
-		p.counter.Incr(ctx, counterRateLimit)
-	default:
-		p.counter.Incr(ctx, counterFailed)
-	}
 }
 
 func (p *Plugin) getClient(config []byte) (*client.Client, error) {

--- a/server/plugins/eodhd/corporateevents/plugin_test.go
+++ b/server/plugins/eodhd/corporateevents/plugin_test.go
@@ -56,7 +56,7 @@ func TestFetchEvents_StockSplitsAndDividends(t *testing.T) {
 	defer srv.Close()
 
 	exchMap := exchangemap.New()
-	p := NewPlugin(nil, nil, srv.Client(), exchMap)
+	p := NewPlugin(nil, srv.Client(), exchMap)
 	ids := []corporateevents.Identifier{{Type: "MIC_TICKER", Domain: "XNAS", Value: "AAPL"}}
 
 	from := time.Date(2014, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -109,7 +109,7 @@ func TestFetchEvents_PrefersUnadjustedValue(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p := NewPlugin(nil, nil, srv.Client(), exchangemap.New())
+	p := NewPlugin(nil, srv.Client(), exchangemap.New())
 	ids := []corporateevents.Identifier{{Type: "MIC_TICKER", Domain: "XNAS", Value: "AAPL"}}
 	got, err := p.FetchEvents(context.Background(), configWithURL(srv.URL), ids, db.AssetClassStock,
 		time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -130,7 +130,7 @@ func TestFetchEvents_404IsPermanent(t *testing.T) {
 		http.NotFound(w, r)
 	}))
 	defer srv.Close()
-	p := NewPlugin(nil, nil, srv.Client(), exchangemap.New())
+	p := NewPlugin(nil, srv.Client(), exchangemap.New())
 	ids := []corporateevents.Identifier{{Type: "MIC_TICKER", Domain: "XNAS", Value: "BOGUS"}}
 	_, err := p.FetchEvents(context.Background(), configWithURL(srv.URL), ids, db.AssetClassStock,
 		time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -146,7 +146,7 @@ func TestFetchEvents_429IsTransient(t *testing.T) {
 		w.WriteHeader(http.StatusTooManyRequests)
 	}))
 	defer srv.Close()
-	p := NewPlugin(nil, nil, srv.Client(), exchangemap.New())
+	p := NewPlugin(nil, srv.Client(), exchangemap.New())
 	ids := []corporateevents.Identifier{{Type: "MIC_TICKER", Domain: "XNAS", Value: "AAPL"}}
 	_, err := p.FetchEvents(context.Background(), configWithURL(srv.URL), ids, db.AssetClassStock,
 		time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -158,7 +158,7 @@ func TestFetchEvents_429IsTransient(t *testing.T) {
 }
 
 func TestFetchEvents_NoSupportedIdentifier(t *testing.T) {
-	p := NewPlugin(nil, nil, nil, exchangemap.New())
+	p := NewPlugin(nil, nil, exchangemap.New())
 	ids := []corporateevents.Identifier{{Type: "ISIN", Value: "US0378331005"}}
 	_, err := p.FetchEvents(context.Background(), nil, ids, db.AssetClassStock,
 		time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -181,7 +181,7 @@ func TestParseSplit_BadFormat(t *testing.T) {
 }
 
 func TestPluginAcceptsAssetClasses(t *testing.T) {
-	p := NewPlugin(nil, nil, nil, nil)
+	p := NewPlugin(nil, nil, nil)
 	ac := p.AcceptableAssetClasses()
 	if !ac[db.AssetClassStock] || !ac[db.AssetClassETF] {
 		t.Error("expected STOCK and ETF accepted")

--- a/server/plugins/eodhd/price/integration_test.go
+++ b/server/plugins/eodhd/price/integration_test.go
@@ -42,7 +42,7 @@ func TestIntegration_EODHD_FetchPrices(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			_, httpClient := vcr.New(t, tc.cassette, vcr.SanitizeAll, "eodhd/price")
 
-			p := NewPlugin(nil, nil, httpClient, nil)
+			p := NewPlugin(nil, httpClient, nil)
 			cfg, err := json.Marshal(configJSON{EODHDAPIKey: apiKey})
 			if err != nil {
 				t.Fatalf("marshal config: %v", err)

--- a/server/plugins/eodhd/price/plugin.go
+++ b/server/plugins/eodhd/price/plugin.go
@@ -13,7 +13,6 @@ import (
 	"github.com/leedenison/portfoliodb/server/plugins/eodhd/client"
 	"github.com/leedenison/portfoliodb/server/plugins/eodhd/exchangemap"
 	"github.com/leedenison/portfoliodb/server/pricefetcher"
-	"github.com/leedenison/portfoliodb/server/telemetry"
 	"github.com/shopspring/decimal"
 )
 
@@ -31,7 +30,6 @@ type configJSON struct {
 
 // Plugin implements pricefetcher.Plugin using the EODHD EOD API.
 type Plugin struct {
-	counter    telemetry.CounterIncrementer
 	log        *slog.Logger
 	httpClient *http.Client
 	exchMap    *exchangemap.ExchangeMap
@@ -41,9 +39,9 @@ type Plugin struct {
 	lastConfig string
 }
 
-// NewPlugin returns a plugin. counter, log and exchMap are optional (nil for tests).
-func NewPlugin(counter telemetry.CounterIncrementer, log *slog.Logger, httpClient *http.Client, exchMap *exchangemap.ExchangeMap) *Plugin {
-	return &Plugin{counter: counter, log: log, httpClient: httpClient, exchMap: exchMap}
+// NewPlugin returns a plugin. log and exchMap are optional (nil for tests).
+func NewPlugin(log *slog.Logger, httpClient *http.Client, exchMap *exchangemap.ExchangeMap) *Plugin {
+	return &Plugin{log: log, httpClient: httpClient, exchMap: exchMap}
 }
 
 func (p *Plugin) DisplayName() string { return "EODHD" }
@@ -98,7 +96,6 @@ func (p *Plugin) FetchPrices(ctx context.Context, config []byte, identifiers []p
 		toStr := chunkEnd.Format("2006-01-02")
 
 		bars, err := c.EODPrices(ctx, symbol, fromStr, toStr)
-		p.reportOutcome(ctx, err)
 		if err != nil {
 			var nf *client.ErrNotFound
 			if errors.As(err, &nf) {
@@ -206,27 +203,6 @@ func (p *Plugin) micToEODHDCode(mic string) string {
 		return ""
 	}
 	return code
-}
-
-const (
-	counterSucceeded = "prices.fetch.eodhd.request.succeeded"
-	counterFailed    = "prices.fetch.eodhd.request.failed"
-	counterRateLimit = "prices.fetch.eodhd.request.rate_limit"
-)
-
-func (p *Plugin) reportOutcome(ctx context.Context, err error) {
-	if p.counter == nil {
-		return
-	}
-	var rl *client.ErrRateLimit
-	switch {
-	case err == nil:
-		p.counter.Incr(ctx, counterSucceeded)
-	case errors.As(err, &rl):
-		p.counter.Incr(ctx, counterRateLimit)
-	default:
-		p.counter.Incr(ctx, counterFailed)
-	}
 }
 
 func (p *Plugin) getClient(config []byte) (*client.Client, error) {

--- a/server/plugins/eodhd/price/plugin_test.go
+++ b/server/plugins/eodhd/price/plugin_test.go
@@ -36,7 +36,7 @@ func TestFetchPrices_Stock(t *testing.T) {
 	defer srv.Close()
 
 	exchMap := exchangemap.New()
-	p := NewPlugin(nil, nil, srv.Client(), exchMap)
+	p := NewPlugin(nil, srv.Client(), exchMap)
 	ids := []pricefetcher.Identifier{{Type: "MIC_TICKER", Domain: "XNYS", Value: "MCD"}}
 	from := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2024, 1, 4, 0, 0, 0, 0, time.UTC)
@@ -73,7 +73,7 @@ func TestFetchPrices_FX(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p := NewPlugin(nil, nil, srv.Client(), nil)
+	p := NewPlugin(nil, srv.Client(), nil)
 	ids := []pricefetcher.Identifier{{Type: "FX_PAIR", Value: "EURUSD"}}
 	from := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
@@ -106,7 +106,7 @@ func TestFetchPrices_FX_GBXUSD(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p := NewPlugin(nil, nil, srv.Client(), nil)
+	p := NewPlugin(nil, srv.Client(), nil)
 	ids := []pricefetcher.Identifier{{Type: "FX_PAIR", Value: "GBXUSD"}}
 	from := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
@@ -130,7 +130,7 @@ func TestFetchPrices_FX_GBXUSD(t *testing.T) {
 }
 
 func TestFetchPrices_NoMatchingIdentifier(t *testing.T) {
-	p := NewPlugin(nil, nil, http.DefaultClient, nil)
+	p := NewPlugin(nil, http.DefaultClient, nil)
 	ids := []pricefetcher.Identifier{{Type: "ISIN", Value: "US0378331005"}}
 	from := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
@@ -142,7 +142,7 @@ func TestFetchPrices_NoMatchingIdentifier(t *testing.T) {
 }
 
 func TestFetchPrices_NoExchangeMap(t *testing.T) {
-	p := NewPlugin(nil, nil, http.DefaultClient, nil)
+	p := NewPlugin(nil, http.DefaultClient, nil)
 	ids := []pricefetcher.Identifier{{Type: "MIC_TICKER", Domain: "XNYS", Value: "AAPL"}}
 	from := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
@@ -160,7 +160,7 @@ func TestFetchPrices_NotFound(t *testing.T) {
 	defer srv.Close()
 
 	exchMap := exchangemap.New()
-	p := NewPlugin(nil, nil, srv.Client(), exchMap)
+	p := NewPlugin(nil, srv.Client(), exchMap)
 	ids := []pricefetcher.Identifier{{Type: "MIC_TICKER", Domain: "XNYS", Value: "INVALID"}}
 	from := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
@@ -183,7 +183,7 @@ func TestFetchPrices_SubscriptionLimit(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p := NewPlugin(nil, nil, srv.Client(), nil)
+	p := NewPlugin(nil, srv.Client(), nil)
 	ids := []pricefetcher.Identifier{{Type: "FX_PAIR", Value: "GBPUSD"}}
 	from := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2025, 4, 7, 0, 0, 0, 0, time.UTC)
@@ -205,7 +205,7 @@ func TestFetchPrices_RateLimit(t *testing.T) {
 	defer srv.Close()
 
 	exchMap := exchangemap.New()
-	p := NewPlugin(nil, nil, srv.Client(), exchMap)
+	p := NewPlugin(nil, srv.Client(), exchMap)
 	ids := []pricefetcher.Identifier{{Type: "MIC_TICKER", Domain: "XNYS", Value: "AAPL"}}
 	from := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
@@ -232,7 +232,7 @@ func TestFetchPrices_LargeRange(t *testing.T) {
 	defer srv.Close()
 
 	exchMap := exchangemap.New()
-	p := NewPlugin(nil, nil, srv.Client(), exchMap)
+	p := NewPlugin(nil, srv.Client(), exchMap)
 	ids := []pricefetcher.Identifier{{Type: "MIC_TICKER", Domain: "XNYS", Value: "AAPL"}}
 	// Range spanning 400 days: should require 2 chunks.
 	from := time.Date(2023, 1, 1, 0, 0, 0, 0, time.UTC)
@@ -253,7 +253,7 @@ func TestFetchPrices_LargeRange(t *testing.T) {
 
 func TestSymbolForAssetClass(t *testing.T) {
 	exchMap := exchangemap.New()
-	p := NewPlugin(nil, nil, nil, exchMap)
+	p := NewPlugin(nil, nil, exchMap)
 
 	tests := []struct {
 		name       string
@@ -312,7 +312,7 @@ func TestSymbolForAssetClass(t *testing.T) {
 }
 
 func TestPluginInterface(t *testing.T) {
-	p := NewPlugin(nil, nil, nil, nil)
+	p := NewPlugin(nil, nil, nil)
 	if p.DisplayName() != "EODHD" {
 		t.Errorf("DisplayName = %q", p.DisplayName())
 	}

--- a/server/plugins/massive/corporateevents/integration_test.go
+++ b/server/plugins/massive/corporateevents/integration_test.go
@@ -99,7 +99,7 @@ func TestIntegration_Massive_FetchEvents(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			_, httpClient := vcr.New(t, tc.cassette, vcr.SanitizeAll, "massive/corporateevents")
 
-			p := NewPlugin(nil, nil, httpClient)
+			p := NewPlugin(nil, httpClient)
 			cfg, err := json.Marshal(configJSON{
 				MassiveAPIKey: apiKey,
 				CallsPerMin:   massiveCallsPerMin,

--- a/server/plugins/massive/corporateevents/plugin.go
+++ b/server/plugins/massive/corporateevents/plugin.go
@@ -23,7 +23,6 @@ import (
 	"github.com/leedenison/portfoliodb/server/corporateevents"
 	"github.com/leedenison/portfoliodb/server/db"
 	"github.com/leedenison/portfoliodb/server/plugins/massive/client"
-	"github.com/leedenison/portfoliodb/server/telemetry"
 )
 
 // PluginID is the stable plugin_id for registration and plugin_config.
@@ -38,7 +37,6 @@ type configJSON struct {
 // Plugin implements corporateevents.Plugin using the Massive corporate
 // actions endpoints.
 type Plugin struct {
-	counter    telemetry.CounterIncrementer
 	log        *slog.Logger
 	httpClient *http.Client
 
@@ -47,9 +45,9 @@ type Plugin struct {
 	lastConfig string
 }
 
-// NewPlugin returns a plugin. counter and log are optional.
-func NewPlugin(counter telemetry.CounterIncrementer, log *slog.Logger, httpClient *http.Client) *Plugin {
-	return &Plugin{counter: counter, log: log, httpClient: httpClient}
+// NewPlugin returns a plugin. log is optional.
+func NewPlugin(log *slog.Logger, httpClient *http.Client) *Plugin {
+	return &Plugin{log: log, httpClient: httpClient}
 }
 
 func (p *Plugin) DisplayName() string { return "Massive" }
@@ -98,12 +96,10 @@ func (p *Plugin) FetchEvents(ctx context.Context, config []byte, identifiers []c
 	toStr := beforeInclusive.Format("2006-01-02")
 
 	splits, err := c.Splits(ctx, ticker, fromStr, toStr)
-	p.reportOutcome(ctx, err)
 	if err != nil {
 		return nil, p.translateError(err, ticker)
 	}
 	dividends, err := c.Dividends(ctx, ticker, fromStr, toStr)
-	p.reportOutcome(ctx, err)
 	if err != nil {
 		return nil, p.translateError(err, ticker)
 	}
@@ -240,27 +236,6 @@ func frequencyFromInt(freq int) string {
 
 func formatFloat(f float64) string {
 	return strconv.FormatFloat(f, 'f', -1, 64)
-}
-
-const (
-	counterSucceeded = "corporate_events.fetch.massive.request.succeeded"
-	counterFailed    = "corporate_events.fetch.massive.request.failed"
-	counterRateLimit = "corporate_events.fetch.massive.request.rate_limit"
-)
-
-func (p *Plugin) reportOutcome(ctx context.Context, err error) {
-	if p.counter == nil {
-		return
-	}
-	var rl *client.ErrRateLimit
-	switch {
-	case err == nil:
-		p.counter.Incr(ctx, counterSucceeded)
-	case errors.As(err, &rl):
-		p.counter.Incr(ctx, counterRateLimit)
-	default:
-		p.counter.Incr(ctx, counterFailed)
-	}
 }
 
 func (p *Plugin) getClient(config []byte) (*client.Client, error) {

--- a/server/plugins/massive/corporateevents/plugin_test.go
+++ b/server/plugins/massive/corporateevents/plugin_test.go
@@ -62,7 +62,7 @@ func TestFetchEvents_StockSplitsAndDividends(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p := NewPlugin(nil, nil, srv.Client())
+	p := NewPlugin(nil, srv.Client())
 	ids := []corporateevents.Identifier{{Type: "MIC_TICKER", Value: "AAPL"}}
 	got, err := p.FetchEvents(context.Background(), configWithURL(srv.URL), ids, db.AssetClassStock,
 		time.Date(2014, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -117,7 +117,7 @@ func TestFetchEvents_PaginationFollowsNextURL(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p := NewPlugin(nil, nil, srv.Client())
+	p := NewPlugin(nil, srv.Client())
 	ids := []corporateevents.Identifier{{Type: "MIC_TICKER", Value: "AAPL"}}
 	got, err := p.FetchEvents(context.Background(), configWithURL(srv.URL), ids, db.AssetClassStock,
 		time.Date(2014, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -138,7 +138,7 @@ func TestFetchEvents_404IsPermanent(t *testing.T) {
 		http.NotFound(w, r)
 	}))
 	defer srv.Close()
-	p := NewPlugin(nil, nil, srv.Client())
+	p := NewPlugin(nil, srv.Client())
 	ids := []corporateevents.Identifier{{Type: "MIC_TICKER", Value: "BOGUS"}}
 	_, err := p.FetchEvents(context.Background(), configWithURL(srv.URL), ids, db.AssetClassStock,
 		time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -155,7 +155,7 @@ func TestFetchEvents_403IsPermanent(t *testing.T) {
 		_, _ = w.Write([]byte(`{"error":"plan does not include corporate actions"}`))
 	}))
 	defer srv.Close()
-	p := NewPlugin(nil, nil, srv.Client())
+	p := NewPlugin(nil, srv.Client())
 	ids := []corporateevents.Identifier{{Type: "MIC_TICKER", Value: "AAPL"}}
 	_, err := p.FetchEvents(context.Background(), configWithURL(srv.URL), ids, db.AssetClassStock,
 		time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -171,7 +171,7 @@ func TestFetchEvents_429IsTransient(t *testing.T) {
 		w.WriteHeader(http.StatusTooManyRequests)
 	}))
 	defer srv.Close()
-	p := NewPlugin(nil, nil, srv.Client())
+	p := NewPlugin(nil, srv.Client())
 	ids := []corporateevents.Identifier{{Type: "MIC_TICKER", Value: "AAPL"}}
 	_, err := p.FetchEvents(context.Background(), configWithURL(srv.URL), ids, db.AssetClassStock,
 		time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -183,7 +183,7 @@ func TestFetchEvents_429IsTransient(t *testing.T) {
 }
 
 func TestFetchEvents_NoSupportedIdentifier(t *testing.T) {
-	p := NewPlugin(nil, nil, nil)
+	p := NewPlugin(nil, nil)
 	ids := []corporateevents.Identifier{{Type: "ISIN", Value: "US0378331005"}}
 	_, err := p.FetchEvents(context.Background(), nil, ids, db.AssetClassStock,
 		time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -234,7 +234,7 @@ func TestFetchEvents_SpecialDividendType(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p := NewPlugin(nil, nil, srv.Client())
+	p := NewPlugin(nil, srv.Client())
 	ids := []corporateevents.Identifier{{Type: "MIC_TICKER", Value: "AAPL"}}
 	got, err := p.FetchEvents(context.Background(), configWithURL(srv.URL), ids, db.AssetClassStock,
 		time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
@@ -270,7 +270,7 @@ func TestFrequencyFromInt(t *testing.T) {
 }
 
 func TestPluginAcceptsAssetClasses(t *testing.T) {
-	p := NewPlugin(nil, nil, nil)
+	p := NewPlugin(nil, nil)
 	ac := p.AcceptableAssetClasses()
 	if !ac[db.AssetClassStock] || !ac[db.AssetClassETF] {
 		t.Error("expected STOCK and ETF accepted")

--- a/server/plugins/massive/price/integration_test.go
+++ b/server/plugins/massive/price/integration_test.go
@@ -69,7 +69,7 @@ func TestIntegration_Massive_FetchPrices_FX(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			_, httpClient := vcr.New(t, tc.cassette, vcr.SanitizeAll, "massive/price")
 
-			p := NewPlugin(nil, nil, httpClient)
+			p := NewPlugin(nil, httpClient)
 			cfg, err := json.Marshal(configJSON{
 				MassiveAPIKey: apiKey,
 			})

--- a/server/plugins/massive/price/plugin.go
+++ b/server/plugins/massive/price/plugin.go
@@ -12,7 +12,6 @@ import (
 	"github.com/leedenison/portfoliodb/server/db"
 	"github.com/leedenison/portfoliodb/server/plugins/massive/client"
 	"github.com/leedenison/portfoliodb/server/pricefetcher"
-	"github.com/leedenison/portfoliodb/server/telemetry"
 	"github.com/shopspring/decimal"
 )
 
@@ -27,7 +26,6 @@ type configJSON struct {
 
 // Plugin implements pricefetcher.Plugin using the Massive aggregates API.
 type Plugin struct {
-	counter    telemetry.CounterIncrementer
 	log        *slog.Logger
 	httpClient *http.Client
 
@@ -36,9 +34,9 @@ type Plugin struct {
 	lastConfig string
 }
 
-// NewPlugin returns a plugin. counter and log are optional (nil for tests).
-func NewPlugin(counter telemetry.CounterIncrementer, log *slog.Logger, httpClient *http.Client) *Plugin {
-	return &Plugin{counter: counter, log: log, httpClient: httpClient}
+// NewPlugin returns a plugin. log is optional (nil for tests).
+func NewPlugin(log *slog.Logger, httpClient *http.Client) *Plugin {
+	return &Plugin{log: log, httpClient: httpClient}
 }
 
 func (p *Plugin) DisplayName() string { return "Massive" }
@@ -104,7 +102,6 @@ func (p *Plugin) FetchPrices(ctx context.Context, config []byte, identifiers []p
 
 		bars, err := c.DailyBars(ctx, ticker, fromStr, toStr)
 		if err != nil {
-			p.reportOutcome(ctx, err)
 			var nf *client.ErrNotFound
 			var fb *client.ErrForbidden
 			if errors.As(err, &nf) {
@@ -118,7 +115,6 @@ func (p *Plugin) FetchPrices(ctx context.Context, config []byte, identifiers []p
 		allBars = append(allBars, bars...)
 		chunkStart = chunkEnd.AddDate(0, 0, 1)
 	}
-	p.reportOutcome(ctx, nil)
 
 	if len(allBars) == 0 {
 		// For stocks/ETFs, check whether the ticker exists at all. The aggs
@@ -134,7 +130,6 @@ func (p *Plugin) FetchPrices(ctx context.Context, config []byte, identifiers []p
 				}
 				// Transient errors (rate limit, network) — propagate so the
 				// price fetcher retries rather than silently returning ErrNoData.
-				p.reportOutcome(ctx, err)
 				return nil, err
 			}
 		}
@@ -203,27 +198,6 @@ func tickerForAssetClass(ids []pricefetcher.Identifier, assetClass string) (stri
 		}
 	}
 	return "", 0
-}
-
-const (
-	counterSucceeded = "prices.fetch.massive.request.succeeded"
-	counterFailed    = "prices.fetch.massive.request.failed"
-	counterRateLimit = "prices.fetch.massive.request.rate_limit"
-)
-
-func (p *Plugin) reportOutcome(ctx context.Context, err error) {
-	if p.counter == nil {
-		return
-	}
-	var rl *client.ErrRateLimit
-	switch {
-	case err == nil:
-		p.counter.Incr(ctx, counterSucceeded)
-	case errors.As(err, &rl):
-		p.counter.Incr(ctx, counterRateLimit)
-	default:
-		p.counter.Incr(ctx, counterFailed)
-	}
 }
 
 func (p *Plugin) getClient(config []byte) (*client.Client, error) {

--- a/server/plugins/massive/price/plugin_test.go
+++ b/server/plugins/massive/price/plugin_test.go
@@ -38,7 +38,7 @@ func TestFetchPrices_Stock(t *testing.T) {
 	srv := barsServer(t, bars)
 	defer srv.Close()
 
-	p := NewPlugin(nil, nil, srv.Client())
+	p := NewPlugin(nil, srv.Client())
 	ids := []pricefetcher.Identifier{{Type: "MIC_TICKER", Value: "AAPL"}}
 	from := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2024, 1, 3, 0, 0, 0, 0, time.UTC)
@@ -70,7 +70,7 @@ func TestFetchPrices_Option(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p := NewPlugin(nil, nil, srv.Client())
+	p := NewPlugin(nil, srv.Client())
 	ids := []pricefetcher.Identifier{{Type: "OCC", Value: "AAPL250321C00150000"}}
 	from := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
@@ -94,7 +94,7 @@ func TestFetchPrices_Option(t *testing.T) {
 }
 
 func TestFetchPrices_NoMatchingIdentifier(t *testing.T) {
-	p := NewPlugin(nil, nil, http.DefaultClient)
+	p := NewPlugin(nil, http.DefaultClient)
 	ids := []pricefetcher.Identifier{{Type: "ISIN", Value: "US0378331005"}}
 	from := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
@@ -111,7 +111,7 @@ func TestFetchPrices_NotFound(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p := NewPlugin(nil, nil, srv.Client())
+	p := NewPlugin(nil, srv.Client())
 	ids := []pricefetcher.Identifier{{Type: "MIC_TICKER", Value: "INVALID"}}
 	from := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
@@ -130,7 +130,7 @@ func TestFetchPrices_Forbidden(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p := NewPlugin(nil, nil, srv.Client())
+	p := NewPlugin(nil, srv.Client())
 	ids := []pricefetcher.Identifier{{Type: "MIC_TICKER", Value: "AAPL"}}
 	from := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
@@ -149,7 +149,7 @@ func TestFetchPrices_Unauthorized(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p := NewPlugin(nil, nil, srv.Client())
+	p := NewPlugin(nil, srv.Client())
 	ids := []pricefetcher.Identifier{{Type: "MIC_TICKER", Value: "AAPL"}}
 	from := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
@@ -167,7 +167,7 @@ func TestFetchPrices_RateLimit(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p := NewPlugin(nil, nil, srv.Client())
+	p := NewPlugin(nil, srv.Client())
 	ids := []pricefetcher.Identifier{{Type: "MIC_TICKER", Value: "AAPL"}}
 	from := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
@@ -193,7 +193,7 @@ func TestFetchPrices_FX(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p := NewPlugin(nil, nil, srv.Client())
+	p := NewPlugin(nil, srv.Client())
 	ids := []pricefetcher.Identifier{{Type: "FX_PAIR", Value: "EURUSD"}}
 	from := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
@@ -215,7 +215,7 @@ func TestFetchPrices_FX(t *testing.T) {
 }
 
 func TestPluginInterface(t *testing.T) {
-	p := NewPlugin(nil, nil, nil)
+	p := NewPlugin(nil, nil)
 	if p.DisplayName() != "Massive" {
 		t.Errorf("DisplayName = %q", p.DisplayName())
 	}
@@ -246,7 +246,7 @@ func TestFetchPrices_FX_GBXUSD(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p := NewPlugin(nil, nil, srv.Client())
+	p := NewPlugin(nil, srv.Client())
 	ids := []pricefetcher.Identifier{{Type: "FX_PAIR", Value: "GBXUSD"}}
 	from := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
@@ -288,7 +288,7 @@ func TestFetchPrices_EmptyBars_TickerNotFound_ReturnsPermanent(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p := NewPlugin(nil, nil, srv.Client())
+	p := NewPlugin(nil, srv.Client())
 	ids := []pricefetcher.Identifier{{Type: "MIC_TICKER", Value: "RHM"}}
 	from := time.Date(2025, 7, 6, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2026, 1, 22, 0, 0, 0, 0, time.UTC)
@@ -319,7 +319,7 @@ func TestFetchPrices_EmptyBars_TickerExists_ReturnsNoData(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p := NewPlugin(nil, nil, srv.Client())
+	p := NewPlugin(nil, srv.Client())
 	ids := []pricefetcher.Identifier{{Type: "MIC_TICKER", Value: "AAPL"}}
 	from := time.Date(2025, 7, 6, 0, 0, 0, 0, time.UTC)
 	to := time.Date(2025, 7, 8, 0, 0, 0, 0, time.UTC)
@@ -344,7 +344,7 @@ func TestFetchPrices_ChunksLargeRanges(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	p := NewPlugin(nil, nil, srv.Client())
+	p := NewPlugin(nil, srv.Client())
 	ids := []pricefetcher.Identifier{{Type: "FX_PAIR", Value: "GBPUSD"}}
 	// 400-day range should require at least 2 chunks (maxChunkDays=200).
 	from := time.Date(2023, 8, 8, 0, 0, 0, 0, time.UTC)


### PR DESCRIPTION
Last of three for [0114](docs/issues/0114-plugins-return-telemetry.md). **Depends on #447** and is based on its branch. Closes 0114.

The price and corporate-event plugin interfaces do not change -- only `Identify` and `ExtractBatch` return telemetry -- but these four plugins held the same injected counter, and no plugin is meant to depend on the telemetry backend any more. After this, nothing under `server/plugins` imports `server/telemetry`:

```
grep -rn "server/telemetry" server/plugins/   # no matches
```

Their per-request counters go with no replacement. The telemetry tables in [the spec](docs/spec/telemetry.md) record plugin calls for identification and description extraction only; a price or corporate-event fetch is accounted for by the run row for its cycle (0116). The existing log lines are what remains of the per-request signal.

The counter itself is still built in `main` and handed to the workers and the ingestion pipeline; 0118 retires it. The ONS inflation plugin never held one, despite the issue text listing it.

## Testing

`make fmt-check vet lint-go`, `make server-test` and `make integration-test` all pass; VCR cassettes are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)