### PR TITLE
Add the telemetry schema, its views and its reading role (0115)

### DIFF
--- a/server/db/postgres/telemetry_schema_test.go
+++ b/server/db/postgres/telemetry_schema_test.go
@@ -1,0 +1,325 @@
+package postgres
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// The telemetry schema carries its judgements in its views rather than in the
+// panels reading them, so the views are the thing worth pinning: a panel saying
+// "where is_import and reached_plugins" is only as good as the definitions behind
+// those two columns, and neither is visible in a dashboard once it is written.
+//
+// These tests write the rows with raw SQL because there is no writer yet -- it
+// arrives with the rest of 0115 -- and because what they are about is the schema,
+// not the Go that will fill it.
+
+// seedRun inserts a run and returns its id.
+func seedRun(t *testing.T, p *Postgres, kind string, startedAt time.Time) string {
+	t.Helper()
+	var id string
+	err := p.q.QueryRowContext(context.Background(), `
+		INSERT INTO telemetry.run (kind, started_at) VALUES ($1, $2) RETURNING id
+	`, kind, startedAt).Scan(&id)
+	if err != nil {
+		t.Fatalf("seed run: %v", err)
+	}
+	return id
+}
+
+// seedResolutionKey inserts a resolution key under a run and returns its id.
+func seedResolutionKey(t *testing.T, p *Postgres, runID string) string {
+	t.Helper()
+	var id string
+	err := p.q.QueryRowContext(context.Background(), `
+		INSERT INTO telemetry.resolution_key
+			(run_id, source, description, tx_count, had_identifier_hints, outcome)
+		VALUES ($1::uuid, 'FIDELITY_CSV', 'APPLE INC COM', 3, FALSE, 'identified')
+		RETURNING id
+	`, runID).Scan(&id)
+	if err != nil {
+		t.Fatalf("seed resolution key: %v", err)
+	}
+	return id
+}
+
+// seedAttempt inserts an identification attempt under a key and returns its id.
+func seedAttempt(t *testing.T, p *Postgres, keyID, purpose, outcome string, depth int) string {
+	t.Helper()
+	var id string
+	err := p.q.QueryRowContext(context.Background(), `
+		INSERT INTO telemetry.identification_attempt
+			(resolution_key_id, purpose, depth, outcome, had_identifier_hints)
+		VALUES ($1::uuid, $2, $3, $4, FALSE)
+		RETURNING id
+	`, keyID, purpose, depth, outcome).Scan(&id)
+	if err != nil {
+		t.Fatalf("seed attempt: %v", err)
+	}
+	return id
+}
+
+// TestTelemetryViews_IsImport pins which run kinds a panel counts as an import.
+// The three import kinds are the ones a person reads after uploading a file; the
+// cycles are the ones that run on their own.
+func TestTelemetryViews_IsImport(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+
+	cases := []struct {
+		kind     string
+		isImport bool
+	}{
+		{"tx_import", true},
+		{"user_archive_import", true},
+		{"system_archive_import", true},
+		{"price_job", false},
+		{"grouping_cycle", false},
+		{"transfer_match_cycle", false},
+		{"corporate_event_cycle", false},
+		{"price_fetch_cycle", false},
+		{"inflation_cycle", false},
+	}
+	for _, c := range cases {
+		t.Run(c.kind, func(t *testing.T) {
+			id := seedRun(t, p, c.kind, time.Now())
+			var got bool
+			if err := p.q.QueryRowContext(ctx,
+				`SELECT is_import FROM telemetry.v_run WHERE id = $1::uuid`, id,
+			).Scan(&got); err != nil {
+				t.Fatalf("select v_run: %v", err)
+			}
+			if got != c.isImport {
+				t.Errorf("is_import for %s = %v, want %v", c.kind, got, c.isImport)
+			}
+		})
+	}
+}
+
+// TestTelemetryViews_ReachedPlugins pins the denominator of the identification
+// failure rate. An attempt that short-circuited in the database, or that had every
+// plugin filtered out, never asked a plugin anything, and counting it would make
+// the rate fall as the instrument table fills -- which reads as improving
+// identification when nothing has changed.
+func TestTelemetryViews_ReachedPlugins(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	runID := seedRun(t, p, "tx_import", time.Now())
+	keyID := seedResolutionKey(t, p, runID)
+
+	cases := []struct {
+		outcome string
+		reached bool
+	}{
+		{"db_short_circuit", false},
+		{"no_eligible_plugins", false},
+		{"identified", true},
+		{"not_identified", true},
+		{"plugin_timeout", true},
+		{"plugin_error", true},
+	}
+	for _, c := range cases {
+		t.Run(c.outcome, func(t *testing.T) {
+			id := seedAttempt(t, p, keyID, "primary", c.outcome, 0)
+			var got bool
+			if err := p.q.QueryRowContext(ctx,
+				`SELECT reached_plugins FROM telemetry.v_identification_attempt WHERE id = $1::uuid`, id,
+			).Scan(&got); err != nil {
+				t.Fatalf("select v_identification_attempt: %v", err)
+			}
+			if got != c.reached {
+				t.Errorf("reached_plugins for %s = %v, want %v", c.outcome, got, c.reached)
+			}
+		})
+	}
+}
+
+// TestTelemetryViews_DoNotFanOut is the property that makes counting a view safe.
+// A view spanning two grains would repeat its parent once per child, so a panel
+// counting resolution keys would report four for a key that made four attempts.
+// Every view here flattens its parents in and stops.
+func TestTelemetryViews_DoNotFanOut(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	runID := seedRun(t, p, "tx_import", time.Now())
+	keyID := seedResolutionKey(t, p, runID)
+	// One primary attempt plus the two the MIC_TICKER against OPENFIGI_SHARE_CLASS
+	// mismatch check makes, which is the ordinary shape for a dual-hint description.
+	seedAttempt(t, p, keyID, "primary", "identified", 0)
+	seedAttempt(t, p, keyID, "mismatch_check", "identified", 0)
+	seedAttempt(t, p, keyID, "mismatch_check", "identified", 0)
+
+	var keys, runs int
+	if err := p.q.QueryRowContext(ctx,
+		`SELECT count(*) FROM telemetry.v_resolution_key WHERE run_id = $1::uuid`, runID,
+	).Scan(&keys); err != nil {
+		t.Fatalf("count v_resolution_key: %v", err)
+	}
+	if keys != 1 {
+		t.Errorf("v_resolution_key rows = %d, want 1", keys)
+	}
+	if err := p.q.QueryRowContext(ctx,
+		`SELECT count(*) FROM telemetry.v_run WHERE id = $1::uuid`, runID,
+	).Scan(&runs); err != nil {
+		t.Fatalf("count v_run: %v", err)
+	}
+	if runs != 1 {
+		t.Errorf("v_run rows = %d, want 1", runs)
+	}
+}
+
+// TestTelemetryRetentionCascades pins retention being a delete over run.started_at
+// and nothing else. Children cascade, so nothing has to know the table list, and a
+// run inside the window keeps everything under it.
+func TestTelemetryRetentionCascades(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	cutoff := time.Now().Add(-360 * 24 * time.Hour)
+
+	oldRun := seedRun(t, p, "tx_import", cutoff.Add(-24*time.Hour))
+	oldKey := seedResolutionKey(t, p, oldRun)
+	oldAttempt := seedAttempt(t, p, oldKey, "primary", "identified", 0)
+	if _, err := p.q.ExecContext(ctx, `
+		INSERT INTO telemetry.identifier_plugin_call
+			(identification_attempt_id, plugin_id, outcome, retries, duration_ms)
+		VALUES ($1::uuid, 'openfigi', 'won', 0, 12)
+	`, oldAttempt); err != nil {
+		t.Fatalf("seed identifier plugin call: %v", err)
+	}
+	if _, err := p.q.ExecContext(ctx, `
+		INSERT INTO telemetry.description_plugin_call
+			(run_id, plugin_id, batch_size, items_with_hints, outcome, duration_ms)
+		VALUES ($1::uuid, 'openai', 20, 18, 'hints_returned', 900)
+	`, oldRun); err != nil {
+		t.Fatalf("seed description plugin call: %v", err)
+	}
+	newRun := seedRun(t, p, "tx_import", cutoff.Add(24*time.Hour))
+	seedResolutionKey(t, p, newRun)
+
+	if _, err := p.q.ExecContext(ctx,
+		`DELETE FROM telemetry.run WHERE started_at < $1`, cutoff,
+	); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	for _, table := range []string{
+		"telemetry.run",
+		"telemetry.resolution_key",
+		"telemetry.identification_attempt",
+		"telemetry.identifier_plugin_call",
+		"telemetry.description_plugin_call",
+	} {
+		var n int
+		if err := p.q.QueryRowContext(ctx,
+			`SELECT count(*) FROM `+table,
+		).Scan(&n); err != nil {
+			t.Fatalf("count %s: %v", table, err)
+		}
+		want := 1
+		if table == "telemetry.identification_attempt" ||
+			table == "telemetry.identifier_plugin_call" ||
+			table == "telemetry.description_plugin_call" {
+			want = 0
+		}
+		if n != want {
+			t.Errorf("%s rows after delete = %d, want %d", table, n, want)
+		}
+	}
+}
+
+// TestTelemetryReaderRoleIsSelectOnly pins what the dashboard's role can do. It is
+// granted through a NOLOGIN group role, so this asks about the privileges rather
+// than about a connection: the login that inherits them arrives with the Grafana
+// container.
+func TestTelemetryReaderRoleIsSelectOnly(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+
+	for _, rel := range []string{
+		"telemetry.run",
+		"telemetry.resolution_key",
+		"telemetry.identification_attempt",
+		"telemetry.identifier_plugin_call",
+		"telemetry.description_plugin_call",
+		"telemetry.v_run",
+		"telemetry.v_resolution_key",
+		"telemetry.v_identification_attempt",
+		"telemetry.v_identifier_plugin_call",
+		"telemetry.v_description_plugin_call",
+	} {
+		var canSelect, canInsert, canUpdate, canDelete bool
+		err := p.q.QueryRowContext(ctx, `
+			SELECT has_table_privilege('telemetry_reader', $1, 'SELECT'),
+			       has_table_privilege('telemetry_reader', $1, 'INSERT'),
+			       has_table_privilege('telemetry_reader', $1, 'UPDATE'),
+			       has_table_privilege('telemetry_reader', $1, 'DELETE')
+		`, rel).Scan(&canSelect, &canInsert, &canUpdate, &canDelete)
+		if err != nil {
+			t.Fatalf("privileges on %s: %v", rel, err)
+		}
+		if !canSelect {
+			t.Errorf("telemetry_reader cannot SELECT %s", rel)
+		}
+		if canInsert || canUpdate || canDelete {
+			t.Errorf("telemetry_reader can write %s: insert=%v update=%v delete=%v",
+				rel, canInsert, canUpdate, canDelete)
+		}
+	}
+}
+
+// TestTelemetryVocabulariesAreClosed pins the rule the whole schema rests on: one
+// row carries exactly one outcome drawn from a closed list. A value outside the
+// list is rejected by the database rather than quietly charted as its own bucket.
+//
+// Each case takes its own transaction because a rejected statement aborts the one
+// it ran in, and the next case would then fail for the wrong reason.
+func TestTelemetryVocabulariesAreClosed(t *testing.T) {
+	t.Run("run kind", func(t *testing.T) {
+		p := testDBTx(t)
+		// An RPC request is deliberately not a kind of run.
+		if _, err := p.q.ExecContext(context.Background(),
+			`INSERT INTO telemetry.run (kind) VALUES ('rpc_request')`,
+		); err == nil {
+			t.Error("run accepted a kind outside its vocabulary")
+		}
+	})
+
+	t.Run("run outcome", func(t *testing.T) {
+		p := testDBTx(t)
+		runID := seedRun(t, p, "tx_import", time.Now())
+		if _, err := p.q.ExecContext(context.Background(),
+			`UPDATE telemetry.run SET outcome = 'cancelled' WHERE id = $1::uuid`, runID,
+		); err == nil {
+			t.Error("run accepted an outcome outside its vocabulary")
+		}
+	})
+
+	t.Run("attempt purpose", func(t *testing.T) {
+		p := testDBTx(t)
+		keyID := seedResolutionKey(t, p, seedRun(t, p, "tx_import", time.Now()))
+		// A cache hit is not an outcome anywhere in this schema: it is an artefact
+		// of deduplication, and counting it would make the population transactions
+		// rather than descriptions.
+		if _, err := p.q.ExecContext(context.Background(), `
+			INSERT INTO telemetry.identification_attempt
+				(resolution_key_id, purpose, depth, outcome, had_identifier_hints)
+			VALUES ($1::uuid, 'cache_hit', 0, 'identified', FALSE)
+		`, keyID); err == nil {
+			t.Error("identification attempt accepted a purpose outside its vocabulary")
+		}
+	})
+
+	t.Run("plugin call outcome", func(t *testing.T) {
+		p := testDBTx(t)
+		keyID := seedResolutionKey(t, p, seedRun(t, p, "tx_import", time.Now()))
+		attemptID := seedAttempt(t, p, keyID, "primary", "identified", 0)
+		if _, err := p.q.ExecContext(context.Background(), `
+			INSERT INTO telemetry.identifier_plugin_call
+				(identification_attempt_id, plugin_id, outcome, retries, duration_ms)
+			VALUES ($1::uuid, 'openfigi', 'cache_hit', 0, 12)
+		`, attemptID); err == nil {
+			t.Error("identifier plugin call accepted an outcome outside its vocabulary")
+		}
+	})
+}

--- a/server/migrations/005_telemetry.sql
+++ b/server/migrations/005_telemetry.sql
@@ -1,0 +1,391 @@
+-- Telemetry: run-scoped event rows read by Grafana through a SELECT-only role.
+-- See docs/spec/telemetry.md for the column lists and outcome vocabularies, and
+-- docs/adr/0053-telemetry-is-run-scoped-event-rows.md for why the Redis counters
+-- were replaced by rows.
+--
+-- One rule governs every table here:
+--
+--   One row is one completed unit of work, and carries exactly one outcome drawn
+--   from a closed, mutually exclusive vocabulary.
+--
+-- The vocabulary being closed is what makes a chart interpretable without knowing
+-- how the code branches, and is why every outcome column is a CHECK over a spelled
+-- out list rather than free text. Where a row has two outcome columns it is because
+-- the unit of work has two sequential stages, not because two grains share a row.
+-- Grains relate by foreign key and are never added together.
+--
+-- A separate schema rather than more tables in public: this is a separate scope,
+-- read by a different role, retained on a different clock, and dropped as a unit if
+-- it ever stops earning its keep.
+--
+-- Plain tables, not hypertables. The volume does not warrant Timescale and foreign
+-- keys into a hypertable are an avoidable complication.
+CREATE SCHEMA telemetry;
+
+-- One activation of one subsystem, of which an ingestion job and a worker cycle are
+-- two kinds. Every event row hangs off a run, which is what makes "what happened
+-- during that import" answerable at all -- the question the counters could not
+-- answer, because they were global running totals.
+--
+-- The row is written twice: created before its children, since they reference it,
+-- and stamped with ended_at and an outcome when the work finishes. A run whose
+-- process died never receives the second write, which is what 'incomplete' is for.
+-- It is an explicit member of the vocabulary rather than a null so that a killed
+-- container reads as a fact, and so that a null outcome can mean genuinely running
+-- now. Under the dev stack's pinned memswap_limit that is a diagnosis rather than an
+-- edge case.
+--
+-- telemetry_incomplete is unrelated to the 'incomplete' outcome: it says a telemetry
+-- write failed, so this run's counts understate. The work may have succeeded while
+-- its telemetry was lost, and a panel should mark such a run rather than trust it.
+--
+-- job_id and user_id are deliberately not foreign keys, for the reason tx_groups.job_id
+-- is not one: a run must outlive the work it describes. Telemetry is retained for 360
+-- days against whatever prunes jobs and users, and a cross-schema ON DELETE CASCADE
+-- would let deleting a job silently destroy the diagnostics explaining it. A job's
+-- status is likewise denormalised onto outcome rather than joined from ingestion_jobs,
+-- because a run's outcome is a historical fact once stamped and because it keeps every
+-- panel reading one table regardless of run kind.
+--
+-- An RPC request is not a kind of run. No handler does substantial synchronous work,
+-- so nothing would populate one, while the SPA's polling would swamp this table.
+CREATE TABLE telemetry.run (
+  id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  kind       TEXT NOT NULL CHECK (kind IN ('tx_import', 'user_archive_import',
+                                           'system_archive_import', 'price_job',
+                                           'grouping_cycle', 'transfer_match_cycle',
+                                           'corporate_event_cycle', 'price_fetch_cycle',
+                                           'inflation_cycle')),
+  -- ingestion_jobs.id when the run is a job; null for a cycle.
+  job_id     UUID,
+  -- Null for cycles, which run on nobody's behalf.
+  user_id    UUID,
+  broker     TEXT,
+  source     TEXT,
+  started_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  ended_at   TIMESTAMPTZ,
+  -- Null while in flight.
+  outcome    TEXT CHECK (outcome IN ('success', 'failed', 'incomplete')),
+  telemetry_incomplete BOOLEAN NOT NULL DEFAULT FALSE
+);
+
+-- started_at carries both the retention delete and the time axis of every drifting
+-- panel, so it is indexed alone; the composite serves a panel bucketing one kind.
+CREATE INDEX idx_telemetry_run_started_at ON telemetry.run (started_at);
+CREATE INDEX idx_telemetry_run_kind_started_at ON telemetry.run (kind, started_at);
+
+-- One distinct (source, instrument_description, identifier hints) triple within a
+-- run -- the thing the ingestion resolver's cacheKeyWithHints names. Not one
+-- transaction: many transactions share a key and resolve once, and tx_count records
+-- that fan-out so a failure affecting 300 rows can be told from one affecting 1.
+--
+-- A cache hit is not an outcome here, because it is not a resolution. Counting one
+-- would make the population transactions rather than descriptions, which is the
+-- confusion of grains this schema exists to end.
+--
+-- Like run, the row is created and later stamped: its children reference it, so it
+-- must exist before its own outcome is known. The columns above extraction_outcome
+-- are the inputs, written on creation; the four below are the results, written when
+-- the key resolves. That is why they are nullable, and a null in them means the same
+-- thing a null run outcome does.
+--
+-- had_identifier_hints, security_type_hint and instrument_kind are here so a spike
+-- can be attributed rather than merely noticed.
+CREATE TABLE telemetry.resolution_key (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_id      UUID NOT NULL REFERENCES telemetry.run (id) ON DELETE CASCADE,
+  source      TEXT NOT NULL,
+  description TEXT NOT NULL,
+  -- Transactions sharing this key.
+  tx_count    INT NOT NULL,
+  had_identifier_hints BOOLEAN NOT NULL,
+  security_type_hint   TEXT,
+  instrument_kind      TEXT,
+  -- Stage 1. The not_attempted_* members are where the skips live: extraction is
+  -- skipped for a description already resolved by DB lookup, and for one whose every
+  -- posting names an identifier, because extraction exists to find an identifier and
+  -- is a paid call.
+  extraction_outcome TEXT CHECK (extraction_outcome IN ('hints_found', 'no_hints',
+                                                        'not_attempted_db_hit',
+                                                        'not_attempted_hints_supplied',
+                                                        'not_attempted_type_filter',
+                                                        'not_attempted_no_plugins')),
+  -- Stage 2. The two db_* members are distinct lookups -- by stored (source,
+  -- description) and by supplied identifier hints -- and conflating them hides which
+  -- path is carrying an import. The three fallback members mirror the messages the
+  -- resolver already records against a row.
+  outcome     TEXT CHECK (outcome IN ('db_source_description', 'db_identifier_hints',
+                                      'identified', 'broker_description_only',
+                                      'extraction_failed', 'plugin_timeout',
+                                      'plugin_unavailable', 'conflicting_hints')),
+  -- MIC_TICKER and OPENFIGI_SHARE_CLASS resolved differently. A flag rather than an
+  -- outcome: resolution continues and succeeds using MIC_TICKER, so a mismatch is not
+  -- a terminal state, and modelling it as one would make outcome non-exhaustive.
+  mismatch_detected BOOLEAN NOT NULL DEFAULT FALSE,
+  -- Null when unresolved.
+  instrument_id     UUID
+);
+
+CREATE INDEX idx_telemetry_resolution_key_run ON telemetry.resolution_key (run_id);
+
+-- One ResolveWithPlugins call. A single resolution key produces several: one primary,
+-- two more when the mismatch check runs, and one per level of underlying recursion.
+-- That is a fact recorded in purpose and depth rather than a discrepancy between two
+-- totals, which is what asking whether counters summed used to reduce it to.
+--
+-- A plugin filtered out by acceptable kind or security type produces no
+-- identifier_plugin_call row, because no call was made. When that filter removes every
+-- plugin the attempt records no_eligible_plugins.
+CREATE TABLE telemetry.identification_attempt (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  resolution_key_id UUID NOT NULL REFERENCES telemetry.resolution_key (id) ON DELETE CASCADE,
+  purpose           TEXT NOT NULL CHECK (purpose IN ('primary', 'mismatch_check', 'underlying')),
+  -- Recursion depth; 0 for the first call.
+  depth             INT NOT NULL,
+  outcome           TEXT NOT NULL CHECK (outcome IN ('db_short_circuit', 'no_eligible_plugins',
+                                                     'identified', 'not_identified',
+                                                     'plugin_timeout', 'plugin_error')),
+  security_type_hint   TEXT,
+  asset_class          TEXT,
+  had_identifier_hints BOOLEAN NOT NULL
+);
+
+CREATE INDEX idx_telemetry_identification_attempt_key
+  ON telemetry.identification_attempt (resolution_key_id);
+
+-- One plugin invocation within an attempt.
+--
+-- won, superseded and discarded_inconsistent are all successes, and are decided by the
+-- orchestrator after every plugin has returned: superseded lost to a better hint match
+-- despite higher precedence, and discarded_inconsistent was dropped as contradicting
+-- the winner. A plugin cannot know either, which is why it returns its transport
+-- outcome and the orchestrator composes the row. retries and duration_ms are the
+-- orchestrator's too: the retry loop and the clock belong to it.
+CREATE TABLE telemetry.identifier_plugin_call (
+  id                        UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  identification_attempt_id UUID NOT NULL
+                            REFERENCES telemetry.identification_attempt (id) ON DELETE CASCADE,
+  plugin_id                 TEXT NOT NULL,
+  outcome                   TEXT NOT NULL CHECK (outcome IN ('won', 'superseded',
+                                                             'discarded_inconsistent',
+                                                             'not_identified', 'rate_limited',
+                                                             'timeout', 'error',
+                                                             'skipped_expired')),
+  retries                   INT NOT NULL,
+  duration_ms               INT NOT NULL
+);
+
+CREATE INDEX idx_telemetry_identifier_plugin_call_attempt
+  ON telemetry.identifier_plugin_call (identification_attempt_id);
+
+-- One plugin invocation over a batch. This hangs off the run rather than off a
+-- resolution key: one ExtractBatch call covers many descriptions at once, so it has no
+-- single parent key. Identifier plugins are called once per plugin per attempt and do
+-- nest. The asymmetry is forced by the code and must not be flattened away -- it is
+-- what made the counters this replaces impossible to add up.
+--
+-- Description plugins run in precedence order and each sees only the items its
+-- predecessors failed on, so batch_size is a different population per plugin and rates
+-- are not comparable between them. Identifier plugins run in parallel and every
+-- eligible plugin is called, so those rates are comparable.
+--
+-- Tokens are columns rather than running totals, which is what makes the cost of one
+-- import answerable. They are null, not zero, for a plugin that costs no tokens.
+CREATE TABLE telemetry.description_plugin_call (
+  id        UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_id    UUID NOT NULL REFERENCES telemetry.run (id) ON DELETE CASCADE,
+  plugin_id TEXT NOT NULL,
+  -- Items passed to this plugin, after the type filter.
+  batch_size       INT NOT NULL,
+  -- Items it returned hints for.
+  items_with_hints INT NOT NULL,
+  outcome   TEXT NOT NULL CHECK (outcome IN ('hints_returned', 'no_hints', 'error',
+                                             'rate_limited', 'quota_exceeded',
+                                             'model_not_found')),
+  prompt_tokens     BIGINT,
+  completion_tokens BIGINT,
+  total_tokens      BIGINT,
+  duration_ms       INT NOT NULL
+);
+
+CREATE INDEX idx_telemetry_description_plugin_call_run
+  ON telemetry.description_plugin_call (run_id);
+
+-- Views.
+--
+-- One per table, each flattening its parents in and never fanning out into its
+-- children. A view spanning two sibling grains duplicates the parent's rows and makes
+-- counting it silently wrong, so v_resolution_key must stay one row per key however
+-- many attempts it produced.
+--
+-- Judgements are computed columns here; selection belongs to the panel. A panel reads
+-- "where is_import and reached_plugins" rather than repeating a list of excluded
+-- outcomes, so a definition is stated once in reviewed SQL rather than retyped into
+-- each dashboard.
+--
+-- A parent's column keeps a prefixed name where the child has one of its own -- both a
+-- run and a resolution key have a source, and both a key and an attempt have an
+-- outcome -- so that a panel naming a column cannot be reading the wrong grain's.
+
+-- is_import is the run kinds that are an import of transactions or an archive, as
+-- against a worker cycle.
+CREATE VIEW telemetry.v_run AS
+SELECT
+  r.id,
+  r.kind,
+  r.job_id,
+  r.user_id,
+  r.broker,
+  r.source,
+  r.started_at,
+  r.ended_at,
+  r.outcome,
+  r.telemetry_incomplete,
+  r.kind IN ('tx_import', 'user_archive_import', 'system_archive_import') AS is_import,
+  -- Null while the run is in flight, which is the same thing outcome says.
+  (EXTRACT(EPOCH FROM (r.ended_at - r.started_at)) * 1000)::BIGINT AS duration_ms
+FROM telemetry.run r;
+
+CREATE VIEW telemetry.v_resolution_key AS
+SELECT
+  k.id,
+  k.run_id,
+  k.source,
+  k.description,
+  k.tx_count,
+  k.had_identifier_hints,
+  k.security_type_hint,
+  k.instrument_kind,
+  k.extraction_outcome,
+  k.outcome,
+  k.mismatch_detected,
+  k.instrument_id,
+  r.kind       AS run_kind,
+  r.job_id     AS run_job_id,
+  r.user_id    AS run_user_id,
+  r.broker     AS run_broker,
+  r.source     AS run_source,
+  r.started_at AS run_started_at,
+  r.outcome    AS run_outcome,
+  r.telemetry_incomplete AS run_telemetry_incomplete,
+  r.kind IN ('tx_import', 'user_archive_import', 'system_archive_import') AS is_import
+FROM telemetry.resolution_key k
+JOIN telemetry.run r ON r.id = k.run_id;
+
+-- reached_plugins is the denominator for identification failure rate. Using all
+-- attempts instead makes the rate fall as the instrument table fills, because more
+-- resolutions short-circuit in the database, which reads as improving identification
+-- when nothing has changed. A failure-rate panel filters purpose = 'primary' as well,
+-- or an import carrying more dual-hint descriptions inflates the denominator with
+-- mismatch-check attempts.
+CREATE VIEW telemetry.v_identification_attempt AS
+SELECT
+  a.id,
+  a.resolution_key_id,
+  a.purpose,
+  a.depth,
+  a.outcome,
+  a.security_type_hint,
+  a.asset_class,
+  a.had_identifier_hints,
+  a.outcome NOT IN ('db_short_circuit', 'no_eligible_plugins') AS reached_plugins,
+  k.source      AS key_source,
+  k.description AS key_description,
+  k.tx_count    AS key_tx_count,
+  k.outcome     AS key_outcome,
+  k.mismatch_detected AS key_mismatch_detected,
+  r.id         AS run_id,
+  r.kind       AS run_kind,
+  r.job_id     AS run_job_id,
+  r.user_id    AS run_user_id,
+  r.broker     AS run_broker,
+  r.source     AS run_source,
+  r.started_at AS run_started_at,
+  r.outcome    AS run_outcome,
+  r.telemetry_incomplete AS run_telemetry_incomplete,
+  r.kind IN ('tx_import', 'user_archive_import', 'system_archive_import') AS is_import
+FROM telemetry.identification_attempt a
+JOIN telemetry.resolution_key k ON k.id = a.resolution_key_id
+JOIN telemetry.run r ON r.id = k.run_id;
+
+CREATE VIEW telemetry.v_identifier_plugin_call AS
+SELECT
+  c.id,
+  c.identification_attempt_id,
+  c.plugin_id,
+  c.outcome,
+  c.retries,
+  c.duration_ms,
+  a.purpose      AS attempt_purpose,
+  a.depth        AS attempt_depth,
+  a.outcome      AS attempt_outcome,
+  a.asset_class  AS attempt_asset_class,
+  a.security_type_hint AS attempt_security_type_hint,
+  a.had_identifier_hints AS attempt_had_identifier_hints,
+  a.outcome NOT IN ('db_short_circuit', 'no_eligible_plugins') AS reached_plugins,
+  k.id          AS resolution_key_id,
+  k.source      AS key_source,
+  k.description AS key_description,
+  k.tx_count    AS key_tx_count,
+  k.outcome     AS key_outcome,
+  r.id         AS run_id,
+  r.kind       AS run_kind,
+  r.job_id     AS run_job_id,
+  r.user_id    AS run_user_id,
+  r.broker     AS run_broker,
+  r.source     AS run_source,
+  r.started_at AS run_started_at,
+  r.outcome    AS run_outcome,
+  r.telemetry_incomplete AS run_telemetry_incomplete,
+  r.kind IN ('tx_import', 'user_archive_import', 'system_archive_import') AS is_import
+FROM telemetry.identifier_plugin_call c
+JOIN telemetry.identification_attempt a ON a.id = c.identification_attempt_id
+JOIN telemetry.resolution_key k ON k.id = a.resolution_key_id
+JOIN telemetry.run r ON r.id = k.run_id;
+
+CREATE VIEW telemetry.v_description_plugin_call AS
+SELECT
+  c.id,
+  c.run_id,
+  c.plugin_id,
+  c.batch_size,
+  c.items_with_hints,
+  c.outcome,
+  c.prompt_tokens,
+  c.completion_tokens,
+  c.total_tokens,
+  c.duration_ms,
+  r.kind       AS run_kind,
+  r.job_id     AS run_job_id,
+  r.user_id    AS run_user_id,
+  r.broker     AS run_broker,
+  r.source     AS run_source,
+  r.started_at AS run_started_at,
+  r.outcome    AS run_outcome,
+  r.telemetry_incomplete AS run_telemetry_incomplete,
+  r.kind IN ('tx_import', 'user_archive_import', 'system_archive_import') AS is_import
+FROM telemetry.description_plugin_call c
+JOIN telemetry.run r ON r.id = c.run_id;
+
+-- The reading role.
+--
+-- telemetry_reader is a NOLOGIN group role holding the privileges, not the login the
+-- dashboard uses. The login role and its password come from compose environment at
+-- container init and are granted membership here, which is what keeps a password out
+-- of a file in the repository. Creating it is guarded because a role is a
+-- cluster-wide object while a migration is per-database.
+--
+-- SELECT and nothing else, on the views and the tables alike. The default privileges
+-- cover a table added by a later migration, so a new grain cannot go unreadable
+-- without anyone noticing.
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'telemetry_reader') THEN
+    CREATE ROLE telemetry_reader NOLOGIN;
+  END IF;
+END
+$$;
+
+GRANT USAGE ON SCHEMA telemetry TO telemetry_reader;
+GRANT SELECT ON ALL TABLES IN SCHEMA telemetry TO telemetry_reader;
+ALTER DEFAULT PRIVILEGES IN SCHEMA telemetry GRANT SELECT ON TABLES TO telemetry_reader;


### PR DESCRIPTION
First of two PRs for [0115](docs/issues/0115-telemetry-schema-and-writer.md). This one is the schema; the writer follows on a branch from this one.

`server/migrations/005_telemetry.sql` creates the `telemetry` schema: `run`, `resolution_key`, `identification_attempt`, `identifier_plugin_call` and `description_plugin_call`, one wide view per table, and SELECT-only grants. Column lists and outcome vocabularies are taken verbatim from docs/spec/telemetry.md; every outcome column is a `CHECK` over a spelled out list.

Three things worth a reviewer's attention:

* **`job_id` and `user_id` are not foreign keys.** The precedent is `tx_groups.job_id`: a run must outlive the work it describes, telemetry is retained for 360 days against whatever prunes jobs, and a cross-schema `ON DELETE CASCADE` into `public.ingestion_jobs` would let deleting a job silently destroy the diagnostics explaining it.
* **`resolution_key` has nullable outcome columns.** Its children reference it, so it must exist before its own outcome is known. Like `run`, it is created with its inputs and stamped with its results -- the write order is forced by the foreign key, not chosen.
* **The reading role is a NOLOGIN group role.** A migration cannot hold a password, so `telemetry_reader` carries the privileges and the login that inherits them arrives at container init with Grafana in 0117.

Tests are raw SQL against the schema, since there is no writer yet: the views compute `is_import` and `reached_plugins` across every kind and outcome, a key with three attempts still yields one row in `v_resolution_key`, a delete over `started_at` cascades to all four child tables, `telemetry_reader` can select and cannot write, and a value outside a vocabulary is rejected.

Nothing writes these tables yet -- emitters land in 0116.

`make check` and `make db-test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)