### PR TITLE
Add the telemetry writer and a retention purge RPC (0115)

### DIFF
--- a/docs/issues/0115-telemetry-schema-and-writer.md
+++ b/docs/issues/0115-telemetry-schema-and-writer.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Telemetry schema and synchronous writer
 milestone: M20
 ---

--- a/docs/issues/0119-schedule-telemetry-retention.md
+++ b/docs/issues/0119-schedule-telemetry-retention.md
@@ -1,0 +1,13 @@
+---
+status: open
+title: Schedule the telemetry retention purge
+dependencies: [0115]
+---
+
+Call the `PurgeTelemetry` RPC on a schedule, so runs past the 360-day window are
+actually deleted rather than merely deletable.
+
+The RPC exists and does the work; nothing invokes it. The service schedules nothing
+of its own, so this is an operator-side scheduler -- a cron entry, a compose sidecar
+or whatever the deployment already uses -- authenticating as an admin service account
+and logging the count the RPC returns.

--- a/docs/spec/telemetry.md
+++ b/docs/spec/telemetry.md
@@ -163,7 +163,17 @@ Writes are synchronous, through a connection pool separate from the application'
 confined to `server/db` as all SQL is. They never join the work's transaction: a failed
 import rolls back, and telemetry riding along would erase the diagnostics for the run
 most worth inspecting. A write that fails sets `telemetry_incomplete` on the run and is
-otherwise ignored -- telemetry never fails the work.
+otherwise ignored -- telemetry never fails the work. No write returns an error, so a
+caller threads ids through without testing them; a write whose parent id is missing is
+skipped, which costs one failure its own subtree and nothing else.
+
+`run` and `resolution_key` are each written twice -- created with what is known when the
+work starts, stamped with its outcome when the work ends. For a run that is what leaves
+one whose process died unstamped. For a resolution key it is forced by the foreign key:
+its identification attempts reference it, so it has to exist before its own outcome is
+known. The other three grains are written once, when their unit of work completes, which
+for an identifier plugin call is the moment the orchestrator decides `won` against
+`superseded` against `discarded_inconsistent`.
 
 Plugins do not write. `Identify` and `ExtractBatch` return a telemetry value alongside
 their result and the orchestrator composes the row, so no plugin depends on the
@@ -177,11 +187,21 @@ retention is a delete over `run.started_at`, at **360 days**. Traffic is low and
 problem may go unnoticed for a long time, so the window is set to outlast the gap
 between a regression landing and someone looking for it.
 
+The delete is exposed as an admin RPC and nothing in the service schedules it. The
+service runs no cron of its own, and a retention window measured in a year is not worth
+one: an operator's scheduler calls the RPC, and the count it answers with is what that
+scheduler logs. This is why the RPC is synchronous and returns what it deleted, unlike
+the `Trigger` RPCs, which poke a worker and answer immediately.
+
 The schema, its tables, its views and the SELECT-only grants live in
 `server/migrations/005_telemetry.sql`, separate from the application schema because it is
-a separate scope rather than a later change to the same one. The reading role's password
-is not in the migration: the role is created at container init from compose
-environment.
+a separate scope rather than a later change to the same one.
+
+The reading role's password is not in the migration, which rules out the migration
+creating the login the dashboard uses. So the migration creates `telemetry_reader`, a
+NOLOGIN group role holding SELECT and nothing else, and the login role is created at
+container init from compose environment and granted membership of it. The privileges are
+then reviewed in the repository and the password never is.
 
 ## 2. Logger
 

--- a/proto/api/v1/api.proto
+++ b/proto/api/v1/api.proto
@@ -267,6 +267,12 @@ service ApiService {
   // Telemetry counters (admin-only). Returns counters discovered from Redis (portfoliodb:counters:*).
   rpc ListTelemetryCounters(ListTelemetryCountersRequest) returns (ListTelemetryCountersResponse);
 
+  // Delete telemetry runs past the retention window, cascading to the event rows
+  // beneath them (admin-only). Synchronous, and returns what it deleted: unlike
+  // the Trigger RPCs there is no worker behind this, and nothing in the service
+  // schedules it -- an external scheduler calls it.
+  rpc PurgeTelemetry(PurgeTelemetryRequest) returns (PurgeTelemetryResponse);
+
   // Worker status (admin-only). Returns current state of background workers.
   rpc ListWorkers(ListWorkersRequest) returns (ListWorkersResponse);
 
@@ -861,6 +867,13 @@ message TelemetryCounter {
 
 message ListTelemetryCountersResponse {
   repeated TelemetryCounter counters = 1;
+}
+
+message PurgeTelemetryRequest {}
+
+message PurgeTelemetryResponse {
+  // Runs deleted. Their event rows went with them.
+  int64 runs_deleted = 1;
 }
 
 // EODPriceProto is a single end-of-day price row for admin browsing.

--- a/server/cmd/portfoliodb/main.go
+++ b/server/cmd/portfoliodb/main.go
@@ -71,11 +71,20 @@ var buildRevision = "dev"
 // it is arrived at -- it is a memory budget as much as a handle count.
 const defaultDBMaxConns = 16
 
+// defaultTelemetryDBMaxConns bounds the telemetry pool, which is separate from the
+// application's because telemetry must never join the work's transaction. Its
+// writes are single-row inserts with no sort nodes, so unlike the application pool
+// it costs handles and not work_mem, and a handful is enough for the few runs in
+// flight at once. It is small because both pools draw on the same
+// max_connections -- 25 in the dev stack -- and Grafana will want some too.
+const defaultTelemetryDBMaxConns = 4
+
 func main() {
 	grpcAddr := flag.String("grpc-addr", envOrDefault("PORTFOLIODB_GRPC_ADDR", ":50051"), "gRPC listen address")
 	dbURL := flag.String("db-url", os.Getenv("PORTFOLIODB_DB_URL"), "PostgreSQL connection URL")
 	redisURL := flag.String("redis-url", envOrDefault("PORTFOLIODB_REDIS_URL", os.Getenv("REDIS_URL")), "Redis connection URL for sessions")
 	dbMaxConns := flag.Int("db-max-conns", parseInt(os.Getenv("PORTFOLIODB_DB_MAX_CONNS"), defaultDBMaxConns), "maximum open database connections")
+	telemetryDBMaxConns := flag.Int("telemetry-db-max-conns", parseInt(os.Getenv("PORTFOLIODB_TELEMETRY_DB_MAX_CONNS"), defaultTelemetryDBMaxConns), "maximum open telemetry database connections")
 	flag.Parse()
 	if *dbURL == "" {
 		log.Fatal("PORTFOLIODB_DB_URL or -db-url required")
@@ -97,6 +106,10 @@ func main() {
 	// 1GB ceiling, which fits the dev stack's 2g postgres alongside its 512MB of
 	// shared buffers, and stays under its max_connections of 25 with room for a
 	// psql session. Raise both together or neither.
+	//
+	// Telemetry adds a second pool of its own further down, so the handle budget is
+	// the sum of the two -- 20 of the dev stack's 25 at the defaults. The memory
+	// budget is unchanged: telemetry writes single rows and sorts nothing.
 	rawConn.SetMaxOpenConns(*dbMaxConns)
 	// Idle matched to open so a busy period does not reconnect on every request,
 	// with an idle timeout so a quiet one gives the backends back.
@@ -113,6 +126,20 @@ func main() {
 	// The engine is wired into the store, so an upload's postings are partitioned in
 	// the transaction that writes them rather than in whatever shape they arrived.
 	database := postgres.New(conn).WithSettler(grouping.NewEngine())
+
+	// A second pool, for telemetry alone. It is separate rather than shared because
+	// telemetry must not join the work's transaction: a failed import rolls back,
+	// and telemetry riding along would erase the diagnostics for the run most worth
+	// inspecting. The two pools add up against one max_connections, so raising
+	// either means checking the sum -- see the comment on the cap above.
+	telemetryConn, err := sql.Open("postgres", *dbURL)
+	if err != nil {
+		log.Fatalf("telemetry db open: %v", err)
+	}
+	defer telemetryConn.Close()
+	telemetryConn.SetMaxOpenConns(*telemetryDBMaxConns)
+	telemetryConn.SetMaxIdleConns(*telemetryDBMaxConns)
+	telemetryConn.SetConnMaxIdleTime(5 * time.Minute)
 
 	// Redis session store
 	ropt, err := redis.ParseURL(*redisURL)
@@ -139,6 +166,9 @@ func main() {
 	slog.SetDefault(slog.New(h))
 	serverLogger := slog.Default()
 	serverLogger.Info("LOG_LEVEL configured", "levels", logger.Summary(logLevelEnv))
+
+	telemetryDB := postgres.NewTelemetry(sqlx.NewDb(telemetryConn, "postgres"),
+		logger.WithCategory(serverLogger, "server/db/telemetry"))
 
 	// Google ID token verifier
 	googleClientID := os.Getenv("GOOGLE_OAUTH_CLIENT_ID")
@@ -334,6 +364,7 @@ func main() {
 		DB:                     database,
 		Redis:                  rdb,
 		CounterPrefix:          counterPrefix,
+		TelemetryDB:            telemetryDB,
 		PluginRegistry:         pluginRegistry,
 		DescRegistry:           descRegistry,
 		PriceRegistry:          priceRegistry,

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -1968,3 +1968,224 @@ type GroupingPosting struct {
 	Resolved     string
 	Correlations []Correlation
 }
+
+// Telemetry.
+//
+// Run-scoped event rows in the telemetry schema, replacing the Redis counters.
+// See docs/spec/telemetry.md for the grains and their vocabularies, and
+// docs/adr/0053-telemetry-is-run-scoped-event-rows.md for why.
+
+// TelemetryRetention is how long a run and its event rows are kept. Traffic is
+// low and a problem may go unnoticed for a long time, so the window is set to
+// outlast the gap between a regression landing and someone looking for it.
+const TelemetryRetention = 360 * 24 * time.Hour
+
+// Run kinds. One activation of one subsystem, of which an ingestion job and a
+// worker cycle are two kinds.
+const (
+	TelemetryRunTxImport            = "tx_import"
+	TelemetryRunUserArchiveImport   = "user_archive_import"
+	TelemetryRunSystemArchiveImport = "system_archive_import"
+	TelemetryRunPriceJob            = "price_job"
+	TelemetryRunGroupingCycle       = "grouping_cycle"
+	TelemetryRunTransferMatchCycle  = "transfer_match_cycle"
+	TelemetryRunCorporateEventCycle = "corporate_event_cycle"
+	TelemetryRunPriceFetchCycle     = "price_fetch_cycle"
+	TelemetryRunInflationCycle      = "inflation_cycle"
+)
+
+// Run outcomes. TelemetryOutcomeIncomplete means the run died, and is stamped by
+// a sweep over runs left without a terminal outcome, which is what lets an
+// unstamped run mean genuinely in flight.
+const (
+	TelemetryOutcomeSuccess    = "success"
+	TelemetryOutcomeFailed     = "failed"
+	TelemetryOutcomeIncomplete = "incomplete"
+)
+
+// Extraction outcomes, stage 1 of a resolution key. The not_attempted members are
+// where the skips live: extraction is skipped for a description already resolved
+// by DB lookup, and for one whose every posting names an identifier, because
+// extraction exists to find an identifier and is a paid call.
+const (
+	TelemetryExtractionHintsFound                = "hints_found"
+	TelemetryExtractionNoHints                   = "no_hints"
+	TelemetryExtractionNotAttemptedDBHit         = "not_attempted_db_hit"
+	TelemetryExtractionNotAttemptedHintsSupplied = "not_attempted_hints_supplied"
+	TelemetryExtractionNotAttemptedTypeFilter    = "not_attempted_type_filter"
+	TelemetryExtractionNotAttemptedNoPlugins     = "not_attempted_no_plugins"
+)
+
+// Resolution outcomes, stage 2 of a resolution key. The two db_ members are
+// distinct lookups -- by stored (source, description) and by supplied identifier
+// hints -- and conflating them hides which path is carrying an import.
+const (
+	TelemetryResolutionDBSourceDescription   = "db_source_description"
+	TelemetryResolutionDBIdentifierHints     = "db_identifier_hints"
+	TelemetryResolutionIdentified            = "identified"
+	TelemetryResolutionBrokerDescriptionOnly = "broker_description_only"
+	TelemetryResolutionExtractionFailed      = "extraction_failed"
+	TelemetryResolutionPluginTimeout         = "plugin_timeout"
+	TelemetryResolutionPluginUnavailable     = "plugin_unavailable"
+	TelemetryResolutionConflictingHints      = "conflicting_hints"
+)
+
+// Identification attempt purposes. A single resolution key produces several
+// attempts: one primary, two more when the mismatch check runs, and one per level
+// of underlying recursion.
+const (
+	TelemetryPurposePrimary       = "primary"
+	TelemetryPurposeMismatchCheck = "mismatch_check"
+	TelemetryPurposeUnderlying    = "underlying"
+)
+
+// Identification attempt outcomes. A plugin filtered out by acceptable kind or
+// security type produces no plugin-call row, because no call was made; when that
+// filter removes every plugin the attempt records no_eligible_plugins.
+const (
+	TelemetryAttemptDBShortCircuit    = "db_short_circuit"
+	TelemetryAttemptNoEligiblePlugins = "no_eligible_plugins"
+	TelemetryAttemptIdentified        = "identified"
+	TelemetryAttemptNotIdentified     = "not_identified"
+	TelemetryAttemptPluginTimeout     = "plugin_timeout"
+	TelemetryAttemptPluginError       = "plugin_error"
+)
+
+// Identifier plugin call outcomes the orchestrator composes. The rest of the
+// vocabulary is the plugin's own transport outcome and lives on
+// identifier.Outcome, which a caller spells with string(). These three are all
+// successes and are decided after every plugin has returned: superseded lost to a
+// better hint match despite higher precedence, and discarded_inconsistent was
+// dropped as contradicting the winner. No plugin can know either.
+const (
+	TelemetryPluginCallWon                   = "won"
+	TelemetryPluginCallSuperseded            = "superseded"
+	TelemetryPluginCallDiscardedInconsistent = "discarded_inconsistent"
+)
+
+// TelemetryRun is one activation of one subsystem, as it stands when it starts.
+// JobID is empty for a cycle, as are UserID, Broker and Source, which cycles run
+// without.
+type TelemetryRun struct {
+	Kind   string
+	JobID  string
+	UserID string
+	Broker string
+	Source string
+}
+
+// TelemetryResolutionKey is one distinct (source, description, identifier hints)
+// triple within a run, as it stands before it resolves. Not one transaction: many
+// transactions share a key and resolve once, and TxCount records that fan-out so a
+// failure affecting 300 rows can be told from one affecting 1.
+type TelemetryResolutionKey struct {
+	RunID              string
+	Source             string
+	Description        string
+	TxCount            int
+	HadIdentifierHints bool
+	SecurityTypeHint   string
+	InstrumentKind     string
+}
+
+// TelemetryResolutionKeyOutcome is what became of a resolution key, stamped onto
+// the row when it resolves. InstrumentID is empty when it did not.
+type TelemetryResolutionKeyOutcome struct {
+	RunID             string
+	ExtractionOutcome string
+	Outcome           string
+	MismatchDetected  bool
+	InstrumentID      string
+}
+
+// TelemetryIdentificationAttempt is one ResolveWithPlugins call, written when it
+// finishes. RunID is not stored on the row -- an attempt reaches its run through
+// its resolution key -- and is carried only so a failed write can mark the run.
+type TelemetryIdentificationAttempt struct {
+	RunID              string
+	ResolutionKeyID    string
+	Purpose            string
+	Depth              int
+	Outcome            string
+	SecurityTypeHint   string
+	AssetClass         string
+	HadIdentifierHints bool
+}
+
+// TelemetryIdentifierPluginCall is one plugin invocation within an attempt.
+// Outcome is the orchestrator's composition of the plugin's transport outcome with
+// what it decided afterwards; Retries and Duration are the orchestrator's alone,
+// since the retry loop and the clock belong to it. RunID is carried for the same
+// reason as on the attempt.
+type TelemetryIdentifierPluginCall struct {
+	RunID     string
+	AttemptID string
+	PluginID  string
+	Outcome   string
+	Retries   int
+	Duration  time.Duration
+}
+
+// TelemetryTokens is the token cost of one description plugin call. Nil on a call
+// to a plugin that costs no tokens, which is what keeps the columns null rather
+// than zero for it.
+type TelemetryTokens struct {
+	Prompt     int64
+	Completion int64
+	Total      int64
+}
+
+// TelemetryDescriptionPluginCall is one plugin invocation over a batch. It hangs
+// off the run rather than off a resolution key: one ExtractBatch call covers many
+// descriptions at once, so it has no single parent key.
+//
+// BatchSize is a different population per plugin -- description plugins run in
+// precedence order and each sees only the items its predecessors failed on -- so
+// rates are not comparable between them.
+type TelemetryDescriptionPluginCall struct {
+	RunID          string
+	PluginID       string
+	BatchSize      int
+	ItemsWithHints int
+	Outcome        string
+	Tokens         *TelemetryTokens
+	Duration       time.Duration
+}
+
+// TelemetryDB writes the event rows in the telemetry schema.
+//
+// It is deliberately not part of DB. It holds its own connection pool and never
+// joins the work's transaction: a failed import rolls back, and telemetry riding
+// along would erase the diagnostics for the run most worth inspecting.
+//
+// No write method returns an error, because telemetry never fails the work. A
+// write that fails is logged, sets telemetry_incomplete on its run and yields an
+// empty id; a write whose parent id is empty is skipped, so one failure costs its
+// own subtree and nothing else. A caller therefore threads ids through without
+// testing them.
+type TelemetryDB interface {
+	// StartRun creates a run and returns its id. The run is stamped separately,
+	// when it ends, which is what leaves a run whose process died unstamped.
+	StartRun(ctx context.Context, r TelemetryRun) string
+	// EndRun stamps ended_at and a terminal outcome.
+	EndRun(ctx context.Context, runID, outcome string)
+
+	// StartResolutionKey creates a resolution key and returns its id. Like a run
+	// it is created and later stamped, because its identification attempts
+	// reference it and so it must exist before its own outcome is known.
+	StartResolutionKey(ctx context.Context, k TelemetryResolutionKey) string
+	// EndResolutionKey stamps what became of a resolution key.
+	EndResolutionKey(ctx context.Context, keyID string, o TelemetryResolutionKeyOutcome)
+
+	// WriteIdentificationAttempt records a finished attempt and returns its id,
+	// for the plugin calls written under it.
+	WriteIdentificationAttempt(ctx context.Context, a TelemetryIdentificationAttempt) string
+	WriteIdentifierPluginCall(ctx context.Context, c TelemetryIdentifierPluginCall)
+	WriteDescriptionPluginCall(ctx context.Context, c TelemetryDescriptionPluginCall)
+
+	// PurgeRunsBefore deletes runs started before cutoff, cascading to their event
+	// rows, and returns how many runs went. Unlike the writes it returns an error,
+	// because it is the work its caller was asked to do rather than telemetry
+	// alongside other work.
+	PurgeRunsBefore(ctx context.Context, cutoff time.Time) (int64, error)
+}

--- a/server/db/postgres/telemetry.go
+++ b/server/db/postgres/telemetry.go
@@ -1,0 +1,221 @@
+package postgres
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/jmoiron/sqlx"
+	"github.com/leedenison/portfoliodb/server/db"
+)
+
+// Telemetry writes the telemetry schema.
+//
+// It takes *sqlx.DB rather than the queryable the rest of this package uses,
+// because joining the work's transaction is the one thing it must not do: a failed
+// import rolls back, and telemetry riding along would erase the diagnostics for
+// the run most worth inspecting. The pool is its own for the same reason -- a
+// connection already inside a transaction cannot write outside it.
+type Telemetry struct {
+	db  *sqlx.DB
+	log *slog.Logger
+}
+
+// NewTelemetry returns a writer over its own pool.
+func NewTelemetry(conn *sqlx.DB, log *slog.Logger) *Telemetry {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Telemetry{db: conn, log: log}
+}
+
+// Ensure Telemetry implements db.TelemetryDB.
+var _ db.TelemetryDB = (*Telemetry)(nil)
+
+// fail records that a telemetry write was lost. It logs, and marks the run so a
+// panel can say its counts understate rather than reading them as a fall in
+// traffic. The mark is itself best-effort: if the database is what failed, there
+// is nowhere left to record that it did, and telemetry never fails the work.
+func (t *Telemetry) fail(ctx context.Context, runID, op string, err error) {
+	t.log.Error("telemetry write failed", "op", op, "run_id", runID, "error", err)
+	id, parseErr := uuid.Parse(runID)
+	if parseErr != nil {
+		return
+	}
+	if _, markErr := t.db.ExecContext(ctx,
+		`UPDATE telemetry.run SET telemetry_incomplete = TRUE WHERE id = $1`, id,
+	); markErr != nil {
+		t.log.Error("telemetry mark incomplete failed", "run_id", runID, "error", markErr)
+	}
+}
+
+// parent returns the parsed id of a row's parent, and false when there is none to
+// write under. An empty id is the previous write having failed, which is already
+// logged and already marked, so the child is skipped silently rather than
+// reported a second time.
+func (t *Telemetry) parent(ctx context.Context, runID, parentID, op string) (uuid.UUID, bool) {
+	if parentID == "" {
+		return uuid.Nil, false
+	}
+	id, err := uuid.Parse(parentID)
+	if err != nil {
+		t.fail(ctx, runID, op, err)
+		return uuid.Nil, false
+	}
+	return id, true
+}
+
+// optUUID renders an optional id for storage, reusing parseNullUUID so that an
+// absent one becomes NULL. An id that will not parse is a bug in the caller rather
+// than a fact about the work, so it is logged and dropped to NULL: losing the
+// pointer is better than losing the row that says what happened.
+func (t *Telemetry) optUUID(s, op string) any {
+	v, err := parseNullUUID(s)
+	if err != nil {
+		t.log.Error("telemetry ignored an unparseable id", "op", op, "value", s, "error", err)
+		return nil
+	}
+	return v
+}
+
+// ms rounds a duration to whole milliseconds, the resolution the columns carry.
+func ms(d time.Duration) int64 {
+	return d.Milliseconds()
+}
+
+// StartRun implements db.TelemetryDB.
+func (t *Telemetry) StartRun(ctx context.Context, r db.TelemetryRun) string {
+	var id uuid.UUID
+	err := t.db.QueryRowContext(ctx, `
+		INSERT INTO telemetry.run (kind, job_id, user_id, broker, source)
+		VALUES ($1, $2, $3, $4, $5)
+		RETURNING id
+	`, r.Kind, t.optUUID(r.JobID, "start run"), t.optUUID(r.UserID, "start run"),
+		nullStr(r.Broker), nullStr(r.Source)).Scan(&id)
+	if err != nil {
+		// No run id to mark: the run is what failed to exist.
+		t.log.Error("telemetry write failed", "op", "start run", "kind", r.Kind, "error", err)
+		return ""
+	}
+	return id.String()
+}
+
+// EndRun implements db.TelemetryDB.
+func (t *Telemetry) EndRun(ctx context.Context, runID, outcome string) {
+	id, ok := t.parent(ctx, runID, runID, "end run")
+	if !ok {
+		return
+	}
+	if _, err := t.db.ExecContext(ctx, `
+		UPDATE telemetry.run SET ended_at = now(), outcome = $2 WHERE id = $1
+	`, id, outcome); err != nil {
+		t.fail(ctx, runID, "end run", err)
+	}
+}
+
+// StartResolutionKey implements db.TelemetryDB.
+func (t *Telemetry) StartResolutionKey(ctx context.Context, k db.TelemetryResolutionKey) string {
+	runID, ok := t.parent(ctx, k.RunID, k.RunID, "start resolution key")
+	if !ok {
+		return ""
+	}
+	var id uuid.UUID
+	err := t.db.QueryRowContext(ctx, `
+		INSERT INTO telemetry.resolution_key
+			(run_id, source, description, tx_count, had_identifier_hints,
+			 security_type_hint, instrument_kind)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		RETURNING id
+	`, runID, k.Source, k.Description, k.TxCount, k.HadIdentifierHints,
+		nullStr(k.SecurityTypeHint), nullStr(k.InstrumentKind)).Scan(&id)
+	if err != nil {
+		t.fail(ctx, k.RunID, "start resolution key", err)
+		return ""
+	}
+	return id.String()
+}
+
+// EndResolutionKey implements db.TelemetryDB.
+func (t *Telemetry) EndResolutionKey(ctx context.Context, keyID string, o db.TelemetryResolutionKeyOutcome) {
+	id, ok := t.parent(ctx, o.RunID, keyID, "end resolution key")
+	if !ok {
+		return
+	}
+	if _, err := t.db.ExecContext(ctx, `
+		UPDATE telemetry.resolution_key
+		SET extraction_outcome = $2, outcome = $3, mismatch_detected = $4, instrument_id = $5
+		WHERE id = $1
+	`, id, nullStr(o.ExtractionOutcome), nullStr(o.Outcome), o.MismatchDetected,
+		t.optUUID(o.InstrumentID, "end resolution key")); err != nil {
+		t.fail(ctx, o.RunID, "end resolution key", err)
+	}
+}
+
+// WriteIdentificationAttempt implements db.TelemetryDB.
+func (t *Telemetry) WriteIdentificationAttempt(ctx context.Context, a db.TelemetryIdentificationAttempt) string {
+	keyID, ok := t.parent(ctx, a.RunID, a.ResolutionKeyID, "write identification attempt")
+	if !ok {
+		return ""
+	}
+	var id uuid.UUID
+	err := t.db.QueryRowContext(ctx, `
+		INSERT INTO telemetry.identification_attempt
+			(resolution_key_id, purpose, depth, outcome, security_type_hint,
+			 asset_class, had_identifier_hints)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		RETURNING id
+	`, keyID, a.Purpose, a.Depth, a.Outcome, nullStr(a.SecurityTypeHint),
+		nullStr(a.AssetClass), a.HadIdentifierHints).Scan(&id)
+	if err != nil {
+		t.fail(ctx, a.RunID, "write identification attempt", err)
+		return ""
+	}
+	return id.String()
+}
+
+// WriteIdentifierPluginCall implements db.TelemetryDB.
+func (t *Telemetry) WriteIdentifierPluginCall(ctx context.Context, c db.TelemetryIdentifierPluginCall) {
+	attemptID, ok := t.parent(ctx, c.RunID, c.AttemptID, "write identifier plugin call")
+	if !ok {
+		return
+	}
+	if _, err := t.db.ExecContext(ctx, `
+		INSERT INTO telemetry.identifier_plugin_call
+			(identification_attempt_id, plugin_id, outcome, retries, duration_ms)
+		VALUES ($1, $2, $3, $4, $5)
+	`, attemptID, c.PluginID, c.Outcome, c.Retries, ms(c.Duration)); err != nil {
+		t.fail(ctx, c.RunID, "write identifier plugin call", err)
+	}
+}
+
+// WriteDescriptionPluginCall implements db.TelemetryDB.
+func (t *Telemetry) WriteDescriptionPluginCall(ctx context.Context, c db.TelemetryDescriptionPluginCall) {
+	runID, ok := t.parent(ctx, c.RunID, c.RunID, "write description plugin call")
+	if !ok {
+		return
+	}
+	var prompt, completion, total any
+	if c.Tokens != nil {
+		prompt, completion, total = c.Tokens.Prompt, c.Tokens.Completion, c.Tokens.Total
+	}
+	if _, err := t.db.ExecContext(ctx, `
+		INSERT INTO telemetry.description_plugin_call
+			(run_id, plugin_id, batch_size, items_with_hints, outcome,
+			 prompt_tokens, completion_tokens, total_tokens, duration_ms)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
+	`, runID, c.PluginID, c.BatchSize, c.ItemsWithHints, c.Outcome,
+		prompt, completion, total, ms(c.Duration)); err != nil {
+		t.fail(ctx, c.RunID, "write description plugin call", err)
+	}
+}
+
+// PurgeRunsBefore implements db.TelemetryDB.
+func (t *Telemetry) PurgeRunsBefore(ctx context.Context, cutoff time.Time) (int64, error) {
+	res, err := t.db.ExecContext(ctx,
+		`DELETE FROM telemetry.run WHERE started_at < $1`, cutoff)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}

--- a/server/db/postgres/telemetry_test.go
+++ b/server/db/postgres/telemetry_test.go
@@ -1,0 +1,355 @@
+package postgres
+
+import (
+	"context"
+	"database/sql"
+	"log/slog"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/jmoiron/sqlx"
+	"github.com/leedenison/portfoliodb/server/db"
+)
+
+// The writer holds its own pool precisely so that it does not join a
+// transaction, which is what makes the rollback-per-test harness unusable here:
+// these tests commit. They clean up by truncating the run table instead, which
+// cascades to everything under it.
+
+// testTelemetry returns a writer over the test database, with the telemetry
+// tables emptied when the test ends.
+func testTelemetry(t *testing.T) *Telemetry {
+	t.Helper()
+	url := os.Getenv("TEST_DATABASE_URL")
+	if url == "" {
+		t.Skip("TEST_DATABASE_URL not set (run via make db-test)")
+	}
+	conn, err := sqlx.Open("postgres", url)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() {
+		if _, err := conn.Exec(`TRUNCATE telemetry.run CASCADE`); err != nil {
+			t.Errorf("truncate: %v", err)
+		}
+		conn.Close()
+	})
+	if err := conn.Ping(); err != nil {
+		t.Fatalf("ping: %v", err)
+	}
+	// Discard the log: the failure paths below are expected to log, and a test
+	// that fails loudly on purpose should not fill the output with it.
+	return NewTelemetry(conn, slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError + 1})))
+}
+
+// scanRun reads back the columns a run is stamped with.
+func scanRun(t *testing.T, tel *Telemetry, runID string) (outcome sql.NullString, endedAt sql.NullTime, incomplete bool) {
+	t.Helper()
+	err := tel.db.QueryRow(
+		`SELECT outcome, ended_at, telemetry_incomplete FROM telemetry.run WHERE id = $1::uuid`,
+		runID,
+	).Scan(&outcome, &endedAt, &incomplete)
+	if err != nil {
+		t.Fatalf("read run: %v", err)
+	}
+	return outcome, endedAt, incomplete
+}
+
+// TestStartRunThenEndRun pins the run being written twice: created before its
+// children, since they reference it, and stamped when the work ends. An unstamped
+// run means genuinely in flight, which is what makes a stamped 'incomplete'
+// readable as a run that died.
+func TestStartRunThenEndRun(t *testing.T) {
+	tel := testTelemetry(t)
+	ctx := context.Background()
+
+	runID := tel.StartRun(ctx, db.TelemetryRun{
+		Kind:   db.TelemetryRunTxImport,
+		Broker: "FIDELITY",
+		Source: "FIDELITY_CSV",
+	})
+	if runID == "" {
+		t.Fatal("StartRun returned no id")
+	}
+	outcome, endedAt, incomplete := scanRun(t, tel, runID)
+	if outcome.Valid {
+		t.Errorf("a run in flight has outcome %q, want null", outcome.String)
+	}
+	if endedAt.Valid {
+		t.Error("a run in flight has an ended_at")
+	}
+	if incomplete {
+		t.Error("a run with no failed write is marked telemetry_incomplete")
+	}
+
+	tel.EndRun(ctx, runID, db.TelemetryOutcomeSuccess)
+	outcome, endedAt, _ = scanRun(t, tel, runID)
+	if outcome.String != db.TelemetryOutcomeSuccess {
+		t.Errorf("outcome = %q, want %q", outcome.String, db.TelemetryOutcomeSuccess)
+	}
+	if !endedAt.Valid {
+		t.Error("a stamped run has no ended_at")
+	}
+}
+
+// TestWriteNest walks one resolution through the grains it produces and reads it
+// back through the views, which is how a dashboard sees it.
+func TestWriteNest(t *testing.T) {
+	tel := testTelemetry(t)
+	ctx := context.Background()
+
+	runID := tel.StartRun(ctx, db.TelemetryRun{Kind: db.TelemetryRunTxImport, Source: "FIDELITY_CSV"})
+	keyID := tel.StartResolutionKey(ctx, db.TelemetryResolutionKey{
+		RunID:            runID,
+		Source:           "FIDELITY_CSV",
+		Description:      "APPLE INC COM",
+		TxCount:          300,
+		SecurityTypeHint: "Stock",
+		InstrumentKind:   "security",
+	})
+	if keyID == "" {
+		t.Fatal("StartResolutionKey returned no id")
+	}
+	attemptID := tel.WriteIdentificationAttempt(ctx, db.TelemetryIdentificationAttempt{
+		RunID:           runID,
+		ResolutionKeyID: keyID,
+		Purpose:         db.TelemetryPurposePrimary,
+		Outcome:         db.TelemetryAttemptIdentified,
+		AssetClass:      "STOCK",
+	})
+	if attemptID == "" {
+		t.Fatal("WriteIdentificationAttempt returned no id")
+	}
+	tel.WriteIdentifierPluginCall(ctx, db.TelemetryIdentifierPluginCall{
+		RunID:     runID,
+		AttemptID: attemptID,
+		PluginID:  "openfigi",
+		Outcome:   db.TelemetryPluginCallWon,
+		Retries:   1,
+		Duration:  1500 * time.Millisecond,
+	})
+	tel.EndResolutionKey(ctx, keyID, db.TelemetryResolutionKeyOutcome{
+		RunID:             runID,
+		ExtractionOutcome: db.TelemetryExtractionHintsFound,
+		Outcome:           db.TelemetryResolutionIdentified,
+	})
+	tel.EndRun(ctx, runID, db.TelemetryOutcomeSuccess)
+
+	// The plugin-call view flattens all three parents in, so one row answers what
+	// happened, under which attempt, for which description, in which run.
+	var (
+		pluginID, callOutcome, attemptPurpose, keyDescription, runKind string
+		retries, durationMS, txCount                                   int
+		reachedPlugins, isImport                                       bool
+	)
+	err := tel.db.QueryRow(`
+		SELECT plugin_id, outcome, retries, duration_ms, attempt_purpose,
+		       reached_plugins, key_description, key_tx_count, run_kind, is_import
+		FROM telemetry.v_identifier_plugin_call WHERE run_id = $1::uuid
+	`, runID).Scan(&pluginID, &callOutcome, &retries, &durationMS, &attemptPurpose,
+		&reachedPlugins, &keyDescription, &txCount, &runKind, &isImport)
+	if err != nil {
+		t.Fatalf("read v_identifier_plugin_call: %v", err)
+	}
+	if pluginID != "openfigi" || callOutcome != db.TelemetryPluginCallWon {
+		t.Errorf("plugin call = (%s, %s), want (openfigi, won)", pluginID, callOutcome)
+	}
+	if retries != 1 || durationMS != 1500 {
+		t.Errorf("retries, duration_ms = (%d, %d), want (1, 1500)", retries, durationMS)
+	}
+	if attemptPurpose != db.TelemetryPurposePrimary || !reachedPlugins {
+		t.Errorf("attempt = (%s, reached=%v), want (primary, reached=true)", attemptPurpose, reachedPlugins)
+	}
+	// tx_count is the fan-out, and is what tells a failure affecting 300 rows from
+	// one affecting 1.
+	if keyDescription != "APPLE INC COM" || txCount != 300 {
+		t.Errorf("key = (%q, %d), want (APPLE INC COM, 300)", keyDescription, txCount)
+	}
+	if runKind != db.TelemetryRunTxImport || !isImport {
+		t.Errorf("run = (%s, import=%v), want (tx_import, import=true)", runKind, isImport)
+	}
+
+	var extraction, resolution string
+	if err := tel.db.QueryRow(`
+		SELECT extraction_outcome, outcome FROM telemetry.v_resolution_key WHERE id = $1::uuid
+	`, keyID).Scan(&extraction, &resolution); err != nil {
+		t.Fatalf("read v_resolution_key: %v", err)
+	}
+	if extraction != db.TelemetryExtractionHintsFound || resolution != db.TelemetryResolutionIdentified {
+		t.Errorf("key outcomes = (%s, %s), want (hints_found, identified)", extraction, resolution)
+	}
+}
+
+// TestWriteDescriptionPluginCallTokens pins tokens being null rather than zero for
+// a plugin that costs none. Zero would say a call was free; null says the question
+// does not arise, and only one of those can be summed into the cost of an import.
+func TestWriteDescriptionPluginCallTokens(t *testing.T) {
+	tel := testTelemetry(t)
+	ctx := context.Background()
+	runID := tel.StartRun(ctx, db.TelemetryRun{Kind: db.TelemetryRunTxImport})
+
+	tel.WriteDescriptionPluginCall(ctx, db.TelemetryDescriptionPluginCall{
+		RunID:          runID,
+		PluginID:       "cash",
+		BatchSize:      12,
+		ItemsWithHints: 4,
+		Outcome:        "hints_returned",
+		Duration:       3 * time.Millisecond,
+	})
+	tel.WriteDescriptionPluginCall(ctx, db.TelemetryDescriptionPluginCall{
+		RunID:          runID,
+		PluginID:       "openai",
+		BatchSize:      8,
+		ItemsWithHints: 7,
+		Outcome:        "hints_returned",
+		Tokens:         &db.TelemetryTokens{Prompt: 900, Completion: 120, Total: 1020},
+		Duration:       2 * time.Second,
+	})
+
+	cases := []struct {
+		plugin    string
+		wantTotal sql.NullInt64
+	}{
+		{"cash", sql.NullInt64{}},
+		{"openai", sql.NullInt64{Int64: 1020, Valid: true}},
+	}
+	for _, c := range cases {
+		t.Run(c.plugin, func(t *testing.T) {
+			var prompt, completion, total sql.NullInt64
+			err := tel.db.QueryRow(`
+				SELECT prompt_tokens, completion_tokens, total_tokens
+				FROM telemetry.description_plugin_call WHERE run_id = $1::uuid AND plugin_id = $2
+			`, runID, c.plugin).Scan(&prompt, &completion, &total)
+			if err != nil {
+				t.Fatalf("read description_plugin_call: %v", err)
+			}
+			if total != c.wantTotal {
+				t.Errorf("total_tokens = %+v, want %+v", total, c.wantTotal)
+			}
+			if prompt.Valid != c.wantTotal.Valid || completion.Valid != c.wantTotal.Valid {
+				t.Errorf("token columns disagree about being set: prompt=%+v completion=%+v", prompt, completion)
+			}
+		})
+	}
+}
+
+// TestFailedWriteMarksTheRun pins the whole of what a failed write does: it marks
+// the run so a panel says the counts understate, and it does not fail the work.
+// A value outside a vocabulary is the failure used here because it is the one a
+// bug would actually produce.
+func TestFailedWriteMarksTheRun(t *testing.T) {
+	tel := testTelemetry(t)
+	ctx := context.Background()
+	runID := tel.StartRun(ctx, db.TelemetryRun{Kind: db.TelemetryRunTxImport})
+	keyID := tel.StartResolutionKey(ctx, db.TelemetryResolutionKey{
+		RunID: runID, Source: "FIDELITY_CSV", Description: "APPLE INC COM", TxCount: 1,
+	})
+
+	attemptID := tel.WriteIdentificationAttempt(ctx, db.TelemetryIdentificationAttempt{
+		RunID:           runID,
+		ResolutionKeyID: keyID,
+		Purpose:         "cache_hit",
+		Outcome:         db.TelemetryAttemptIdentified,
+	})
+	if attemptID != "" {
+		t.Errorf("a rejected write returned an id: %q", attemptID)
+	}
+	if _, _, incomplete := scanRun(t, tel, runID); !incomplete {
+		t.Error("a failed write left the run unmarked")
+	}
+
+	// The subtree below a failed write is skipped rather than attempted, so one
+	// failure costs its own children and nothing else.
+	tel.WriteIdentifierPluginCall(ctx, db.TelemetryIdentifierPluginCall{
+		RunID:     runID,
+		AttemptID: attemptID,
+		PluginID:  "openfigi",
+		Outcome:   db.TelemetryPluginCallWon,
+	})
+	var calls int
+	if err := tel.db.QueryRow(
+		`SELECT count(*) FROM telemetry.identifier_plugin_call`,
+	).Scan(&calls); err != nil {
+		t.Fatalf("count identifier_plugin_call: %v", err)
+	}
+	if calls != 0 {
+		t.Errorf("identifier_plugin_call rows = %d, want 0", calls)
+	}
+}
+
+// TestWriteUnderAMissingParentMarksTheRun covers the other way a parent can be
+// unusable: an id that is well formed but names nothing, which the foreign key
+// rejects.
+func TestWriteUnderAMissingParentMarksTheRun(t *testing.T) {
+	tel := testTelemetry(t)
+	ctx := context.Background()
+	runID := tel.StartRun(ctx, db.TelemetryRun{Kind: db.TelemetryRunTxImport})
+
+	id := tel.WriteIdentificationAttempt(ctx, db.TelemetryIdentificationAttempt{
+		RunID:           runID,
+		ResolutionKeyID: "6f1a3c2e-0000-4000-8000-000000000000",
+		Purpose:         db.TelemetryPurposePrimary,
+		Outcome:         db.TelemetryAttemptIdentified,
+	})
+	if id != "" {
+		t.Errorf("a write under a missing parent returned an id: %q", id)
+	}
+	if _, _, incomplete := scanRun(t, tel, runID); !incomplete {
+		t.Error("a failed write left the run unmarked")
+	}
+}
+
+// TestPurgeRunsBefore pins retention being a delete over started_at that cascades,
+// so nothing has to know the table list, and a run inside the window keeps
+// everything under it.
+func TestPurgeRunsBefore(t *testing.T) {
+	tel := testTelemetry(t)
+	ctx := context.Background()
+	cutoff := time.Now().Add(-db.TelemetryRetention)
+
+	oldRun := tel.StartRun(ctx, db.TelemetryRun{Kind: db.TelemetryRunTxImport})
+	if _, err := tel.db.Exec(
+		`UPDATE telemetry.run SET started_at = $2 WHERE id = $1::uuid`,
+		oldRun, cutoff.Add(-24*time.Hour),
+	); err != nil {
+		t.Fatalf("age the run: %v", err)
+	}
+	oldKey := tel.StartResolutionKey(ctx, db.TelemetryResolutionKey{
+		RunID: oldRun, Source: "FIDELITY_CSV", Description: "APPLE INC COM", TxCount: 1,
+	})
+	tel.WriteIdentificationAttempt(ctx, db.TelemetryIdentificationAttempt{
+		RunID:           oldRun,
+		ResolutionKeyID: oldKey,
+		Purpose:         db.TelemetryPurposePrimary,
+		Outcome:         db.TelemetryAttemptIdentified,
+	})
+	newRun := tel.StartRun(ctx, db.TelemetryRun{Kind: db.TelemetryRunTxImport})
+	tel.StartResolutionKey(ctx, db.TelemetryResolutionKey{
+		RunID: newRun, Source: "FIDELITY_CSV", Description: "MSFT", TxCount: 1,
+	})
+
+	deleted, err := tel.PurgeRunsBefore(ctx, cutoff)
+	if err != nil {
+		t.Fatalf("PurgeRunsBefore: %v", err)
+	}
+	if deleted != 1 {
+		t.Errorf("deleted = %d, want 1", deleted)
+	}
+	for _, c := range []struct {
+		table string
+		want  int
+	}{
+		{"telemetry.run", 1},
+		{"telemetry.resolution_key", 1},
+		{"telemetry.identification_attempt", 0},
+	} {
+		var n int
+		if err := tel.db.QueryRow(`SELECT count(*) FROM ` + c.table).Scan(&n); err != nil {
+			t.Fatalf("count %s: %v", c.table, err)
+		}
+		if n != c.want {
+			t.Errorf("%s rows = %d, want %d", c.table, n, c.want)
+		}
+	}
+}

--- a/server/service/api/server.go
+++ b/server/service/api/server.go
@@ -23,6 +23,7 @@ type Server struct {
 	db                     db.DB
 	rdb                    *redis.Client
 	counterPrefix          string
+	telemetryDB            db.TelemetryDB
 	pluginRegistry         *identifier.Registry
 	descRegistry           *description.Registry
 	priceRegistry          *pricefetcher.Registry
@@ -42,6 +43,7 @@ type ServerConfig struct {
 	DB                     db.DB
 	Redis                  *redis.Client
 	CounterPrefix          string
+	TelemetryDB            db.TelemetryDB             // optional; when set, PurgeTelemetry deletes past the retention window
 	PluginRegistry         *identifier.Registry       // optional; enables display_name in identifier plugin list
 	DescRegistry           *description.Registry      // optional; enables display_name in description plugin list
 	PriceRegistry          *pricefetcher.Registry     // optional; enables display_name in price plugin list
@@ -62,6 +64,7 @@ func NewServer(cfg ServerConfig) *Server {
 		db:                     cfg.DB,
 		rdb:                    cfg.Redis,
 		counterPrefix:          cfg.CounterPrefix,
+		telemetryDB:            cfg.TelemetryDB,
 		pluginRegistry:         cfg.PluginRegistry,
 		descRegistry:           cfg.DescRegistry,
 		priceRegistry:          cfg.PriceRegistry,

--- a/server/service/api/telemetry.go
+++ b/server/service/api/telemetry.go
@@ -2,9 +2,11 @@ package api
 
 import (
 	"context"
+	"time"
 
 	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
 	"github.com/leedenison/portfoliodb/server/auth"
+	"github.com/leedenison/portfoliodb/server/db"
 	"github.com/leedenison/portfoliodb/server/telemetry"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -24,4 +26,24 @@ func (s *Server) ListTelemetryCounters(ctx context.Context, req *apiv1.ListTelem
 		counters = append(counters, &apiv1.TelemetryCounter{Name: e.Name, Value: e.Value})
 	}
 	return &apiv1.ListTelemetryCountersResponse{Counters: counters}, nil
+}
+
+// PurgeTelemetry deletes runs past the retention window, and with them the event
+// rows beneath them (admin only).
+//
+// It does the delete rather than poking a worker, because there is no worker: the
+// service does not schedule retention, and an external scheduler calls this. The
+// count it returns is what that scheduler logs.
+func (s *Server) PurgeTelemetry(ctx context.Context, req *apiv1.PurgeTelemetryRequest) (*apiv1.PurgeTelemetryResponse, error) {
+	if _, authErr := auth.RequireAdmin(ctx); authErr != nil {
+		return nil, authErr
+	}
+	if s.telemetryDB == nil {
+		return nil, status.Error(codes.Unavailable, "telemetry is not configured")
+	}
+	deleted, err := s.telemetryDB.PurgeRunsBefore(ctx, time.Now().Add(-db.TelemetryRetention))
+	if err != nil {
+		return nil, status.Error(codes.Internal, err.Error())
+	}
+	return &apiv1.PurgeTelemetryResponse{RunsDeleted: deleted}, nil
 }

--- a/server/service/api/telemetry_test.go
+++ b/server/service/api/telemetry_test.go
@@ -1,0 +1,71 @@
+package api
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/db/mock"
+	"github.com/leedenison/portfoliodb/server/testutil"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/grpc/codes"
+)
+
+// newPurgeServer returns a server with a mocked telemetry writer.
+func newPurgeServer(t *testing.T) (*Server, *mock.MockTelemetryDB) {
+	t.Helper()
+	ctrl := gomock.NewController(t)
+	t.Cleanup(func() { ctrl.Finish() })
+	tel := mock.NewMockTelemetryDB(ctrl)
+	return NewServer(ServerConfig{DB: mock.NewMockDB(ctrl), TelemetryDB: tel}), tel
+}
+
+func TestPurgeTelemetry_RequiresAdmin(t *testing.T) {
+	srv, _ := newPurgeServer(t)
+	_, err := srv.PurgeTelemetry(authCtx("user-1", "sub|user"), &apiv1.PurgeTelemetryRequest{})
+	testutil.RequireGRPCCode(t, err, codes.PermissionDenied)
+}
+
+// TestPurgeTelemetry_DeletesPastTheRetentionWindow pins the cutoff being the
+// window rather than anything the caller chose. The scheduler says when to run;
+// how far back to keep is the schema's business.
+func TestPurgeTelemetry_DeletesPastTheRetentionWindow(t *testing.T) {
+	srv, tel := newPurgeServer(t)
+	var got time.Time
+	tel.EXPECT().PurgeRunsBefore(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ any, cutoff time.Time) (int64, error) {
+			got = cutoff
+			return 7, nil
+		})
+
+	resp, err := srv.PurgeTelemetry(adminCtx("admin-1", "sub|admin"), &apiv1.PurgeTelemetryRequest{})
+	if err != nil {
+		t.Fatalf("PurgeTelemetry: %v", err)
+	}
+	if resp.GetRunsDeleted() != 7 {
+		t.Errorf("runs_deleted = %d, want 7", resp.GetRunsDeleted())
+	}
+	want := time.Now().Add(-db.TelemetryRetention)
+	if diff := got.Sub(want); diff > time.Minute || diff < -time.Minute {
+		t.Errorf("cutoff = %v, want within a minute of %v", got, want)
+	}
+}
+
+func TestPurgeTelemetry_ReportsAFailedDelete(t *testing.T) {
+	srv, tel := newPurgeServer(t)
+	tel.EXPECT().PurgeRunsBefore(gomock.Any(), gomock.Any()).Return(int64(0), errors.New("boom"))
+
+	_, err := srv.PurgeTelemetry(adminCtx("admin-1", "sub|admin"), &apiv1.PurgeTelemetryRequest{})
+	testutil.RequireGRPCCode(t, err, codes.Internal)
+}
+
+// TestPurgeTelemetry_UnconfiguredIsUnavailable covers a server built without a
+// writer, which says so rather than reporting nothing deleted -- a scheduler
+// reading zeroes forever would have no way to tell the two apart.
+func TestPurgeTelemetry_UnconfiguredIsUnavailable(t *testing.T) {
+	srv, _ := newAPIServerWithMock(t)
+	_, err := srv.PurgeTelemetry(adminCtx("admin-1", "sub|admin"), &apiv1.PurgeTelemetryRequest{})
+	testutil.RequireGRPCCode(t, err, codes.Unavailable)
+}


### PR DESCRIPTION
Second of two PRs for [0115](docs/issues/0115-telemetry-schema-and-writer.md), and it closes the issue. **Based on #449** -- review that one first; this branch targets it, and GitHub will retarget to `main` when #449 merges.

`TelemetryDB` is declared in `server/db/db.go` beside the other domain interfaces, but deliberately **not** part of the `DB` composition: it holds its own pool and never joins the work's transaction. `postgres.Telemetry` implements it over `*sqlx.DB` rather than the `queryable` the rest of the package uses, so joining a transaction is impossible rather than merely discouraged.

Points worth a reviewer's attention:

* **No write method returns an error.** A failed write logs, marks `telemetry_incomplete` on its run, and yields an empty id; a write whose parent id is empty is skipped. One failure costs its own subtree and nothing else, and 0116's call sites thread ids through with no error handling to get wrong. `PurgeRunsBefore` is the exception -- it is the work its caller was asked to do, not telemetry alongside other work.
* **A second connection pool.** Both pools draw on one `max_connections`, 20 of the dev stack's 25 at the defaults (16 + 4, via `PORTFOLIODB_TELEMETRY_DB_MAX_CONNS`). Telemetry writes single rows and sorts nothing, so it costs handles and not `work_mem`. **0117 needs to cap Grafana's own pool, or raise `max_connections`** -- the default Grafana pool would blow the remaining five.
* **`PurgeTelemetry` is synchronous and returns a count**, unlike the `Trigger` family, because there is no worker behind it and nothing in the service schedules it. Issue 0119 (unscheduled) covers the operator-side scheduler that calls it.

Tests commit rather than roll back, since the writer must hold a real pool, and truncate `telemetry.run` on cleanup. They cover the two-phase run and resolution key, a full nest read back through `v_identifier_plugin_call`, tokens staying null rather than zero for a plugin that costs none, a rejected write and a write under a missing parent both marking the run without erroring, the skipped subtree beneath a failed write, and the purge cascading.

Nothing emits yet -- the call sites arrive with 0116.

`make check`, `make db-test` and `make server-test` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)