### PR TITLE
Open a telemetry run for every job and every cycle (0116)

### DIFF
--- a/docs/spec/telemetry.md
+++ b/docs/spec/telemetry.md
@@ -39,7 +39,7 @@ One activation of one subsystem. Created before its children and stamped when it
 | column | notes |
 | --- | --- |
 | `id` | referenced by every event row |
-| `kind` | `tx_import`, `user_archive_import`, `system_archive_import`, `price_job`, `grouping_cycle`, `transfer_match_cycle`, `corporate_event_cycle`, `price_fetch_cycle`, `inflation_cycle` |
+| `kind` | `tx_import`, `user_archive_import`, `system_archive_import`, `grouping_cycle`, `transfer_match_cycle`, `corporate_event_cycle`, `price_fetch_cycle`, `inflation_cycle` |
 | `job_id` | `ingestion_jobs.id` when the run is a job; null for a cycle |
 | `user_id`, `broker`, `source` | null for cycles |
 | `started_at`, `ended_at` | |
@@ -48,8 +48,15 @@ One activation of one subsystem. Created before its children and stamped when it
 
 `incomplete` means the run died. It is stamped by a sweep at service startup over runs
 with no terminal outcome, which is what lets a null outcome mean genuinely running now.
+The sweep leaves `ended_at` null, because the run ended when its process died and
+nothing recorded when that was; a run stamped `incomplete` therefore has no duration.
 `telemetry_incomplete` is unrelated to it: the work may have succeeded while its
 telemetry was lost, and a panel should mark such a run rather than trust its counts.
+
+The three import kinds are the three ingestion job types. The five cycle kinds are the
+five triggered workers, and a cycle that finds no work still opens a run and stamps it
+`success`: it ran, and a run table with holes in it is harder to read than one with
+quiet rows.
 
 ### resolution_key
 

--- a/server/cmd/portfoliodb/main.go
+++ b/server/cmd/portfoliodb/main.go
@@ -312,6 +312,7 @@ func main() {
 		IdentifierRegistry:    pluginRegistry,
 		DescriptionRegistry:   descRegistry,
 		Counter:               counter,
+		TelemetryDB:           telemetryDB,
 		Logger:                ingestionLogger,
 		PriceTrigger:          priceTrigger,
 		CorporateEventTrigger: corporateEventTrigger,
@@ -319,11 +320,19 @@ func main() {
 		GroupingTrigger:       groupingTrigger,
 		Workers:               workers,
 	})
-	go pricefetcher.RunWorker(ctx, database, priceRegistry, counter, logger.WithCategory(serverLogger, "server/pricefetcher"), priceTrigger, workers)
-	go inflationfetcher.RunWorker(ctx, database, inflationRegistry, counter, logger.WithCategory(serverLogger, "server/inflationfetcher"), inflationTrigger, workers)
-	go corporateevents.RunWorker(ctx, database, corporateEventRegistry, counter, logger.WithCategory(serverLogger, "server/corporateevents"), corporateEventTrigger, workers)
-	go transfermatch.RunWorker(ctx, database, counter, logger.WithCategory(serverLogger, "server/transfermatch"), transferMatchTrigger, workers)
-	go grouping.RunWorker(ctx, database, counter, logger.WithCategory(serverLogger, "server/grouping"), groupingTrigger, workers)
+	go pricefetcher.RunWorker(ctx, database, priceRegistry, counter, telemetryDB, logger.WithCategory(serverLogger, "server/pricefetcher"), priceTrigger, workers)
+	go inflationfetcher.RunWorker(ctx, database, inflationRegistry, counter, telemetryDB, logger.WithCategory(serverLogger, "server/inflationfetcher"), inflationTrigger, workers)
+	go corporateevents.RunWorker(ctx, database, corporateEventRegistry, counter, telemetryDB, logger.WithCategory(serverLogger, "server/corporateevents"), corporateEventTrigger, workers)
+	go transfermatch.RunWorker(ctx, database, counter, telemetryDB, logger.WithCategory(serverLogger, "server/transfermatch"), transferMatchTrigger, workers)
+	go grouping.RunWorker(ctx, database, counter, telemetryDB, logger.WithCategory(serverLogger, "server/grouping"), groupingTrigger, workers)
+	// Stamp the runs a previous process left unfinished. This has to happen before
+	// the re-enqueue below, which opens runs of its own that must not be swept, and
+	// it is what lets a run with no outcome mean one running now.
+	if swept, err := telemetryDB.SweepIncompleteRuns(ctx); err != nil {
+		log.Printf("telemetry: sweep incomplete runs: %v", err)
+	} else if swept > 0 {
+		log.Printf("telemetry: stamped %d run(s) incomplete", swept)
+	}
 	// Re-enqueue incomplete jobs from a previous run.
 	if pending, err := database.ListPendingJobs(ctx); err == nil {
 		for _, p := range pending {

--- a/server/corporateevents/run_telemetry_test.go
+++ b/server/corporateevents/run_telemetry_test.go
@@ -1,0 +1,62 @@
+package corporateevents
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/db/mock"
+	"go.uber.org/mock/gomock"
+)
+
+// TestCycleOpensARun pins the run a trigger opens. The run table is the
+// worker-runs chart, so a cycle that found no work still opens one and stamps it
+// success -- it ran -- while a cycle whose read failed stamps failed.
+func TestCycleOpensARun(t *testing.T) {
+	tests := []struct {
+		name    string
+		readErr error
+		want    string
+	}{
+		{name: "no work", readErr: nil, want: db.TelemetryOutcomeSuccess},
+		{name: "read failed", readErr: errors.New("boom"), want: db.TelemetryOutcomeFailed},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			t.Cleanup(ctrl.Finish)
+			mockDB := mock.NewMockDB(ctrl)
+			tel := mock.NewMockTelemetryDB(ctrl)
+			mockDB.EXPECT().HeldEventBearingInstruments(gomock.Any()).Return(nil, tc.readErr)
+			mockDB.EXPECT().ListPendingOptionSplits(gomock.Any(), "").Return(nil, nil).AnyTimes()
+			var kind, outcome string
+			ended := make(chan struct{})
+			tel.EXPECT().StartRun(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, r db.TelemetryRun) string {
+					kind = r.Kind
+					return "run-1"
+				})
+			tel.EXPECT().EndRun(gomock.Any(), "run-1", gomock.Any()).
+				Do(func(_ context.Context, _, o string) {
+					outcome = o
+					close(ended)
+				})
+
+			trigger := make(chan struct{}, 1)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go RunWorker(ctx, mockDB, NewRegistry(), nil, tel, nil, trigger, nil)
+			trigger <- struct{}{}
+			<-ended
+
+			if kind != db.TelemetryRunCorporateEventCycle {
+				t.Errorf("run kind = %q, want %q", kind, db.TelemetryRunCorporateEventCycle)
+			}
+			if outcome != tc.want {
+				t.Errorf("outcome = %q, want %q", outcome, tc.want)
+			}
+		})
+	}
+}

--- a/server/corporateevents/worker.go
+++ b/server/corporateevents/worker.go
@@ -28,7 +28,10 @@ const (
 // RunWorker processes corporate event fetch cycles triggered via the trigger
 // channel. It blocks until ctx is cancelled. Each signal on trigger runs one
 // cycle; rapid signals are debounced via a buffered channel of size 1.
-func RunWorker(ctx context.Context, database db.DB, registry *Registry, counter telemetry.CounterIncrementer, log *slog.Logger, trigger <-chan struct{}, workers *worker.Registry) {
+func RunWorker(ctx context.Context, database db.DB, registry *Registry, counter telemetry.CounterIncrementer, tel db.TelemetryDB, log *slog.Logger, trigger <-chan struct{}, workers *worker.Registry) {
+	if tel == nil {
+		tel = db.NopTelemetry{}
+	}
 	const name = "corporate_event_fetcher"
 	if workers != nil {
 		workers.SetIdle(name)
@@ -41,7 +44,12 @@ func RunWorker(ctx context.Context, database db.DB, registry *Registry, counter 
 			if !ok {
 				return
 			}
-			runCycle(ctx, database, registry, counter, log, workers)
+			runID := tel.StartRun(ctx, db.TelemetryRun{Kind: db.TelemetryRunCorporateEventCycle})
+			outcome := db.TelemetryOutcomeSuccess
+			if err := runCycle(ctx, database, registry, counter, log, workers); err != nil {
+				outcome = db.TelemetryOutcomeFailed
+			}
+			tel.EndRun(ctx, runID, outcome)
 		}
 	}
 }
@@ -53,7 +61,7 @@ type pluginEntry struct {
 	config []byte
 }
 
-func runCycle(ctx context.Context, database db.DB, registry *Registry, counter telemetry.CounterIncrementer, log *slog.Logger, workers *worker.Registry) {
+func runCycle(ctx context.Context, database db.DB, registry *Registry, counter telemetry.CounterIncrementer, log *slog.Logger, workers *worker.Registry) error {
 	const name = "corporate_event_fetcher"
 	if counter != nil {
 		counter.Incr(ctx, "corporate_event_fetcher.cycles")
@@ -88,10 +96,10 @@ func runCycle(ctx context.Context, database db.DB, registry *Registry, counter t
 		if log != nil {
 			log.ErrorContext(ctx, "corporate event fetch: held instruments", "err", err)
 		}
-		return
+		return err
 	}
 	if len(held) == 0 {
-		return
+		return nil
 	}
 
 	configs, err := database.ListEnabledPluginConfigs(ctx, db.PluginCategoryCorporateEvent)
@@ -99,10 +107,10 @@ func runCycle(ctx context.Context, database db.DB, registry *Registry, counter t
 		if log != nil {
 			log.ErrorContext(ctx, "corporate event fetch: list configs", "err", err)
 		}
-		return
+		return err
 	}
 	if len(configs) == 0 {
-		return
+		return nil
 	}
 	var plugins []pluginEntry
 	for _, cfg := range configs {
@@ -113,7 +121,7 @@ func runCycle(ctx context.Context, database db.DB, registry *Registry, counter t
 		plugins = append(plugins, pluginEntry{id: cfg.PluginID, plugin: p, config: cfg.Config})
 	}
 	if len(plugins) == 0 {
-		return
+		return nil
 	}
 
 	if workers != nil {
@@ -129,14 +137,14 @@ func runCycle(ctx context.Context, database db.DB, registry *Registry, counter t
 		if log != nil {
 			log.ErrorContext(ctx, "corporate event fetch: load blocks", "err", err)
 		}
-		return
+		return err
 	}
 	instRows, err := database.ListInstrumentsByIDs(ctx, instIDs)
 	if err != nil {
 		if log != nil {
 			log.ErrorContext(ctx, "corporate event fetch: load instruments", "err", err)
 		}
-		return
+		return err
 	}
 	instByID := make(map[string]*db.InstrumentRow, len(instRows))
 	for _, r := range instRows {
@@ -147,7 +155,7 @@ func runCycle(ctx context.Context, database db.DB, registry *Registry, counter t
 		if log != nil {
 			log.ErrorContext(ctx, "corporate event fetch: load coverage", "err", err)
 		}
-		return
+		return err
 	}
 	coverageByInst := make(map[string][]db.CorporateEventCoverage, len(coverage))
 	for _, c := range coverage {
@@ -158,7 +166,7 @@ func runCycle(ctx context.Context, database db.DB, registry *Registry, counter t
 	endBefore := time.Now().UTC().Truncate(db.Day).AddDate(0, 0, DefaultLookaheadDays+1)
 	for _, h := range held {
 		if ctx.Err() != nil {
-			return
+			return nil
 		}
 		inst := instByID[h.InstrumentID]
 		if inst == nil {
@@ -167,6 +175,7 @@ func runCycle(ctx context.Context, database db.DB, registry *Registry, counter t
 		processInstrument(ctx, database, plugins, inst, h.EarliestTxDate, endBefore,
 			coverageByInst[h.InstrumentID], blocked[h.InstrumentID], log)
 	}
+	return nil
 }
 
 // processInstrument fills the missing date intervals for one instrument by

--- a/server/corporateevents/worker_test.go
+++ b/server/corporateevents/worker_test.go
@@ -224,7 +224,7 @@ func TestRunCycle_OptionPassRunsWithNoPluginsEnabled(t *testing.T) {
 	}}, nil)
 	mockDB.EXPECT().ApplyOptionSplit(gomock.Any(), gomock.Any()).Return(nil)
 
-	runCycle(ctx, mockDB, NewRegistry(), nil, nil, nil)
+	_ = runCycle(ctx, mockDB, NewRegistry(), nil, nil, nil)
 }
 
 // TestRunCycle_OptionPassRunsWithNothingHeld verifies the same for the other
@@ -237,7 +237,7 @@ func TestRunCycle_OptionPassRunsWithNothingHeld(t *testing.T) {
 	mockDB.EXPECT().HeldEventBearingInstruments(gomock.Any()).Return(nil, nil)
 	mockDB.EXPECT().ListPendingOptionSplits(gomock.Any(), "").Return(nil, nil)
 
-	runCycle(ctx, mockDB, NewRegistry(), nil, nil, nil)
+	_ = runCycle(ctx, mockDB, NewRegistry(), nil, nil, nil)
 }
 
 func TestRunCycle_EmptyResultRecordsCoverage(t *testing.T) {
@@ -293,7 +293,7 @@ func TestRunCycle_EmptyResultRecordsCoverage(t *testing.T) {
 	// The option pass runs once per cycle regardless of what landed.
 	mockDB.EXPECT().ListPendingOptionSplits(gomock.Any(), "").Return(nil, nil)
 
-	runCycle(ctx, mockDB, reg, nil, nil, nil)
+	_ = runCycle(ctx, mockDB, reg, nil, nil, nil)
 
 	if highPrec.calls != 1 {
 		t.Errorf("high plugin: expected 1 call, got %d", highPrec.calls)
@@ -346,7 +346,7 @@ func TestRunCycle_SplitsLandTriggerRecompute(t *testing.T) {
 	// The option pass runs once for the cycle, across all underlyings.
 	mockDB.EXPECT().ListPendingOptionSplits(gomock.Any(), "").Return(nil, nil)
 
-	runCycle(ctx, mockDB, reg, nil, nil, nil)
+	_ = runCycle(ctx, mockDB, reg, nil, nil, nil)
 
 	if plugin.calls != 1 {
 		t.Errorf("expected 1 call, got %d", plugin.calls)
@@ -401,7 +401,7 @@ func TestRunCycle_OptionPassRunsWithoutSplitsLanding(t *testing.T) {
 		Splits: []db.StockSplit{split(instID, date(2025, 1, 15), "1", "2")},
 	}}, nil)
 	mockDB.EXPECT().ApplyOptionSplit(gomock.Any(), gomock.Any()).Return(nil)
-	runCycle(ctx, mockDB, reg, nil, nil, nil)
+	_ = runCycle(ctx, mockDB, reg, nil, nil, nil)
 }
 
 // TestRunCycle_PermanentErrorCreatesBlock verifies that ErrPermanent results
@@ -452,7 +452,7 @@ func TestRunCycle_PermanentErrorCreatesBlock(t *testing.T) {
 	// The option pass runs once per cycle regardless of what landed.
 	mockDB.EXPECT().ListPendingOptionSplits(gomock.Any(), "").Return(nil, nil)
 
-	runCycle(ctx, mockDB, reg, nil, nil, nil)
+	_ = runCycle(ctx, mockDB, reg, nil, nil, nil)
 
 	if failing.calls != 1 || good.calls != 1 {
 		t.Errorf("expected both plugins called once, got broken=%d good=%d", failing.calls, good.calls)
@@ -523,7 +523,7 @@ func TestRunCycle_SpecialDividendRoutedToUnhandled(t *testing.T) {
 	// The option pass runs once per cycle regardless of what landed.
 	mockDB.EXPECT().ListPendingOptionSplits(gomock.Any(), "").Return(nil, nil)
 
-	runCycle(ctx, mockDB, reg, nil, nil, nil)
+	_ = runCycle(ctx, mockDB, reg, nil, nil, nil)
 }
 
 // TestRunCycle_BlockedPluginSkipped verifies that fetch blocks are honored.
@@ -563,7 +563,7 @@ func TestRunCycle_BlockedPluginSkipped(t *testing.T) {
 	// The option pass runs once per cycle regardless of what landed.
 	mockDB.EXPECT().ListPendingOptionSplits(gomock.Any(), "").Return(nil, nil)
 
-	runCycle(ctx, mockDB, reg, nil, nil, nil)
+	_ = runCycle(ctx, mockDB, reg, nil, nil, nil)
 
 	if plugin.calls != 0 {
 		t.Errorf("expected 0 calls, got %d", plugin.calls)

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -531,8 +531,14 @@ type JobPartResult struct {
 // JobDetail is everything GetJob knows about one job. UserID is empty when no
 // such job exists, which is how a caller distinguishes "not found" from an error.
 type JobDetail struct {
-	Status               apiv1.JobStatus
-	UserID               string
+	Status apiv1.JobStatus
+	UserID string
+	// Broker and Source are what the job was created against, and are empty for
+	// an archive import, which names neither. They are read back rather than
+	// taken from the payload so that a job whose payload will not load still
+	// says whose upload it was.
+	Broker               string
+	Source               string
 	TotalCount           int32
 	ProcessedCount       int32
 	ValidationErrors     []*apiv1.ValidationError // errors with no part of their own
@@ -1986,7 +1992,6 @@ const (
 	TelemetryRunTxImport            = "tx_import"
 	TelemetryRunUserArchiveImport   = "user_archive_import"
 	TelemetryRunSystemArchiveImport = "system_archive_import"
-	TelemetryRunPriceJob            = "price_job"
 	TelemetryRunGroupingCycle       = "grouping_cycle"
 	TelemetryRunTransferMatchCycle  = "transfer_match_cycle"
 	TelemetryRunCorporateEventCycle = "corporate_event_cycle"
@@ -2183,9 +2188,47 @@ type TelemetryDB interface {
 	WriteIdentifierPluginCall(ctx context.Context, c TelemetryIdentifierPluginCall)
 	WriteDescriptionPluginCall(ctx context.Context, c TelemetryDescriptionPluginCall)
 
+	// SweepIncompleteRuns stamps every run left without a terminal outcome as
+	// incomplete, and returns how many it stamped. Called once at startup, before
+	// any work begins: a run with no outcome is then either one this process is
+	// running now or one whose process died, and the sweep is what tells the two
+	// apart. It returns an error for the reason PurgeRunsBefore does.
+	SweepIncompleteRuns(ctx context.Context) (int64, error)
+
 	// PurgeRunsBefore deletes runs started before cutoff, cascading to their event
 	// rows, and returns how many runs went. Unlike the writes it returns an error,
 	// because it is the work its caller was asked to do rather than telemetry
 	// alongside other work.
 	PurgeRunsBefore(ctx context.Context, cutoff time.Time) (int64, error)
 }
+
+// NopTelemetry is a TelemetryDB that records nothing, for a build or a test with
+// no telemetry pool behind it.
+//
+// It exists so that no code below the wiring point tests a handle for nil. Its
+// StartRun yields an empty id, and the writer contract already skips a row whose
+// parent id is empty, so an entire subtree of calls costs one comparison each and
+// writes nothing.
+type NopTelemetry struct{}
+
+var _ TelemetryDB = NopTelemetry{}
+
+func (NopTelemetry) StartRun(context.Context, TelemetryRun) string { return "" }
+
+func (NopTelemetry) EndRun(context.Context, string, string) {}
+
+func (NopTelemetry) StartResolutionKey(context.Context, TelemetryResolutionKey) string { return "" }
+
+func (NopTelemetry) EndResolutionKey(context.Context, string, TelemetryResolutionKeyOutcome) {}
+
+func (NopTelemetry) WriteIdentificationAttempt(context.Context, TelemetryIdentificationAttempt) string {
+	return ""
+}
+
+func (NopTelemetry) WriteIdentifierPluginCall(context.Context, TelemetryIdentifierPluginCall) {}
+
+func (NopTelemetry) WriteDescriptionPluginCall(context.Context, TelemetryDescriptionPluginCall) {}
+
+func (NopTelemetry) SweepIncompleteRuns(context.Context) (int64, error) { return 0, nil }
+
+func (NopTelemetry) PurgeRunsBefore(context.Context, time.Time) (int64, error) { return 0, nil }

--- a/server/db/postgres/jobs.go
+++ b/server/db/postgres/jobs.go
@@ -89,8 +89,8 @@ func (p *Postgres) GetJob(ctx context.Context, jobID string) (*db.JobDetail, err
 	var d db.JobDetail
 	var statusStr string
 	var jobUserID uuid.UUID
-	err = p.q.QueryRowContext(ctx, `SELECT status, user_id, total_count, processed_count FROM ingestion_jobs WHERE id = $1`, jobUUID).
-		Scan(&statusStr, &jobUserID, &d.TotalCount, &d.ProcessedCount)
+	err = p.q.QueryRowContext(ctx, `SELECT status, user_id, COALESCE(broker, ''), COALESCE(source, ''), total_count, processed_count FROM ingestion_jobs WHERE id = $1`, jobUUID).
+		Scan(&statusStr, &jobUserID, &d.Broker, &d.Source, &d.TotalCount, &d.ProcessedCount)
 	if err == sql.ErrNoRows {
 		// No such job. UserID stays empty, which is how the caller tells this
 		// apart from a failure to read one that exists.

--- a/server/db/postgres/telemetry.go
+++ b/server/db/postgres/telemetry.go
@@ -210,6 +210,21 @@ func (t *Telemetry) WriteDescriptionPluginCall(ctx context.Context, c db.Telemet
 	}
 }
 
+// SweepIncompleteRuns implements db.TelemetryDB.
+//
+// ended_at is deliberately left null. The run ended when its process died, which
+// is a time nobody recorded; stamping now() would date it to this startup and
+// give the view a duration measuring how long the service was down.
+func (t *Telemetry) SweepIncompleteRuns(ctx context.Context) (int64, error) {
+	res, err := t.db.ExecContext(ctx, `
+		UPDATE telemetry.run SET outcome = $1 WHERE outcome IS NULL
+	`, db.TelemetryOutcomeIncomplete)
+	if err != nil {
+		return 0, err
+	}
+	return res.RowsAffected()
+}
+
 // PurgeRunsBefore implements db.TelemetryDB.
 func (t *Telemetry) PurgeRunsBefore(ctx context.Context, cutoff time.Time) (int64, error) {
 	res, err := t.db.ExecContext(ctx,

--- a/server/db/postgres/telemetry_schema_test.go
+++ b/server/db/postgres/telemetry_schema_test.go
@@ -74,7 +74,6 @@ func TestTelemetryViews_IsImport(t *testing.T) {
 		{"tx_import", true},
 		{"user_archive_import", true},
 		{"system_archive_import", true},
-		{"price_job", false},
 		{"grouping_cycle", false},
 		{"transfer_match_cycle", false},
 		{"corporate_event_cycle", false},

--- a/server/db/postgres/telemetry_test.go
+++ b/server/db/postgres/telemetry_test.go
@@ -303,6 +303,43 @@ func TestWriteUnderAMissingParentMarksTheRun(t *testing.T) {
 // TestPurgeRunsBefore pins retention being a delete over started_at that cascades,
 // so nothing has to know the table list, and a run inside the window keeps
 // everything under it.
+// TestSweepIncompleteRuns pins what makes a null outcome readable. A run left
+// unstamped by a process that died is indistinguishable from one running now
+// until the sweep at the next startup stamps it, and a run that already reached a
+// terminal outcome must not be restamped by it.
+func TestSweepIncompleteRuns(t *testing.T) {
+	tel := testTelemetry(t)
+	ctx := context.Background()
+
+	died := tel.StartRun(ctx, db.TelemetryRun{Kind: db.TelemetryRunTxImport})
+	finished := tel.StartRun(ctx, db.TelemetryRun{Kind: db.TelemetryRunGroupingCycle})
+	tel.EndRun(ctx, finished, db.TelemetryOutcomeSuccess)
+
+	swept, err := tel.SweepIncompleteRuns(ctx)
+	if err != nil {
+		t.Fatalf("SweepIncompleteRuns: %v", err)
+	}
+	if swept != 1 {
+		t.Errorf("swept = %d, want 1", swept)
+	}
+
+	outcome, endedAt, _ := scanRun(t, tel, died)
+	if outcome.String != db.TelemetryOutcomeIncomplete {
+		t.Errorf("outcome of a run that died = %q, want %q", outcome.String, db.TelemetryOutcomeIncomplete)
+	}
+	// The run ended when its process died, which nothing recorded. Stamping now()
+	// would date it to this startup and give the view a duration measuring how
+	// long the service was down.
+	if endedAt.Valid {
+		t.Error("the sweep stamped an ended_at it cannot know")
+	}
+
+	outcome, _, _ = scanRun(t, tel, finished)
+	if outcome.String != db.TelemetryOutcomeSuccess {
+		t.Errorf("the sweep restamped a finished run as %q", outcome.String)
+	}
+}
+
 func TestPurgeRunsBefore(t *testing.T) {
 	tel := testTelemetry(t)
 	ctx := context.Background()

--- a/server/grouping/run_telemetry_test.go
+++ b/server/grouping/run_telemetry_test.go
@@ -1,0 +1,62 @@
+package grouping
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/db/mock"
+	"go.uber.org/mock/gomock"
+)
+
+// TestCycleOpensARun pins the run a trigger opens. The run table is the
+// worker-runs chart, so a cycle that found no work still opens one and stamps it
+// success -- it ran -- while a cycle whose read failed stamps failed.
+func TestCycleOpensARun(t *testing.T) {
+	tests := []struct {
+		name    string
+		readErr error
+		want    string
+	}{
+		{name: "no work", readErr: nil, want: db.TelemetryOutcomeSuccess},
+		{name: "read failed", readErr: errors.New("boom"), want: db.TelemetryOutcomeFailed},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			t.Cleanup(ctrl.Finish)
+			mockDB := mock.NewMockDB(ctrl)
+			tel := mock.NewMockTelemetryDB(ctrl)
+			mockDB.EXPECT().ListGroupingSeeds(gomock.Any(), gomock.Any()).Return(nil, tc.readErr)
+
+			var kind, outcome string
+			ended := make(chan struct{})
+			tel.EXPECT().StartRun(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, r db.TelemetryRun) string {
+					kind = r.Kind
+					return "run-1"
+				})
+			tel.EXPECT().EndRun(gomock.Any(), "run-1", gomock.Any()).
+				Do(func(_ context.Context, _, o string) {
+					outcome = o
+					close(ended)
+				})
+
+			trigger := make(chan struct{}, 1)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go RunWorker(ctx, mockDB, nil, tel, nil, trigger, nil)
+			trigger <- struct{}{}
+			<-ended
+
+			if kind != db.TelemetryRunGroupingCycle {
+				t.Errorf("run kind = %q, want %q", kind, db.TelemetryRunGroupingCycle)
+			}
+			if outcome != tc.want {
+				t.Errorf("outcome = %q, want %q", outcome, tc.want)
+			}
+		})
+	}
+}

--- a/server/grouping/worker.go
+++ b/server/grouping/worker.go
@@ -25,7 +25,10 @@ const name = "grouping"
 // clock in this process. The ingestion worker fires it after a tx import commits, so
 // legs that have just landed beside older ones are joined without waiting for the
 // next tick.
-func RunWorker(ctx context.Context, database db.DB, counter telemetry.CounterIncrementer, log *slog.Logger, trigger <-chan struct{}, workers *worker.Registry) {
+func RunWorker(ctx context.Context, database db.DB, counter telemetry.CounterIncrementer, tel db.TelemetryDB, log *slog.Logger, trigger <-chan struct{}, workers *worker.Registry) {
+	if tel == nil {
+		tel = db.NopTelemetry{}
+	}
 	if workers != nil {
 		workers.SetIdle(name)
 	}
@@ -37,7 +40,12 @@ func RunWorker(ctx context.Context, database db.DB, counter telemetry.CounterInc
 			if !ok {
 				return
 			}
-			runCycle(ctx, database, counter, log, workers)
+			runID := tel.StartRun(ctx, db.TelemetryRun{Kind: db.TelemetryRunGroupingCycle})
+			outcome := db.TelemetryOutcomeSuccess
+			if err := runCycle(ctx, database, counter, log, workers); err != nil {
+				outcome = db.TelemetryOutcomeFailed
+			}
+			tel.EndRun(ctx, runID, outcome)
 		}
 	}
 }
@@ -48,7 +56,7 @@ func RunWorker(ctx context.Context, database db.DB, counter telemetry.CounterInc
 // It writes only its disagreements, so a cycle that repartitions nothing writes
 // nothing -- which is what lets it run over a region far wider than any upload
 // without churning ids for postings nobody touched.
-func runCycle(ctx context.Context, database db.DB, counter telemetry.CounterIncrementer, log *slog.Logger, workers *worker.Registry) {
+func runCycle(ctx context.Context, database db.DB, counter telemetry.CounterIncrementer, log *slog.Logger, workers *worker.Registry) error {
 	if counter != nil {
 		counter.Incr(ctx, "grouping.cycles")
 	}
@@ -67,10 +75,10 @@ func runCycle(ctx context.Context, database db.DB, counter telemetry.CounterIncr
 		if log != nil {
 			log.ErrorContext(ctx, "grouping: list seeds", "err", err)
 		}
-		return
+		return err
 	}
 	if len(seeds) == 0 {
-		return
+		return nil
 	}
 	if workers != nil {
 		workers.SetRunning(name, fmt.Sprintf("Grouping from %d postings", len(seeds)))
@@ -80,12 +88,18 @@ func runCycle(ctx context.Context, database db.DB, counter telemetry.CounterIncr
 	}
 
 	total := Divergence{}
+	// A user whose derivation fails does not stop the others -- one user's
+	// neighbourhoods have nothing to do with another's -- but the cycle still
+	// reports the failure, so a run that got through none of its users is not
+	// recorded as a success.
+	var failed error
 	for _, userID := range usersOf(seeds) {
 		d, err := cycleUser(ctx, database, userID, byUser(seeds, userID))
 		if err != nil {
 			if log != nil {
 				log.ErrorContext(ctx, "grouping: derive", "user", userID, "err", err)
 			}
+			failed = err
 			continue
 		}
 		total.Groups += d.Groups
@@ -111,6 +125,7 @@ func runCycle(ctx context.Context, database db.DB, counter telemetry.CounterIncr
 			"derived", total.Groups, "stored", total.Stored, "agreed", total.Agreed,
 			"joined", total.Joined, "split", total.Split, "examples", total.Examples)
 	}
+	return failed
 }
 
 // cycleUser grows each seed's neighbourhood, partitions it, and measures the result

--- a/server/grouping/worker_test.go
+++ b/server/grouping/worker_test.go
@@ -34,7 +34,7 @@ func TestRunCycle_SeedsFromResidualGroups(t *testing.T) {
 	mockDB.EXPECT().ListGroupingSeeds(gomock.Any(), db.GroupingSeedOpts{Residual: true}).
 		Return(nil, nil)
 
-	runCycle(context.Background(), mockDB, nil, nil, nil)
+	_ = runCycle(context.Background(), mockDB, nil, nil, nil)
 }
 
 // A cycle that repartitions nothing writes nothing. The two postings here already
@@ -59,7 +59,7 @@ func TestRunCycle_WritesNothingWhenItAgrees(t *testing.T) {
 	mockDB.EXPECT().PostingsByOrdinals(gomock.Any(), "u1", gomock.Any(), gomock.Any()).
 		Return(nil, nil).AnyTimes()
 
-	runCycle(context.Background(), mockDB, nil, nil, nil)
+	_ = runCycle(context.Background(), mockDB, nil, nil, nil)
 }
 
 // TestRunCycle_PartitionsEachUsersOwnData verifies a neighbourhood never crosses a
@@ -86,7 +86,7 @@ func TestRunCycle_PartitionsEachUsersOwnData(t *testing.T) {
 	mockDB.EXPECT().PostingsByOrdinals(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil, nil).AnyTimes()
 
-	runCycle(context.Background(), mockDB, nil, nil, nil)
+	_ = runCycle(context.Background(), mockDB, nil, nil, nil)
 
 	if !seen["u1"] || !seen["u2"] {
 		t.Fatalf("read for users %v, want both u1 and u2", seen)
@@ -102,7 +102,7 @@ func TestRunCycle_SurvivesAReadError(t *testing.T) {
 	mockDB.EXPECT().ListGroupingSeeds(gomock.Any(), gomock.Any()).
 		Return(nil, errors.New("read failed"))
 
-	runCycle(context.Background(), mockDB, nil, nil, nil)
+	_ = runCycle(context.Background(), mockDB, nil, nil, nil)
 }
 
 // TestRunCycle_SurvivesOneUsersFailure verifies a neighbourhood that cannot be read
@@ -125,5 +125,5 @@ func TestRunCycle_SurvivesOneUsersFailure(t *testing.T) {
 	mockDB.EXPECT().PostingsByOrdinals(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
 		Return(nil, nil).AnyTimes()
 
-	runCycle(context.Background(), mockDB, nil, nil, nil)
+	_ = runCycle(context.Background(), mockDB, nil, nil, nil)
 }

--- a/server/inflationfetcher/run_telemetry_test.go
+++ b/server/inflationfetcher/run_telemetry_test.go
@@ -1,0 +1,62 @@
+package inflationfetcher
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/db/mock"
+	"go.uber.org/mock/gomock"
+)
+
+// TestCycleOpensARun pins the run a trigger opens. The run table is the
+// worker-runs chart, so a cycle that found no work still opens one and stamps it
+// success -- it ran -- while a cycle whose read failed stamps failed.
+func TestCycleOpensARun(t *testing.T) {
+	tests := []struct {
+		name    string
+		readErr error
+		want    string
+	}{
+		{name: "no work", readErr: nil, want: db.TelemetryOutcomeSuccess},
+		{name: "read failed", readErr: errors.New("boom"), want: db.TelemetryOutcomeFailed},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			t.Cleanup(ctrl.Finish)
+			mockDB := mock.NewMockDB(ctrl)
+			tel := mock.NewMockTelemetryDB(ctrl)
+			mockDB.EXPECT().DistinctDisplayCurrencies(gomock.Any()).Return(nil, tc.readErr)
+
+			var kind, outcome string
+			ended := make(chan struct{})
+			tel.EXPECT().StartRun(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, r db.TelemetryRun) string {
+					kind = r.Kind
+					return "run-1"
+				})
+			tel.EXPECT().EndRun(gomock.Any(), "run-1", gomock.Any()).
+				Do(func(_ context.Context, _, o string) {
+					outcome = o
+					close(ended)
+				})
+
+			trigger := make(chan struct{}, 1)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go RunWorker(ctx, mockDB, NewRegistry(), nil, tel, nil, trigger, nil)
+			trigger <- struct{}{}
+			<-ended
+
+			if kind != db.TelemetryRunInflationCycle {
+				t.Errorf("run kind = %q, want %q", kind, db.TelemetryRunInflationCycle)
+			}
+			if outcome != tc.want {
+				t.Errorf("outcome = %q, want %q", outcome, tc.want)
+			}
+		})
+	}
+}

--- a/server/inflationfetcher/worker.go
+++ b/server/inflationfetcher/worker.go
@@ -22,7 +22,10 @@ var gapStart = time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC)
 // RunWorker processes inflation fetch cycles triggered via the trigger channel.
 // It blocks until ctx is cancelled. Each signal on trigger runs one cycle;
 // rapid signals are debounced (buffered channel of size 1).
-func RunWorker(ctx context.Context, database db.DB, registry *Registry, counter telemetry.CounterIncrementer, log *slog.Logger, trigger <-chan struct{}, workers *worker.Registry) {
+func RunWorker(ctx context.Context, database db.DB, registry *Registry, counter telemetry.CounterIncrementer, tel db.TelemetryDB, log *slog.Logger, trigger <-chan struct{}, workers *worker.Registry) {
+	if tel == nil {
+		tel = db.NopTelemetry{}
+	}
 	const name = "inflation_fetcher"
 	if workers != nil {
 		workers.SetIdle(name)
@@ -35,7 +38,12 @@ func RunWorker(ctx context.Context, database db.DB, registry *Registry, counter 
 			if !ok {
 				return
 			}
-			runCycle(ctx, database, registry, counter, log, workers)
+			runID := tel.StartRun(ctx, db.TelemetryRun{Kind: db.TelemetryRunInflationCycle})
+			outcome := db.TelemetryOutcomeSuccess
+			if err := runCycle(ctx, database, registry, counter, log, workers); err != nil {
+				outcome = db.TelemetryOutcomeFailed
+			}
+			tel.EndRun(ctx, runID, outcome)
 		}
 	}
 }
@@ -47,7 +55,7 @@ type pluginEntry struct {
 	config []byte
 }
 
-func runCycle(ctx context.Context, database db.DB, registry *Registry, counter telemetry.CounterIncrementer, log *slog.Logger, workers *worker.Registry) {
+func runCycle(ctx context.Context, database db.DB, registry *Registry, counter telemetry.CounterIncrementer, log *slog.Logger, workers *worker.Registry) error {
 	const name = "inflation_fetcher"
 	if counter != nil {
 		counter.Incr(ctx, "inflation_fetcher.cycles")
@@ -63,13 +71,13 @@ func runCycle(ctx context.Context, database db.DB, registry *Registry, counter t
 		if log != nil {
 			log.ErrorContext(ctx, "inflation fetch: display currencies", "err", err)
 		}
-		return
+		return err
 	}
 	if len(currencies) == 0 {
 		if log != nil {
 			log.InfoContext(ctx, "inflation fetch: no display currencies configured, skipping")
 		}
-		return
+		return nil
 	}
 
 	configs, err := database.ListEnabledPluginConfigs(ctx, db.PluginCategoryInflation)
@@ -77,13 +85,13 @@ func runCycle(ctx context.Context, database db.DB, registry *Registry, counter t
 		if log != nil {
 			log.ErrorContext(ctx, "inflation fetch: list configs", "err", err)
 		}
-		return
+		return err
 	}
 	if len(configs) == 0 {
 		if log != nil {
 			log.InfoContext(ctx, "inflation fetch: no enabled inflation plugins, skipping")
 		}
-		return
+		return nil
 	}
 
 	var plugins []pluginEntry
@@ -102,7 +110,7 @@ func runCycle(ctx context.Context, database db.DB, registry *Registry, counter t
 		})
 	}
 	if len(plugins) == 0 {
-		return
+		return nil
 	}
 
 	if workers != nil {
@@ -110,6 +118,7 @@ func runCycle(ctx context.Context, database db.DB, registry *Registry, counter t
 	}
 
 	processCurrencies(ctx, database, plugins, currencies, log)
+	return nil
 }
 
 func processCurrencies(ctx context.Context, database db.DB, plugins []pluginEntry, currencies []string, log *slog.Logger) {

--- a/server/migrations/005_telemetry.sql
+++ b/server/migrations/005_telemetry.sql
@@ -52,7 +52,7 @@ CREATE SCHEMA telemetry;
 CREATE TABLE telemetry.run (
   id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   kind       TEXT NOT NULL CHECK (kind IN ('tx_import', 'user_archive_import',
-                                           'system_archive_import', 'price_job',
+                                           'system_archive_import',
                                            'grouping_cycle', 'transfer_match_cycle',
                                            'corporate_event_cycle', 'price_fetch_cycle',
                                            'inflation_cycle')),
@@ -242,7 +242,8 @@ SELECT
   r.outcome,
   r.telemetry_incomplete,
   r.kind IN ('tx_import', 'user_archive_import', 'system_archive_import') AS is_import,
-  -- Null while the run is in flight, which is the same thing outcome says.
+  -- Null while the run is in flight, and null for a run stamped incomplete: the
+  -- sweep knows the process died but not when, so there is no end to measure to.
   (EXTRACT(EPOCH FROM (r.ended_at - r.started_at)) * 1000)::BIGINT AS duration_ms
 FROM telemetry.run r;
 

--- a/server/pricefetcher/run_telemetry_test.go
+++ b/server/pricefetcher/run_telemetry_test.go
@@ -1,0 +1,62 @@
+package pricefetcher
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/db/mock"
+	"go.uber.org/mock/gomock"
+)
+
+// TestCycleOpensARun pins the run a trigger opens. The run table is the
+// worker-runs chart, so a cycle that found no work still opens one and stamps it
+// success -- it ran -- while a cycle whose read failed stamps failed.
+func TestCycleOpensARun(t *testing.T) {
+	tests := []struct {
+		name    string
+		readErr error
+		want    string
+	}{
+		{name: "no work", readErr: nil, want: db.TelemetryOutcomeSuccess},
+		{name: "read failed", readErr: errors.New("boom"), want: db.TelemetryOutcomeFailed},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			t.Cleanup(ctrl.Finish)
+			mockDB := mock.NewMockDB(ctrl)
+			tel := mock.NewMockTelemetryDB(ctrl)
+			mockDB.EXPECT().PriceGaps(gomock.Any(), gomock.Any()).Return(nil, tc.readErr)
+			mockDB.EXPECT().FXGaps(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+			var kind, outcome string
+			ended := make(chan struct{})
+			tel.EXPECT().StartRun(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, r db.TelemetryRun) string {
+					kind = r.Kind
+					return "run-1"
+				})
+			tel.EXPECT().EndRun(gomock.Any(), "run-1", gomock.Any()).
+				Do(func(_ context.Context, _, o string) {
+					outcome = o
+					close(ended)
+				})
+
+			trigger := make(chan struct{}, 1)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go RunWorker(ctx, mockDB, NewRegistry(), nil, tel, nil, trigger, nil)
+			trigger <- struct{}{}
+			<-ended
+
+			if kind != db.TelemetryRunPriceFetchCycle {
+				t.Errorf("run kind = %q, want %q", kind, db.TelemetryRunPriceFetchCycle)
+			}
+			if outcome != tc.want {
+				t.Errorf("outcome = %q, want %q", outcome, tc.want)
+			}
+		})
+	}
+}

--- a/server/pricefetcher/worker.go
+++ b/server/pricefetcher/worker.go
@@ -18,7 +18,10 @@ const DefaultPricePluginTimeout = 60 * time.Second
 // RunWorker processes price fetch cycles triggered via the trigger channel.
 // It blocks until ctx is cancelled. Each signal on trigger runs one cycle;
 // rapid signals are debounced (buffered channel of size 1).
-func RunWorker(ctx context.Context, database db.DB, registry *Registry, counter telemetry.CounterIncrementer, log *slog.Logger, trigger <-chan struct{}, workers *worker.Registry) {
+func RunWorker(ctx context.Context, database db.DB, registry *Registry, counter telemetry.CounterIncrementer, tel db.TelemetryDB, log *slog.Logger, trigger <-chan struct{}, workers *worker.Registry) {
+	if tel == nil {
+		tel = db.NopTelemetry{}
+	}
 	const name = "price_fetcher"
 	if workers != nil {
 		workers.SetIdle(name)
@@ -31,7 +34,12 @@ func RunWorker(ctx context.Context, database db.DB, registry *Registry, counter 
 			if !ok {
 				return
 			}
-			runCycle(ctx, database, registry, counter, log, workers)
+			runID := tel.StartRun(ctx, db.TelemetryRun{Kind: db.TelemetryRunPriceFetchCycle})
+			outcome := db.TelemetryOutcomeSuccess
+			if err := runCycle(ctx, database, registry, counter, log, workers); err != nil {
+				outcome = db.TelemetryOutcomeFailed
+			}
+			tel.EndRun(ctx, runID, outcome)
 		}
 	}
 }
@@ -44,7 +52,7 @@ type pluginEntry struct {
 	maxHistDays *int
 }
 
-func runCycle(ctx context.Context, database db.DB, registry *Registry, counter telemetry.CounterIncrementer, log *slog.Logger, workers *worker.Registry) {
+func runCycle(ctx context.Context, database db.DB, registry *Registry, counter telemetry.CounterIncrementer, log *slog.Logger, workers *worker.Registry) error {
 	const name = "price_fetcher"
 	if counter != nil {
 		counter.Incr(ctx, "price_fetcher.cycles")
@@ -62,7 +70,7 @@ func runCycle(ctx context.Context, database db.DB, registry *Registry, counter t
 		if log != nil {
 			log.ErrorContext(ctx, "price fetch: gaps", "err", err)
 		}
-		return
+		return err
 	}
 
 	fxGaps, err := database.FXGaps(ctx, opts)
@@ -70,14 +78,14 @@ func runCycle(ctx context.Context, database db.DB, registry *Registry, counter t
 		if log != nil {
 			log.ErrorContext(ctx, "price fetch: fx gaps", "err", err)
 		}
-		return
+		return err
 	}
 
 	allGaps := make([]db.InstrumentDateRanges, 0, len(gaps)+len(fxGaps))
 	allGaps = append(allGaps, gaps...)
 	allGaps = append(allGaps, fxGaps...)
 	if len(allGaps) == 0 {
-		return
+		return nil
 	}
 
 	if workers != nil {
@@ -89,10 +97,10 @@ func runCycle(ctx context.Context, database db.DB, registry *Registry, counter t
 		if log != nil {
 			log.ErrorContext(ctx, "price fetch: list configs", "err", err)
 		}
-		return
+		return err
 	}
 	if len(configs) == 0 {
-		return
+		return nil
 	}
 
 	var plugins []pluginEntry
@@ -109,7 +117,7 @@ func runCycle(ctx context.Context, database db.DB, registry *Registry, counter t
 		})
 	}
 	if len(plugins) == 0 {
-		return
+		return nil
 	}
 
 	// Batch-load blocked (instrument, plugin) pairs.
@@ -119,7 +127,7 @@ func runCycle(ctx context.Context, database db.DB, registry *Registry, counter t
 		if log != nil {
 			log.ErrorContext(ctx, "price fetch: load blocks", "err", err)
 		}
-		return
+		return err
 	}
 
 	// Batch-load all instruments for the gaps
@@ -128,7 +136,7 @@ func runCycle(ctx context.Context, database db.DB, registry *Registry, counter t
 		if log != nil {
 			log.ErrorContext(ctx, "price fetch: load instruments", "err", err)
 		}
-		return
+		return err
 	}
 	instByID := make(map[string]*db.InstrumentRow, len(instRows))
 	for _, r := range instRows {
@@ -142,10 +150,11 @@ func runCycle(ctx context.Context, database db.DB, registry *Registry, counter t
 		if log != nil {
 			log.ErrorContext(ctx, "price fetch: load coverage", "err", err)
 		}
-		return
+		return err
 	}
 
 	processGaps(ctx, database, plugins, allGaps, instByID, blocked, coverage, log)
+	return nil
 }
 
 // processGaps iterates instrument gaps and fetches prices from matching plugins.

--- a/server/pricefetcher/worker_test.go
+++ b/server/pricefetcher/worker_test.go
@@ -163,7 +163,7 @@ func TestRunCycle_FXGapsProcessed(t *testing.T) {
 	}, nil)
 	mockDB.EXPECT().UpsertPricesForRange(gomock.Any(), fxInstID, pluginID, gomock.Any(), from, to, gomock.Any()).Return(nil)
 
-	runCycle(ctx, mockDB, reg, nil, nil, nil)
+	_ = runCycle(ctx, mockDB, reg, nil, nil, nil)
 
 	if stub.calls != 1 {
 		t.Errorf("expected 1 FetchPrices call for FX gap, got %d", stub.calls)
@@ -245,7 +245,7 @@ func TestRunCycle_BlockedPluginSkipped(t *testing.T) {
 		},
 	}, nil)
 
-	runCycle(ctx, mockDB, reg, nil, nil, nil)
+	_ = runCycle(ctx, mockDB, reg, nil, nil, nil)
 
 	if stub.calls != 0 {
 		t.Errorf("expected 0 FetchPrices calls for blocked plugin, got %d", stub.calls)
@@ -290,7 +290,7 @@ func TestRunCycle_ErrPermanentCreatesBlock(t *testing.T) {
 	}, nil)
 	mockDB.EXPECT().CreatePriceFetchBlock(gomock.Any(), instID, pluginID, "ticker not found").Return(nil)
 
-	runCycle(ctx, mockDB, reg, nil, nil, nil)
+	_ = runCycle(ctx, mockDB, reg, nil, nil, nil)
 
 	if stub.calls != 1 {
 		t.Errorf("expected 1 FetchPrices call, got %d", stub.calls)
@@ -344,7 +344,7 @@ func TestRunCycle_MaxHistoryTruncation(t *testing.T) {
 	mockDB.EXPECT().UpsertPricesForRange(gomock.Any(), instID, pluginID, nil, from, cutoff, gomock.Any()).Return(nil)
 	mockDB.EXPECT().UpsertPricesForRange(gomock.Any(), instID, pluginID, gomock.Any(), cutoff, to, gomock.Any()).Return(nil)
 
-	runCycle(ctx, mockDB, reg, nil, nil, nil)
+	_ = runCycle(ctx, mockDB, reg, nil, nil, nil)
 
 	if stub.calls != 1 {
 		t.Errorf("expected 1 FetchPrices call (truncated), got %d", stub.calls)
@@ -394,7 +394,7 @@ func TestRunCycle_MaxHistorySkipsOldGap(t *testing.T) {
 	// rather than being asked about again every cycle.
 	mockDB.EXPECT().UpsertPricesForRange(gomock.Any(), instID, pluginID, nil, from, to, gomock.Any()).Return(nil)
 
-	runCycle(ctx, mockDB, reg, nil, nil, nil)
+	_ = runCycle(ctx, mockDB, reg, nil, nil, nil)
 
 	if stub.calls != 0 {
 		t.Errorf("expected 0 FetchPrices calls for gap older than max history, got %d", stub.calls)
@@ -430,7 +430,7 @@ func TestRunCycle_NoDataRecordsCoverage(t *testing.T) {
 	}, nil)
 	mockDB.EXPECT().UpsertPricesForRange(gomock.Any(), instID, pluginID, nil, from, to, gomock.Any()).Return(nil)
 
-	runCycle(ctx, mockDB, reg, nil, nil, nil)
+	_ = runCycle(ctx, mockDB, reg, nil, nil, nil)
 
 	if stub.calls != 1 {
 		t.Errorf("expected 1 FetchPrices call, got %d", stub.calls)
@@ -466,7 +466,7 @@ func TestRunCycle_CoveredRangeNotRefetched(t *testing.T) {
 		{ID: instID, AssetClass: strPtr("STOCK"), Identifiers: []db.IdentifierInput{{Type: "MIC_TICKER", Value: "AAPL"}}},
 	}, nil)
 
-	runCycle(ctx, mockDB, reg, nil, nil, nil)
+	_ = runCycle(ctx, mockDB, reg, nil, nil, nil)
 
 	if stub.calls != 0 {
 		t.Errorf("expected no FetchPrices call for an already covered range, got %d", stub.calls)
@@ -507,7 +507,7 @@ func TestRunCycle_OtherPluginStillAskedAfterCoverage(t *testing.T) {
 	}, nil)
 	mockDB.EXPECT().UpsertPricesForRange(gomock.Any(), instID, freshID, gomock.Any(), from, to, gomock.Any()).Return(nil)
 
-	runCycle(ctx, mockDB, reg, nil, nil, nil)
+	_ = runCycle(ctx, mockDB, reg, nil, nil, nil)
 
 	if covered.calls != 0 {
 		t.Errorf("covered plugin should not be asked again, got %d calls", covered.calls)
@@ -550,7 +550,7 @@ func TestRunWorker_DebounceCollapsesTriggers(t *testing.T) {
 
 	done := make(chan struct{})
 	go func() {
-		RunWorker(ctx, mockDB, NewRegistry(), counter, nil, trigger, nil)
+		RunWorker(ctx, mockDB, NewRegistry(), counter, nil, nil, trigger, nil)
 		close(done)
 	}()
 

--- a/server/service/ingestion/run_telemetry_test.go
+++ b/server/service/ingestion/run_telemetry_test.go
@@ -1,0 +1,156 @@
+package ingestion
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
+	ingestionv1 "github.com/leedenison/portfoliodb/proto/ingestion/v1"
+	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/db/mock"
+	"github.com/leedenison/portfoliodb/server/identifier"
+	"go.uber.org/mock/gomock"
+	"google.golang.org/protobuf/types/known/timestamppb"
+)
+
+// expectRun records the run a job opens and the outcome it is stamped with, and
+// returns pointers to both so a test can assert on them after processJob returns.
+func expectRun(tel *mock.MockTelemetryDB, runID string) (*db.TelemetryRun, *string) {
+	var started db.TelemetryRun
+	var outcome string
+	tel.EXPECT().
+		StartRun(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, r db.TelemetryRun) string {
+			started = r
+			return runID
+		})
+	tel.EXPECT().
+		EndRun(gomock.Any(), runID, gomock.Any()).
+		Do(func(_ context.Context, _, o string) { outcome = o })
+	return &started, &outcome
+}
+
+// TestJobRunScopeComesFromTheJobRow pins where a run's scope is read from. Taking
+// it off the job row rather than the payload is what lets a job whose payload will
+// not load still record whose upload it was, which is the case most worth seeing.
+func TestJobRunScopeComesFromTheJobRow(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	database := mock.NewMockDB(ctrl)
+	tel := mock.NewMockTelemetryDB(ctrl)
+	j := &JobRequest{JobID: "job-1", JobType: db.JobTypeTx}
+
+	database.EXPECT().SetJobStatus(gomock.Any(), "job-1", apiv1.JobStatus_RUNNING).Return(nil)
+	database.EXPECT().GetJob(gomock.Any(), "job-1").Return(&db.JobDetail{
+		Status: apiv1.JobStatus_RUNNING, UserID: "user-1", Broker: "FIDELITY", Source: "FIDELITY:acct:history",
+	}, nil)
+	database.EXPECT().LoadJobPayload(gomock.Any(), "job-1").Return(nil, errors.New("payload gone"))
+	database.EXPECT().SetJobStatus(gomock.Any(), "job-1", apiv1.JobStatus_FAILED).Return(nil)
+	database.EXPECT().ClearJobPayload(gomock.Any(), "job-1").Return(nil)
+	started, outcome := expectRun(tel, "run-1")
+
+	processJob(context.Background(), WorkerOptions{DB: database, TelemetryDB: tel}, j)
+
+	want := db.TelemetryRun{
+		Kind:   db.TelemetryRunTxImport,
+		JobID:  "job-1",
+		UserID: "user-1",
+		Broker: "FIDELITY",
+		Source: "FIDELITY:acct:history",
+	}
+	if *started != want {
+		t.Errorf("StartRun(%+v), want %+v", *started, want)
+	}
+	if *outcome != db.TelemetryOutcomeFailed {
+		t.Errorf("outcome = %q, want %q", *outcome, db.TelemetryOutcomeFailed)
+	}
+}
+
+// TestJobRunStampsSuccess pins the other half: a job that reaches SUCCESS stamps
+// its run success, so the run's outcome and the job's agree without a join.
+func TestJobRunStampsSuccess(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	database := mock.NewMockDB(ctrl)
+	tel := mock.NewMockTelemetryDB(ctrl)
+	registry := identifier.NewRegistry()
+
+	// One posting the ignore rules drop, which is the shortest path to a job that
+	// stores nothing and still succeeds.
+	payload := marshalPayload(t, &ingestionv1.UpsertTxsRequest{
+		Window: &archivev1.TxWindow{
+			Broker: typev1.Broker_IBKR,
+			Source: "IBKR:test:statement",
+			Postings: []*archivev1.Posting{{
+				OrderDate: timestamppb.Now(), TradeDate: timestamppb.Now(),
+				InstrumentDescription: "GBP", BrokerTxType: []typev1.TxType{typev1.TxType_TRANSFER},
+				AssetClassHint: typev1.AssetClass_CASH, Quantity: "1",
+			}},
+		},
+	})
+	j := &JobRequest{JobID: "job-2", JobType: db.JobTypeTx}
+
+	database.EXPECT().SetJobStatus(gomock.Any(), "job-2", apiv1.JobStatus_RUNNING).Return(nil)
+	database.EXPECT().GetJob(gomock.Any(), "job-2").Return(
+		&db.JobDetail{Status: apiv1.JobStatus_RUNNING, UserID: "user-1"}, nil)
+	database.EXPECT().LoadJobPayload(gomock.Any(), "job-2").Return(payload, nil)
+	database.EXPECT().ListIgnoredAssetClasses(gomock.Any(), "user-1").Return(
+		[]db.IgnoredAssetClass{{Broker: "IBKR", AssetClass: "CASH"}}, nil)
+	database.EXPECT().ListHoldingDeclarations(gomock.Any(), "user-1").Return(nil, nil)
+	database.EXPECT().SetJobStatus(gomock.Any(), "job-2", apiv1.JobStatus_SUCCESS).Return(nil)
+	database.EXPECT().ClearJobPayload(gomock.Any(), "job-2").Return(nil)
+	_, outcome := expectRun(tel, "run-2")
+
+	processJob(context.Background(), WorkerOptions{
+		DB: database, TelemetryDB: tel, IdentifierRegistry: registry,
+	}, j)
+
+	if *outcome != db.TelemetryOutcomeSuccess {
+		t.Errorf("outcome = %q, want %q", *outcome, db.TelemetryOutcomeSuccess)
+	}
+}
+
+// TestUnknownJobTypeOpensNoRun pins the closed vocabulary. A job type this build
+// does not know has no kind to file a run under, and inventing one would put a
+// value in the column no panel could interpret.
+func TestUnknownJobTypeOpensNoRun(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	database := mock.NewMockDB(ctrl)
+	tel := mock.NewMockTelemetryDB(ctrl)
+	j := &JobRequest{JobID: "job-3", JobType: "not_a_job_type"}
+
+	database.EXPECT().SetJobStatus(gomock.Any(), "job-3", apiv1.JobStatus_RUNNING).Return(nil)
+	database.EXPECT().GetJob(gomock.Any(), "job-3").Return(&db.JobDetail{UserID: "user-1"}, nil)
+	database.EXPECT().SetJobStatus(gomock.Any(), "job-3", apiv1.JobStatus_FAILED).Return(nil)
+	// No StartRun. EndRun is still called, with the empty id the writer skips on.
+	tel.EXPECT().EndRun(gomock.Any(), "", db.TelemetryOutcomeFailed)
+
+	processJob(context.Background(), WorkerOptions{DB: database, TelemetryDB: tel}, j)
+}
+
+// TestJobRunKinds pins the map from job type to run kind. The three import kinds
+// in the vocabulary are exactly the three job types; anything else opens no run.
+func TestJobRunKinds(t *testing.T) {
+	tests := []struct {
+		name    string
+		jobType string
+		want    string
+	}{
+		{name: "tx", jobType: db.JobTypeTx, want: db.TelemetryRunTxImport},
+		{name: "system archive", jobType: db.JobTypeSystemArchive, want: db.TelemetryRunSystemArchiveImport},
+		{name: "user archive", jobType: db.JobTypeUserArchive, want: db.TelemetryRunUserArchiveImport},
+		{name: "unknown", jobType: "price", want: ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := telemetryRunKind(tc.jobType); got != tc.want {
+				t.Errorf("telemetryRunKind(%q) = %q, want %q", tc.jobType, got, tc.want)
+			}
+		})
+	}
+}

--- a/server/service/ingestion/system_import.go
+++ b/server/service/ingestion/system_import.go
@@ -26,6 +26,10 @@ var errUnknownPart = errors.New("this build cannot apply that archive part")
 type systemImportResult struct {
 	pricesPersisted bool
 	eventsPersisted bool
+	// failed says the job ended FAILED, which is what the run records. It is the
+	// import's own verdict rather than a re-read of the job row, so the two
+	// cannot drift.
+	failed bool
 }
 
 // processSystemImport applies the parts of a system archive in restore order,
@@ -45,12 +49,14 @@ func processSystemImport(ctx context.Context, database db.DB, registry *identifi
 	if err != nil {
 		log.Printf("system archive job %s: load payload: %v", j.JobID, err)
 		failWholeJob(ctx, database, j.JobID, "payload", err.Error())
+		out.failed = true
 		return out
 	}
 	var a archivev1.SystemArchive
 	if err := proto.Unmarshal(payload, &a); err != nil {
 		log.Printf("system archive job %s: unmarshal payload: %v", j.JobID, err)
 		failWholeJob(ctx, database, j.JobID, "payload", err.Error())
+		out.failed = true
 		return out
 	}
 
@@ -73,6 +79,7 @@ func processSystemImport(ctx context.Context, database db.DB, registry *identifi
 	if err != nil {
 		log.Printf("system archive job %s: read parts: %v", j.JobID, err)
 		failWholeJob(ctx, database, j.JobID, "job", err.Error())
+		out.failed = true
 		return out
 	}
 
@@ -138,6 +145,7 @@ func processSystemImport(ctx context.Context, database db.DB, registry *identifi
 	if anyFailed {
 		status = apiv1.JobStatus_FAILED
 	}
+	out.failed = anyFailed
 	finishJob(ctx, database, j.JobID, status)
 	return out
 }

--- a/server/service/ingestion/user_import.go
+++ b/server/service/ingestion/user_import.go
@@ -25,6 +25,10 @@ type userImportResult struct {
 	declarationsStored bool
 	// userID is whose archive this was, for the recalc a stored posting earns.
 	userID string
+	// failed says the job ended FAILED, which is what the run records. It is the
+	// import's own verdict rather than a re-read of the job row, so the two
+	// cannot drift.
+	failed bool
 }
 
 // processUserImport applies the parts of a user archive in restore order,
@@ -42,12 +46,14 @@ func processUserImport(ctx context.Context, deps ingestDeps, j *JobRequest) user
 	if err != nil {
 		log.Printf("user archive job %s: load payload: %v", j.JobID, err)
 		failWholeJob(ctx, database, j.JobID, "payload", err.Error())
+		out.failed = true
 		return out
 	}
 	var a archivev1.UserArchive
 	if err := proto.Unmarshal(payload, &a); err != nil {
 		log.Printf("user archive job %s: unmarshal payload: %v", j.JobID, err)
 		failWholeJob(ctx, database, j.JobID, "payload", err.Error())
+		out.failed = true
 		return out
 	}
 
@@ -57,6 +63,7 @@ func processUserImport(ctx context.Context, deps ingestDeps, j *JobRequest) user
 	if err != nil {
 		log.Printf("user archive job %s: read parts: %v", j.JobID, err)
 		failWholeJob(ctx, database, j.JobID, "job", err.Error())
+		out.failed = true
 		return out
 	}
 
@@ -121,6 +128,7 @@ func processUserImport(ctx context.Context, deps ingestDeps, j *JobRequest) user
 	if anyFailed {
 		status = apiv1.JobStatus_FAILED
 	}
+	out.failed = anyFailed
 	finishJob(ctx, database, j.JobID, status)
 	return out
 }

--- a/server/service/ingestion/worker.go
+++ b/server/service/ingestion/worker.go
@@ -25,8 +25,8 @@ import (
 var ingestionLog *slog.Logger
 
 // WorkerOptions configures RunWorker. All fields except DB and Queue are
-// optional: a nil Counter, Logger, Trigger, or Registry is treated as "not
-// set" and the worker degrades gracefully (no telemetry, default logger,
+// optional: a nil Counter, TelemetryDB, Logger, Trigger, or Registry is treated
+// as "not set" and the worker degrades gracefully (no telemetry, default logger,
 // no downstream nudge).
 type WorkerOptions struct {
 	// DB is the database abstraction the worker reads jobs from and writes
@@ -43,6 +43,10 @@ type WorkerOptions struct {
 	DescriptionRegistry *description.Registry
 	// Counter is an optional metrics counter; nil disables telemetry.
 	Counter telemetry.CounterIncrementer
+	// TelemetryDB records a run per job and the event rows beneath it; nil
+	// disables recording. It is separate from DB because it holds its own pool
+	// and must never join the work's transaction.
+	TelemetryDB db.TelemetryDB
 	// Logger is the slog logger for ingestion-side logging; nil falls back
 	// to slog.Default().
 	Logger *slog.Logger
@@ -97,13 +101,55 @@ func RunWorker(ctx context.Context, opts WorkerOptions) {
 	}
 }
 
+// telemetryRunKind maps a job type onto the run kind that describes it. An empty
+// return is a job type this build does not know, which opens no run: the
+// vocabulary is closed, so there is no kind to file it under.
+func telemetryRunKind(jobType string) string {
+	switch jobType {
+	case db.JobTypeTx:
+		return db.TelemetryRunTxImport
+	case db.JobTypeSystemArchive:
+		return db.TelemetryRunSystemArchiveImport
+	case db.JobTypeUserArchive:
+		return db.TelemetryRunUserArchiveImport
+	}
+	return ""
+}
+
 func processJob(ctx context.Context, opts WorkerOptions, j *JobRequest) {
 	_ = opts.DB.SetJobStatus(ctx, j.JobID, apiv1.JobStatus_RUNNING)
 
+	tel := opts.TelemetryDB
+	if tel == nil {
+		tel = db.NopTelemetry{}
+	}
+	// The job row, not the payload, is what the run's scope comes from. A job
+	// whose payload will not load or unmarshal still leaves a run recording whose
+	// upload it was and that it failed, which is the case most worth seeing.
+	var detail db.JobDetail
+	if d, err := opts.DB.GetJob(ctx, j.JobID); err == nil && d != nil {
+		detail = *d
+	}
+	var runID string
+	if kind := telemetryRunKind(j.JobType); kind != "" {
+		runID = tel.StartRun(ctx, db.TelemetryRun{
+			Kind:   kind,
+			JobID:  j.JobID,
+			UserID: detail.UserID,
+			Broker: detail.Broker,
+			Source: detail.Source,
+		})
+	}
+	// Failed unless something below says otherwise, so a path that returns without
+	// deciding is recorded as the failure it is rather than as a success.
+	outcome := db.TelemetryOutcomeFailed
+	defer func() { tel.EndRun(ctx, runID, outcome) }()
+
 	switch j.JobType {
 	case db.JobTypeTx:
-		if ok, userID := processTx(ctx, opts.DB, opts.IdentifierRegistry, opts.DescriptionRegistry, opts.Counter, j); ok {
-			if err := recalcAfterIngestion(ctx, opts.DB, userID); err != nil {
+		if ok := processTx(ctx, opts.DB, opts.IdentifierRegistry, opts.DescriptionRegistry, opts.Counter, j, detail.UserID); ok {
+			outcome = db.TelemetryOutcomeSuccess
+			if err := recalcAfterIngestion(ctx, opts.DB, detail.UserID); err != nil {
 				log.Printf("ingestion job %s: recalc INITIALIZE txs: %v", j.JobID, err)
 			}
 			// The corporate event fetcher is not nudged because splits are
@@ -119,6 +165,9 @@ func processJob(ctx context.Context, opts WorkerOptions, j *JobRequest) {
 		}
 	case db.JobTypeSystemArchive:
 		res := processSystemImport(ctx, opts.DB, opts.IdentifierRegistry, j)
+		if !res.failed {
+			outcome = db.TelemetryOutcomeSuccess
+		}
 		// Nudged once for the whole import rather than per part. Instruments
 		// trigger nothing: an imported instrument has no holdings yet, so it
 		// opens no price gap.
@@ -136,6 +185,9 @@ func processJob(ctx context.Context, opts WorkerOptions, j *JobRequest) {
 			Counter:      opts.Counter,
 		}
 		res := processUserImport(ctx, deps, j)
+		if !res.failed {
+			outcome = db.TelemetryOutcomeSuccess
+		}
 		// Nudged once for the whole import rather than per part.
 		//
 		// Restored postings earn what a broker upload earns: the pads a
@@ -181,24 +233,21 @@ func finishJob(ctx context.Context, database db.DB, jobID string, status apiv1.J
 	_ = database.ClearJobPayload(ctx, jobID)
 }
 
-func processTx(ctx context.Context, database db.DB, registry *identifier.Registry, descRegistry *description.Registry, counter telemetry.CounterIncrementer, j *JobRequest) (bool, string) {
-	// Look up userID from the job row.
-	var userID string
-	if d, err := database.GetJob(ctx, j.JobID); err == nil {
-		userID = d.UserID
-	}
-
+// processTx applies a broker upload. userID comes from the job row, which the
+// caller has already read to scope the run, so it is passed in rather than read
+// a second time.
+func processTx(ctx context.Context, database db.DB, registry *identifier.Registry, descRegistry *description.Registry, counter telemetry.CounterIncrementer, j *JobRequest, userID string) bool {
 	payload, err := database.LoadJobPayload(ctx, j.JobID)
 	if err != nil {
 		log.Printf("ingestion job %s: load payload: %v", j.JobID, err)
 		finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
-		return false, ""
+		return false
 	}
 	var req ingestionv1.UpsertTxsRequest
 	if err := proto.Unmarshal(payload, &req); err != nil {
 		log.Printf("ingestion job %s: unmarshal payload: %v", j.JobID, err)
 		finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
-		return false, ""
+		return false
 	}
 
 	// A tx job has no part rows, so its reporter is the unscoped kind: it writes
@@ -213,7 +262,7 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 		rep.Flush(ctx)
 		log.Printf("ingestion job %s: %v", j.JobID, err)
 		finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
-		return false, ""
+		return false
 	}
 
 	res, err := ingestBatch(ctx, ingestDeps{
@@ -241,7 +290,7 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 	if err != nil {
 		log.Printf("ingestion job %s: %v", j.JobID, err)
 		finishJob(ctx, database, j.JobID, apiv1.JobStatus_FAILED)
-		return false, ""
+		return false
 	}
 
 	// Recompute split-adjusted values for instruments that have split rows.
@@ -249,7 +298,7 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 	recomputeSplitAdjustedTxs(ctx, database, res.InstrumentIDs)
 
 	finishJob(ctx, database, j.JobID, apiv1.JobStatus_SUCCESS)
-	return true, userID
+	return true
 }
 
 // recomputeSplitAdjustedTxs checks which of the given instrument IDs have

--- a/server/transfermatch/run_telemetry_test.go
+++ b/server/transfermatch/run_telemetry_test.go
@@ -1,0 +1,62 @@
+package transfermatch
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/db/mock"
+	"go.uber.org/mock/gomock"
+)
+
+// TestCycleOpensARun pins the run a trigger opens. The run table is the
+// worker-runs chart, so a cycle that found no work still opens one and stamps it
+// success -- it ran -- while a cycle whose read failed stamps failed.
+func TestCycleOpensARun(t *testing.T) {
+	tests := []struct {
+		name    string
+		readErr error
+		want    string
+	}{
+		{name: "no work", readErr: nil, want: db.TelemetryOutcomeSuccess},
+		{name: "read failed", readErr: errors.New("boom"), want: db.TelemetryOutcomeFailed},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			t.Cleanup(ctrl.Finish)
+			mockDB := mock.NewMockDB(ctrl)
+			tel := mock.NewMockTelemetryDB(ctrl)
+			mockDB.EXPECT().ListUnmatchedTransferSides(gomock.Any(), gomock.Any()).Return(nil, tc.readErr)
+
+			var kind, outcome string
+			ended := make(chan struct{})
+			tel.EXPECT().StartRun(gomock.Any(), gomock.Any()).
+				DoAndReturn(func(_ context.Context, r db.TelemetryRun) string {
+					kind = r.Kind
+					return "run-1"
+				})
+			tel.EXPECT().EndRun(gomock.Any(), "run-1", gomock.Any()).
+				Do(func(_ context.Context, _, o string) {
+					outcome = o
+					close(ended)
+				})
+
+			trigger := make(chan struct{}, 1)
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			go RunWorker(ctx, mockDB, nil, tel, nil, trigger, nil)
+			trigger <- struct{}{}
+			<-ended
+
+			if kind != db.TelemetryRunTransferMatchCycle {
+				t.Errorf("run kind = %q, want %q", kind, db.TelemetryRunTransferMatchCycle)
+			}
+			if outcome != tc.want {
+				t.Errorf("outcome = %q, want %q", outcome, tc.want)
+			}
+		})
+	}
+}

--- a/server/transfermatch/worker.go
+++ b/server/transfermatch/worker.go
@@ -27,7 +27,10 @@ const name = "transfer_match"
 // just landed does not wait for the next tick. Neither is redundant: a cadence alone
 // would leave a just-imported transfer reported as unmatched until it came round,
 // and the ingestion nudge alone would never retry a cycle that failed.
-func RunWorker(ctx context.Context, database db.DB, counter telemetry.CounterIncrementer, log *slog.Logger, trigger <-chan struct{}, workers *worker.Registry) {
+func RunWorker(ctx context.Context, database db.DB, counter telemetry.CounterIncrementer, tel db.TelemetryDB, log *slog.Logger, trigger <-chan struct{}, workers *worker.Registry) {
+	if tel == nil {
+		tel = db.NopTelemetry{}
+	}
 	if workers != nil {
 		workers.SetIdle(name)
 	}
@@ -39,7 +42,12 @@ func RunWorker(ctx context.Context, database db.DB, counter telemetry.CounterInc
 			if !ok {
 				return
 			}
-			runCycle(ctx, database, counter, log, workers)
+			runID := tel.StartRun(ctx, db.TelemetryRun{Kind: db.TelemetryRunTransferMatchCycle})
+			outcome := db.TelemetryOutcomeSuccess
+			if err := runCycle(ctx, database, counter, log, workers); err != nil {
+				outcome = db.TelemetryOutcomeFailed
+			}
+			tel.EndRun(ctx, runID, outcome)
 		}
 	}
 }
@@ -51,7 +59,7 @@ func RunWorker(ctx context.Context, database db.DB, counter telemetry.CounterInc
 // arrived is not necessarily in the import being processed. The read is bounded by
 // the partial index over residual postings and by the anti-join, so a corpus with
 // nothing outstanding costs one query.
-func runCycle(ctx context.Context, database db.DB, counter telemetry.CounterIncrementer, log *slog.Logger, workers *worker.Registry) {
+func runCycle(ctx context.Context, database db.DB, counter telemetry.CounterIncrementer, log *slog.Logger, workers *worker.Registry) error {
 	if counter != nil {
 		counter.Incr(ctx, "transfer_match.cycles")
 	}
@@ -66,10 +74,10 @@ func runCycle(ctx context.Context, database db.DB, counter telemetry.CounterIncr
 		if log != nil {
 			log.ErrorContext(ctx, "transfer match: list sides", "err", err)
 		}
-		return
+		return err
 	}
 	if len(sides) == 0 {
-		return
+		return nil
 	}
 	if workers != nil {
 		workers.SetRunning(name, fmt.Sprintf("Matching %d transfer sides", len(sides)))
@@ -80,14 +88,14 @@ func runCycle(ctx context.Context, database db.DB, counter telemetry.CounterIncr
 
 	matches := Match(sides, DefaultOpts())
 	if len(matches) == 0 {
-		return
+		return nil
 	}
 	written, err := database.CreateTransferMatches(ctx, matches)
 	if err != nil {
 		if log != nil {
 			log.ErrorContext(ctx, "transfer match: create matches", "err", err)
 		}
-		return
+		return err
 	}
 	if counter != nil {
 		// Pairs, not sides, which is why this is not called ".matched": next to
@@ -100,4 +108,5 @@ func runCycle(ctx context.Context, database db.DB, counter telemetry.CounterIncr
 		log.InfoContext(ctx, "transfer match",
 			"sides", len(sides), "matched", written, "unmatched", len(sides)-written*2)
 	}
+	return nil
 }

--- a/server/transfermatch/worker_test.go
+++ b/server/transfermatch/worker_test.go
@@ -36,7 +36,7 @@ func TestRunCycle_WritesThePairsItFinds(t *testing.T) {
 			return len(ms), nil
 		})
 
-	runCycle(ctx, mockDB, nil, nil, nil)
+	_ = runCycle(ctx, mockDB, nil, nil, nil)
 }
 
 // TestRunCycle_ReadsEveryUser verifies the pass is whole-corpus rather than scoped to
@@ -50,7 +50,7 @@ func TestRunCycle_ReadsEveryUser(t *testing.T) {
 	mockDB.EXPECT().ListUnmatchedTransferSides(gomock.Any(), db.TransferSideOpts{UserID: ""}).
 		Return(nil, nil)
 
-	runCycle(context.Background(), mockDB, nil, nil, nil)
+	_ = runCycle(context.Background(), mockDB, nil, nil, nil)
 }
 
 // TestRunCycle_WritesNothingWhenNothingPairs verifies a corpus of unmatchable sides
@@ -64,7 +64,7 @@ func TestRunCycle_WritesNothingWhenNothingPairs(t *testing.T) {
 		Return([]db.TransferSide{side("g-isa", "AS10000001", "-19599", 0, "553113055")}, nil)
 	// No CreateTransferMatches call is expected: gomock fails the test if one comes.
 
-	runCycle(context.Background(), mockDB, nil, nil, nil)
+	_ = runCycle(context.Background(), mockDB, nil, nil, nil)
 }
 
 // TestRunCycle_SurvivesAReadError verifies a failing cycle returns rather than
@@ -77,7 +77,7 @@ func TestRunCycle_SurvivesAReadError(t *testing.T) {
 	mockDB.EXPECT().ListUnmatchedTransferSides(gomock.Any(), gomock.Any()).
 		Return(nil, errors.New("connection reset"))
 
-	runCycle(context.Background(), mockDB, nil, nil, nil)
+	_ = runCycle(context.Background(), mockDB, nil, nil, nil)
 }
 
 // TestRunCycle_SurvivesAWriteError verifies the same for the write half.
@@ -93,5 +93,5 @@ func TestRunCycle_SurvivesAWriteError(t *testing.T) {
 	mockDB.EXPECT().CreateTransferMatches(gomock.Any(), gomock.Any()).
 		Return(0, errors.New("deadlock detected"))
 
-	runCycle(context.Background(), mockDB, nil, nil, nil)
+	_ = runCycle(context.Background(), mockDB, nil, nil, nil)
 }


### PR DESCRIPTION
First of three PRs for issue 0116. This one populates `telemetry.run`; the event
rows beneath it follow in the next two.

Work in this system is either an ingestion job or a worker cycle, and a run is one
activation of either. A job's run is scoped from the job row rather than from its
payload, so a job whose payload will not load still leaves a run saying whose upload
it was and that it died. That needed `broker` and `source` on `JobDetail` -- the
columns were already on `ingestion_jobs` -- and `processTx` now takes the user id the
caller has already read instead of reading the job a second time.

A cycle's run wraps `runCycle` from `RunWorker` rather than living inside it, so the
lifecycle is in one place per worker and the cycle bodies stay free of telemetry.
`runCycle` returns an error to say how it went; every logged early return keeps its
log line. A cycle that finds no work still opens a run and stamps `success`.

The startup sweep is what makes a null outcome mean "running now". It runs before the
re-enqueue of pending jobs, which opens runs that must not be swept, and it leaves
`ended_at` null: the run ended when its process died, and stamping `now()` would give
the view a duration measuring the outage instead.

`NopTelemetry` keeps nil out of the call sites -- `StartRun` returning an empty id is
already the writer's signal to skip a child.

`price_job` is dropped from the vocabulary. There is no price job type; price import
became an archive part, so nothing could ever produce that kind.

Verified with `make check`, `make server-test` and `make db-test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)