### PR TITLE
Record a resolution key and its extraction calls (0116)

### DIFF
--- a/docs/spec/telemetry.md
+++ b/docs/spec/telemetry.md
@@ -93,6 +93,17 @@ resolver already records against a row.
 using MIC_TICKER, so a mismatch is not a terminal state, and modelling it as one would
 make the outcome column non-exhaustive.
 
+The price and corporate event parts of an archive resolve instruments through the same
+resolver, but from an identifier and no broker description. They still write a key,
+because an identification attempt reaches its run through one. The identifier names it
+-- `description` is `TYPE:DOMAIN:VALUE` and `source` is empty, an archive being no
+broker's export -- and `tx_count` carries the archive groups sharing it, the fan-out
+this grain records whatever the things sharing it are called. `extraction_outcome` is
+`not_attempted_hints_supplied` for the reason a posting carrying an identifier skips
+extraction, and an instrument ensured from the supplied identifier alone is
+`broker_description_only`: no plugin resolved it and the row's own contents are what
+the instrument was built from, which is that member's shape.
+
 ### identification_attempt
 
 One `ResolveWithPlugins` call. A single resolution key produces several: one `primary`,

--- a/server/service/ingestion/corporate_event_worker.go
+++ b/server/service/ingestion/corporate_event_worker.go
@@ -22,7 +22,7 @@ import (
 // and an error only for a hard failure: an event the import could not read is a
 // validation error on a part that still succeeded.
 func importCorporateEventPart(ctx context.Context, database db.DB, pluginRegistry *identifier.Registry,
-	part *archivev1.CorporateEventPart, eventsAsOf *time.Time, resolveCache map[string]*resolveEntry, rep *archiveimport.PartReporter) (bool, error) {
+	part *archivev1.CorporateEventPart, eventsAsOf *time.Time, resolveCache map[string]*resolveEntry, keys *resolutionKeys, rep *archiveimport.PartReporter) (bool, error) {
 	groups := part.GetGroups()
 	total := 0
 	for _, g := range groups {
@@ -35,7 +35,7 @@ func importCorporateEventPart(ctx context.Context, database db.DB, pluginRegistr
 	splitInstruments := make(map[string]bool)
 
 	for gi, g := range groups {
-		instID, gErr := resolveEventGroupInstrument(ctx, database, pluginRegistry, resolveCache, g, eventsAsOf)
+		instID, gErr := resolveEventGroupInstrument(ctx, database, pluginRegistry, resolveCache, keys, g, eventsAsOf)
 		if gErr != nil {
 			// One unresolvable instrument fails its whole group: every event
 			// under it names the same instrument, so none of them can land.
@@ -88,7 +88,7 @@ func importCorporateEventPart(ctx context.Context, database db.DB, pluginRegistr
 	// failure above does not advertise data we did not persist. Per-span
 	// validation errors (a bad date, an empty interval) join the per-event ones.
 	// A hard DB error from the coverage upsert still fails the part.
-	covCount, covErrs, err := writeImportCoverage(ctx, database, groups, resolveCache, pluginRegistry, eventsAsOf)
+	covCount, covErrs, err := writeImportCoverage(ctx, database, groups, resolveCache, keys, pluginRegistry, eventsAsOf)
 	rep.Errs(covErrs)
 	if err != nil {
 		rep.Errf(-1, "coverage", err.Error())
@@ -119,20 +119,20 @@ func importCorporateEventPart(ctx context.Context, database db.DB, pluginRegistr
 // coverage span under it -- invokes the identifier plugins at most once. The
 // asset class passed to the resolver is the group's declared hint, as is asOf,
 // which split-adjusts OCC symbols to the file's declared knowledge time.
-func resolveEventGroupInstrument(ctx context.Context, database db.DB, pluginRegistry *identifier.Registry, cache map[string]*resolveEntry, g *archivev1.CorporateEventGroup, asOf *time.Time) (string, *apiv1.ValidationError) {
+func resolveEventGroupInstrument(ctx context.Context, database db.DB, pluginRegistry *identifier.Registry, cache map[string]*resolveEntry, keys *resolutionKeys, g *archivev1.CorporateEventGroup, asOf *time.Time) (string, *apiv1.ValidationError) {
 	ref := g.GetInstrument()
 	idType := typev1.IdentifierType_name[int32(ref.GetType())]
 	if !identifier.AllowedIdentifierTypes[idType] {
 		return "", &apiv1.ValidationError{Field: "instrument.type", Message: fmt.Sprintf("unknown identifier type %q", idType)}
 	}
-	key := idType + "\x00" + ref.GetDomain() + "\x00" + ref.GetValue()
-	entry, ok := cache[key]
+	r := identifierRef{Type: idType, Domain: ref.GetDomain(), Value: ref.GetValue()}
+	entry, ok := cache[r.cacheKey()]
 	if !ok {
 		acStr := db.AssetClassToStr(g.GetAssetClass())
 		result, err := resolveOrIdentifyInstrument(ctx, database, pluginRegistry,
-			idType, ref.GetDomain(), ref.GetValue(), acStr, "", asOf)
+			idType, ref.GetDomain(), ref.GetValue(), acStr, "", asOf, keys, r.cacheKey())
 		entry = &resolveEntry{result: result, err: err}
-		cache[key] = entry
+		cache[r.cacheKey()] = entry
 	}
 	if entry.err != nil {
 		return "", &apiv1.ValidationError{Field: "instrument", Message: entry.err.Error()}
@@ -264,7 +264,7 @@ func dividendTypeToString(t archivev1.DividendType) string {
 // A group whose instrument did not resolve is skipped in silence here: the
 // event pass already reported it, and saying so twice would double-count one
 // failure.
-func writeImportCoverage(ctx context.Context, database db.DB, groups []*archivev1.CorporateEventGroup, cache map[string]*resolveEntry, pluginRegistry *identifier.Registry, asOf *time.Time) (int, []*apiv1.ValidationError, error) {
+func writeImportCoverage(ctx context.Context, database db.DB, groups []*archivev1.CorporateEventGroup, cache map[string]*resolveEntry, keys *resolutionKeys, pluginRegistry *identifier.Registry, asOf *time.Time) (int, []*apiv1.ValidationError, error) {
 	var (
 		written int
 		errs    []*apiv1.ValidationError
@@ -273,7 +273,7 @@ func writeImportCoverage(ctx context.Context, database db.DB, groups []*archivev
 		if len(g.GetCoverage()) == 0 {
 			continue
 		}
-		instID, gErr := resolveEventGroupInstrument(ctx, database, pluginRegistry, cache, g, asOf)
+		instID, gErr := resolveEventGroupInstrument(ctx, database, pluginRegistry, cache, keys, g, asOf)
 		if gErr != nil {
 			continue
 		}

--- a/server/service/ingestion/corporate_event_worker_test.go
+++ b/server/service/ingestion/corporate_event_worker_test.go
@@ -32,7 +32,7 @@ func runEventPart(t *testing.T, database db.DB, registry *identifier.Registry,
 	part *archivev1.CorporateEventPart, asOf *time.Time) (bool, []*apiv1.ValidationError, error) {
 	t.Helper()
 	rep := archiveimport.NewDetachedReporter()
-	persisted, err := importCorporateEventPart(context.Background(), database, registry, part, asOf, newResolveCache(), rep)
+	persisted, err := importCorporateEventPart(context.Background(), database, registry, part, asOf, newResolveCache(), nil, rep)
 	return persisted, rep.Errors(), err
 }
 

--- a/server/service/ingestion/ingest.go
+++ b/server/service/ingestion/ingest.go
@@ -35,6 +35,20 @@ type ingestDeps struct {
 	Registry     *identifier.Registry
 	DescRegistry *description.Registry
 	Counter      telemetry.CounterIncrementer
+	// Telemetry and RunID are the run this batch is part of. Either left unset
+	// records nothing: a batch outside a run has nothing to hang its event rows
+	// off, and the writer would reject them.
+	Telemetry db.TelemetryDB
+	RunID     string
+}
+
+// writeDescriptionPluginCall records one ExtractBatch invocation against the run,
+// and does nothing when the batch is not part of one.
+func (d ingestDeps) writeDescriptionPluginCall(ctx context.Context, c db.TelemetryDescriptionPluginCall) {
+	if d.Telemetry == nil || d.RunID == "" {
+		return
+	}
+	d.Telemetry.WriteDescriptionPluginCall(ctx, c)
 }
 
 // ingestParams is one batch of postings and the scope they are stored under.
@@ -152,12 +166,12 @@ func ingestBatch(ctx context.Context, deps ingestDeps, p ingestParams, rep *arch
 		return out, nil
 	}
 
-	cache, extractedHints, err := extractDescHints(ctx, deps.DB, deps.DescRegistry, deps.Counter, p.Source, p.Broker, txs)
+	cache, extractedHints, extraction, err := extractDescHints(ctx, deps, p.Source, p.Broker, txs)
 	if err != nil {
 		rep.Errf(-1, "txs", err.Error())
 		return out, fmt.Errorf("extract description hints: %w", err)
 	}
-	instrumentIDs, idErrs, err := resolveInstruments(ctx, deps.DB, deps.Registry, p.Broker, p.Source, deps.Counter, txs, rowIdx, cache, extractedHints, rep)
+	instrumentIDs, idErrs, err := resolveInstruments(ctx, deps, p.Broker, p.Source, txs, rowIdx, cache, extractedHints, extraction, rep)
 	if err != nil {
 		rep.Errf(-1, "instrument_description", err.Error())
 		return out, fmt.Errorf("resolve instruments: %w", err)

--- a/server/service/ingestion/price_worker.go
+++ b/server/service/ingestion/price_worker.go
@@ -34,7 +34,7 @@ type resolveEntry struct {
 // carrying both prices and corporate events for one instrument identifies it
 // once rather than once per part.
 func importPricePart(ctx context.Context, database db.DB, pluginRegistry *identifier.Registry,
-	part *archivev1.PricePart, pricesAsOf *time.Time, resolveCache map[string]*resolveEntry, rep *archiveimport.PartReporter) (bool, error) {
+	part *archivev1.PricePart, pricesAsOf *time.Time, resolveCache map[string]*resolveEntry, keys *resolutionKeys, rep *archiveimport.PartReporter) (bool, error) {
 	groups := part.GetGroups()
 	total := 0
 	for _, g := range groups {
@@ -44,7 +44,7 @@ func importPricePart(ctx context.Context, database db.DB, pluginRegistry *identi
 
 	var resolved []resolvedGroup
 	for i, g := range groups {
-		instID, err := resolveGroupInstrument(ctx, database, pluginRegistry, resolveCache, g, pricesAsOf)
+		instID, err := resolveGroupInstrument(ctx, database, pluginRegistry, resolveCache, keys, g, pricesAsOf)
 		if err != nil {
 			rep.Errf(i, "instrument", err.Error())
 			rep.Advance(ctx, len(g.GetRows()))
@@ -103,21 +103,21 @@ type resolvedGroup struct {
 // rows is still worth writing: it is the only place they travel for an
 // instrument that was covered and had nothing.
 func resolveGroupInstrument(ctx context.Context, database db.DB, pluginRegistry *identifier.Registry,
-	cache map[string]*resolveEntry, g *archivev1.PriceGroup, asOf *time.Time) (string, error) {
+	cache map[string]*resolveEntry, keys *resolutionKeys, g *archivev1.PriceGroup, asOf *time.Time) (string, error) {
 	ref := g.GetInstrument()
 	idType := ref.GetType().String()
 	if !identifier.AllowedIdentifierTypes[idType] {
 		return "", fmt.Errorf("unknown identifier_type %q", idType)
 	}
 
-	key := idType + "\x00" + ref.GetDomain() + "\x00" + ref.GetValue()
-	entry, cached := cache[key]
+	r := identifierRef{Type: idType, Domain: ref.GetDomain(), Value: ref.GetValue()}
+	entry, cached := cache[r.cacheKey()]
 	if !cached {
 		acStr := db.AssetClassToStr(g.GetAssetClass())
 		result, err := resolveOrIdentifyInstrument(ctx, database, pluginRegistry,
-			idType, ref.GetDomain(), ref.GetValue(), acStr, g.GetCurrency(), asOf)
+			idType, ref.GetDomain(), ref.GetValue(), acStr, g.GetCurrency(), asOf, keys, r.cacheKey())
 		entry = &resolveEntry{result: result, err: err}
-		cache[key] = entry
+		cache[r.cacheKey()] = entry
 	}
 	if entry.err != nil {
 		return "", entry.err
@@ -331,7 +331,11 @@ func upsertGroups(ctx context.Context, database db.DB, groups []resolvedGroup) e
 // resolveOrIdentifyInstrument finds an instrument by identifier, or creates one.
 // When the resolved instrument's metadata differs from the supplied hints, the
 // returned ResolveResult.HintDiffs will be non-empty.
-func resolveOrIdentifyInstrument(ctx context.Context, database db.DB, pluginRegistry *identifier.Registry, idType, domain, value, assetClass, currency string, hintsValidAt *time.Time) (identification.ResolveResult, error) {
+// keys and key stamp the resolution key this identifier was written as. A branch
+// that returns an error leaves the key unstamped, because a resolution that could
+// not run has no outcome to report -- as against one that ran and found nothing,
+// which has several.
+func resolveOrIdentifyInstrument(ctx context.Context, database db.DB, pluginRegistry *identifier.Registry, idType, domain, value, assetClass, currency string, hintsValidAt *time.Time, keys *resolutionKeys, key string) (identification.ResolveResult, error) {
 	hint := identifier.Identifier{Type: idType, Domain: domain, Value: value}
 	hints := identifier.Hints{SecurityTypeHint: assetClass, Currency: currency}
 
@@ -346,6 +350,7 @@ func resolveOrIdentifyInstrument(ctx context.Context, database db.DB, pluginRegi
 		if err != nil {
 			return identification.ResolveResult{}, fmt.Errorf("identification error for %s %q: %v", idType, value, err)
 		}
+		keys.end(ctx, key, resolutionOutcome(result), result.InstrumentID)
 		return result, nil
 	}
 
@@ -354,6 +359,7 @@ func resolveOrIdentifyInstrument(ctx context.Context, database db.DB, pluginRegi
 		return identification.ResolveResult{}, fmt.Errorf("lookup error for %s %q: %v", idType, value, err)
 	}
 	if len(resolved) > 1 {
+		keys.end(ctx, key, db.TelemetryResolutionConflictingHints, "")
 		return identification.ResolveResult{}, fmt.Errorf("ambiguous: multiple instruments match %s %q", idType, value)
 	}
 	if len(resolved) == 1 {
@@ -364,12 +370,17 @@ func resolveOrIdentifyInstrument(ctx context.Context, database db.DB, pluginRegi
 		}
 		normMIC := identification.NewDBMICNormalizer(database)
 		diffs := identification.CompareHints(ctx, hints, []identifier.Identifier{hint}, inst, nil, normMIC)
+		keys.end(ctx, key, db.TelemetryResolutionDBIdentifierHints, resolved[0].ID)
 		return identification.ResolveResult{InstrumentID: resolved[0].ID, Identified: true, HintDiffs: diffs}, nil
 	}
 	id, err := ensureWithSuppliedIdentifier(ctx, database, assetClass, currency, idType, domain, value, hintsValidAt)
 	if err != nil {
 		return identification.ResolveResult{}, err
 	}
+	// No plugin resolved it and an instrument was ensured from what the row itself
+	// carried, which is the same shape as the broker-description-only fallback on
+	// the transaction path.
+	keys.end(ctx, key, db.TelemetryResolutionBrokerDescriptionOnly, id)
 	return identification.ResolveResult{InstrumentID: id}, nil
 }
 

--- a/server/service/ingestion/price_worker_test.go
+++ b/server/service/ingestion/price_worker_test.go
@@ -34,7 +34,7 @@ func runPricePart(t *testing.T, database db.DB, registry *identifier.Registry,
 		at = &v
 	}
 	rep := archiveimport.NewDetachedReporter()
-	persisted, err := importPricePart(context.Background(), database, registry, part, at, newResolveCache(), rep)
+	persisted, err := importPricePart(context.Background(), database, registry, part, at, newResolveCache(), nil, rep)
 	return persisted, rep.Errors(), err
 }
 

--- a/server/service/ingestion/resolution_telemetry.go
+++ b/server/service/ingestion/resolution_telemetry.go
@@ -1,0 +1,214 @@
+package ingestion
+
+import (
+	"context"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/identifier"
+	"github.com/leedenison/portfoliodb/server/service/identification"
+)
+
+// resolutionKeys owns the telemetry rows for the distinct resolution keys of one
+// batch, and for the identifiers of one archive.
+//
+// A resolution key is not a transaction: many transactions share one and resolve
+// once. The fan-out is therefore counted here, over the whole batch, before
+// anything resolves. Resolve only ever sees the first transaction of each key --
+// the rest are served from the batch cache -- so counting as it went would record
+// 1 against every key and lose the difference between a failure affecting 300
+// rows and one affecting 1.
+//
+// A nil *resolutionKeys records nothing and is safe to call, which is what a
+// caller with no telemetry writer passes.
+type resolutionKeys struct {
+	tel   db.TelemetryDB
+	runID string
+	// ids maps a resolution key -- what cacheKeyWithHints names -- to the row it
+	// was written as. An id missing or empty is a write that failed, and the
+	// writer already skips the children of one, so nothing here tests for it.
+	ids map[string]string
+	// extraction is stage 1, decided in the pre-pass before any key resolves and
+	// held until the key is stamped, because one row carries both stages.
+	extraction map[string]string
+	// mismatched is the MIC_TICKER against OPENFIGI_SHARE_CLASS disagreement,
+	// detected between the two stages and likewise held.
+	mismatched map[string]bool
+	stamped    map[string]bool
+}
+
+// newResolutionKeys writes a key row per distinct (source, description, hints)
+// triple over txs, and returns the ledger that stamps them.
+//
+// hints is parallel to txs, so the caller's filtered hint lists are reused rather
+// than derived a second time -- deriving them again would repeat the discard
+// logging that filtering does.
+//
+// extraction is keyed by cacheKey(source, description) -- no hints -- because that
+// is the grain the extraction pre-pass dedupes on. The two notions of distinct
+// coincide exactly when no posting carries a client hint, which is the only case
+// extraction runs in: a key that carries hints is never extracted, and is recorded
+// as not attempted for that reason.
+func newResolutionKeys(ctx context.Context, tel db.TelemetryDB, runID, source string, txs []*apiv1.Tx, hints [][]identifier.Identifier, extraction map[string]string) *resolutionKeys {
+	if tel == nil || runID == "" {
+		return nil
+	}
+	k := &resolutionKeys{
+		tel:        tel,
+		runID:      runID,
+		ids:        make(map[string]string),
+		extraction: make(map[string]string),
+		mismatched: make(map[string]bool),
+		stamped:    make(map[string]bool),
+	}
+	type seed struct {
+		desc     string
+		hasHints bool
+		txHints  identifier.Hints
+		txCount  int
+	}
+	var order []string
+	seeds := make(map[string]*seed)
+	for i, tx := range txs {
+		desc := tx.GetInstrumentDescription()
+		key := cacheKeyWithHints(source, desc, hints[i])
+		s := seeds[key]
+		if s == nil {
+			s = &seed{desc: desc, hasHints: len(hints[i]) > 0, txHints: HintsFromTx(tx)}
+			seeds[key] = s
+			order = append(order, key)
+		}
+		s.txCount++
+	}
+	for _, key := range order {
+		s := seeds[key]
+		ex := db.TelemetryExtractionNotAttemptedHintsSupplied
+		if !s.hasHints {
+			ex = extraction[cacheKey(source, s.desc)]
+		}
+		k.extraction[key] = ex
+		k.ids[key] = tel.StartResolutionKey(ctx, db.TelemetryResolutionKey{
+			RunID:              runID,
+			Source:             source,
+			Description:        s.desc,
+			TxCount:            s.txCount,
+			HadIdentifierHints: s.hasHints,
+			SecurityTypeHint:   s.txHints.SecurityTypeHint,
+			InstrumentKind:     s.txHints.InstrumentKind,
+		})
+	}
+	return k
+}
+
+// mismatch records that MIC_TICKER and OPENFIGI_SHARE_CLASS resolved differently
+// for this key. It is a flag rather than an outcome because resolution continues
+// and succeeds using MIC_TICKER.
+func (k *resolutionKeys) mismatch(key string) {
+	if k == nil {
+		return
+	}
+	k.mismatched[key] = true
+}
+
+// end stamps a key with what became of it, filling stage 1 in from what the
+// pre-pass recorded.
+//
+// The first stamp wins. A key resolves once and every later transaction sharing
+// it is answered from the batch cache, so a second call is the same key being
+// read rather than a second resolution.
+func (k *resolutionKeys) end(ctx context.Context, key, outcome, instrumentID string) {
+	if k == nil || k.stamped[key] {
+		return
+	}
+	k.stamped[key] = true
+	k.tel.EndResolutionKey(ctx, k.ids[key], db.TelemetryResolutionKeyOutcome{
+		RunID:             k.runID,
+		ExtractionOutcome: k.extraction[key],
+		Outcome:           outcome,
+		MismatchDetected:  k.mismatched[key],
+		InstrumentID:      instrumentID,
+	})
+}
+
+// resolutionOutcome names what became of a resolution that reached the identifier
+// plugins. The three fallback members mirror the messages the resolver already
+// records against a row, so a key's outcome and the row's message cannot disagree.
+func resolutionOutcome(r identification.ResolveResult) string {
+	switch {
+	case r.Identified:
+		return db.TelemetryResolutionIdentified
+	case r.HadTimeout:
+		return db.TelemetryResolutionPluginTimeout
+	case r.HadError:
+		return db.TelemetryResolutionPluginUnavailable
+	}
+	return db.TelemetryResolutionBrokerDescriptionOnly
+}
+
+// identifierRef is an instrument as an archive names it: an identifier and
+// nothing else. It is the grain the price and corporate event parts resolve and
+// cache on, and the grain their resolution keys are written at.
+type identifierRef struct {
+	Type   string
+	Domain string
+	Value  string
+}
+
+// cacheKey is what the per-archive resolve cache keys on, so the cache and the
+// telemetry ledger cannot disagree about what counts as the same instrument.
+func (r identifierRef) cacheKey() string {
+	return r.Type + "\x00" + r.Domain + "\x00" + r.Value
+}
+
+// description names the key in the absence of a broker description, which is what
+// these parts resolve without.
+func (r identifierRef) description() string {
+	return r.Type + ":" + r.Domain + ":" + r.Value
+}
+
+// newIdentifierResolutionKeys writes a key row per distinct identifier an archive
+// names, and returns the ledger that stamps them.
+//
+// The price and corporate event parts identify instruments through the same
+// resolver the transaction path uses, but from an identifier rather than from a
+// broker description. They still need a key, because an identification attempt
+// reaches its run through one. So the identifier names the key, tx_count carries
+// the archive groups sharing it -- the fan-out this grain exists to record,
+// whatever the things sharing it are called -- and source is empty, because an
+// archive is not a broker export and names none.
+//
+// Extraction is recorded as not attempted because every one of these rows already
+// names an identifier, which is the same reason a posting carrying one skips it.
+func newIdentifierResolutionKeys(ctx context.Context, tel db.TelemetryDB, runID string, refs []identifierRef) *resolutionKeys {
+	if tel == nil || runID == "" {
+		return nil
+	}
+	k := &resolutionKeys{
+		tel:        tel,
+		runID:      runID,
+		ids:        make(map[string]string),
+		extraction: make(map[string]string),
+		mismatched: make(map[string]bool),
+		stamped:    make(map[string]bool),
+	}
+	var order []identifierRef
+	counts := make(map[string]int)
+	for _, r := range refs {
+		key := r.cacheKey()
+		if counts[key] == 0 {
+			order = append(order, r)
+		}
+		counts[key]++
+	}
+	for _, r := range order {
+		key := r.cacheKey()
+		k.extraction[key] = db.TelemetryExtractionNotAttemptedHintsSupplied
+		k.ids[key] = tel.StartResolutionKey(ctx, db.TelemetryResolutionKey{
+			RunID:              runID,
+			Description:        r.description(),
+			TxCount:            counts[key],
+			HadIdentifierHints: true,
+		})
+	}
+	return k
+}

--- a/server/service/ingestion/resolution_telemetry_test.go
+++ b/server/service/ingestion/resolution_telemetry_test.go
@@ -1,0 +1,384 @@
+package ingestion
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	apiv1 "github.com/leedenison/portfoliodb/proto/api/v1"
+	typev1 "github.com/leedenison/portfoliodb/proto/type/v1"
+	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/db/mock"
+	"github.com/leedenison/portfoliodb/server/identifier"
+	descpkg "github.com/leedenison/portfoliodb/server/identifier/description"
+	"go.uber.org/mock/gomock"
+)
+
+// keySpy records the key rows a ledger writes and the outcomes it stamps them
+// with, keyed by description so a test names the row it means.
+type keySpy struct {
+	started map[string]db.TelemetryResolutionKey
+	ended   map[string]db.TelemetryResolutionKeyOutcome
+	desc    map[string]string // row id -> description
+}
+
+func newKeySpy(t *testing.T, tel *mock.MockTelemetryDB) *keySpy {
+	t.Helper()
+	s := &keySpy{
+		started: map[string]db.TelemetryResolutionKey{},
+		ended:   map[string]db.TelemetryResolutionKeyOutcome{},
+		desc:    map[string]string{},
+	}
+	n := 0
+	tel.EXPECT().StartResolutionKey(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, k db.TelemetryResolutionKey) string {
+			n++
+			id := string(rune('a' + n))
+			s.started[k.Description] = k
+			s.desc[id] = k.Description
+			return id
+		}).AnyTimes()
+	tel.EXPECT().EndResolutionKey(gomock.Any(), gomock.Any(), gomock.Any()).
+		Do(func(_ context.Context, id string, o db.TelemetryResolutionKeyOutcome) {
+			s.ended[s.desc[id]] = o
+		}).AnyTimes()
+	return s
+}
+
+// tx is the least a posting needs to name a resolution key.
+func tx(desc string) *apiv1.Tx {
+	return &apiv1.Tx{
+		InstrumentDescription: desc,
+		AssetClassHint:        typev1.AssetClass_STOCK,
+	}
+}
+
+// TestResolutionKeyCountsItsFanOut pins the grain. A resolution key is not a
+// transaction: many share one and resolve once, so tx_count is what tells a
+// failure affecting three postings from one affecting one.
+func TestResolutionKeyCountsItsFanOut(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	tel := mock.NewMockTelemetryDB(ctrl)
+	spy := newKeySpy(t, tel)
+
+	txs := []*apiv1.Tx{tx("APPLE INC"), tx("APPLE INC"), tx("APPLE INC"), tx("MSFT")}
+	hints := make([][]identifier.Identifier, len(txs))
+
+	newResolutionKeys(context.Background(), tel, "run-1", "FIDELITY_CSV", txs, hints, nil)
+
+	if len(spy.started) != 2 {
+		t.Fatalf("wrote %d keys, want 2", len(spy.started))
+	}
+	if got := spy.started["APPLE INC"].TxCount; got != 3 {
+		t.Errorf("tx_count for the shared description = %d, want 3", got)
+	}
+	if got := spy.started["MSFT"].TxCount; got != 1 {
+		t.Errorf("tx_count for the lone description = %d, want 1", got)
+	}
+	if k := spy.started["APPLE INC"]; k.Source != "FIDELITY_CSV" || k.HadIdentifierHints {
+		t.Errorf("key = %+v, want source FIDELITY_CSV and no identifier hints", k)
+	}
+}
+
+// TestResolutionKeyHintsSplitTheKey pins the other half of the grain: two
+// postings sharing a description but carrying different identifier hints resolve
+// independently, so they are two keys rather than one.
+func TestResolutionKeyHintsSplitTheKey(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	tel := mock.NewMockTelemetryDB(ctrl)
+	var started []db.TelemetryResolutionKey
+	tel.EXPECT().StartResolutionKey(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, k db.TelemetryResolutionKey) string {
+			started = append(started, k)
+			return "key"
+		}).AnyTimes()
+
+	txs := []*apiv1.Tx{tx("APPLE INC"), tx("APPLE INC")}
+	hints := [][]identifier.Identifier{
+		nil,
+		{{Type: "MIC_TICKER", Domain: "XNAS", Value: "AAPL"}},
+	}
+
+	newResolutionKeys(context.Background(), tel, "run-1", "FIDELITY_CSV", txs, hints, nil)
+
+	if len(started) != 2 {
+		t.Fatalf("wrote %d keys, want 2", len(started))
+	}
+	// Extraction exists to find an identifier in a description; the key that
+	// already names one skips it.
+	for _, k := range started {
+		if k.HadIdentifierHints && k.TxCount != 1 {
+			t.Errorf("hinted key tx_count = %d, want 1", k.TxCount)
+		}
+	}
+}
+
+// TestResolutionKeyExtractionOutcome pins stage one landing on the key. A key
+// carrying identifier hints records not-attempted whatever the pre-pass did with
+// the description it shares, because extraction is not attempted for that key.
+func TestResolutionKeyExtractionOutcome(t *testing.T) {
+	tests := []struct {
+		name       string
+		hints      []identifier.Identifier
+		extraction map[string]string
+		want       string
+	}{
+		{
+			name:       "extracted",
+			extraction: map[string]string{cacheKey("SRC", "APPLE INC"): db.TelemetryExtractionHintsFound},
+			want:       db.TelemetryExtractionHintsFound,
+		},
+		{
+			name:       "db hit",
+			extraction: map[string]string{cacheKey("SRC", "APPLE INC"): db.TelemetryExtractionNotAttemptedDBHit},
+			want:       db.TelemetryExtractionNotAttemptedDBHit,
+		},
+		{
+			name:       "hints supplied",
+			hints:      []identifier.Identifier{{Type: "MIC_TICKER", Value: "AAPL"}},
+			extraction: map[string]string{cacheKey("SRC", "APPLE INC"): db.TelemetryExtractionHintsFound},
+			want:       db.TelemetryExtractionNotAttemptedHintsSupplied,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			t.Cleanup(ctrl.Finish)
+			tel := mock.NewMockTelemetryDB(ctrl)
+			spy := newKeySpy(t, tel)
+
+			txs := []*apiv1.Tx{tx("APPLE INC")}
+			keys := newResolutionKeys(context.Background(), tel, "run-1", "SRC", txs,
+				[][]identifier.Identifier{tc.hints}, tc.extraction)
+			keys.end(context.Background(),
+				cacheKeyWithHints("SRC", "APPLE INC", tc.hints),
+				db.TelemetryResolutionIdentified, "inst-1")
+
+			got := spy.ended["APPLE INC"]
+			if got.ExtractionOutcome != tc.want {
+				t.Errorf("extraction outcome = %q, want %q", got.ExtractionOutcome, tc.want)
+			}
+			if got.Outcome != db.TelemetryResolutionIdentified {
+				t.Errorf("outcome = %q, want %q", got.Outcome, db.TelemetryResolutionIdentified)
+			}
+			if got.InstrumentID != "inst-1" {
+				t.Errorf("instrument id = %q, want inst-1", got.InstrumentID)
+			}
+		})
+	}
+}
+
+// TestResolutionKeyStampsOnce pins the first stamp standing. A key resolves once
+// and every later transaction sharing it is answered from the batch cache, so a
+// second stamp would be the key being read rather than resolved again.
+func TestResolutionKeyStampsOnce(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	tel := mock.NewMockTelemetryDB(ctrl)
+	tel.EXPECT().StartResolutionKey(gomock.Any(), gomock.Any()).Return("key-1")
+	tel.EXPECT().EndResolutionKey(gomock.Any(), "key-1", gomock.Any()).
+		Do(func(_ context.Context, _ string, o db.TelemetryResolutionKeyOutcome) {
+			if o.Outcome != db.TelemetryResolutionIdentified {
+				t.Errorf("outcome = %q, want the first stamp to stand", o.Outcome)
+			}
+		}).Times(1)
+
+	ctx := context.Background()
+	txs := []*apiv1.Tx{tx("APPLE INC")}
+	keys := newResolutionKeys(ctx, tel, "run-1", "SRC", txs, make([][]identifier.Identifier, 1), nil)
+	key := cacheKeyWithHints("SRC", "APPLE INC", nil)
+	keys.end(ctx, key, db.TelemetryResolutionIdentified, "inst-1")
+	keys.end(ctx, key, db.TelemetryResolutionDBSourceDescription, "inst-1")
+}
+
+// TestNilLedgerRecordsNothing pins the nil ledger being usable, which is what
+// keeps a build with no telemetry writer free of checks at every call site.
+func TestNilLedgerRecordsNothing(t *testing.T) {
+	var keys *resolutionKeys
+	keys.mismatch("k")
+	keys.end(context.Background(), "k", db.TelemetryResolutionIdentified, "inst-1")
+
+	if got := newResolutionKeys(context.Background(), nil, "run-1", "SRC", nil, nil, nil); got != nil {
+		t.Error("a ledger with no writer is not nil")
+	}
+	if got := newResolutionKeys(context.Background(), mock.NewMockTelemetryDB(gomock.NewController(t)), "", "SRC", nil, nil, nil); got != nil {
+		t.Error("a ledger outside a run is not nil")
+	}
+}
+
+// TestIdentifierResolutionKeys pins the synthetic key the price and corporate
+// event parts get. They resolve from an identifier and no description, but an
+// identification attempt reaches its run through a key, so the identifier names
+// one and tx_count carries the groups sharing it.
+func TestIdentifierResolutionKeys(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	tel := mock.NewMockTelemetryDB(ctrl)
+	spy := newKeySpy(t, tel)
+
+	refs := []identifierRef{
+		{Type: "MIC_TICKER", Domain: "XNAS", Value: "AAPL"},
+		{Type: "MIC_TICKER", Domain: "XNAS", Value: "AAPL"},
+		{Type: "CUSIP", Value: "594918104"},
+	}
+	newIdentifierResolutionKeys(context.Background(), tel, "run-1", refs)
+
+	if len(spy.started) != 2 {
+		t.Fatalf("wrote %d keys, want 2", len(spy.started))
+	}
+	k, ok := spy.started["MIC_TICKER:XNAS:AAPL"]
+	if !ok {
+		t.Fatalf("no key named by the identifier; wrote %v", spy.started)
+	}
+	if k.TxCount != 2 {
+		t.Errorf("tx_count = %d, want 2 groups sharing the identifier", k.TxCount)
+	}
+	if !k.HadIdentifierHints || k.Source != "" {
+		t.Errorf("key = %+v, want identifier hints and no source", k)
+	}
+}
+
+// TestDescriptionPluginCallRows pins one row per ExtractBatch invocation, tokens
+// included. Tokens are columns rather than running totals, which is what makes
+// the cost of one import answerable, and they stay null for a plugin that costs
+// nothing to call.
+func TestDescriptionPluginCallRows(t *testing.T) {
+	tests := []struct {
+		name       string
+		plugin     *fakeDescPlugin
+		wantOut    string
+		wantHints  int
+		wantTokens *db.TelemetryTokens
+	}{
+		{
+			name: "hints and tokens",
+			plugin: &fakeDescPlugin{
+				results: map[string][]identifier.Identifier{"item-1": {{Type: "MIC_TICKER", Value: "AAPL"}}},
+				tokens:  &descpkg.Usage{PromptTokens: 11, CompletionTokens: 3, TotalTokens: 14},
+			},
+			wantOut:    string(descpkg.OutcomeHintsReturned),
+			wantHints:  1,
+			wantTokens: &db.TelemetryTokens{Prompt: 11, Completion: 3, Total: 14},
+		},
+		{
+			name:      "no hints and no token cost",
+			plugin:    &fakeDescPlugin{results: map[string][]identifier.Identifier{}},
+			wantOut:   string(descpkg.OutcomeNoHints),
+			wantHints: 0,
+		},
+		{
+			name:      "the call failed",
+			plugin:    &fakeDescPlugin{err: errors.New("upstream down")},
+			wantOut:   string(descpkg.OutcomeError),
+			wantHints: 0,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctrl := gomock.NewController(t)
+			t.Cleanup(ctrl.Finish)
+			database := mock.NewMockDB(ctrl)
+			tel := mock.NewMockTelemetryDB(ctrl)
+			descRegistry := descpkg.NewRegistry()
+			descRegistry.Register("fake", tc.plugin)
+			database.EXPECT().
+				ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryDescription).
+				Return([]db.PluginConfigRow{{PluginID: "fake", Precedence: 1}}, nil)
+
+			var got db.TelemetryDescriptionPluginCall
+			tel.EXPECT().WriteDescriptionPluginCall(gomock.Any(), gomock.Any()).
+				Do(func(_ context.Context, c db.TelemetryDescriptionPluginCall) { got = c }).Times(1)
+
+			items := []descpkg.BatchItem{{ID: "item-1", InstrumentDescription: "APPLE INC"}}
+			deps := ingestDeps{DB: database, DescRegistry: descRegistry, Telemetry: tel, RunID: "run-1"}
+			if _, _, err := runDescriptionPluginsBatch(context.Background(), deps, "FIDELITY", "SRC", items); err != nil {
+				t.Fatalf("runDescriptionPluginsBatch: %v", err)
+			}
+
+			if got.RunID != "run-1" || got.PluginID != "fake" {
+				t.Errorf("row = %+v, want it against run-1 and plugin fake", got)
+			}
+			if got.BatchSize != 1 {
+				t.Errorf("batch_size = %d, want 1", got.BatchSize)
+			}
+			if got.Outcome != tc.wantOut {
+				t.Errorf("outcome = %q, want %q", got.Outcome, tc.wantOut)
+			}
+			if got.ItemsWithHints != tc.wantHints {
+				t.Errorf("items_with_hints = %d, want %d", got.ItemsWithHints, tc.wantHints)
+			}
+			switch {
+			case tc.wantTokens == nil && got.Tokens != nil:
+				t.Errorf("tokens = %+v, want null for a plugin with no token cost", got.Tokens)
+			case tc.wantTokens != nil && (got.Tokens == nil || *got.Tokens != *tc.wantTokens):
+				t.Errorf("tokens = %+v, want %+v", got.Tokens, tc.wantTokens)
+			}
+		})
+	}
+}
+
+// TestExtractionOutcomesPerItem pins where the skips live. An item no enabled
+// plugin accepted was never put to one, which is not the same as one that was
+// asked about and yielded nothing.
+func TestExtractionOutcomesPerItem(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	database := mock.NewMockDB(ctrl)
+	descRegistry := descpkg.NewRegistry()
+	descRegistry.Register("stock", &fakeDescPlugin{
+		acceptable: map[string]bool{identifier.SecurityTypeHintStock: true},
+		results:    map[string][]identifier.Identifier{"found": {{Type: "MIC_TICKER", Value: "AAPL"}}},
+	})
+	database.EXPECT().
+		ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryDescription).
+		Return([]db.PluginConfigRow{{PluginID: "stock", Precedence: 1}}, nil)
+
+	stock := identifier.Hints{SecurityTypeHint: identifier.SecurityTypeHintStock}
+	items := []descpkg.BatchItem{
+		{ID: "found", InstrumentDescription: "APPLE INC", Hints: stock},
+		{ID: "missed", InstrumentDescription: "SOMETHING", Hints: stock},
+		{ID: "filtered", InstrumentDescription: "USD", Hints: identifier.Hints{SecurityTypeHint: identifier.SecurityTypeHintCash}},
+	}
+	_, outcomes, err := runDescriptionPluginsBatch(context.Background(),
+		ingestDeps{DB: database, DescRegistry: descRegistry}, "FIDELITY", "SRC", items)
+	if err != nil {
+		t.Fatalf("runDescriptionPluginsBatch: %v", err)
+	}
+
+	want := map[string]string{
+		"found":    db.TelemetryExtractionHintsFound,
+		"missed":   db.TelemetryExtractionNoHints,
+		"filtered": db.TelemetryExtractionNotAttemptedTypeFilter,
+	}
+	for id, w := range want {
+		if outcomes[id] != w {
+			t.Errorf("outcome for %q = %q, want %q", id, outcomes[id], w)
+		}
+	}
+}
+
+// TestExtractionNotAttemptedWithoutPlugins pins the installation with no
+// description plugins. Nothing was asked, so nothing found nothing.
+func TestExtractionNotAttemptedWithoutPlugins(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	database := mock.NewMockDB(ctrl)
+	descRegistry := descpkg.NewRegistry()
+	database.EXPECT().
+		ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryDescription).
+		Return(nil, nil)
+
+	items := []descpkg.BatchItem{{ID: "item-1", InstrumentDescription: "APPLE INC"}}
+	_, outcomes, err := runDescriptionPluginsBatch(context.Background(),
+		ingestDeps{DB: database, DescRegistry: descRegistry}, "FIDELITY", "SRC", items)
+	if err != nil {
+		t.Fatalf("runDescriptionPluginsBatch: %v", err)
+	}
+	if outcomes["item-1"] != db.TelemetryExtractionNotAttemptedNoPlugins {
+		t.Errorf("outcome = %q, want %q", outcomes["item-1"], db.TelemetryExtractionNotAttemptedNoPlugins)
+	}
+}

--- a/server/service/ingestion/resolve.go
+++ b/server/service/ingestion/resolve.go
@@ -116,25 +116,62 @@ func batchItemDescByID(items []description.BatchItem, id string) string {
 	return ""
 }
 
+// descriptionTokens renders a plugin's token usage for storage. Nil stays nil,
+// which is what keeps the token columns null rather than zero for a plugin that
+// costs nothing to call.
+func descriptionTokens(u *description.Usage) *db.TelemetryTokens {
+	if u == nil {
+		return nil
+	}
+	return &db.TelemetryTokens{
+		Prompt:     u.PromptTokens,
+		Completion: u.CompletionTokens,
+		Total:      u.TotalTokens,
+	}
+}
+
 // runDescriptionPluginsBatch runs description plugins on all items via ExtractBatch. Only items whose security type is acceptable to a plugin are passed to that plugin. First plugin that returns a non-empty map wins. Result is keyed by BatchItem.ID.
-func runDescriptionPluginsBatch(ctx context.Context, database db.PluginConfigDB, descRegistry *description.Registry, counter telemetry.CounterIncrementer, broker, source string, items []description.BatchItem) (map[string][]identifier.Identifier, error) {
-	if descRegistry == nil || len(items) == 0 {
-		return nil, nil
+//
+// It also returns what became of each item, keyed by BatchItem.ID, which is stage
+// one of the item's resolution key. The not-attempted members are the skips: an
+// item no enabled plugin accepted was never put to one, and an installation with
+// no description plugins at all attempts nothing.
+//
+// One description_plugin_call row is written per ExtractBatch call, including the
+// calls that fail: a plugin populates its telemetry on every path, and a call that
+// errored is the one most worth having a row for. The row hangs off the run rather
+// than off a key because one call covers many descriptions at once.
+func runDescriptionPluginsBatch(ctx context.Context, deps ingestDeps, broker, source string, items []description.BatchItem) (map[string][]identifier.Identifier, map[string]string, error) {
+	outcomes := make(map[string]string, len(items))
+	noPlugins := func() map[string]string {
+		for _, item := range items {
+			outcomes[item.ID] = db.TelemetryExtractionNotAttemptedNoPlugins
+		}
+		return outcomes
 	}
-	configs, err := database.ListEnabledPluginConfigs(ctx, db.PluginCategoryDescription)
+	if deps.DescRegistry == nil || len(items) == 0 {
+		return nil, noPlugins(), nil
+	}
+	configs, err := deps.DB.ListEnabledPluginConfigs(ctx, db.PluginCategoryDescription)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	if len(configs) > 0 && counter != nil {
-		counter.IncrBy(ctx, "instruments.resolution.totals.description.attempts", int64(len(items)))
+	if len(configs) > 0 && deps.Counter != nil {
+		deps.Counter.IncrBy(ctx, "instruments.resolution.totals.description.attempts", int64(len(items)))
 	}
 	resolved := make(map[string]bool)
+	// attempted is an item that reached at least one plugin. One that reached none
+	// was excluded by every plugin's type filter, which is a skip rather than a
+	// failure to find anything.
+	attempted := make(map[string]bool)
+	anyPlugin := false
 	merged := make(map[string][]identifier.Identifier)
 	for _, c := range configs {
-		p := descRegistry.Get(c.PluginID)
+		p := deps.DescRegistry.Get(c.PluginID)
 		if p == nil {
 			continue
 		}
+		anyPlugin = true
 		acceptableKinds := p.AcceptableInstrumentKinds()
 		acceptableTypes := p.AcceptableSecurityTypes()
 		var filtered []description.BatchItem
@@ -144,16 +181,32 @@ func runDescriptionPluginsBatch(ctx context.Context, database db.PluginConfigDB,
 			}
 			if identifier.ShouldAttemptPlugin(acceptableKinds, acceptableTypes, item.Hints.InstrumentKind, item.Hints.SecurityTypeHint) {
 				filtered = append(filtered, item)
+				attempted[item.ID] = true
 			}
 		}
 		if len(filtered) == 0 {
 			ingestionLogger().DebugContext(ctx, "description plugin batch skipped (no items with acceptable security type)", "plugin_id", c.PluginID)
 			continue
 		}
+		started := time.Now()
 		res, err := p.ExtractBatch(ctx, c.Config, broker, source, filtered)
+		call := db.TelemetryDescriptionPluginCall{
+			RunID:     deps.RunID,
+			PluginID:  c.PluginID,
+			BatchSize: len(filtered),
+			Outcome:   string(res.Telemetry.Outcome),
+			Tokens:    descriptionTokens(res.Telemetry.Tokens),
+			Duration:  time.Since(started),
+		}
 		if err != nil {
-			if counter != nil {
-				counter.Incr(ctx, "instruments.resolution.totals.description.plugin_error")
+			// A plugin that returned an error without saying how it went is not
+			// meant to happen, but the row is worth more than the exactness here.
+			if call.Outcome == "" {
+				call.Outcome = string(description.OutcomeError)
+			}
+			deps.writeDescriptionPluginCall(ctx, call)
+			if deps.Counter != nil {
+				deps.Counter.Incr(ctx, "instruments.resolution.totals.description.plugin_error")
 			}
 			ingestionLogger().DebugContext(ctx, "description plugin batch result: error", "plugin_id", c.PluginID, "err", err)
 			continue
@@ -166,8 +219,10 @@ func runDescriptionPluginsBatch(ctx context.Context, database db.PluginConfigDB,
 				merged[id] = filteredHints
 				resolved[id] = true
 				hasAny = true
+				call.ItemsWithHints++
 			}
 		}
+		deps.writeDescriptionPluginCall(ctx, call)
 		if hasAny {
 			for id, hints := range out {
 				if len(hints) > 0 {
@@ -178,13 +233,26 @@ func runDescriptionPluginsBatch(ctx context.Context, database db.PluginConfigDB,
 			ingestionLogger().DebugContext(ctx, "description plugin batch result: no hints", "plugin_id", c.PluginID, "batch_ids", batchItemIDs(filtered))
 		}
 	}
+	if !anyPlugin {
+		return nil, noPlugins(), nil
+	}
+	for _, item := range items {
+		switch {
+		case resolved[item.ID]:
+			outcomes[item.ID] = db.TelemetryExtractionHintsFound
+		case attempted[item.ID]:
+			outcomes[item.ID] = db.TelemetryExtractionNoHints
+		default:
+			outcomes[item.ID] = db.TelemetryExtractionNotAttemptedTypeFilter
+		}
+	}
 	if len(merged) > 0 {
-		return merged, nil
+		return merged, outcomes, nil
 	}
-	if counter != nil {
-		counter.Incr(ctx, "instruments.resolution.totals.description.no_hints")
+	if deps.Counter != nil {
+		deps.Counter.Incr(ctx, "instruments.resolution.totals.description.no_hints")
 	}
-	return nil, nil
+	return nil, outcomes, nil
 }
 
 // Resolve resolves (source, instrumentDescription) to an instrument_id using the batch cache, then (when no client
@@ -194,10 +262,14 @@ func runDescriptionPluginsBatch(ctx context.Context, database db.PluginConfigDB,
 // When client supplies identifier_hints, resolution is by identifiers only and (source, description) is not persisted
 // to the DB as a BROKER_DESCRIPTION identifier (though results are still cached in the in-memory batch cache).
 // hints are optional (exchange, currency, MIC, security type). counter is optional; when non-nil and plugins are invoked, instrument.identify.attempts is incremented.
-func Resolve(ctx context.Context, database db.DB, registry *identifier.Registry, broker, source, instrumentDescription string, hints identifier.Hints, identifierHints []identifier.Identifier, cache map[string]resolveResult, rowIndex int32, counter telemetry.CounterIncrementer, extractedHintsCache map[string][]identifier.Identifier, hintsValidAt *time.Time) (resolveResult, error) {
+func Resolve(ctx context.Context, database db.DB, registry *identifier.Registry, broker, source, instrumentDescription string, hints identifier.Hints, identifierHints []identifier.Identifier, cache map[string]resolveResult, rowIndex int32, counter telemetry.CounterIncrementer, extractedHintsCache map[string][]identifier.Identifier, hintsValidAt *time.Time, keys *resolutionKeys) (resolveResult, error) {
 	key := cacheKeyWithHints(source, instrumentDescription, identifierHints)
 	if cache != nil {
 		if r, ok := cache[key]; ok {
+			// A hit nothing in this batch resolved is the pre-pass's DB lookup by
+			// (source, description). One this batch did resolve has already
+			// stamped its key, and the first stamp is the one that stands.
+			keys.end(ctx, key, db.TelemetryResolutionDBSourceDescription, r.InstrumentID)
 			return r, nil
 		}
 	}
@@ -213,6 +285,7 @@ func Resolve(ctx context.Context, database db.DB, registry *identifier.Registry,
 			return resolveResult{}, err
 		}
 		if len(ids) > 1 {
+			keys.end(ctx, key, db.TelemetryResolutionConflictingHints, "")
 			return resolveResult{}, fmt.Errorf("conflicting identifier hints resolve to different instruments")
 		}
 		if len(ids) == 1 {
@@ -220,10 +293,11 @@ func Resolve(ctx context.Context, database db.DB, registry *identifier.Registry,
 			if cache != nil {
 				cache[key] = r
 			}
+			keys.end(ctx, key, db.TelemetryResolutionDBIdentifierHints, r.InstrumentID)
 			return r, nil
 		}
 		// No DB hit: call identifier plugins with hints; do not persist (source, description) as BROKER_DESCRIPTION.
-		return resolveWithIdentifierPlugins(ctx, database, registry, broker, source, instrumentDescription, hints, identifierHints, cache, key, rowIndex, counter, false, hintsValidAt)
+		return resolveWithIdentifierPlugins(ctx, database, registry, broker, source, instrumentDescription, hints, identifierHints, cache, key, rowIndex, counter, false, hintsValidAt, keys)
 	}
 
 	// Path B: no client hints -- use pre-extracted description hints, then identifier plugins.
@@ -252,6 +326,7 @@ func Resolve(ctx context.Context, database db.DB, registry *identifier.Registry,
 		if cache != nil {
 			cache[key] = r
 		}
+		keys.end(ctx, key, db.TelemetryResolutionExtractionFailed, instID)
 		return r, nil
 	}
 
@@ -261,9 +336,11 @@ func Resolve(ctx context.Context, database db.DB, registry *identifier.Registry,
 	tickerHints := hintsByType(extractedHints, "MIC_TICKER")
 	figiHints := hintsByType(extractedHints, "OPENFIGI_SHARE_CLASS")
 	if len(tickerHints) > 0 && len(figiHints) > 0 {
-		// Resolve with nil cache and nil counter so we don't pollute cache or double-count identify attempts.
-		resultByTicker, _ := resolveWithIdentifierPlugins(ctx, database, registry, broker, source, instrumentDescription, hints, tickerHints, nil, key, rowIndex, nil, true, hintsValidAt)
-		resultByFigi, _ := resolveWithIdentifierPlugins(ctx, database, registry, broker, source, instrumentDescription, hints, figiHints, nil, key, rowIndex, nil, true, hintsValidAt)
+		// Resolve with nil cache, nil counter and no key ledger: these two are
+		// probes, so they must not pollute the cache, double-count identify
+		// attempts, or stamp the key before the resolution that decides it.
+		resultByTicker, _ := resolveWithIdentifierPlugins(ctx, database, registry, broker, source, instrumentDescription, hints, tickerHints, nil, key, rowIndex, nil, true, hintsValidAt, nil)
+		resultByFigi, _ := resolveWithIdentifierPlugins(ctx, database, registry, broker, source, instrumentDescription, hints, figiHints, nil, key, rowIndex, nil, true, hintsValidAt, nil)
 		idByTicker := resultByTicker.InstrumentID
 		idByFigi := resultByFigi.InstrumentID
 		// Consider "unresolved" (broker-description-only) as empty for mismatch check
@@ -271,6 +348,7 @@ func Resolve(ctx context.Context, database db.DB, registry *identifier.Registry,
 			if counter != nil {
 				counter.Incr(ctx, "instruments.resolution.totals.description.identifier_mismatch")
 			}
+			keys.mismatch(key)
 			ingestionLogger().ErrorContext(ctx, "MIC_TICKER and OPENFIGI_SHARE_CLASS resolved to different instruments; using MIC_TICKER",
 				"source", source, "instrument_description", instrumentDescription,
 				"instrument_id_by_ticker", idByTicker, "instrument_id_by_figi", idByFigi)
@@ -279,7 +357,7 @@ func Resolve(ctx context.Context, database db.DB, registry *identifier.Registry,
 	}
 
 	// Resolve by (validated) hints; always store (source, description) when ensuring.
-	return resolveWithIdentifierPlugins(ctx, database, registry, broker, source, instrumentDescription, hints, hintsToUse, cache, key, rowIndex, counter, true, hintsValidAt)
+	return resolveWithIdentifierPlugins(ctx, database, registry, broker, source, instrumentDescription, hints, hintsToUse, cache, key, rowIndex, counter, true, hintsValidAt, keys)
 }
 
 // hintDiffsSummary formats hint diffs as a readable string (e.g. "Currency: USD->EUR, ISIN: US037->US038").
@@ -311,7 +389,7 @@ func hintsByType(hints []identifier.Identifier, typ string) []identifier.Identif
 
 // resolveWithIdentifierPlugins delegates to the shared identification package and wraps the result
 // in ingestion-specific resolveResult with cache and error handling.
-func resolveWithIdentifierPlugins(ctx context.Context, database db.DB, registry *identifier.Registry, broker, source, instrumentDescription string, hints identifier.Hints, identifierHints []identifier.Identifier, cache map[string]resolveResult, key string, rowIndex int32, counter telemetry.CounterIncrementer, storeSourceDescription bool, hintsValidAt *time.Time) (resolveResult, error) {
+func resolveWithIdentifierPlugins(ctx context.Context, database db.DB, registry *identifier.Registry, broker, source, instrumentDescription string, hints identifier.Hints, identifierHints []identifier.Identifier, cache map[string]resolveResult, key string, rowIndex int32, counter telemetry.CounterIncrementer, storeSourceDescription bool, hintsValidAt *time.Time, keys *resolutionKeys) (resolveResult, error) {
 	// Ingestion-specific fallback: broker-description-only instrument.
 	fallback := func(ctx context.Context, database db.DB) (string, error) {
 		return database.EnsureInstrument(ctx, "", "", "", instrumentDescription, "", "",
@@ -345,5 +423,6 @@ func resolveWithIdentifierPlugins(ctx context.Context, database db.DB, registry 
 	if cache != nil {
 		cache[key] = r
 	}
+	keys.end(ctx, key, resolutionOutcome(result), r.InstrumentID)
 	return r, nil
 }

--- a/server/service/ingestion/resolve_test.go
+++ b/server/service/ingestion/resolve_test.go
@@ -56,7 +56,7 @@ func TestResolve_CacheHit_FromPrePass(t *testing.T) {
 		cacheKey(source, "AAPL"): {InstrumentID: "existing-id"},
 	}
 
-	r, err := Resolve(ctx, database, registry, "IBKR", source, "AAPL", identifier.Hints{}, nil, cache, 0, nil, nil, nil)
+	r, err := Resolve(ctx, database, registry, "IBKR", source, "AAPL", identifier.Hints{}, nil, cache, 0, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
@@ -89,7 +89,7 @@ func TestResolve_TickerOnlyFallback_ResolvesByTypeAndValue(t *testing.T) {
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "AAPL").
 		Return("fallback-id", nil)
 
-	r, err := Resolve(ctx, database, registry, "IBKR", source, "AAPL", identifier.Hints{}, nil, nil, 0, nil, tickerHintsCache(source, "AAPL"), nil)
+	r, err := Resolve(ctx, database, registry, "IBKR", source, "AAPL", identifier.Hints{}, nil, nil, 0, nil, tickerHintsCache(source, "AAPL"), nil, nil)
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
@@ -116,7 +116,7 @@ func TestResolve_CacheHit_NoPluginCall(t *testing.T) {
 	cache[key] = resolveResult{InstrumentID: "cached-id", FirstRowIndex: 0}
 
 	// No DB or plugin calls when cache has entry
-	r, err := Resolve(ctx, database, registry, "IBKR", source, "GOOG", identifier.Hints{}, nil, cache, 1, nil, nil, nil)
+	r, err := Resolve(ctx, database, registry, "IBKR", source, "GOOG", identifier.Hints{}, nil, cache, 1, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
@@ -139,7 +139,7 @@ func TestResolve_NoExtractedHints_ExtractionFailed(t *testing.T) {
 		EnsureInstrument(gomock.Any(), "", "", "", "UNKNOWN", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: source, Value: "UNKNOWN", Canonical: false}}, "", nil, nil, nil).
 		Return("broker-only-id", nil)
 
-	r, err := Resolve(ctx, database, registry, "IBKR", source, "UNKNOWN", identifier.Hints{}, nil, nil, 0, nil, nil, nil)
+	r, err := Resolve(ctx, database, registry, "IBKR", source, "UNKNOWN", identifier.Hints{}, nil, nil, 0, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
@@ -178,7 +178,7 @@ func TestResolve_AllPluginsErrNotIdentified_BrokerDescriptionOnly(t *testing.T) 
 		EnsureInstrument(gomock.Any(), "", "", "", "UNKNOWN", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: source, Value: "UNKNOWN", Canonical: false}}, "", nil, nil, nil).
 		Return("broker-only-id", nil)
 
-	r, err := Resolve(ctx, database, registry, "IBKR", source, "UNKNOWN", identifier.Hints{}, nil, nil, 0, nil, tickerHintsCache(source, "UNKNOWN"), nil)
+	r, err := Resolve(ctx, database, registry, "IBKR", source, "UNKNOWN", identifier.Hints{}, nil, nil, 0, nil, tickerHintsCache(source, "UNKNOWN"), nil, nil)
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
@@ -221,7 +221,7 @@ func TestResolve_OnePluginSuccess_EnsureInstrumentWithResult(t *testing.T) {
 			return "resolved-id", nil
 		})
 
-	r, err := Resolve(ctx, database, registry, "IBKR", source, "AAPL", identifier.Hints{}, nil, nil, 0, nil, tickerHintsCache(source, "AAPL"), nil)
+	r, err := Resolve(ctx, database, registry, "IBKR", source, "AAPL", identifier.Hints{}, nil, nil, 0, nil, tickerHintsCache(source, "AAPL"), nil, nil)
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
@@ -282,7 +282,7 @@ func TestResolve_BrokerDescriptionAlwaysStored(t *testing.T) {
 			return "resolved-id", nil
 		})
 
-	r, err := Resolve(ctx, database, registry, "IBKR", source, desc, identifier.Hints{}, nil, nil, 0, nil, tickerHintsCache(source, desc), nil)
+	r, err := Resolve(ctx, database, registry, "IBKR", source, desc, identifier.Hints{}, nil, nil, 0, nil, tickerHintsCache(source, desc), nil, nil)
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
@@ -337,7 +337,7 @@ func TestResolve_PluginReturnsUnderlying_ResolvesUnderlyingThenDerivative(t *tes
 		EnsureInstrument(gomock.Any(), "OPTION", "SMART", "USD", "AAPL Call 20250117 200 C", gomock.Any(), gomock.Any(), gomock.Any(), "underlying-uuid", nil, nil, nil).
 		Return("option-uuid", nil)
 
-	r, err := Resolve(ctx, database, registry, "IBKR", source, desc, identifier.Hints{}, nil, nil, 0, nil, tickerHintsCache(source, desc), nil)
+	r, err := Resolve(ctx, database, registry, "IBKR", source, desc, identifier.Hints{}, nil, nil, 0, nil, tickerHintsCache(source, desc), nil, nil)
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
@@ -387,7 +387,7 @@ func TestResolve_TwoPlugins_HigherPrecedenceWins(t *testing.T) {
 		EnsureInstrument(gomock.Any(), "", "", "", "High", gomock.Any(), gomock.Any(), gomock.Any(), "", nil, nil, nil).
 		Return("high-id", nil)
 
-	r, err := Resolve(ctx, database, registry, "IBKR", source, "X", identifier.Hints{}, nil, nil, 0, nil, tickerHintsCache(source, "X"), nil)
+	r, err := Resolve(ctx, database, registry, "IBKR", source, "X", identifier.Hints{}, nil, nil, 0, nil, tickerHintsCache(source, "X"), nil, nil)
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
@@ -445,7 +445,7 @@ func TestResolve_TwoPlugins_MergedIdentifiersByPrecedence(t *testing.T) {
 			return "merged-id", nil
 		})
 
-	r, err := Resolve(ctx, database, registry, "IBKR", source, "Y", identifier.Hints{}, nil, nil, 0, nil, tickerHintsCache(source, "Y"), nil)
+	r, err := Resolve(ctx, database, registry, "IBKR", source, "Y", identifier.Hints{}, nil, nil, 0, nil, tickerHintsCache(source, "Y"), nil, nil)
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
@@ -499,7 +499,7 @@ func TestResolve_TwoPlugins_SameType_HighPrecedenceWins(t *testing.T) {
 			return "id", nil
 		})
 
-	_, err := Resolve(ctx, database, registry, "IBKR", source, "Z", identifier.Hints{}, nil, nil, 0, nil, tickerHintsCache(source, "Z"), nil)
+	_, err := Resolve(ctx, database, registry, "IBKR", source, "Z", identifier.Hints{}, nil, nil, 0, nil, tickerHintsCache(source, "Z"), nil, nil)
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
@@ -534,7 +534,7 @@ func TestResolve_PluginTimeout_FallbackAndMessage(t *testing.T) {
 		EnsureInstrument(gomock.Any(), "", "", "", "SLOW", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: source, Value: "SLOW", Canonical: false}}, "", nil, nil, nil).
 		Return("fallback-id", nil)
 
-	r, err := Resolve(ctx, database, registry, "IBKR", source, "SLOW", identifier.Hints{}, nil, nil, 0, nil, tickerHintsCache(source, "SLOW"), nil)
+	r, err := Resolve(ctx, database, registry, "IBKR", source, "SLOW", identifier.Hints{}, nil, nil, 0, nil, tickerHintsCache(source, "SLOW"), nil, nil)
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
@@ -571,7 +571,7 @@ func TestResolve_PluginUnavailable_FallbackAndMessage(t *testing.T) {
 		EnsureInstrument(gomock.Any(), "", "", "", "BAD", "", "", []db.IdentifierInput{{Type: "BROKER_DESCRIPTION", Domain: source, Value: "BAD", Canonical: false}}, "", nil, nil, nil).
 		Return("fallback-id", nil)
 
-	r, err := Resolve(ctx, database, registry, "IBKR", source, "BAD", identifier.Hints{}, nil, nil, 0, nil, tickerHintsCache(source, "BAD"), nil)
+	r, err := Resolve(ctx, database, registry, "IBKR", source, "BAD", identifier.Hints{}, nil, nil, 0, nil, tickerHintsCache(source, "BAD"), nil, nil)
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}
@@ -586,6 +586,9 @@ type fakeDescPlugin struct {
 	acceptable      map[string]bool
 	results         map[string][]identifier.Identifier
 	err             error
+	// tokens is what the plugin reports the call cost. Nil is a plugin that costs
+	// nothing to call, which is what keeps the token columns null for it.
+	tokens *descpkg.Usage
 }
 
 func (p *fakeDescPlugin) DisplayName() string                        { return "FakeDesc" }
@@ -594,7 +597,7 @@ func (p *fakeDescPlugin) AcceptableInstrumentKinds() map[string]bool { return p.
 func (p *fakeDescPlugin) AcceptableSecurityTypes() map[string]bool   { return p.acceptable }
 func (p *fakeDescPlugin) ExtractBatch(_ context.Context, _ []byte, _, _ string, items []descpkg.BatchItem) (descpkg.Result, error) {
 	if p.err != nil {
-		return descpkg.Result{Telemetry: descpkg.Telemetry{Outcome: descpkg.OutcomeError}}, p.err
+		return descpkg.Result{Telemetry: descpkg.Telemetry{Outcome: descpkg.OutcomeError, Tokens: p.tokens}}, p.err
 	}
 	out := make(map[string][]identifier.Identifier)
 	for _, item := range items {
@@ -606,7 +609,7 @@ func (p *fakeDescPlugin) ExtractBatch(_ context.Context, _ []byte, _, _ string, 
 	if len(out) > 0 {
 		outcome = descpkg.OutcomeHintsReturned
 	}
-	return descpkg.Result{Hints: out, Telemetry: descpkg.Telemetry{Outcome: outcome}}, nil
+	return descpkg.Result{Hints: out, Telemetry: descpkg.Telemetry{Outcome: outcome, Tokens: p.tokens}}, nil
 }
 
 // TestRunDescriptionPluginsBatch_MultiplePlugins_DifferentSecurityTypes verifies
@@ -650,7 +653,7 @@ func TestRunDescriptionPluginsBatch_MultiplePlugins_DifferentSecurityTypes(t *te
 		{ID: "stock-1", InstrumentDescription: "AAPL APPLE INC", Hints: identifier.Hints{InstrumentKind: identifier.InstrumentKindSecurity, SecurityTypeHint: identifier.SecurityTypeHintStock}},
 	}
 
-	got, err := runDescriptionPluginsBatch(context.Background(), database, descRegistry, nil, "broker", "source", items)
+	got, _, err := runDescriptionPluginsBatch(context.Background(), ingestDeps{DB: database, DescRegistry: descRegistry}, "broker", "source", items)
 	if err != nil {
 		t.Fatalf("runDescriptionPluginsBatch: %v", err)
 	}
@@ -709,7 +712,7 @@ func TestRunDescriptionPluginsBatch_TransferSkipsCash(t *testing.T) {
 		}},
 	}
 
-	got, err := runDescriptionPluginsBatch(context.Background(), database, descRegistry, nil, "broker", "source", items)
+	got, _, err := runDescriptionPluginsBatch(context.Background(), ingestDeps{DB: database, DescRegistry: descRegistry}, "broker", "source", items)
 	if err != nil {
 		t.Fatalf("runDescriptionPluginsBatch: %v", err)
 	}
@@ -800,7 +803,7 @@ func TestResolve_SameDescription_DifferentHints_NoCacheConflict(t *testing.T) {
 
 	r1, err := Resolve(ctx, database, registry, "IBKR", source, desc,
 		identifier.Hints{}, []identifier.Identifier{{Type: "CUSIP", Value: "594918104"}},
-		cache, 0, nil, nil, nil)
+		cache, 0, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Resolve (security): %v", err)
 	}
@@ -815,7 +818,7 @@ func TestResolve_SameDescription_DifferentHints_NoCacheConflict(t *testing.T) {
 
 	r2, err := Resolve(ctx, database, registry, "IBKR", source, desc,
 		identifier.Hints{}, []identifier.Identifier{{Type: "CURRENCY", Value: "USD"}},
-		cache, 1, nil, nil, nil)
+		cache, 1, nil, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("Resolve (cash): %v", err)
 	}
@@ -896,7 +899,7 @@ func TestResolve_PluginFailsThenRetrySucceeds(t *testing.T) {
 		EnsureInstrument(gomock.Any(), "", "", "", "Retried", gomock.Any(), gomock.Any(), gomock.Any(), "", nil, nil, nil).
 		Return("retried-id", nil)
 
-	r, err := Resolve(ctx, database, registry, "IBKR", source, "RETRY", identifier.Hints{}, nil, nil, 0, nil, tickerHintsCache(source, "RETRY"), nil)
+	r, err := Resolve(ctx, database, registry, "IBKR", source, "RETRY", identifier.Hints{}, nil, nil, 0, nil, tickerHintsCache(source, "RETRY"), nil, nil)
 	if err != nil {
 		t.Fatalf("Resolve: %v", err)
 	}

--- a/server/service/ingestion/system_import.go
+++ b/server/service/ingestion/system_import.go
@@ -12,7 +12,6 @@ import (
 	archivev1 "github.com/leedenison/portfoliodb/proto/archive/v1"
 	"github.com/leedenison/portfoliodb/server/archiveimport"
 	"github.com/leedenison/portfoliodb/server/db"
-	"github.com/leedenison/portfoliodb/server/identifier"
 )
 
 // errUnknownPart is a part row naming something this build cannot apply, which
@@ -42,7 +41,29 @@ type systemImportResult struct {
 // already describes -- an optimisation, not a prerequisite -- and abandoning
 // the rest would throw away work that would otherwise land. Which parts did not
 // apply is what the per-part results are for.
-func processSystemImport(ctx context.Context, database db.DB, registry *identifier.Registry, j *JobRequest) systemImportResult {
+// archiveIdentifierRefs lists the instrument every price and corporate event group
+// names, in document order and with repeats, so a ledger built from it counts the
+// groups sharing each identifier.
+func archiveIdentifierRefs(a *archivev1.SystemArchive) []identifierRef {
+	var refs []identifierRef
+	for _, g := range a.GetPrices().GetGroups() {
+		ref := g.GetInstrument()
+		refs = append(refs, identifierRef{
+			Type: ref.GetType().String(), Domain: ref.GetDomain(), Value: ref.GetValue(),
+		})
+	}
+	for _, g := range a.GetCorporateEvents().GetGroups() {
+		ref := g.GetInstrument()
+		refs = append(refs, identifierRef{
+			Type: ref.GetType().String(), Domain: ref.GetDomain(), Value: ref.GetValue(),
+		})
+	}
+	return refs
+}
+
+func processSystemImport(ctx context.Context, deps ingestDeps, j *JobRequest) systemImportResult {
+	database := deps.DB
+	registry := deps.Registry
 	var out systemImportResult
 
 	payload, err := database.LoadJobPayload(ctx, j.JobID)
@@ -72,6 +93,10 @@ func processSystemImport(ctx context.Context, database db.DB, registry *identifi
 	// the corporate event part is the ordinary case, and resolving it twice means
 	// paying a plugin twice.
 	resolveCache := newResolveCache()
+	// Keys for the identifiers the archive names, counted over the whole document
+	// for the same reason the cache spans it: a price group and a corporate event
+	// group naming the same instrument resolve it once between them.
+	resolveKeys := newIdentifierResolutionKeys(ctx, deps.Telemetry, deps.RunID, archiveIdentifierRefs(&a))
 
 	// Which parts to run comes from the job's own rows rather than from the
 	// document, so a job resumed after a restart skips what already finished.
@@ -102,9 +127,9 @@ func processSystemImport(ctx context.Context, database db.DB, registry *identifi
 		case archivev1.ArchivePart_INSTRUMENTS:
 			_, partErr = archiveimport.InstrumentPart(ctx, database, a.GetInstruments(), rep)
 		case archivev1.ArchivePart_PRICES:
-			out.pricesPersisted, partErr = importPricePart(ctx, database, registry, a.GetPrices(), asOf, resolveCache, rep)
+			out.pricesPersisted, partErr = importPricePart(ctx, database, registry, a.GetPrices(), asOf, resolveCache, resolveKeys, rep)
 		case archivev1.ArchivePart_CORPORATE_EVENTS:
-			out.eventsPersisted, partErr = importCorporateEventPart(ctx, database, registry, a.GetCorporateEvents(), asOf, resolveCache, rep)
+			out.eventsPersisted, partErr = importCorporateEventPart(ctx, database, registry, a.GetCorporateEvents(), asOf, resolveCache, resolveKeys, rep)
 		case archivev1.ArchivePart_INFLATION_INDICES:
 			_, partErr = archiveimport.InflationPart(ctx, database, a.GetInflationIndices(), asOf, rep)
 		case archivev1.ArchivePart_FETCH_BLOCKS:

--- a/server/service/ingestion/system_import_test.go
+++ b/server/service/ingestion/system_import_test.go
@@ -95,7 +95,7 @@ func TestProcessSystemImport_RunsPartsInRestoreOrder(t *testing.T) {
 		database.EXPECT().ClearJobPayload(gomock.Any(), j.JobID).Return(nil),
 	)
 
-	processSystemImport(context.Background(), database, identifier.NewRegistry(), j)
+	processSystemImport(context.Background(), ingestDeps{DB: database, Registry: identifier.NewRegistry()}, j)
 
 	want := []string{
 		"INSTRUMENTS:RUNNING", "INSTRUMENTS:SUCCESS",
@@ -161,7 +161,7 @@ func TestProcessSystemImport_FailedPartDoesNotStopTheRest(t *testing.T) {
 	database.EXPECT().SetJobStatus(gomock.Any(), j.JobID, apiv1.JobStatus_FAILED).Return(nil)
 	database.EXPECT().ClearJobPayload(gomock.Any(), j.JobID).Return(nil)
 
-	processSystemImport(context.Background(), database, identifier.NewRegistry(), j)
+	processSystemImport(context.Background(), ingestDeps{DB: database, Registry: identifier.NewRegistry()}, j)
 
 	if failedPart != archivev1.ArchivePart_PRICES {
 		t.Fatalf("failed part = %v, want PRICES", failedPart)
@@ -215,7 +215,7 @@ func TestProcessSystemImport_ResumeSkipsFinishedParts(t *testing.T) {
 	database.EXPECT().EnsureInstrument(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(0)
 	database.EXPECT().ResetJobPartProgress(gomock.Any(), j.JobID, archivev1.ArchivePart_PRICES).Return(nil)
 
-	processSystemImport(context.Background(), database, identifier.NewRegistry(), j)
+	processSystemImport(context.Background(), ingestDeps{DB: database, Registry: identifier.NewRegistry()}, j)
 }
 
 // A payload that cannot be read is the job's failure rather than any part's,
@@ -235,7 +235,7 @@ func TestProcessSystemImport_UnreadablePayloadFailsTheJob(t *testing.T) {
 		database.EXPECT().ClearJobPayload(gomock.Any(), j.JobID).Return(nil),
 	)
 
-	processSystemImport(context.Background(), database, identifier.NewRegistry(), j)
+	processSystemImport(context.Background(), ingestDeps{DB: database, Registry: identifier.NewRegistry()}, j)
 }
 
 func contains(ss []string, want string) bool {

--- a/server/service/ingestion/worker.go
+++ b/server/service/ingestion/worker.go
@@ -147,7 +147,14 @@ func processJob(ctx context.Context, opts WorkerOptions, j *JobRequest) {
 
 	switch j.JobType {
 	case db.JobTypeTx:
-		if ok := processTx(ctx, opts.DB, opts.IdentifierRegistry, opts.DescriptionRegistry, opts.Counter, j, detail.UserID); ok {
+		if ok := processTx(ctx, ingestDeps{
+			DB:           opts.DB,
+			Registry:     opts.IdentifierRegistry,
+			DescRegistry: opts.DescriptionRegistry,
+			Counter:      opts.Counter,
+			Telemetry:    tel,
+			RunID:        runID,
+		}, j, detail.UserID); ok {
 			outcome = db.TelemetryOutcomeSuccess
 			if err := recalcAfterIngestion(ctx, opts.DB, detail.UserID); err != nil {
 				log.Printf("ingestion job %s: recalc INITIALIZE txs: %v", j.JobID, err)
@@ -164,7 +171,12 @@ func processJob(ctx context.Context, opts WorkerOptions, j *JobRequest) {
 			pluginutil.Trigger(opts.GroupingTrigger)
 		}
 	case db.JobTypeSystemArchive:
-		res := processSystemImport(ctx, opts.DB, opts.IdentifierRegistry, j)
+		res := processSystemImport(ctx, ingestDeps{
+			DB:        opts.DB,
+			Registry:  opts.IdentifierRegistry,
+			Telemetry: tel,
+			RunID:     runID,
+		}, j)
 		if !res.failed {
 			outcome = db.TelemetryOutcomeSuccess
 		}
@@ -183,6 +195,8 @@ func processJob(ctx context.Context, opts WorkerOptions, j *JobRequest) {
 			Registry:     opts.IdentifierRegistry,
 			DescRegistry: opts.DescriptionRegistry,
 			Counter:      opts.Counter,
+			Telemetry:    tel,
+			RunID:        runID,
 		}
 		res := processUserImport(ctx, deps, j)
 		if !res.failed {
@@ -236,7 +250,8 @@ func finishJob(ctx context.Context, database db.DB, jobID string, status apiv1.J
 // processTx applies a broker upload. userID comes from the job row, which the
 // caller has already read to scope the run, so it is passed in rather than read
 // a second time.
-func processTx(ctx context.Context, database db.DB, registry *identifier.Registry, descRegistry *description.Registry, counter telemetry.CounterIncrementer, j *JobRequest, userID string) bool {
+func processTx(ctx context.Context, deps ingestDeps, j *JobRequest, userID string) bool {
+	database := deps.DB
 	payload, err := database.LoadJobPayload(ctx, j.JobID)
 	if err != nil {
 		log.Printf("ingestion job %s: load payload: %v", j.JobID, err)
@@ -265,12 +280,7 @@ func processTx(ctx context.Context, database db.DB, registry *identifier.Registr
 		return false
 	}
 
-	res, err := ingestBatch(ctx, ingestDeps{
-		DB:           database,
-		Registry:     registry,
-		DescRegistry: descRegistry,
-		Counter:      counter,
-	}, ingestParams{
+	res, err := ingestBatch(ctx, deps, ingestParams{
 		UserID:          userID,
 		Broker:          db.BrokerToStr(w.GetBroker()),
 		Source:          w.GetSource(),
@@ -353,9 +363,13 @@ func filterIgnoredTxs(txs []*apiv1.Tx, broker string, ignored []db.IgnoredAssetC
 // lookup would miss for the whole document and pay for extracting it. The test
 // is over every posting sharing the description, so one posting arriving without
 // a hint still gets the description extracted.
-func extractDescHints(ctx context.Context, database db.DB, descRegistry *description.Registry, counter telemetry.CounterIncrementer, source, broker string, txs []*apiv1.Tx) (map[string]resolveResult, map[string][]identifier.Identifier, error) {
+// It also returns what became of extraction for each distinct (source,
+// description), which is stage one of that description's resolution key.
+func extractDescHints(ctx context.Context, deps ingestDeps, source, broker string, txs []*apiv1.Tx) (map[string]resolveResult, map[string][]identifier.Identifier, map[string]string, error) {
+	database := deps.DB
 	cache := make(map[string]resolveResult)
 	var extractedHintsCache map[string][]identifier.Identifier
+	extraction := make(map[string]string)
 	needsExtraction := make(map[string]bool)
 	for _, tx := range txs {
 		if len(tx.GetIdentifierHints()) == 0 {
@@ -374,10 +388,13 @@ func extractDescHints(ctx context.Context, database db.DB, descRegistry *descrip
 		seen[key] = true
 		id, err := database.FindInstrumentBySourceDescription(ctx, source, desc)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 		if id != "" {
 			cache[key] = resolveResult{InstrumentID: id}
+			// Extraction exists to find an identifier in a description, and this
+			// one is already resolved, so it is skipped rather than paid for.
+			extraction[key] = db.TelemetryExtractionNotAttemptedDBHit
 		} else if needsExtraction[key] {
 			batchID := shortHashForBatch(key)
 			idByKey[key] = batchID
@@ -389,21 +406,32 @@ func extractDescHints(ctx context.Context, database db.DB, descRegistry *descrip
 		}
 	}
 	if len(batchItems) > 0 {
-		hintsByID, err := runDescriptionPluginsBatch(ctx, database, descRegistry, counter, broker, source, batchItems)
+		hintsByID, itemOutcomes, err := runDescriptionPluginsBatch(ctx, deps, broker, source, batchItems)
 		if err == nil && hintsByID != nil {
 			extractedHintsCache = make(map[string][]identifier.Identifier)
 			for key, id := range idByKey {
 				extractedHintsCache[key] = hintsByID[id]
 			}
 		}
+		for key, id := range idByKey {
+			extraction[key] = itemOutcomes[id]
+		}
 	}
-	return cache, extractedHintsCache, nil
+	return cache, extractedHintsCache, extraction, nil
 }
 
 // resolveInstruments resolves each tx to an instrument ID using the pre-populated
 // cache and extracted hints. Returns the instrument IDs (parallel to txs) and any
 // identification errors collected from the cache.
-func resolveInstruments(ctx context.Context, database db.DB, registry *identifier.Registry, broker, source string, counter telemetry.CounterIncrementer, txs []*apiv1.Tx, originalIndices []int, cache map[string]resolveResult, extractedHintsCache map[string][]identifier.Identifier, rep *archiveimport.PartReporter) ([]string, []db.IdentificationError, error) {
+func resolveInstruments(ctx context.Context, deps ingestDeps, broker, source string, txs []*apiv1.Tx, originalIndices []int, cache map[string]resolveResult, extractedHintsCache map[string][]identifier.Identifier, extraction map[string]string, rep *archiveimport.PartReporter) ([]string, []db.IdentificationError, error) {
+	// Filtered once and reused below, because filtering logs what it discards and
+	// deriving the same list twice would say it twice.
+	txHints := make([][]identifier.Identifier, len(txs))
+	for i, tx := range txs {
+		txHints[i] = identifierHintsFromTx(ctx, tx)
+	}
+	keys := newResolutionKeys(ctx, deps.Telemetry, deps.RunID, source, txs, txHints, extraction)
+
 	instrumentIDs := make([]string, len(txs))
 	for i, tx := range txs {
 		desc := tx.GetInstrumentDescription()
@@ -413,7 +441,7 @@ func resolveInstruments(ctx context.Context, database db.DB, registry *identifie
 			t := tx.GetTradeDate().AsTime()
 			hintsValidAt = &t
 		}
-		r, err := Resolve(ctx, database, registry, broker, source, desc, HintsFromTx(tx), identifierHintsFromTx(ctx, tx), cache, rowIndex, counter, extractedHintsCache, hintsValidAt)
+		r, err := Resolve(ctx, deps.DB, deps.Registry, broker, source, desc, HintsFromTx(tx), txHints[i], cache, rowIndex, deps.Counter, extractedHintsCache, hintsValidAt, keys)
 		if err != nil {
 			return nil, nil, fmt.Errorf("row %d: %w", rowIndex, err)
 		}


### PR DESCRIPTION
Second of three PRs for issue 0116. **Depends on #451** and is based on its branch.

Hangs the resolution keys and the description plugin calls off the run #451 opens.

A resolution key is one distinct `(source, description, hints)` triple, not one
transaction. The fan-out is counted over the whole batch *before* anything resolves,
because `Resolve` only ever sees the first transaction of each key -- counting as it
went would record 1 against every key.

The two stages of a key are decided in different places, so the ledger holds stage one
from the extraction pre-pass until the resolution stamps stage two. The pre-pass
dedupes on `(source, description)` while resolution dedupes on the triple; they
coincide exactly when no posting carries a client hint, which is the only case
extraction runs in, and a key that carries hints records extraction as not attempted
rather than borrowing its sibling's outcome.

The first stamp stands. The two probes the MIC_TICKER against OPENFIGI_SHARE_CLASS
check makes get no ledger, for the same reason they get no cache: they must not stamp
the key before the resolution that decides it. Their disagreement sets
`mismatch_detected` instead.

One `description_plugin_call` row per `ExtractBatch` invocation, including the ones
that fail. Tokens stay null for a plugin that costs nothing to call.

The price and corporate event archive parts identify from an identifier and no
description, so the identifier names their key and `tx_count` carries the archive
groups sharing it. `identifierRef` now owns the cache key those parts already used, so
the resolve cache and the ledger cannot disagree about what is the same instrument.

Verified with `make check` and `make server-test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)