### PR TITLE
Record an identification attempt and its plugin calls (0116)

### DIFF
--- a/docs/issues/0116-emit-run-scoped-telemetry.md
+++ b/docs/issues/0116-emit-run-scoped-telemetry.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Emit run-scoped telemetry from ingestion, identification and the workers
 milestone: M20
 dependencies: [0114, 0115]

--- a/docs/spec/telemetry.md
+++ b/docs/spec/telemetry.md
@@ -121,6 +121,14 @@ A plugin filtered out by acceptable kind or security type produces no
 `identifier_plugin_call` row, because no call was made. When that filter removes every
 plugin the attempt records `no_eligible_plugins`.
 
+`asset_class` is the class the attempt landed on, against `security_type_hint`, which is
+the class it was asked about. An attempt that identified nothing has no class to record.
+
+A resolution that fails outright -- a database read that errored rather than a plugin
+that found nothing -- writes no attempt row. `outcome` is not nullable, and there is no
+member for a unit of work that did not complete; the run's own outcome is where that
+failure shows.
+
 ### identifier_plugin_call
 
 One plugin invocation within an attempt.

--- a/server/service/identification/attempt_telemetry_test.go
+++ b/server/service/identification/attempt_telemetry_test.go
@@ -1,0 +1,386 @@
+package identification
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/db/mock"
+	"github.com/leedenison/portfoliodb/server/identifier"
+	"go.uber.org/mock/gomock"
+)
+
+// telPlugin is a fakePlugin that also reports how the call went, which is the
+// half of a plugin-call row only a plugin can supply.
+type telPlugin struct {
+	inst    *identifier.Instrument
+	ids     []identifier.Identifier
+	outcome identifier.Outcome
+	err     error
+	// failFirst makes the first call fail so the retry loop runs once, which is
+	// what puts a 1 in the retries column.
+	failFirst bool
+	calls     int
+}
+
+func (p *telPlugin) Identify(_ context.Context, _ []byte, _, _, _ string, _ identifier.Hints, _ []identifier.Identifier) (identifier.Result, error) {
+	p.calls++
+	if p.failFirst && p.calls == 1 {
+		return identifier.Result{Telemetry: identifier.Telemetry{Outcome: identifier.OutcomeError}}, errTransport
+	}
+	return identifier.Result{
+		Instrument:  p.inst,
+		Identifiers: p.ids,
+		Telemetry:   identifier.Telemetry{Outcome: p.outcome},
+	}, p.err
+}
+func (p *telPlugin) AcceptableInstrumentKinds() map[string]bool { return nil }
+func (p *telPlugin) AcceptableSecurityTypes() map[string]bool   { return nil }
+func (p *telPlugin) DefaultConfig() []byte                      { return nil }
+func (p *telPlugin) DisplayName() string                        { return "Tel" }
+
+var errTransport = errTransportType{}
+
+type errTransportType struct{}
+
+func (errTransportType) Error() string { return "transport failed" }
+
+// attemptSpy records the attempt rows a resolution writes and the plugin calls
+// under each of them.
+type attemptSpy struct {
+	attempts []db.TelemetryIdentificationAttempt
+	calls    map[string][]db.TelemetryIdentifierPluginCall
+}
+
+func newAttemptSpy(t *testing.T, tel *mock.MockTelemetryDB) *attemptSpy {
+	t.Helper()
+	s := &attemptSpy{calls: map[string][]db.TelemetryIdentifierPluginCall{}}
+	tel.EXPECT().WriteIdentificationAttempt(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, a db.TelemetryIdentificationAttempt) string {
+			s.attempts = append(s.attempts, a)
+			return string(rune('a' + len(s.attempts) - 1))
+		}).AnyTimes()
+	tel.EXPECT().WriteIdentifierPluginCall(gomock.Any(), gomock.Any()).
+		Do(func(_ context.Context, c db.TelemetryIdentifierPluginCall) {
+			s.calls[c.PluginID] = append(s.calls[c.PluginID], c)
+		}).AnyTimes()
+	return s
+}
+
+// scope is the attempt a test resolves under.
+func scope(tel *mock.MockTelemetryDB) Attempt {
+	return Attempt{DB: tel, RunID: "run-1", KeyID: "key-1", Purpose: db.TelemetryPurposePrimary}
+}
+
+// TestAttemptDBShortCircuit pins the outcome that keeps a failure rate honest. A
+// resolution answered from the instrument table called no plugin, so counting it
+// among the attempts that reached one makes the rate fall as the table fills.
+func TestAttemptDBShortCircuit(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
+	tel := mock.NewMockTelemetryDB(ctrl)
+	spy := newAttemptSpy(t, tel)
+
+	database.EXPECT().FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "AAPL").
+		Return("inst-1", "STOCK", "XNAS", "USD", nil)
+
+	_, err := ResolveWithPlugins(context.Background(), database, identifier.NewRegistry(),
+		"", "", "", identifier.Hints{SecurityTypeHint: identifier.SecurityTypeHintStock},
+		[]identifier.Identifier{{Type: "MIC_TICKER", Value: "AAPL"}},
+		false, nil, nil, scope(tel), nil, 0, nil)
+	if err != nil {
+		t.Fatalf("ResolveWithPlugins: %v", err)
+	}
+
+	if len(spy.attempts) != 1 {
+		t.Fatalf("wrote %d attempts, want 1", len(spy.attempts))
+	}
+	a := spy.attempts[0]
+	if a.Outcome != db.TelemetryAttemptDBShortCircuit {
+		t.Errorf("outcome = %q, want %q", a.Outcome, db.TelemetryAttemptDBShortCircuit)
+	}
+	if a.Purpose != db.TelemetryPurposePrimary || a.Depth != 0 || !a.HadIdentifierHints {
+		t.Errorf("attempt = %+v, want a primary attempt at depth 0 with hints", a)
+	}
+	if a.AssetClass != "STOCK" {
+		t.Errorf("asset class = %q, want the class it resolved to", a.AssetClass)
+	}
+	if len(spy.calls) != 0 {
+		t.Errorf("wrote %d plugin calls for a resolution that called none", len(spy.calls))
+	}
+}
+
+// TestAttemptNoEligiblePlugins pins the other denominator exclusion. A plugin the
+// eligibility filter removed made no call, so it produces no row, and an attempt
+// left with none records that rather than a failure to identify.
+func TestAttemptNoEligiblePlugins(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
+	tel := mock.NewMockTelemetryDB(ctrl)
+	spy := newAttemptSpy(t, tel)
+
+	registry := identifier.NewRegistry()
+	registry.Register("cash-only", &cashOnlyPlugin{})
+	database.EXPECT().FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "AAPL").
+		Return("", "", "", "", nil)
+	database.EXPECT().FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "AAPL").Return("", nil)
+	database.EXPECT().ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryIdentifier).
+		Return([]db.PluginConfigRow{{PluginID: "cash-only", Precedence: 10}}, nil)
+
+	_, err := ResolveWithPlugins(context.Background(), database, registry,
+		"", "", "", identifier.Hints{SecurityTypeHint: identifier.SecurityTypeHintStock},
+		[]identifier.Identifier{{Type: "MIC_TICKER", Value: "AAPL"}},
+		false, nil, nil, scope(tel), nil, 0, nil)
+	if err != nil {
+		t.Fatalf("ResolveWithPlugins: %v", err)
+	}
+
+	if len(spy.attempts) != 1 || spy.attempts[0].Outcome != db.TelemetryAttemptNoEligiblePlugins {
+		t.Fatalf("attempts = %+v, want one recording no eligible plugins", spy.attempts)
+	}
+	if len(spy.calls) != 0 {
+		t.Errorf("wrote %d plugin calls for a plugin that was never called", len(spy.calls))
+	}
+}
+
+// cashOnlyPlugin accepts nothing a stock hint routes to it.
+type cashOnlyPlugin struct{ telPlugin }
+
+func (p *cashOnlyPlugin) AcceptableSecurityTypes() map[string]bool {
+	return map[string]bool{identifier.SecurityTypeHintCash: true}
+}
+
+// TestPluginCallOutcomesAreComposed pins the three outcomes no plugin can know.
+// They are decided after every plugin has returned: the winner won, a plugin that
+// agreed with it but did not win was superseded, and one contradicting it was
+// discarded.
+func TestPluginCallOutcomesAreComposed(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
+	database.EXPECT().SaveProviderIdentifiers(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	tel := mock.NewMockTelemetryDB(ctrl)
+	spy := newAttemptSpy(t, tel)
+
+	// Highest precedence answers first but does not match the currency hint;
+	// the middle one does, so it wins despite losing on precedence. The last
+	// contradicts the winner's currency and is dropped from the merge.
+	registry := identifier.NewRegistry()
+	registry.Register("high", &telPlugin{
+		inst:    &identifier.Instrument{Name: "Apple", AssetClass: "STOCK", Currency: "USD"},
+		ids:     []identifier.Identifier{{Type: "ISIN", Value: "US0378331005"}},
+		outcome: identifier.OutcomeIdentified,
+	})
+	registry.Register("mid", &telPlugin{
+		inst:    &identifier.Instrument{Name: "Apple", AssetClass: "STOCK", Currency: "USD"},
+		ids:     []identifier.Identifier{{Type: "MIC_TICKER", Value: "AAPL"}},
+		outcome: identifier.OutcomeIdentified,
+	})
+	registry.Register("odd", &telPlugin{
+		inst:    &identifier.Instrument{Name: "Apple", AssetClass: "STOCK", Currency: "EUR"},
+		outcome: identifier.OutcomeIdentified,
+	})
+
+	database.EXPECT().FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "AAPL").
+		Return("", "", "", "", nil)
+	database.EXPECT().FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "AAPL").Return("", nil)
+	database.EXPECT().ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryIdentifier).
+		Return([]db.PluginConfigRow{
+			{PluginID: "high", Precedence: 30},
+			{PluginID: "mid", Precedence: 20},
+			{PluginID: "odd", Precedence: 10},
+		}, nil)
+	database.EXPECT().EnsureInstrument(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+		gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return("inst-1", nil)
+	database.EXPECT().UpdateIdentityAsOf(gomock.Any(), "inst-1").Return(nil)
+
+	_, err := ResolveWithPlugins(context.Background(), database, registry,
+		"", "", "", identifier.Hints{Currency: "USD"},
+		[]identifier.Identifier{{Type: "MIC_TICKER", Value: "AAPL"}},
+		false, nil, nil, scope(tel), nil, 0, nil)
+	if err != nil {
+		t.Fatalf("ResolveWithPlugins: %v", err)
+	}
+
+	if len(spy.attempts) != 1 || spy.attempts[0].Outcome != db.TelemetryAttemptIdentified {
+		t.Fatalf("attempts = %+v, want one identified", spy.attempts)
+	}
+	want := map[string]string{
+		"high": db.TelemetryPluginCallWon,
+		"mid":  db.TelemetryPluginCallSuperseded,
+		"odd":  db.TelemetryPluginCallDiscardedInconsistent,
+	}
+	for id, w := range want {
+		got := spy.calls[id]
+		if len(got) != 1 {
+			t.Errorf("wrote %d calls for %q, want 1", len(got), id)
+			continue
+		}
+		if got[0].Outcome != w {
+			t.Errorf("outcome for %q = %q, want %q", id, got[0].Outcome, w)
+		}
+		if got[0].AttemptID == "" || got[0].RunID != "run-1" {
+			t.Errorf("call for %q = %+v, want it under the attempt and the run", id, got[0])
+		}
+	}
+}
+
+// TestPluginTransportOutcomePassesThrough pins the half of the vocabulary the
+// plugin owns. Massive declining to call upstream about a long-expired contract
+// is not an ordinary non-identification, and the row says so.
+func TestPluginTransportOutcomePassesThrough(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
+	tel := mock.NewMockTelemetryDB(ctrl)
+	spy := newAttemptSpy(t, tel)
+
+	registry := identifier.NewRegistry()
+	registry.Register("expired", &telPlugin{
+		outcome: identifier.OutcomeSkippedExpired,
+		err:     identifier.ErrNotIdentified,
+	})
+	database.EXPECT().FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "AAPL").
+		Return("", "", "", "", nil)
+	database.EXPECT().FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "AAPL").Return("", nil)
+	database.EXPECT().ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryIdentifier).
+		Return([]db.PluginConfigRow{{PluginID: "expired", Precedence: 10}}, nil)
+
+	_, err := ResolveWithPlugins(context.Background(), database, registry,
+		"", "", "", identifier.Hints{},
+		[]identifier.Identifier{{Type: "MIC_TICKER", Value: "AAPL"}},
+		false, nil, nil, scope(tel), nil, 0, nil)
+	if err != nil {
+		t.Fatalf("ResolveWithPlugins: %v", err)
+	}
+
+	if len(spy.attempts) != 1 || spy.attempts[0].Outcome != db.TelemetryAttemptNotIdentified {
+		t.Fatalf("attempts = %+v, want one not identified", spy.attempts)
+	}
+	got := spy.calls["expired"]
+	if len(got) != 1 || got[0].Outcome != string(identifier.OutcomeSkippedExpired) {
+		t.Fatalf("calls = %+v, want one skipped_expired", got)
+	}
+	if got[0].Retries != 0 {
+		t.Errorf("retries = %d, want 0: a non-identification is permanent", got[0].Retries)
+	}
+}
+
+// TestPluginCallCountsRetries pins the retry column being the resolver's. The
+// plugin never learns it was called twice; the loop that called it does.
+func TestPluginCallCountsRetries(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
+	tel := mock.NewMockTelemetryDB(ctrl)
+	spy := newAttemptSpy(t, tel)
+
+	prev := PluginRetryBackoff
+	PluginRetryBackoff = time.Millisecond
+	t.Cleanup(func() { PluginRetryBackoff = prev })
+
+	registry := identifier.NewRegistry()
+	registry.Register("flaky", &telPlugin{
+		failFirst: true,
+		outcome:   identifier.OutcomeNotIdentified,
+		err:       identifier.ErrNotIdentified,
+	})
+	database.EXPECT().FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "AAPL").
+		Return("", "", "", "", nil)
+	database.EXPECT().FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "AAPL").Return("", nil)
+	database.EXPECT().ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryIdentifier).
+		Return([]db.PluginConfigRow{{PluginID: "flaky", Precedence: 10}}, nil)
+
+	if _, err := ResolveWithPlugins(context.Background(), database, registry,
+		"", "", "", identifier.Hints{},
+		[]identifier.Identifier{{Type: "MIC_TICKER", Value: "AAPL"}},
+		false, nil, nil, scope(tel), nil, 0, nil); err != nil {
+		t.Fatalf("ResolveWithPlugins: %v", err)
+	}
+
+	got := spy.calls["flaky"]
+	if len(got) != 1 {
+		t.Fatalf("wrote %d calls, want 1 -- a row is one invocation, retries and all", len(got))
+	}
+	if got[0].Retries != 1 {
+		t.Errorf("retries = %d, want 1", got[0].Retries)
+	}
+}
+
+// TestUnderlyingRecursionIsItsOwnAttempt pins the purpose column. Resolving a
+// derivative's underlying is a second ResolveWithPlugins call over the same key,
+// and without purpose and depth it is indistinguishable from the first.
+func TestUnderlyingRecursionIsItsOwnAttempt(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
+	database.EXPECT().SaveProviderIdentifiers(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	tel := mock.NewMockTelemetryDB(ctrl)
+	spy := newAttemptSpy(t, tel)
+
+	registry := identifier.NewRegistry()
+	registry.Register("opt", &telPlugin{
+		inst: &identifier.Instrument{
+			Name:                  "AAPL Call",
+			AssetClass:            "OPTION",
+			UnderlyingIdentifiers: []identifier.Identifier{{Type: "MIC_TICKER", Value: "AAPL"}},
+		},
+		outcome: identifier.OutcomeIdentified,
+	})
+
+	database.EXPECT().FindInstrumentWithMetaByIdentifier(gomock.Any(), "OCC", "", "AAPL240315C00100000").
+		Return("", "", "", "", nil)
+	database.EXPECT().FindInstrumentByTypeAndValue(gomock.Any(), "OCC", "AAPL240315C00100000").Return("", nil)
+	// The underlying resolves straight from the instrument table, which is a
+	// second attempt that short-circuits.
+	database.EXPECT().FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "AAPL").
+		Return("underlying-id", "STOCK", "XNAS", "USD", nil)
+	database.EXPECT().ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryIdentifier).
+		Return([]db.PluginConfigRow{{PluginID: "opt", Precedence: 10}}, nil)
+	database.EXPECT().EnsureInstrument(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+		gomock.Any(), gomock.Any(), gomock.Any(), "underlying-id", gomock.Any(), gomock.Any(), gomock.Any()).
+		Return("opt-id", nil)
+	database.EXPECT().UpdateIdentityAsOf(gomock.Any(), "opt-id").Return(nil)
+
+	_, err := ResolveWithPlugins(context.Background(), database, registry,
+		"", "", "", identifier.Hints{},
+		[]identifier.Identifier{{Type: "OCC", Value: "AAPL240315C00100000"}},
+		false, nil, nil, scope(tel), nil, 0, nil)
+	if err != nil {
+		t.Fatalf("ResolveWithPlugins: %v", err)
+	}
+
+	if len(spy.attempts) != 2 {
+		t.Fatalf("wrote %d attempts, want 2 -- the option and its underlying", len(spy.attempts))
+	}
+	// The underlying finishes first, so it is written first.
+	under, primary := spy.attempts[0], spy.attempts[1]
+	if under.Purpose != db.TelemetryPurposeUnderlying || under.Depth != 1 {
+		t.Errorf("underlying attempt = %+v, want purpose underlying at depth 1", under)
+	}
+	if under.Outcome != db.TelemetryAttemptDBShortCircuit {
+		t.Errorf("underlying outcome = %q, want %q", under.Outcome, db.TelemetryAttemptDBShortCircuit)
+	}
+	if primary.Purpose != db.TelemetryPurposePrimary || primary.Depth != 0 {
+		t.Errorf("primary attempt = %+v, want purpose primary at depth 0", primary)
+	}
+	if under.ResolutionKeyID != primary.ResolutionKeyID {
+		t.Error("the underlying attempt hangs off a different key from the resolution that caused it")
+	}
+}

--- a/server/service/identification/resolve.go
+++ b/server/service/identification/resolve.go
@@ -158,10 +158,64 @@ func FilterIdentifierHints(ctx context.Context, hints []identifier.Identifier, l
 // superseded or discarded as inconsistent -- is decided by winner selection
 // below, once every plugin has returned.
 type pluginResult struct {
-	inst *identifier.Instrument
-	ids  []identifier.Identifier
-	tel  identifier.Telemetry
-	err  error
+	inst  *identifier.Instrument
+	ids   []identifier.Identifier
+	tel   identifier.Telemetry
+	stats callStats
+	err   error
+}
+
+// Attempt is where one ResolveWithPlugins call records itself: the run it belongs
+// to and the resolution key it resolves. Purpose distinguishes the primary call
+// from the two the MIC_TICKER against OPENFIGI_SHARE_CLASS mismatch check makes
+// and from underlying recursion, which are otherwise indistinguishable.
+//
+// Depth is not a field. It is already a parameter of the call, so holding it here
+// too would let the two disagree.
+//
+// The zero Attempt records nothing, which is what a caller outside a run passes.
+type Attempt struct {
+	DB      db.TelemetryDB
+	RunID   string
+	KeyID   string
+	Purpose string
+}
+
+// write records a finished attempt and returns its id, for the plugin calls
+// written under it. The scope fills itself in, so the caller states only what it
+// learned. An empty id is an attempt that was not recorded, and the writer
+// already skips the children of one.
+func (a Attempt) write(ctx context.Context, r db.TelemetryIdentificationAttempt) string {
+	if a.DB == nil || a.KeyID == "" {
+		return ""
+	}
+	r.RunID = a.RunID
+	r.ResolutionKeyID = a.KeyID
+	r.Purpose = a.Purpose
+	return a.DB.WriteIdentificationAttempt(ctx, r)
+}
+
+// writeCall records one plugin invocation under an attempt.
+func (a Attempt) writeCall(ctx context.Context, attemptID, pluginID, outcome string, stats callStats) {
+	if a.DB == nil || attemptID == "" {
+		return
+	}
+	a.DB.WriteIdentifierPluginCall(ctx, db.TelemetryIdentifierPluginCall{
+		RunID:     a.RunID,
+		AttemptID: attemptID,
+		PluginID:  pluginID,
+		Outcome:   outcome,
+		Retries:   stats.Retries,
+		Duration:  stats.Duration,
+	})
+}
+
+// underlying returns the scope an underlying resolution runs under: the same run
+// and the same key, since it is the same description being resolved, but named as
+// the recursion it is.
+func (a Attempt) underlying() Attempt {
+	a.Purpose = db.TelemetryPurposeUnderlying
+	return a
 }
 
 // MICNormalizer maps a MIC to its operating MIC. Returns the input unchanged
@@ -346,12 +400,20 @@ func ResolveWithPlugins(
 	storeSourceDescription bool,
 	fallback FallbackFunc,
 	counter telemetry.CounterIncrementer,
+	tel Attempt,
 	logger *slog.Logger,
 	depth int,
 	hintsValidAt *time.Time,
 ) (ResolveResult, error) {
 	l := resolveLogger(logger)
 	normMIC := NewDBMICNormalizer(database)
+	// What the attempt row states about its inputs. Its outcome and the asset
+	// class it landed on are filled in at each of the returns below.
+	row := db.TelemetryIdentificationAttempt{
+		Depth:              depth,
+		SecurityTypeHint:   hints.SecurityTypeHint,
+		HadIdentifierHints: len(identifierHints) > 0,
+	}
 
 	// Adjust OCC hints for known stock splits before any lookups. identityAsOf
 	// is the market time the resulting hints reflect, and it is what the winner
@@ -370,6 +432,12 @@ func ResolveWithPlugins(
 			Currency:   resolved[0].Currency,
 		}
 		diffs := CompareHints(ctx, hints, identifierHints, inst, nil, normMIC)
+		// No plugin was called, which is why this is its own outcome rather than
+		// an identification with no plugin-call rows under it. It is also why a
+		// failure rate over all attempts falls as the instrument table fills.
+		row.Outcome = db.TelemetryAttemptDBShortCircuit
+		row.AssetClass = resolved[0].AssetClass
+		tel.write(ctx, row)
 		return ResolveResult{InstrumentID: resolved[0].ID, Identified: true, HintDiffs: diffs}, nil
 	}
 
@@ -410,8 +478,8 @@ func ResolveWithPlugins(
 			defer wg.Done()
 			in := inputs[idx]
 			timeout := timeoutFromConfig(in.config.Config)
-			res, err := callPluginWithRetry(ctx, in.plugin, in.config.Config, broker, source, instrumentDescription, hints, identifierHints, timeout, PluginRetryBackoff)
-			results[idx] = pluginResult{inst: res.Instrument, ids: res.Identifiers, tel: res.Telemetry, err: err}
+			res, stats, err := callPluginWithRetry(ctx, in.plugin, in.config.Config, broker, source, instrumentDescription, hints, identifierHints, timeout, PluginRetryBackoff)
+			results[idx] = pluginResult{inst: res.Instrument, ids: res.Identifiers, tel: res.Telemetry, stats: stats, err: err}
 		}(i)
 	}
 	wg.Wait()
@@ -426,6 +494,15 @@ func ResolveWithPlugins(
 		} else {
 			l.DebugContext(ctx, "identifier plugin result", "plugin_id", in.config.PluginID, "instrument_description", instrumentDescription, "result", "not_identified")
 		}
+	}
+
+	// One outcome per plugin invocation, seeded with what the plugin reported and
+	// refined below for the ones that succeeded: won, superseded and discarded are
+	// the orchestrator's to decide, and it cannot decide any of them until every
+	// plugin has returned.
+	callOutcomes := make([]string, len(results))
+	for i := range results {
+		callOutcomes[i] = string(results[i].tel.Outcome)
 	}
 
 	// Check whether any meaningful hints are supplied (to avoid vacuous matching).
@@ -473,6 +550,26 @@ func ResolveWithPlugins(
 			"instrument_description", instrumentDescription)
 	}
 
+	// writeAttempt records the attempt and the invocations under it. It is deferred
+	// to the returns below rather than run here, because the winner path resolves
+	// the underlying first and that recursion is a separate attempt: writing this
+	// one now would nest the wrong way round in time.
+	writeAttempt := func(outcome, assetClass string) {
+		row.Outcome = outcome
+		row.AssetClass = assetClass
+		attemptID := tel.write(ctx, row)
+		for i := range results {
+			o := callOutcomes[i]
+			if o == string(identifier.OutcomeIdentified) {
+				// The plugin says it identified something the resolver did not
+				// take as a success. The row records what the resolver saw: won,
+				// superseded and discarded are its words, and this is none of them.
+				o = string(identifier.OutcomeNotIdentified)
+			}
+			tel.writeCall(ctx, attemptID, inputs[i].config.PluginID, o, results[i].stats)
+		}
+	}
+
 	if winner != nil {
 		l.DebugContext(ctx, "identifier plugin chosen", "plugin_id", inputs[winnerIdx].config.PluginID, "instrument_description", instrumentDescription, "instrument_name", winner.inst.Name)
 		seenType := make(map[string]bool)
@@ -483,8 +580,18 @@ func ResolveWithPlugins(
 			if r.err != nil || r.inst == nil {
 				continue
 			}
+			// Decided here rather than recomputed later: consistentWith logs a
+			// warning per mismatch, so asking it twice would say it twice.
 			if i != winnerIdx && !consistentWith(ctx, l, inputs[winnerIdx].config.PluginID, inputs[i].config.PluginID, winner, r, normMIC) {
+				callOutcomes[i] = db.TelemetryPluginCallDiscardedInconsistent
 				continue
+			}
+			if i == winnerIdx {
+				callOutcomes[i] = db.TelemetryPluginCallWon
+			} else {
+				// Identified the same instrument but did not win it. Precedence or
+				// a better hint match put another plugin ahead.
+				callOutcomes[i] = db.TelemetryPluginCallSuperseded
 			}
 			for _, idn := range r.ids {
 				if !seenType[idn.Type] {
@@ -525,7 +632,7 @@ func ResolveWithPlugins(
 			uIdnHints := make([]identifier.Identifier, len(inst.UnderlyingIdentifiers))
 			copy(uIdnHints, inst.UnderlyingIdentifiers)
 			// Underlying resolution: no source description, no fallback needed (use nil).
-			uResult, uErr := ResolveWithPlugins(ctx, database, registry, broker, source, "", uHints, uIdnHints, false, nil, counter, logger, depth+1, nil)
+			uResult, uErr := ResolveWithPlugins(ctx, database, registry, broker, source, "", uHints, uIdnHints, false, nil, counter, tel.underlying(), logger, depth+1, nil)
 			if uErr != nil {
 				l.WarnContext(ctx, "underlying resolution failed", "instrument_description", instrumentDescription, "err", uErr)
 			} else if uResult.InstrumentID != "" {
@@ -566,7 +673,22 @@ func ResolveWithPlugins(
 				l.WarnContext(ctx, "save provider identifiers failed", "instrument_id", id, "err", err)
 			}
 		}
+		writeAttempt(db.TelemetryAttemptIdentified, inst.AssetClass)
 		return ResolveResult{InstrumentID: id, Identified: true, HintDiffs: diffs}, nil
+	}
+
+	// Nothing identified it. A plugin removed by the eligibility filter made no
+	// call, so an attempt that had no eligible plugin left is not a failure to
+	// identify -- it is the denominator a failure rate must exclude.
+	switch {
+	case len(inputs) == 0:
+		writeAttempt(db.TelemetryAttemptNoEligiblePlugins, "")
+	case hadTimeout:
+		writeAttempt(db.TelemetryAttemptPluginTimeout, "")
+	case hadOtherErr:
+		writeAttempt(db.TelemetryAttemptPluginError, "")
+	default:
+		writeAttempt(db.TelemetryAttemptNotIdentified, "")
 	}
 
 	// Unresolved: call fallback if provided.
@@ -630,11 +752,22 @@ func timeoutFromConfig(config []byte) time.Duration {
 	return time.Duration(*c.TimeoutSeconds) * time.Second
 }
 
+// callStats is what only the caller of a plugin knows about the invocation: the
+// retry loop and the clock belong to the resolver, not to the plugin. Duration
+// spans the whole invocation including any retry, because that is what one
+// identifier_plugin_call row describes.
+type callStats struct {
+	Retries  int
+	Duration time.Duration
+}
+
 // callPluginWithRetry calls Identify with exponential backoff retry.
 // ErrNotIdentified is treated as a permanent error (no retry). Each attempt gets its own
 // context timeout derived from the parent so cancellation still propagates.
-func callPluginWithRetry(ctx context.Context, p identifier.Plugin, config []byte, broker, source, instrumentDescription string, hints identifier.Hints, identifierHints []identifier.Identifier, timeout, initialBackoff time.Duration) (identifier.Result, error) {
+func callPluginWithRetry(ctx context.Context, p identifier.Plugin, config []byte, broker, source, instrumentDescription string, hints identifier.Hints, identifierHints []identifier.Identifier, timeout, initialBackoff time.Duration) (identifier.Result, callStats, error) {
 	var res identifier.Result
+	var calls int
+	started := time.Now()
 
 	bo := backoff.NewExponentialBackOff()
 	bo.InitialInterval = initialBackoff
@@ -642,6 +775,7 @@ func callPluginWithRetry(ctx context.Context, p identifier.Plugin, config []byte
 	bCtx := backoff.WithContext(backoff.WithMaxRetries(bo, 1), ctx)
 
 	err := backoff.Retry(func() error {
+		calls++
 		attemptCtx, cancel := context.WithTimeout(ctx, timeout)
 		defer cancel()
 		var attemptErr error
@@ -655,7 +789,7 @@ func callPluginWithRetry(ctx context.Context, p identifier.Plugin, config []byte
 		return attemptErr
 	}, bCtx)
 
-	return res, err
+	return res, callStats{Retries: calls - 1, Duration: time.Since(started)}, err
 }
 
 // optionFieldsFromIdentifiers extracts strike, expiry, and put/call from the

--- a/server/service/identification/resolve_test.go
+++ b/server/service/identification/resolve_test.go
@@ -177,7 +177,7 @@ func TestResolveWithPlugins_DBHit(t *testing.T) {
 	result, err := ResolveWithPlugins(context.Background(), database, registry,
 		"", "", "", identifier.Hints{},
 		[]identifier.Identifier{{Type: "MIC_TICKER", Value: "AAPL"}},
-		false, nil, nil, nil, 0, nil)
+		false, nil, nil, Attempt{}, nil, 0, nil)
 	if err != nil {
 		t.Fatalf("ResolveWithPlugins: %v", err)
 	}
@@ -218,7 +218,7 @@ func TestResolveWithPlugins_PluginSuccess(t *testing.T) {
 	result, err := ResolveWithPlugins(context.Background(), database, registry,
 		"", "", "", identifier.Hints{SecurityTypeHint: identifier.SecurityTypeHintStock},
 		[]identifier.Identifier{{Type: "MIC_TICKER", Value: "AAPL"}},
-		false, nil, nil, nil, 0, nil)
+		false, nil, nil, Attempt{}, nil, 0, nil)
 	if err != nil {
 		t.Fatalf("ResolveWithPlugins: %v", err)
 	}
@@ -257,7 +257,7 @@ func TestResolveWithPlugins_StampsIdentityAsOfOnPluginSuccess(t *testing.T) {
 	if _, err := ResolveWithPlugins(context.Background(), database, registry,
 		"", "", "", identifier.Hints{SecurityTypeHint: identifier.SecurityTypeHintStock},
 		[]identifier.Identifier{{Type: "MIC_TICKER", Value: "AAPL"}},
-		false, nil, nil, nil, 0, nil); err != nil {
+		false, nil, nil, Attempt{}, nil, 0, nil); err != nil {
 		t.Fatalf("ResolveWithPlugins: %v", err)
 	}
 }
@@ -285,7 +285,7 @@ func TestResolveWithPlugins_NoStampOnFallback(t *testing.T) {
 	result, err := ResolveWithPlugins(context.Background(), database, registry,
 		"", "src", "desc", identifier.Hints{SecurityTypeHint: identifier.SecurityTypeHintStock},
 		[]identifier.Identifier{{Type: "MIC_TICKER", Value: "AAPL"}},
-		true, fallback, nil, nil, 0, nil)
+		true, fallback, nil, Attempt{}, nil, 0, nil)
 	if err != nil {
 		t.Fatalf("ResolveWithPlugins: %v", err)
 	}
@@ -322,7 +322,7 @@ func TestResolveWithPlugins_AllPluginsFail_Fallback(t *testing.T) {
 	result, err := ResolveWithPlugins(context.Background(), database, registry,
 		"", "", "", identifier.Hints{},
 		[]identifier.Identifier{{Type: "MIC_TICKER", Value: "XYZ"}},
-		false, fallback, nil, nil, 0, nil)
+		false, fallback, nil, Attempt{}, nil, 0, nil)
 	if err != nil {
 		t.Fatalf("ResolveWithPlugins: %v", err)
 	}
@@ -367,7 +367,7 @@ func TestResolveWithPlugins_Timeout_SetsHadTimeout(t *testing.T) {
 	result, err := ResolveWithPlugins(context.Background(), database, registry,
 		"", "", "", identifier.Hints{},
 		[]identifier.Identifier{{Type: "MIC_TICKER", Value: "SLOW"}},
-		false, fallback, nil, nil, 0, nil)
+		false, fallback, nil, Attempt{}, nil, 0, nil)
 	if err != nil {
 		t.Fatalf("ResolveWithPlugins: %v", err)
 	}
@@ -401,7 +401,7 @@ func TestResolveWithPlugins_NilFallback_ReturnsEmpty(t *testing.T) {
 	result, err := ResolveWithPlugins(context.Background(), database, registry,
 		"", "", "", identifier.Hints{},
 		[]identifier.Identifier{{Type: "MIC_TICKER", Value: "XYZ"}},
-		false, nil, nil, nil, 0, nil)
+		false, nil, nil, Attempt{}, nil, 0, nil)
 	if err != nil {
 		t.Fatalf("ResolveWithPlugins: %v", err)
 	}
@@ -452,7 +452,7 @@ func TestResolveWithPlugins_StoreSourceDescription(t *testing.T) {
 	_, err := ResolveWithPlugins(context.Background(), database, registry,
 		"IBKR", source, desc, identifier.Hints{},
 		[]identifier.Identifier{{Type: "MIC_TICKER", Value: desc}},
-		true, nil, nil, nil, 0, nil)
+		true, nil, nil, Attempt{}, nil, 0, nil)
 	if err != nil {
 		t.Fatalf("ResolveWithPlugins: %v", err)
 	}
@@ -488,7 +488,7 @@ func TestResolveWithPlugins_PluginError_SetsHadError(t *testing.T) {
 	result, err := ResolveWithPlugins(context.Background(), database, registry,
 		"", "", "", identifier.Hints{},
 		[]identifier.Identifier{{Type: "MIC_TICKER", Value: "BAD"}},
-		false, fallback, nil, nil, 0, nil)
+		false, fallback, nil, Attempt{}, nil, 0, nil)
 	if err != nil {
 		t.Fatalf("ResolveWithPlugins: %v", err)
 	}
@@ -545,7 +545,7 @@ func TestCallPluginWithRetry_SuccessNoRetry(t *testing.T) {
 		inst: &identifier.Instrument{Name: "OK"},
 		ids:  []identifier.Identifier{{Type: "MIC_TICKER", Value: "X"}},
 	}
-	res, err := callPluginWithRetry(context.Background(), p, nil, "", "", "X", identifier.Hints{}, nil, time.Second, time.Millisecond)
+	res, _, err := callPluginWithRetry(context.Background(), p, nil, "", "", "X", identifier.Hints{}, nil, time.Second, time.Millisecond)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -559,7 +559,7 @@ func TestCallPluginWithRetry_SuccessNoRetry(t *testing.T) {
 
 func TestCallPluginWithRetry_ErrNotIdentified_NoRetry(t *testing.T) {
 	p := &fakePlugin{err: identifier.ErrNotIdentified}
-	_, err := callPluginWithRetry(context.Background(), p, nil, "", "", "X", identifier.Hints{}, nil, time.Second, time.Millisecond)
+	_, _, err := callPluginWithRetry(context.Background(), p, nil, "", "", "X", identifier.Hints{}, nil, time.Second, time.Millisecond)
 	if !errors.Is(err, identifier.ErrNotIdentified) {
 		t.Errorf("err = %v, want ErrNotIdentified", err)
 	}
@@ -594,7 +594,7 @@ func TestCallPluginWithRetry_RetrySucceeds(t *testing.T) {
 		inst: &identifier.Instrument{Name: "Retried"},
 		ids:  []identifier.Identifier{{Type: "MIC_TICKER", Value: "X"}},
 	}
-	res, err := callPluginWithRetry(context.Background(), p, nil, "", "", "X", identifier.Hints{}, nil, time.Second, time.Millisecond)
+	res, _, err := callPluginWithRetry(context.Background(), p, nil, "", "", "X", identifier.Hints{}, nil, time.Second, time.Millisecond)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -616,7 +616,7 @@ func TestCallPluginWithRetry_ParentCancelStopsRetry(t *testing.T) {
 	// (i.e. we no longer use context.Background() for retry).
 	ctx, cancel := context.WithCancel(context.Background())
 	p := &cancelOnRetryPlugin{cancel: cancel, inst: &identifier.Instrument{Name: "Never"}}
-	res, err := callPluginWithRetry(ctx, p, nil, "", "", "X", identifier.Hints{}, nil, time.Second, time.Millisecond)
+	res, _, err := callPluginWithRetry(ctx, p, nil, "", "", "X", identifier.Hints{}, nil, time.Second, time.Millisecond)
 	if err == nil {
 		t.Fatalf("expected error from cancelled context, got inst=%v", res.Instrument)
 	}
@@ -779,7 +779,7 @@ func TestResolveWithPlugins_InconsistentPluginExcluded(t *testing.T) {
 	_, err := ResolveWithPlugins(context.Background(), database, registry,
 		"", "", "", identifier.Hints{},
 		[]identifier.Identifier{{Type: "MIC_TICKER", Value: "AAPL"}},
-		false, nil, nil, nil, 0, nil)
+		false, nil, nil, Attempt{}, nil, 0, nil)
 	if err != nil {
 		t.Fatalf("ResolveWithPlugins: %v", err)
 	}
@@ -1003,7 +1003,7 @@ func TestResolveWithPlugins_ConsistentPluginsMerged(t *testing.T) {
 	_, err := ResolveWithPlugins(context.Background(), database, registry,
 		"", "", "", identifier.Hints{},
 		[]identifier.Identifier{{Type: "MIC_TICKER", Value: "AAPL"}},
-		false, nil, nil, nil, 0, nil)
+		false, nil, nil, Attempt{}, nil, 0, nil)
 	if err != nil {
 		t.Fatalf("ResolveWithPlugins: %v", err)
 	}
@@ -1179,7 +1179,7 @@ func TestResolveWithPlugins_HintMatchPrefersLowerPrecedence(t *testing.T) {
 	result, err := ResolveWithPlugins(context.Background(), database, registry,
 		"", "", "", identifier.Hints{Currency: "GBX"},
 		[]identifier.Identifier{{Type: "MIC_TICKER", Domain: "XLON", Value: "BA"}},
-		false, nil, nil, nil, 0, nil)
+		false, nil, nil, Attempt{}, nil, 0, nil)
 	if err != nil {
 		t.Fatalf("ResolveWithPlugins: %v", err)
 	}
@@ -1230,7 +1230,7 @@ func TestResolveWithPlugins_NoHintMatch_FallsBackToPrecedence(t *testing.T) {
 	result, err := ResolveWithPlugins(context.Background(), database, registry,
 		"", "", "", identifier.Hints{Currency: "GBX"},
 		[]identifier.Identifier{{Type: "MIC_TICKER", Value: "AAPL"}},
-		false, nil, nil, nil, 0, nil)
+		false, nil, nil, Attempt{}, nil, 0, nil)
 	if err != nil {
 		t.Fatalf("ResolveWithPlugins: %v", err)
 	}
@@ -1277,7 +1277,7 @@ func TestResolveWithPlugins_NoHints_PurePrecedence(t *testing.T) {
 	result, err := ResolveWithPlugins(context.Background(), database, registry,
 		"", "", "", identifier.Hints{},
 		[]identifier.Identifier{{Type: "MIC_TICKER", Value: "AAPL"}},
-		false, nil, nil, nil, 0, nil)
+		false, nil, nil, Attempt{}, nil, 0, nil)
 	if err != nil {
 		t.Fatalf("ResolveWithPlugins: %v", err)
 	}
@@ -1322,7 +1322,7 @@ func TestResolveWithPlugins_AllMatch_HighestPrecedenceWins(t *testing.T) {
 	result, err := ResolveWithPlugins(context.Background(), database, registry,
 		"", "", "", identifier.Hints{Currency: "GBX"},
 		[]identifier.Identifier{{Type: "MIC_TICKER", Domain: "XLON", Value: "BA"}},
-		false, nil, nil, nil, 0, nil)
+		false, nil, nil, Attempt{}, nil, 0, nil)
 	if err != nil {
 		t.Fatalf("ResolveWithPlugins: %v", err)
 	}
@@ -1369,7 +1369,7 @@ func TestResolveWithPlugins_SparseResultDoesNotVacuouslyMatch(t *testing.T) {
 	result, err := ResolveWithPlugins(context.Background(), database, registry,
 		"", "", "", identifier.Hints{Currency: "GBX"},
 		[]identifier.Identifier{{Type: "MIC_TICKER", Domain: "XLON", Value: "BA"}},
-		false, nil, nil, nil, 0, nil)
+		false, nil, nil, Attempt{}, nil, 0, nil)
 	if err != nil {
 		t.Fatalf("ResolveWithPlugins: %v", err)
 	}

--- a/server/service/ingestion/price_worker.go
+++ b/server/service/ingestion/price_worker.go
@@ -346,7 +346,7 @@ func resolveOrIdentifyInstrument(ctx context.Context, database db.DB, pluginRegi
 		result, err := identification.ResolveWithPlugins(ctx, database, pluginRegistry,
 			"", "", "", hints,
 			[]identifier.Identifier{hint},
-			false, fallback, nil, nil, 0, hintsValidAt)
+			false, fallback, nil, keys.attempt(key, db.TelemetryPurposePrimary), nil, 0, hintsValidAt)
 		if err != nil {
 			return identification.ResolveResult{}, fmt.Errorf("identification error for %s %q: %v", idType, value, err)
 		}

--- a/server/service/ingestion/resolution_telemetry.go
+++ b/server/service/ingestion/resolution_telemetry.go
@@ -130,6 +130,21 @@ func (k *resolutionKeys) end(ctx context.Context, key, outcome, instrumentID str
 	})
 }
 
+// attempt returns the scope one ResolveWithPlugins call over this key records
+// itself under. A caller with no ledger gets the zero Attempt, which records
+// nothing.
+func (k *resolutionKeys) attempt(key, purpose string) identification.Attempt {
+	if k == nil {
+		return identification.Attempt{}
+	}
+	return identification.Attempt{
+		DB:      k.tel,
+		RunID:   k.runID,
+		KeyID:   k.ids[key],
+		Purpose: purpose,
+	}
+}
+
 // resolutionOutcome names what became of a resolution that reached the identifier
 // plugins. The three fallback members mirror the messages the resolver already
 // records against a row, so a key's outcome and the row's message cannot disagree.

--- a/server/service/ingestion/resolution_telemetry_test.go
+++ b/server/service/ingestion/resolution_telemetry_test.go
@@ -382,3 +382,70 @@ func TestExtractionNotAttemptedWithoutPlugins(t *testing.T) {
 		t.Errorf("outcome = %q, want %q", outcomes["item-1"], db.TelemetryExtractionNotAttemptedNoPlugins)
 	}
 }
+
+// TestMismatchCheckProbesAreTheirOwnAttempts pins the two calls the issue names.
+// When extraction returns both a MIC_TICKER and an OPENFIGI_SHARE_CLASS the
+// resolver resolves each separately to see whether they agree; both are real
+// resolutions against real plugins, and until now both were made with a nil
+// counter and were invisible. Naming them mismatch_check is also what stops them
+// inflating the denominator of a failure rate over primary attempts.
+func TestMismatchCheckProbesAreTheirOwnAttempts(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	database := mock.NewMockDB(ctrl)
+	database.EXPECT().LookupOperatingMIC(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, mic string) (string, error) { return mic, nil }).AnyTimes()
+	tel := mock.NewMockTelemetryDB(ctrl)
+	spy := newKeySpy(t, tel)
+
+	var attempts []db.TelemetryIdentificationAttempt
+	tel.EXPECT().WriteIdentificationAttempt(gomock.Any(), gomock.Any()).
+		DoAndReturn(func(_ context.Context, a db.TelemetryIdentificationAttempt) string {
+			attempts = append(attempts, a)
+			return "attempt"
+		}).AnyTimes()
+
+	const source, desc = "IBKR:test:statement", "APPLE INC COM"
+	// Both hints already resolve to the same instrument, so every call short
+	// circuits in the database and no plugin is involved.
+	database.EXPECT().FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "AAPL").
+		Return("inst-1", "STOCK", "XNAS", "USD", nil).AnyTimes()
+	database.EXPECT().FindInstrumentWithMetaByIdentifier(gomock.Any(), "OPENFIGI_SHARE_CLASS", "", "BBG000B9XRY4").
+		Return("inst-1", "STOCK", "XNAS", "USD", nil).AnyTimes()
+
+	ctx := context.Background()
+	txs := []*apiv1.Tx{tx(desc)}
+	keys := newResolutionKeys(ctx, tel, "run-1", source, txs, make([][]identifier.Identifier, 1), nil)
+	extracted := map[string][]identifier.Identifier{
+		cacheKey(source, desc): {
+			{Type: "MIC_TICKER", Value: "AAPL"},
+			{Type: "OPENFIGI_SHARE_CLASS", Value: "BBG000B9XRY4"},
+		},
+	}
+
+	if _, err := Resolve(ctx, database, identifier.NewRegistry(), "IBKR", source, desc,
+		identifier.Hints{}, nil, nil, 0, nil, extracted, nil, keys); err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	if len(attempts) != 3 {
+		t.Fatalf("wrote %d attempts, want 3 -- two probes and the resolution", len(attempts))
+	}
+	byPurpose := map[string]int{}
+	for _, a := range attempts {
+		byPurpose[a.Purpose]++
+	}
+	if byPurpose[db.TelemetryPurposeMismatchCheck] != 2 {
+		t.Errorf("mismatch_check attempts = %d, want 2", byPurpose[db.TelemetryPurposeMismatchCheck])
+	}
+	if byPurpose[db.TelemetryPurposePrimary] != 1 {
+		t.Errorf("primary attempts = %d, want 1", byPurpose[db.TelemetryPurposePrimary])
+	}
+	// The probes must not stamp the key: the resolution that decides it does.
+	if got := spy.ended[desc]; got.Outcome != db.TelemetryResolutionIdentified {
+		t.Errorf("key outcome = %q, want %q from the primary resolution", got.Outcome, db.TelemetryResolutionIdentified)
+	}
+	if spy.ended[desc].MismatchDetected {
+		t.Error("mismatch_detected set for two hints that agreed")
+	}
+}

--- a/server/service/ingestion/resolve.go
+++ b/server/service/ingestion/resolve.go
@@ -297,7 +297,7 @@ func Resolve(ctx context.Context, database db.DB, registry *identifier.Registry,
 			return r, nil
 		}
 		// No DB hit: call identifier plugins with hints; do not persist (source, description) as BROKER_DESCRIPTION.
-		return resolveWithIdentifierPlugins(ctx, database, registry, broker, source, instrumentDescription, hints, identifierHints, cache, key, rowIndex, counter, false, hintsValidAt, keys)
+		return resolveWithIdentifierPlugins(ctx, database, registry, broker, source, instrumentDescription, hints, identifierHints, cache, key, rowIndex, counter, false, hintsValidAt, keys, db.TelemetryPurposePrimary)
 	}
 
 	// Path B: no client hints -- use pre-extracted description hints, then identifier plugins.
@@ -336,11 +336,13 @@ func Resolve(ctx context.Context, database db.DB, registry *identifier.Registry,
 	tickerHints := hintsByType(extractedHints, "MIC_TICKER")
 	figiHints := hintsByType(extractedHints, "OPENFIGI_SHARE_CLASS")
 	if len(tickerHints) > 0 && len(figiHints) > 0 {
-		// Resolve with nil cache, nil counter and no key ledger: these two are
-		// probes, so they must not pollute the cache, double-count identify
-		// attempts, or stamp the key before the resolution that decides it.
-		resultByTicker, _ := resolveWithIdentifierPlugins(ctx, database, registry, broker, source, instrumentDescription, hints, tickerHints, nil, key, rowIndex, nil, true, hintsValidAt, nil)
-		resultByFigi, _ := resolveWithIdentifierPlugins(ctx, database, registry, broker, source, instrumentDescription, hints, figiHints, nil, key, rowIndex, nil, true, hintsValidAt, nil)
+		// Resolve with nil cache and nil counter: these two are probes, so they
+		// must not pollute the cache or double-count identify attempts. They do
+		// record an attempt each, named for what they are -- the pair is real work
+		// against real plugins, and calling them mismatch_check is what stops them
+		// inflating the denominator of a failure rate over primary attempts.
+		resultByTicker, _ := resolveWithIdentifierPlugins(ctx, database, registry, broker, source, instrumentDescription, hints, tickerHints, nil, key, rowIndex, nil, true, hintsValidAt, keys, db.TelemetryPurposeMismatchCheck)
+		resultByFigi, _ := resolveWithIdentifierPlugins(ctx, database, registry, broker, source, instrumentDescription, hints, figiHints, nil, key, rowIndex, nil, true, hintsValidAt, keys, db.TelemetryPurposeMismatchCheck)
 		idByTicker := resultByTicker.InstrumentID
 		idByFigi := resultByFigi.InstrumentID
 		// Consider "unresolved" (broker-description-only) as empty for mismatch check
@@ -357,7 +359,7 @@ func Resolve(ctx context.Context, database db.DB, registry *identifier.Registry,
 	}
 
 	// Resolve by (validated) hints; always store (source, description) when ensuring.
-	return resolveWithIdentifierPlugins(ctx, database, registry, broker, source, instrumentDescription, hints, hintsToUse, cache, key, rowIndex, counter, true, hintsValidAt, keys)
+	return resolveWithIdentifierPlugins(ctx, database, registry, broker, source, instrumentDescription, hints, hintsToUse, cache, key, rowIndex, counter, true, hintsValidAt, keys, db.TelemetryPurposePrimary)
 }
 
 // hintDiffsSummary formats hint diffs as a readable string (e.g. "Currency: USD->EUR, ISIN: US037->US038").
@@ -389,7 +391,10 @@ func hintsByType(hints []identifier.Identifier, typ string) []identifier.Identif
 
 // resolveWithIdentifierPlugins delegates to the shared identification package and wraps the result
 // in ingestion-specific resolveResult with cache and error handling.
-func resolveWithIdentifierPlugins(ctx context.Context, database db.DB, registry *identifier.Registry, broker, source, instrumentDescription string, hints identifier.Hints, identifierHints []identifier.Identifier, cache map[string]resolveResult, key string, rowIndex int32, counter telemetry.CounterIncrementer, storeSourceDescription bool, hintsValidAt *time.Time, keys *resolutionKeys) (resolveResult, error) {
+// purpose names the attempt this call records. Only the primary one stamps the
+// key: the mismatch-check probes run against the same key and would otherwise
+// stamp it with their own answer before the resolution that decides it.
+func resolveWithIdentifierPlugins(ctx context.Context, database db.DB, registry *identifier.Registry, broker, source, instrumentDescription string, hints identifier.Hints, identifierHints []identifier.Identifier, cache map[string]resolveResult, key string, rowIndex int32, counter telemetry.CounterIncrementer, storeSourceDescription bool, hintsValidAt *time.Time, keys *resolutionKeys, purpose string) (resolveResult, error) {
 	// Ingestion-specific fallback: broker-description-only instrument.
 	fallback := func(ctx context.Context, database db.DB) (string, error) {
 		return database.EnsureInstrument(ctx, "", "", "", instrumentDescription, "", "",
@@ -397,7 +402,7 @@ func resolveWithIdentifierPlugins(ctx context.Context, database db.DB, registry 
 			"", nil, nil, nil)
 	}
 
-	result, err := identification.ResolveWithPlugins(ctx, database, registry, broker, source, instrumentDescription, hints, identifierHints, storeSourceDescription, fallback, counter, ingestionLogger(), 0, hintsValidAt)
+	result, err := identification.ResolveWithPlugins(ctx, database, registry, broker, source, instrumentDescription, hints, identifierHints, storeSourceDescription, fallback, counter, keys.attempt(key, purpose), ingestionLogger(), 0, hintsValidAt)
 	if err != nil {
 		return resolveResult{}, err
 	}
@@ -423,6 +428,8 @@ func resolveWithIdentifierPlugins(ctx context.Context, database db.DB, registry 
 	if cache != nil {
 		cache[key] = r
 	}
-	keys.end(ctx, key, resolutionOutcome(result), r.InstrumentID)
+	if purpose == db.TelemetryPurposePrimary {
+		keys.end(ctx, key, resolutionOutcome(result), r.InstrumentID)
+	}
 	return r, nil
 }


### PR DESCRIPTION
Last of three PRs for issue 0116. **Depends on #452** (which depends on #451) and is
based on its branch. Closes 0116.

One `identification_attempt` per `ResolveWithPlugins` call. `purpose` and `depth` make
the several a single resolution key produces tellable apart: one `primary`, two for the
MIC_TICKER against OPENFIGI_SHARE_CLASS mismatch check -- made until now with a nil
counter, and invisible -- and one per level of underlying recursion. Naming the probes
`mismatch_check` also keeps them out of the denominator of a failure rate over primary
attempts.

`db_short_circuit` and `no_eligible_plugins` are outcomes rather than absences because
both mean no plugin was called. Counting them among the attempts that reached one makes
identification look like it is improving as the instrument table fills.

One `identifier_plugin_call` per invocation. `won`, `superseded` and
`discarded_inconsistent` are decided in the merge loop and captured there rather than
recomputed -- `consistentWith` logs a warning per mismatch, so asking it twice would say
it twice. Everything else is the plugin's own transport outcome, passed through.

`retries` and `duration_ms` come back from `callPluginWithRetry`, because the retry loop
and the clock belong to the resolver.

An attempt whose database read errored writes no row: `outcome` is not nullable and
there is no member for a unit of work that did not complete. The run's outcome is where
that failure shows.

Verified with `make check` and `make server-test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)