### PR TITLE
Add a Grafana container reading the telemetry schema (0117)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,8 @@ build: $(STAMP_DIR)/generate
 google-finance-cli: $(STAMP_DIR)/generate
 	$(COMPOSE_TOOLS) sh -c 'CGO_ENABLED=0 go build -o bin/google-finance-cli ./cli/google'
 
-# Full stack (Postgres 5432, Redis 6379, portfoliodb, Envoy, client SPA) for local dev. SPA at localhost:8080.
+# Full stack (Postgres 5432, Redis 6379, portfoliodb, Envoy, client SPA, Grafana) for local dev.
+# SPA at localhost:8080, telemetry dashboards at localhost:3000.
 # Uses dev override: source mounts, host UID/GID, Air + next dev for live-reload.
 run: $(STAMP_DIR)/generate
 	HOST_UID=$$(id -u) HOST_GID=$$(id -g) $(COMPOSE_DEV) up -d --build
@@ -230,7 +231,7 @@ help:
 	@echo "  make generate           Run protobuf + mock codegen (auto-skipped if up-to-date)"
 	@echo ""
 	@echo "Development:"
-	@echo "  make run                Start dev stack (Postgres, Redis, gRPC, Envoy, Next.js)"
+	@echo "  make run                Start dev stack (Postgres, Redis, gRPC, Envoy, Next.js, Grafana)"
 	@echo "  make logs               Tail portfoliodb service logs"
 	@echo "  make stop               Stop dev stack"
 	@echo "  make build              Build server binary"

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ make run
 
 The gRPC server listens on `localhost:50051` behind Envoy on `http://localhost:8080` for gRPC-Web.
 
+Grafana serves the telemetry dashboards on `http://localhost:3000`, bound to loopback only. Sign in with **GRAFANA_ADMIN_USER** / **GRAFANA_ADMIN_PASSWORD** (`admin` / `portfoliodb` unless set in `.env`). Its datasource reads the `telemetry` schema through a SELECT-only login named by **TELEMETRY_READER_USER** / **TELEMETRY_READER_PASSWORD** (both `telemetry` by default).
+
+That login is created by `docker/postgres/init/10-telemetry-reader.sh`, which the Postgres entrypoint runs only on an empty data directory. The dev stack keeps its database across `make stop` / `make run`, so a stack that predates Grafana needs `make clean-docker` (or `docker volume rm portfoliodb-dev_postgres_data`) once before the datasource can connect.
+
 **GOOGLE_OAUTH_CLIENT_ID** is required for Auth (server uses it to verify Google ID tokens). Create a **OAuth 2.0 Client ID** (Web application) in [Google Cloud Console](https://console.cloud.google.com/apis/credentials).
 
 **DB_INITIALISE_SCRIPT** (optional) — Path to a SQL file run against the database after Postgres is up, when you use `make run`. Set it in `.env` (e.g. `DB_INITIALISE_SCRIPT=local/dev-init.sql`). Use it to load seed data, create test users, or run one-off migrations. If unset or the file is missing, the step is skipped. 

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -15,6 +15,13 @@ services:
   postgres:
     volumes:
       - postgres_data:/var/lib/postgresql/data
+      # Creates the login Grafana reads telemetry with. Runs only on an empty
+      # data directory, and postgres_data above outlives make stop, so an
+      # existing stack needs `make clean-docker` once before it fires.
+      - ./postgres/init:/docker-entrypoint-initdb.d:ro
+    environment:
+      TELEMETRY_READER_USER: ${TELEMETRY_READER_USER:-telemetry}
+      TELEMETRY_READER_PASSWORD: ${TELEMETRY_READER_PASSWORD:-telemetry}
     cpus: 2
     mem_limit: 2g
     memswap_limit: 2g
@@ -91,5 +98,41 @@ services:
     memswap_limit: 4g
     pids_limit: 512
 
+  # Reads the telemetry schema through the SELECT-only login, with its datasource
+  # and dashboards provisioned from docker/grafana. Nothing here is configured in
+  # the browser: a dashboard edited there cannot be saved.
+  grafana:
+    image: grafana/grafana:11.6.0
+    depends_on:
+      postgres:
+        condition: service_healthy
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
+      # Not 'admin', which Grafana treats as unset and prompts to change on first
+      # login, which a provisioned dev container should not need to do.
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:-portfoliodb}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      # A dev container should not phone home.
+      GF_ANALYTICS_REPORTING_ENABLED: "false"
+      GF_ANALYTICS_CHECK_FOR_UPDATES: "false"
+      # Read by provisioning/datasources/telemetry.yaml, which is what keeps the
+      # password out of a file in the repository.
+      TELEMETRY_READER_USER: ${TELEMETRY_READER_USER:-telemetry}
+      TELEMETRY_READER_PASSWORD: ${TELEMETRY_READER_PASSWORD:-telemetry}
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/etc/grafana/dashboards:ro
+      - grafana_data:/var/lib/grafana
+    # Loopback only, unlike every other service here. Those publish on all
+    # interfaces so a phone on the LAN can reach the SPA; this one reads the
+    # whole telemetry schema and has no reason to leave the machine.
+    ports:
+      - "127.0.0.1:3000:3000"
+    cpus: 1
+    mem_limit: 512m
+    memswap_limit: 512m
+    pids_limit: 256
+
 volumes:
   postgres_data:
+  grafana_data:

--- a/docker/grafana/provisioning/access-control/.gitkeep
+++ b/docker/grafana/provisioning/access-control/.gitkeep
@@ -1,0 +1,3 @@
+Grafana reads every subdirectory of its provisioning path and logs an error for
+each one missing. This mount shadows the image's own provisioning directory, so
+the ones we provision nothing into have to exist anyway, empty.

--- a/docker/grafana/provisioning/alerting/empty.yaml
+++ b/docker/grafana/provisioning/alerting/empty.yaml
@@ -1,0 +1,5 @@
+# Nothing is provisioned here. The directory has to exist because this mount
+# shadows the image's own provisioning directory and Grafana logs an error for
+# each subdirectory it cannot read, and the file has to be .yaml because the
+# alerting provisioner warns about any other suffix it finds.
+apiVersion: 1

--- a/docker/grafana/provisioning/dashboards/dashboards.yaml
+++ b/docker/grafana/provisioning/dashboards/dashboards.yaml
@@ -1,0 +1,17 @@
+# Dashboards are files in the repository and nothing else. allowUiUpdates is
+# false so a panel edited in the browser cannot be saved: the change would live
+# in the container volume and drift from the repository silently. To change a
+# panel, edit it in the UI, export the JSON and commit it.
+apiVersion: 1
+
+providers:
+  - name: portfoliodb
+    folder: PortfolioDB
+    type: file
+    allowUiUpdates: false
+    updateIntervalSeconds: 10
+    options:
+      # Outside /var/lib/grafana, which is a named volume; a bind mount beneath
+      # it would be shadowed.
+      path: /etc/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/docker/grafana/provisioning/datasources/telemetry.yaml
+++ b/docker/grafana/provisioning/datasources/telemetry.yaml
@@ -1,0 +1,27 @@
+# The telemetry schema, read as the SELECT-only login created by
+# docker/postgres/init/10-telemetry-reader.sh.
+#
+# Grafana expands ${VAR} in a provisioning file from its own environment, which
+# is what lets the credentials come from compose while this file stays in the
+# repository. The uid is fixed because the dashboards reference it by uid: a
+# generated one would change on every fresh volume and orphan every panel.
+apiVersion: 1
+
+datasources:
+  - name: Telemetry
+    uid: portfoliodb-telemetry
+    type: postgres
+    url: postgres:5432
+    user: ${TELEMETRY_READER_USER}
+    isDefault: true
+    editable: false
+    jsonData:
+      database: portfoliodb
+      sslmode: disable
+      postgresVersion: 1600
+      # The telemetry tables are plain tables, not hypertables, even though the
+      # image carries the extension. Claiming otherwise here makes Grafana emit
+      # time_bucket() against tables that have no such index.
+      timescaledb: false
+    secureJsonData:
+      password: ${TELEMETRY_READER_PASSWORD}

--- a/docker/grafana/provisioning/plugins/.gitkeep
+++ b/docker/grafana/provisioning/plugins/.gitkeep
@@ -1,0 +1,3 @@
+Grafana reads every subdirectory of its provisioning path and logs an error for
+each one missing. This mount shadows the image's own provisioning directory, so
+the ones we provision nothing into have to exist anyway, empty.

--- a/docker/postgres/init/10-telemetry-reader.sh
+++ b/docker/postgres/init/10-telemetry-reader.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# Create the login role Grafana reads the telemetry schema with.
+#
+# The privileges live on telemetry_reader, a NOLOGIN group role, and are granted
+# by server/migrations/005_telemetry.sql where they can be reviewed in the
+# repository. Only the login and its password come from here, which is what keeps
+# a password out of a file in the repository.
+#
+# The ordering is the subtle part. This runs from /docker-entrypoint-initdb.d,
+# which fires on an empty data directory, before the service has ever connected
+# and so before the migration has run. telemetry_reader therefore does not exist
+# yet and this script has to create it; the migration guards its own CREATE ROLE
+# on pg_roles, finds this one and only adds the grants. Do not "fix" the apparent
+# duplication by deleting either half. No guard is needed here because the
+# cluster is empty by definition, and the test and e2e stacks, which mount
+# nothing, take the role from the migration alone.
+#
+# Note that initdb only runs on an empty data directory while the dev stack keeps
+# postgres_data across make stop / make run, so an existing stack needs
+# `make clean-docker` once before this script has ever fired.
+set -e
+
+psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --dbname "$POSTGRES_DB" \
+	-v reader="$TELEMETRY_READER_USER" -v password="$TELEMETRY_READER_PASSWORD" <<'SQL'
+CREATE ROLE telemetry_reader NOLOGIN;
+CREATE ROLE :"reader" LOGIN PASSWORD :'password';
+GRANT telemetry_reader TO :"reader";
+SQL

--- a/docs/layout.md
+++ b/docs/layout.md
@@ -139,3 +139,7 @@ Go code for the PortfolioDB command line tools.
 
 - **docker/**
   Docker Compose files (dev, test, e2e), Envoy configs, and per-component Dockerfiles in `docker/server/` and `docker/client/`.
+- **docker/grafana/**
+  Grafana's provisioned datasource and dashboard provider under `provisioning/`, and the dashboard JSON under `dashboards/`. Both are mounted read only; a dashboard edited in the browser cannot be saved, so these files are the only source.
+- **docker/postgres/init/**
+  Scripts run by the Postgres entrypoint on an empty data directory. Creates the login Grafana reads the telemetry schema with; the privileges themselves are granted by `server/migrations/005_telemetry.sql`.

--- a/docs/spec/telemetry.md
+++ b/docs/spec/telemetry.md
@@ -225,11 +225,32 @@ a separate scope rather than a later change to the same one.
 
 The reading role's password is not in the migration, which rules out the migration
 creating the login the dashboard uses. So the migration creates `telemetry_reader`, a
-NOLOGIN group role holding SELECT and nothing else, and the login role is created at
-container init from compose environment and granted membership of it. The privileges are
-then reviewed in the repository and the password never is.
+NOLOGIN group role holding SELECT and nothing else, and the login role is created by
+`docker/postgres/init/10-telemetry-reader.sh` from compose environment and granted
+membership of it. The privileges are then reviewed in the repository and the password
+never is.
 
-## 2. Logger
+That script runs from the Postgres entrypoint, on an empty data directory, before the
+service has connected and so before the migration has run. It therefore creates
+`telemetry_reader` itself; the migration guards its own `CREATE ROLE` on `pg_roles` and
+adds only the grants. The apparent duplication is what the ordering costs. The test and
+e2e stacks mount no init script and take the role from the migration alone, which is why
+the privilege test needs no login to run against.
+
+## 2. Dashboards
+
+Grafana runs as a container in the dev stack, bound to loopback, with its datasource and
+its dashboards provisioned from files under `docker/grafana`. Dashboards are read only in
+the browser: an edit saved there would live in the container volume and drift from the
+repository unnoticed.
+
+There are two, over the same tables. One is scoped by a run picker, for reading a single
+import during manual testing; the other buckets over time, for drift. Panels select from
+the views and carry no definitions of their own -- `where is_import and reached_plugins`,
+never a repeated list of excluded outcomes. A judgement a panel needs and the views do not
+carry is a gap in the views.
+
+## 3. Logger
 
 ### Overview
 


### PR DESCRIPTION
First of four for 0117. This is the container and its plumbing; the dashboards
themselves come in a later PR, so `docker/grafana/dashboards/` lands empty.

## What is here

- **Grafana in the dev overlay only.** The base compose file is shared with the
  e2e stack, so the service, the postgres init mount and the `grafana_data`
  volume all go in `docker-compose.dev.yml`. It carries the same cap set as the
  other small services, and binds `127.0.0.1:3000` -- the only service here that
  does not publish on every interface, since it reads the whole telemetry schema.
- **The reading login.** `docker/postgres/init/10-telemetry-reader.sh` creates
  it from compose environment and grants it membership of `telemetry_reader`,
  which is what `005_telemetry.sql` and the spec always said would happen.
- **Provisioning.** The datasource reads its credentials from `${VAR}`, so the
  password stays out of the repo. Dashboards are `allowUiUpdates: false`.

## The ordering, since it looks like duplication

initdb runs on an empty data directory, before the service has connected and so
before the migration has run. `telemetry_reader` does not exist yet, so the init
script creates it; the migration's existing `pg_roles` guard then finds it and
adds only the grants. Neither half is redundant. The test and e2e stacks mount
no init script and take the role from the migration alone, which is why
`TestTelemetryReaderRoleIsSelectOnly` needs no change.

**Upgrade note:** initdb only fires on an empty data directory and the dev stack
keeps `postgres_data` across `make stop`, so an existing stack needs
`make clean-docker` once before the datasource can connect. Documented in the
README and in a compose comment.

## Verified

Brought the same compose files up under a throwaway project name, so no existing
dev database was touched:

- init script ran; `telemetry` and `telemetry_reader` both exist
- `005_telemetry.sql` applied cleanly over the pre-created role -- the guard
  cooperates rather than conflicting
- as the reader: `select` on `telemetry.v_run` succeeds, `insert` into
  `telemetry.run` is refused
- Grafana starts with an empty error/warn log, `/api/health` reports
  `database: ok`, and the datasource health check returns
  `Database Connection OK` -- i.e. it really is connecting as that login
- port maps to `127.0.0.1` only; unauthenticated API request returns 401;
  `allow_sign_up`, `reporting_enabled` and `check_for_updates` all false
- base, e2e and test stacks still validate and still have no `grafana` service

The three empty `provisioning/` subdirectories are not noise: the mount shadows
the image's own provisioning directory, and Grafana logs an error for each
subdirectory it cannot read. `alerting/` needs a `.yaml` rather than a
`.gitkeep` because its provisioner warns about any other suffix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)