### PR TITLE
Carry the dashboards' judgements in the telemetry views (0117)

### DIFF
--- a/docs/spec/telemetry.md
+++ b/docs/spec/telemetry.md
@@ -170,11 +170,18 @@ One view per table, each flattening its parents in and never fanning out into it
 children -- a view spanning two sibling grains duplicates the parent's rows and makes
 counting it silently wrong.
 
-Judgements are computed columns on the view; selection belongs to the panel. At least:
+Judgements are computed columns on the view; selection belongs to the panel. A judgement
+a panel needs and no view carries is a gap in the views, not a licence to inline an
+outcome list into a dashboard. They are:
 
-- `is_import` -- the run kind is one of the three import kinds.
-- `reached_plugins` -- the attempt outcome is neither `db_short_circuit` nor
-  `no_eligible_plugins`.
+| column | on | meaning |
+| --- | --- | --- |
+| `is_import` | every view | the run kind is one of the three import kinds |
+| `reached_plugins` | attempt, identifier call | the attempt outcome is neither `db_short_circuit` nor `no_eligible_plugins` |
+| `resolved` (`key_resolved` on children) | key, attempt, identifier call | the key ended holding a real identifier |
+| `had_attempt` | key | the key produced at least one identification attempt |
+| `transport_failed` | identifier call | the call did not complete |
+| `call_failed` | description call | the call produced no answer |
 
 `reached_plugins` is the denominator for identification failure rate. Using all attempts
 instead makes the rate fall as the instrument table fills, because more resolutions
@@ -182,6 +189,65 @@ short-circuit in the database, which reads as improving identification when noth
 changed. A failure-rate panel filters `purpose = 'primary'` as well, or an import
 carrying more dual-hint descriptions inflates the denominator with mismatch-check
 attempts.
+
+`resolved` covers `db_source_description`, `db_identifier_hints` and `identified`, and
+deliberately excludes `broker_description_only`: nothing identified that instrument and
+the row's own contents are all it was built from, which is a failure for a transaction
+import however ordinary it looks. It is the expected outcome for an archive run, so a
+panel charting the complement splits by run kind rather than blending the two. A null
+outcome counts as not resolved rather than as null, or an unstamped key would drop out of
+both the column and its negation. `instrument_id IS NOT NULL` is not the same test and is
+not a substitute: an archive key ensured from a supplied identifier has an instrument and
+identified nothing.
+
+`had_attempt` separates a key that never asked from one that asked and was told nothing.
+Four of the five paths that stamp a key return before `ResolveWithPlugins` is called, so
+no attempt is ordinary rather than a fault.
+
+`transport_failed` and `call_failed` both draw the line at the call completing.
+`not_identified` and `no_hints` stay outside them: an empty answer is an answer, and
+counting it as a fault makes a plugin that correctly knew nothing read as a plugin that
+is down.
+
+`v_run` also carries `key_count`, `key_tx_count` and `description_call_count`. These are
+scalar subqueries, one per child table, and they are the only sanctioned way for a view
+to reach into a second child. The rule above forbids a view *fanning out* into two
+sibling grains, because that repeats the parent once per child and makes counting it
+wrong; an aggregate repeats nothing and `v_run` stays one row per run. A panel wanting
+per-run child counts uses these and never a join.
+
+`key_tx_count` is transactions that needed resolution, not rows in the imported file: a
+row naming no instrument never becomes a key. It is the closest thing to an import's size
+the schema holds, and it is the denominator every rate over resolution keys wants. A
+transaction count on `run` itself is deliberately not recorded -- it would mean postings
+for one import kind, heterogeneous rows processed for another, nothing for the third and
+null for every cycle, which is a column meaning a different thing per row and the grain
+confusion this schema exists to end. The imported file's own row count is not available
+at all: `run.job_id` is not a foreign key and `ingestion_jobs` is outside the reading
+role, both by design.
+
+### Naming an instrument
+
+A resolution key records `instrument_id` and nothing readable, which leaves no panel able
+to say which instrument a description landed on -- the question asked after every manual
+import, since a description resolving to the wrong listing looks identical to it
+resolving to the right one in a bare UUID.
+
+Recording a label when the key is stamped was rejected: the readable instrument is two
+frames below the write site and deliberately discarded, and three of the five paths that
+stamp a key never hold one, so the column would be null exactly where identification was
+most interesting.
+
+So `telemetry.v_instrument_label` is a lookup instead. A view runs with its owner's
+privileges rather than its caller's, so granting SELECT on it lets the reading role turn
+an id into a name while still holding no privilege on `instruments` and no USAGE on
+`public`. That indirection is the point: one narrow window, reviewed in the migration,
+rather than a grant on the application schema. It is the only place the telemetry schema
+reads outside itself.
+
+It is a live lookup and not a recorded fact -- an instrument renamed today changes what a
+panel says about a run from last year -- which is why it is a separate view and is joined
+by a panel rather than folded into the views above.
 
 ### Writing
 

--- a/server/db/postgres/telemetry_schema_test.go
+++ b/server/db/postgres/telemetry_schema_test.go
@@ -246,6 +246,7 @@ func TestTelemetryReaderRoleIsSelectOnly(t *testing.T) {
 		"telemetry.v_identification_attempt",
 		"telemetry.v_identifier_plugin_call",
 		"telemetry.v_description_plugin_call",
+		"telemetry.v_instrument_label",
 	} {
 		var canSelect, canInsert, canUpdate, canDelete bool
 		err := p.q.QueryRowContext(ctx, `
@@ -321,4 +322,308 @@ func TestTelemetryVocabulariesAreClosed(t *testing.T) {
 			t.Error("identifier plugin call accepted an outcome outside its vocabulary")
 		}
 	})
+}
+
+// seedKeyWithOutcome inserts a resolution key carrying a given stage 2 outcome,
+// which may be empty for a key whose run died before it resolved.
+func seedKeyWithOutcome(t *testing.T, p *Postgres, runID, outcome string, txCount int) string {
+	t.Helper()
+	var oc any
+	if outcome != "" {
+		oc = outcome
+	}
+	var id string
+	err := p.q.QueryRowContext(context.Background(), `
+		INSERT INTO telemetry.resolution_key
+			(run_id, source, description, tx_count, had_identifier_hints, outcome)
+		VALUES ($1::uuid, 'FIDELITY_CSV', 'APPLE INC COM', $2, FALSE, $3)
+		RETURNING id
+	`, runID, txCount, oc).Scan(&id)
+	if err != nil {
+		t.Fatalf("seed key with outcome %q: %v", outcome, err)
+	}
+	return id
+}
+
+// seedIdentifierCall inserts an identifier plugin call under an attempt.
+func seedIdentifierCall(t *testing.T, p *Postgres, attemptID, outcome string) string {
+	t.Helper()
+	var id string
+	err := p.q.QueryRowContext(context.Background(), `
+		INSERT INTO telemetry.identifier_plugin_call
+			(identification_attempt_id, plugin_id, outcome, retries, duration_ms)
+		VALUES ($1::uuid, 'openfigi', $2, 0, 12)
+		RETURNING id
+	`, attemptID, outcome).Scan(&id)
+	if err != nil {
+		t.Fatalf("seed identifier call %q: %v", outcome, err)
+	}
+	return id
+}
+
+// seedDescriptionCall inserts a description plugin call under a run.
+func seedDescriptionCall(t *testing.T, p *Postgres, runID, outcome string) string {
+	t.Helper()
+	var id string
+	err := p.q.QueryRowContext(context.Background(), `
+		INSERT INTO telemetry.description_plugin_call
+			(run_id, plugin_id, batch_size, items_with_hints, outcome, duration_ms)
+		VALUES ($1::uuid, 'openai', 10, 4, $2, 900)
+		RETURNING id
+	`, runID, outcome).Scan(&id)
+	if err != nil {
+		t.Fatalf("seed description call %q: %v", outcome, err)
+	}
+	return id
+}
+
+// TestTelemetryViews_Resolved pins which key outcomes count as having ended with
+// an identifier. broker_description_only is the member worth staring at: an
+// instrument exists, so instrument_id is not null, and nothing identified it.
+// A panel listing what went wrong in an import has to include it, which is why
+// this judgement cannot be replaced by a null check on instrument_id.
+func TestTelemetryViews_Resolved(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	runID := seedRun(t, p, "tx_import", time.Now())
+
+	cases := []struct {
+		outcome  string
+		resolved bool
+	}{
+		{"db_source_description", true},
+		{"db_identifier_hints", true},
+		{"identified", true},
+		{"broker_description_only", false},
+		{"extraction_failed", false},
+		{"plugin_timeout", false},
+		{"plugin_unavailable", false},
+		{"conflicting_hints", false},
+		// Never stamped: the run died before the key resolved. Not resolved, and
+		// not null either, or the row would drop out of both this column and its
+		// negation and go unnoticed by every panel.
+		{"", false},
+	}
+	for _, c := range cases {
+		name := c.outcome
+		if name == "" {
+			name = "not_stamped"
+		}
+		t.Run(name, func(t *testing.T) {
+			id := seedKeyWithOutcome(t, p, runID, c.outcome, 1)
+			var got bool
+			if err := p.q.QueryRowContext(ctx,
+				`SELECT resolved FROM telemetry.v_resolution_key WHERE id = $1::uuid`, id,
+			).Scan(&got); err != nil {
+				t.Fatalf("select v_resolution_key: %v", err)
+			}
+			if got != c.resolved {
+				t.Errorf("resolved for %q = %v, want %v", c.outcome, got, c.resolved)
+			}
+		})
+	}
+}
+
+// TestTelemetryViews_HadAttempt separates a key that never asked a plugin
+// anything from one that asked and was told nothing. Four of the five paths that
+// stamp a key return before identification is reached, so no attempt is ordinary
+// rather than a fault, and the two are the first thing to tell apart in a key
+// that did not resolve.
+func TestTelemetryViews_HadAttempt(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	runID := seedRun(t, p, "tx_import", time.Now())
+
+	without := seedKeyWithOutcome(t, p, runID, "db_source_description", 1)
+	with := seedKeyWithOutcome(t, p, runID, "identified", 1)
+	seedAttempt(t, p, with, "primary", "identified", 0)
+
+	for _, c := range []struct {
+		name string
+		id   string
+		want bool
+	}{
+		{"no attempt", without, false},
+		{"one attempt", with, true},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			var got bool
+			if err := p.q.QueryRowContext(ctx,
+				`SELECT had_attempt FROM telemetry.v_resolution_key WHERE id = $1::uuid`, c.id,
+			).Scan(&got); err != nil {
+				t.Fatalf("select v_resolution_key: %v", err)
+			}
+			if got != c.want {
+				t.Errorf("had_attempt = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestTelemetryViews_TransportFailed pins the line between the API breaking and
+// the API not knowing. not_identified is a completed call with an empty answer
+// and must stay out of it, or a plugin that works and finds nothing reads as a
+// plugin that is down.
+func TestTelemetryViews_TransportFailed(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	runID := seedRun(t, p, "tx_import", time.Now())
+	keyID := seedResolutionKey(t, p, runID)
+	attemptID := seedAttempt(t, p, keyID, "primary", "identified", 0)
+
+	cases := []struct {
+		outcome string
+		failed  bool
+	}{
+		{"won", false},
+		{"superseded", false},
+		{"discarded_inconsistent", false},
+		{"not_identified", false},
+		{"skipped_expired", false},
+		{"rate_limited", true},
+		{"timeout", true},
+		{"error", true},
+	}
+	for _, c := range cases {
+		t.Run(c.outcome, func(t *testing.T) {
+			id := seedIdentifierCall(t, p, attemptID, c.outcome)
+			var got bool
+			if err := p.q.QueryRowContext(ctx,
+				`SELECT transport_failed FROM telemetry.v_identifier_plugin_call WHERE id = $1::uuid`, id,
+			).Scan(&got); err != nil {
+				t.Fatalf("select v_identifier_plugin_call: %v", err)
+			}
+			if got != c.failed {
+				t.Errorf("transport_failed for %s = %v, want %v", c.outcome, got, c.failed)
+			}
+		})
+	}
+}
+
+// TestTelemetryViews_CallFailed keeps no_hints out of the failure bucket. A
+// description plugin that ran, answered, and had nothing to offer is not broken,
+// and counting it as broken would bury the calls that genuinely were.
+func TestTelemetryViews_CallFailed(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	runID := seedRun(t, p, "tx_import", time.Now())
+
+	cases := []struct {
+		outcome string
+		failed  bool
+	}{
+		{"hints_returned", false},
+		{"no_hints", false},
+		{"error", true},
+		{"rate_limited", true},
+		{"quota_exceeded", true},
+		{"model_not_found", true},
+	}
+	for _, c := range cases {
+		t.Run(c.outcome, func(t *testing.T) {
+			id := seedDescriptionCall(t, p, runID, c.outcome)
+			var got bool
+			if err := p.q.QueryRowContext(ctx,
+				`SELECT call_failed FROM telemetry.v_description_plugin_call WHERE id = $1::uuid`, id,
+			).Scan(&got); err != nil {
+				t.Fatalf("select v_description_plugin_call: %v", err)
+			}
+			if got != c.failed {
+				t.Errorf("call_failed for %s = %v, want %v", c.outcome, got, c.failed)
+			}
+		})
+	}
+}
+
+// TestTelemetryViews_RunRollupsDoNotMultiply is the test a JOIN would fail. The
+// run below has two resolution keys and two description plugin calls, which are
+// sibling grains: joining v_run to both would produce four rows and report each
+// count as twice what it is. The rollups are scalar subqueries for that reason,
+// and the seeded attempts are here so that a join through the key side would be
+// wrong by a second factor as well.
+func TestTelemetryViews_RunRollupsDoNotMultiply(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	runID := seedRun(t, p, "tx_import", time.Now())
+
+	first := seedKeyWithOutcome(t, p, runID, "identified", 3)
+	seedKeyWithOutcome(t, p, runID, "broker_description_only", 5)
+	seedAttempt(t, p, first, "primary", "identified", 0)
+	seedAttempt(t, p, first, "mismatch_check", "identified", 0)
+	seedDescriptionCall(t, p, runID, "hints_returned")
+	seedDescriptionCall(t, p, runID, "no_hints")
+
+	var rows, keyCount, keyTxCount, descCount int
+	err := p.q.QueryRowContext(ctx, `
+		SELECT count(*), max(key_count), max(key_tx_count), max(description_call_count)
+		FROM telemetry.v_run WHERE id = $1::uuid
+	`, runID).Scan(&rows, &keyCount, &keyTxCount, &descCount)
+	if err != nil {
+		t.Fatalf("select v_run: %v", err)
+	}
+	if rows != 1 {
+		t.Errorf("v_run rows = %d, want 1", rows)
+	}
+	if keyCount != 2 {
+		t.Errorf("key_count = %d, want 2", keyCount)
+	}
+	// The fan-out the keys carry, not the number of keys: 3 + 5.
+	if keyTxCount != 8 {
+		t.Errorf("key_tx_count = %d, want 8", keyTxCount)
+	}
+	if descCount != 2 {
+		t.Errorf("description_call_count = %d, want 2", descCount)
+	}
+}
+
+// TestTelemetryViews_RunRollupsAreZeroNotNull keeps a quiet run readable. A cycle
+// that found no work still opens a run, and a panel dividing by its key count
+// should see 0 rather than a null that silently drops the row.
+func TestTelemetryViews_RunRollupsAreZeroNotNull(t *testing.T) {
+	p := testDBTx(t)
+	runID := seedRun(t, p, "grouping_cycle", time.Now())
+
+	var keyCount, keyTxCount, descCount int
+	err := p.q.QueryRowContext(context.Background(), `
+		SELECT key_count, key_tx_count, description_call_count
+		FROM telemetry.v_run WHERE id = $1::uuid
+	`, runID).Scan(&keyCount, &keyTxCount, &descCount)
+	if err != nil {
+		t.Fatalf("select v_run: %v", err)
+	}
+	if keyCount != 0 || keyTxCount != 0 || descCount != 0 {
+		t.Errorf("rollups for an empty run = (%d, %d, %d), want all 0",
+			keyCount, keyTxCount, descCount)
+	}
+}
+
+// TestTelemetryReaderReadsLabelsWithoutReachingPublic pins the one place the
+// telemetry schema reads outside itself, and the mechanism that makes it safe.
+// A view runs with its owner's privileges, so the reading role can turn an
+// instrument id into a name through telemetry.v_instrument_label while holding
+// no privilege on instruments itself. If that ever stops being true, the fix is
+// not to grant on instruments.
+//
+// SET LOCAL ROLE rather than a second connection: the reader is a NOLOGIN group
+// role, and the transaction is rolled back, so the role reverts with it.
+func TestTelemetryReaderReadsLabelsWithoutReachingPublic(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+
+	if _, err := p.q.ExecContext(ctx, `SET LOCAL ROLE telemetry_reader`); err != nil {
+		t.Fatalf("set role: %v", err)
+	}
+
+	var n int
+	if err := p.q.QueryRowContext(ctx,
+		`SELECT count(*) FROM telemetry.v_instrument_label`,
+	).Scan(&n); err != nil {
+		t.Fatalf("telemetry_reader cannot read v_instrument_label: %v", err)
+	}
+
+	if err := p.q.QueryRowContext(ctx,
+		`SELECT count(*) FROM instruments`,
+	).Scan(&n); err == nil {
+		t.Error("telemetry_reader can read instruments directly; the view indirection is not what is granting access")
+	}
 }

--- a/server/migrations/005_telemetry.sql
+++ b/server/migrations/005_telemetry.sql
@@ -244,7 +244,23 @@ SELECT
   r.kind IN ('tx_import', 'user_archive_import', 'system_archive_import') AS is_import,
   -- Null while the run is in flight, and null for a run stamped incomplete: the
   -- sweep knows the process died but not when, so there is no end to measure to.
-  (EXTRACT(EPOCH FROM (r.ended_at - r.started_at)) * 1000)::BIGINT AS duration_ms
+  (EXTRACT(EPOCH FROM (r.ended_at - r.started_at)) * 1000)::BIGINT AS duration_ms,
+  -- How big was this run. Scalar subqueries, one per child table, because a join
+  -- to two sibling grains would multiply both counts -- the failure the one view
+  -- per table rule exists to prevent. An aggregate is not that failure: it
+  -- duplicates no row, and v_run stays one row per run. Anything reaching into a
+  -- second child must be written this way, never as a second JOIN.
+  (SELECT count(*) FROM telemetry.resolution_key k
+     WHERE k.run_id = r.id) AS key_count,
+  -- Transactions that needed resolution, not rows in the imported file: a row
+  -- naming no instrument never becomes a key. This is the denominator every rate
+  -- over resolution keys wants, and the closest thing to an import's size that
+  -- the schema records -- ingestion_jobs is out of the reading role's reach by
+  -- design, so the file's own row count is not available here.
+  (SELECT coalesce(sum(k.tx_count), 0) FROM telemetry.resolution_key k
+     WHERE k.run_id = r.id) AS key_tx_count,
+  (SELECT count(*) FROM telemetry.description_plugin_call c
+     WHERE c.run_id = r.id) AS description_call_count
 FROM telemetry.run r;
 
 CREATE VIEW telemetry.v_resolution_key AS
@@ -261,6 +277,30 @@ SELECT
   k.outcome,
   k.mismatch_detected,
   k.instrument_id,
+  -- The key ended holding a real identifier, from wherever it came.
+  --
+  -- broker_description_only is deliberately outside it: nothing identified the
+  -- instrument and the row's own contents are all it was built from, which is a
+  -- failure for a transaction import however ordinary it looks. It is also the
+  -- expected outcome for an archive run, which is why a panel charting the
+  -- complement of this column splits by run kind rather than blending the two --
+  -- an archive sits at its own high level and drifts against itself.
+  --
+  -- instrument_id IS NOT NULL is not the same test and must not be substituted:
+  -- an archive key ensured from a supplied identifier has an instrument and
+  -- identified nothing. A key whose outcome was never stamped is not resolved
+  -- either, hence the explicit null handling rather than a bare IN, which would
+  -- yield null and drop the row out of both this column and its negation.
+  k.outcome IS NOT NULL AND k.outcome IN ('db_source_description',
+                                          'db_identifier_hints',
+                                          'identified') AS resolved,
+  -- Whether identification was reached at all. Four of the five paths that stamp
+  -- a key return before ResolveWithPlugins is called, so no attempt is the normal
+  -- case rather than a fault, and telling "never asked" from "asked and failed"
+  -- is the first question about a key that did not resolve. EXISTS rather than a
+  -- join: this view stays one row per key.
+  EXISTS (SELECT 1 FROM telemetry.identification_attempt a
+            WHERE a.resolution_key_id = k.id) AS had_attempt,
   r.kind       AS run_kind,
   r.job_id     AS run_job_id,
   r.user_id    AS run_user_id,
@@ -294,6 +334,9 @@ SELECT
   k.description AS key_description,
   k.tx_count    AS key_tx_count,
   k.outcome     AS key_outcome,
+  k.outcome IS NOT NULL AND k.outcome IN ('db_source_description',
+                                          'db_identifier_hints',
+                                          'identified') AS key_resolved,
   k.mismatch_detected AS key_mismatch_detected,
   r.id         AS run_id,
   r.kind       AS run_kind,
@@ -317,6 +360,12 @@ SELECT
   c.outcome,
   c.retries,
   c.duration_ms,
+  -- The call did not complete. Distinct from not_identified, which is the call
+  -- completing and the answer being no, and from the three orchestrator-decided
+  -- successes above it. The API breaking and the API not knowing are different
+  -- events with different fixes, and a panel counting plugin failures means this
+  -- one. skipped_expired is outside it: nothing was called.
+  c.outcome IN ('rate_limited', 'timeout', 'error') AS transport_failed,
   a.purpose      AS attempt_purpose,
   a.depth        AS attempt_depth,
   a.outcome      AS attempt_outcome,
@@ -329,6 +378,9 @@ SELECT
   k.description AS key_description,
   k.tx_count    AS key_tx_count,
   k.outcome     AS key_outcome,
+  k.outcome IS NOT NULL AND k.outcome IN ('db_source_description',
+                                          'db_identifier_hints',
+                                          'identified') AS key_resolved,
   r.id         AS run_id,
   r.kind       AS run_kind,
   r.job_id     AS run_job_id,
@@ -352,6 +404,11 @@ SELECT
   c.batch_size,
   c.items_with_hints,
   c.outcome,
+  -- The call did not produce an answer. no_hints is deliberately outside it: an
+  -- empty answer is an answer, and counting it as a fault would make a plugin
+  -- that correctly recognised it knew nothing look broken.
+  c.outcome IN ('error', 'rate_limited', 'quota_exceeded',
+                'model_not_found') AS call_failed,
   c.prompt_tokens,
   c.completion_tokens,
   c.total_tokens,
@@ -367,6 +424,41 @@ SELECT
   r.kind IN ('tx_import', 'user_archive_import', 'system_archive_import') AS is_import
 FROM telemetry.description_plugin_call c
 JOIN telemetry.run r ON r.id = c.run_id;
+
+-- The one thing here that reads outside the telemetry schema.
+--
+-- A resolution key records instrument_id and nothing readable, so no panel can
+-- say which instrument a description landed on -- which is the question asked
+-- after every manual import, because "APPLE INC COM" resolving to the wrong
+-- listing looks identical to it resolving to the right one in a bare UUID.
+--
+-- Recording a label at write time was rejected: the readable instrument is two
+-- frames below the write site and deliberately discarded, and three of the five
+-- paths that stamp a key never hold one at all, so the column would be null
+-- exactly where identification was most interesting.
+--
+-- So the lookup lives here instead. A view runs with its owner's privileges, not
+-- its caller's, so granting SELECT on this view lets the reading role resolve a
+-- UUID to a name while still holding no USAGE on public and no privilege on
+-- instruments. That is the point of the indirection: one narrow window, reviewed
+-- in this file, rather than a grant on the application schema.
+--
+-- It is a live lookup and not a recorded fact. An instrument renamed today
+-- changes what a panel says about a run from last year. That is the right
+-- trade for a label -- the recorded facts are the outcome columns, and they do
+-- not move -- but it is why nothing here is joined into the views above.
+--
+-- instruments.name is already the readable form: a trigger keeps it at the
+-- preferred identifier, ticker first, falling back through OCC and the broker
+-- description to the id itself. See 001_initial.sql.
+CREATE VIEW telemetry.v_instrument_label AS
+SELECT
+  i.id,
+  i.name        AS label,
+  i.exchange,
+  i.asset_class,
+  i.currency
+FROM instruments i;
 
 -- The reading role.
 --


### PR DESCRIPTION
Second of four for 0117. **Stacked on #454** -- review that first; this PR
targets its branch.

No Go outside tests: the whole change is `005_telemetry.sql` and what pins it.

## Why this is here and not deferred

0117 says panels select from the views and carry no definitions of their own.
Designing the panels turned that into a test of the views, and five judgements
failed it -- each one a panel that could only be written by retyping an outcome
list into a dashboard, where nobody reviews it.

## The judgements

| column | meaning | the member worth arguing about |
|---|---|---|
| `resolved` / `key_resolved` | the key ended holding a real identifier | `broker_description_only` is **excluded** |
| `had_attempt` | the key produced any identification attempt | -- |
| `transport_failed` | an identifier call did not complete | `not_identified` is **excluded** |
| `call_failed` | a description call produced no answer | `no_hints` is **excluded** |

`broker_description_only` is the one to check: an instrument exists, so
`instrument_id` is not null, and nothing identified it. That makes
`instrument_id IS NOT NULL` a different test, not a cheaper spelling of this
one. It is also the *expected* outcome for an archive run, which is why the
drift panel splits by run kind instead of blending. A null outcome counts as
not resolved rather than as null, or an unstamped key falls out of both the
column and its negation and no panel ever shows it.

## Rollups on `v_run`

`key_count`, `key_tx_count`, `description_call_count`. "How big was this run"
needs two sibling child grains, and a join to both repeats the run once per
child and reports each count as a multiple of itself. These are scalar
subqueries, which repeat nothing.

`TestTelemetryViews_RunRollupsDoNotMultiply` seeds exactly the shape a join gets
wrong -- two keys, two description calls, and attempts under one of the keys so
a join through the key side would be wrong by a second factor.

This is not a reversal of adr/0053. That rule forbids a view *fanning out*; an
aggregate duplicates no row and `v_run` stays one row per run. The spec now
states the distinction, since the next person adding a panel will need it.

## `v_instrument_label`, and why the grant is not widened

A resolution key records a bare UUID, so no panel can say whether "APPLE INC
COM" landed on the right listing -- which is the question after every manual
import.

Recording a label at write time was rejected on inspection: the readable
instrument is two frames below the write site and deliberately discarded on
return, and three of the five paths that stamp a key never hold one, so the
column would be null exactly where identification was most interesting.

So it is a lookup. A view runs with its **owner's** privileges, so SELECT on
this view lets the reader resolve a name while holding nothing on `instruments`
and no USAGE on `public`. `TestTelemetryReaderReadsLabelsWithoutReachingPublic`
pins both halves with `SET LOCAL ROLE` -- reading through the view succeeds,
reading `instruments` directly fails. If that ever inverts, the fix is not to
grant on `instruments`.

It is a live lookup, not a recorded fact: renaming an instrument changes what a
panel says about an old run. That is the right trade for a label, and it is why
it stays a separate view joined by a panel rather than folded into the others.

## Refused, with the reason recorded

A transaction count on `run`. It would mean postings for `tx_import`,
heterogeneous rows-processed for `user_archive_import`, nothing for
`system_archive_import` and null for all five cycles -- a column meaning a
different thing per row, which is the grain confusion this schema exists to
end. `key_tx_count` gives the denominator the panels actually wanted:
transactions that needed resolution. The imported file's own row count stays
unavailable, since `run.job_id` is not a foreign key and `ingestion_jobs` is
outside the reading role, both by design.

## Verified

`make db-test`: 0 failures. New coverage walks every member of all four
vocabularies, so a member added to a CHECK later cannot fall silently into the
wrong bucket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)