### PR TITLE
Record which description plugin ran first (0120)

### DIFF
--- a/docs/issues/0120-description-plugin-call-precedence.md
+++ b/docs/issues/0120-description-plugin-call-precedence.md
@@ -1,0 +1,16 @@
+---
+status: open
+title: Record which description plugin ran first
+milestone: M20
+dependencies: [0116]
+---
+
+Description plugins run in precedence order and each sees only the items its
+predecessors failed on, which is why `batch_size` is a different population per plugin
+and their hit rates are not comparable. Nothing records that order, so the chain cannot
+be reconstructed from the rows and a panel can only guess it from batch size.
+
+Record the plugin's precedence rather than a loop index: a plugin whose filtered batch is
+empty writes no row at all, so an index would not be the ordinal of the rows that exist.
+A gap in the sequence then means that plugin was skipped, which is how a filtered-out
+identifier plugin already reads.

--- a/docs/spec/telemetry.md
+++ b/docs/spec/telemetry.md
@@ -152,6 +152,7 @@ One plugin invocation over a batch.
 | column | notes |
 | --- | --- |
 | `run_id`, `plugin_id` | |
+| `precedence` | where this plugin sat in the chain, higher first |
 | `batch_size` | items passed to this plugin, after the type filter |
 | `items_with_hints` | items it returned hints for |
 | `outcome` | `hints_returned`, `no_hints`, `error`, `rate_limited`, `quota_exceeded`, `model_not_found` |
@@ -163,6 +164,13 @@ predecessors failed on, so `batch_size` is a different population per plugin and
 are not comparable between them. Identifier plugins run in parallel and every eligible
 plugin is called, so those rates are comparable. Tokens are columns rather than running
 totals, which is what makes the cost of one import answerable.
+
+`precedence` is what makes that narrowing readable: without it the order the batches
+shrank in cannot be recovered from the rows, and `batch_size` descending is only a guess
+at it, arbitrary the moment two plugins are handed equal batches. It is the plugin's
+configured precedence rather than an ordinal of the rows written, because a plugin whose
+filtered batch is empty writes no row at all -- so a gap in the sequence means that
+plugin was skipped, which is how a filtered-out identifier plugin already reads.
 
 ### Views
 

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -2146,10 +2146,12 @@ type TelemetryTokens struct {
 //
 // BatchSize is a different population per plugin -- description plugins run in
 // precedence order and each sees only the items its predecessors failed on -- so
-// rates are not comparable between them.
+// rates are not comparable between them. Precedence is what makes that order
+// readable afterwards, higher first.
 type TelemetryDescriptionPluginCall struct {
 	RunID          string
 	PluginID       string
+	Precedence     int
 	BatchSize      int
 	ItemsWithHints int
 	Outcome        string

--- a/server/db/postgres/telemetry.go
+++ b/server/db/postgres/telemetry.go
@@ -201,10 +201,10 @@ func (t *Telemetry) WriteDescriptionPluginCall(ctx context.Context, c db.Telemet
 	}
 	if _, err := t.db.ExecContext(ctx, `
 		INSERT INTO telemetry.description_plugin_call
-			(run_id, plugin_id, batch_size, items_with_hints, outcome,
+			(run_id, plugin_id, precedence, batch_size, items_with_hints, outcome,
 			 prompt_tokens, completion_tokens, total_tokens, duration_ms)
-		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
-	`, runID, c.PluginID, c.BatchSize, c.ItemsWithHints, c.Outcome,
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+	`, runID, c.PluginID, c.Precedence, c.BatchSize, c.ItemsWithHints, c.Outcome,
 		prompt, completion, total, ms(c.Duration)); err != nil {
 		t.fail(ctx, c.RunID, "write description plugin call", err)
 	}

--- a/server/db/postgres/telemetry_schema_test.go
+++ b/server/db/postgres/telemetry_schema_test.go
@@ -188,8 +188,8 @@ func TestTelemetryRetentionCascades(t *testing.T) {
 	}
 	if _, err := p.q.ExecContext(ctx, `
 		INSERT INTO telemetry.description_plugin_call
-			(run_id, plugin_id, batch_size, items_with_hints, outcome, duration_ms)
-		VALUES ($1::uuid, 'openai', 20, 18, 'hints_returned', 900)
+			(run_id, plugin_id, precedence, batch_size, items_with_hints, outcome, duration_ms)
+		VALUES ($1::uuid, 'openai', 100, 20, 18, 'hints_returned', 900)
 	`, oldRun); err != nil {
 		t.Fatalf("seed description plugin call: %v", err)
 	}
@@ -367,8 +367,8 @@ func seedDescriptionCall(t *testing.T, p *Postgres, runID, outcome string) strin
 	var id string
 	err := p.q.QueryRowContext(context.Background(), `
 		INSERT INTO telemetry.description_plugin_call
-			(run_id, plugin_id, batch_size, items_with_hints, outcome, duration_ms)
-		VALUES ($1::uuid, 'openai', 10, 4, $2, 900)
+			(run_id, plugin_id, precedence, batch_size, items_with_hints, outcome, duration_ms)
+		VALUES ($1::uuid, 'openai', 100, 10, 4, $2, 900)
 		RETURNING id
 	`, runID, outcome).Scan(&id)
 	if err != nil {

--- a/server/db/postgres/telemetry_test.go
+++ b/server/db/postgres/telemetry_test.go
@@ -390,3 +390,72 @@ func TestPurgeRunsBefore(t *testing.T) {
 		}
 	}
 }
+
+// TestWriteDescriptionPluginCallPrecedence pins the order the chain ran in
+// surviving the write. Without it the rows carry batch sizes whose populations
+// cannot be put back in sequence, and batch_size descending is only a guess at
+// it -- two plugins handed equal batches order arbitrarily.
+func TestWriteDescriptionPluginCallPrecedence(t *testing.T) {
+	tel := testTelemetry(t)
+	ctx := context.Background()
+	runID := tel.StartRun(ctx, db.TelemetryRun{Kind: db.TelemetryRunTxImport})
+
+	// The narrowing a chain produces: the second plugin sees only what the first
+	// failed on. Both are written with the precedence they ran at.
+	tel.WriteDescriptionPluginCall(ctx, db.TelemetryDescriptionPluginCall{
+		RunID:          runID,
+		PluginID:       "cash",
+		Precedence:     100,
+		BatchSize:      40,
+		ItemsWithHints: 28,
+		Outcome:        "hints_returned",
+		Duration:       time.Millisecond,
+	})
+	tel.WriteDescriptionPluginCall(ctx, db.TelemetryDescriptionPluginCall{
+		RunID:          runID,
+		PluginID:       "openai",
+		Precedence:     50,
+		BatchSize:      12,
+		ItemsWithHints: 9,
+		Outcome:        "hints_returned",
+		Duration:       time.Second,
+	})
+
+	rows, err := tel.db.Query(`
+		SELECT plugin_id, precedence, batch_size
+		FROM telemetry.v_description_plugin_call
+		WHERE run_id = $1::uuid
+		ORDER BY precedence DESC
+	`, runID)
+	if err != nil {
+		t.Fatalf("read v_description_plugin_call: %v", err)
+	}
+	defer rows.Close()
+
+	type call struct {
+		plugin     string
+		precedence int
+		batchSize  int
+	}
+	var got []call
+	for rows.Next() {
+		var c call
+		if err := rows.Scan(&c.plugin, &c.precedence, &c.batchSize); err != nil {
+			t.Fatalf("scan: %v", err)
+		}
+		got = append(got, c)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows: %v", err)
+	}
+
+	want := []call{{"cash", 100, 40}, {"openai", 50, 12}}
+	if len(got) != len(want) {
+		t.Fatalf("rows = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("row %d = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+}

--- a/server/migrations/005_telemetry.sql
+++ b/server/migrations/005_telemetry.sql
@@ -195,6 +195,16 @@ CREATE TABLE telemetry.description_plugin_call (
   id        UUID PRIMARY KEY DEFAULT gen_random_uuid(),
   run_id    UUID NOT NULL REFERENCES telemetry.run (id) ON DELETE CASCADE,
   plugin_id TEXT NOT NULL,
+  -- Where this plugin sat in the chain, higher first. This is what makes the
+  -- population differences above readable: without it the order the batches
+  -- narrowed in cannot be recovered from the rows, and batch_size is only a
+  -- guess at it.
+  --
+  -- The plugin's configured precedence rather than a loop index, because a
+  -- plugin whose filtered batch is empty writes no row at all. A gap in the
+  -- sequence therefore means that plugin was skipped, which is how a
+  -- filtered-out identifier plugin already reads.
+  precedence INT NOT NULL,
   -- Items passed to this plugin, after the type filter.
   batch_size       INT NOT NULL,
   -- Items it returned hints for.
@@ -401,6 +411,7 @@ SELECT
   c.id,
   c.run_id,
   c.plugin_id,
+  c.precedence,
   c.batch_size,
   c.items_with_hints,
   c.outcome,

--- a/server/service/ingestion/resolution_telemetry_test.go
+++ b/server/service/ingestion/resolution_telemetry_test.go
@@ -287,7 +287,7 @@ func TestDescriptionPluginCallRows(t *testing.T) {
 			descRegistry.Register("fake", tc.plugin)
 			database.EXPECT().
 				ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryDescription).
-				Return([]db.PluginConfigRow{{PluginID: "fake", Precedence: 1}}, nil)
+				Return([]db.PluginConfigRow{{PluginID: "fake", Precedence: 70}}, nil)
 
 			var got db.TelemetryDescriptionPluginCall
 			tel.EXPECT().WriteDescriptionPluginCall(gomock.Any(), gomock.Any()).
@@ -304,6 +304,12 @@ func TestDescriptionPluginCallRows(t *testing.T) {
 			}
 			if got.BatchSize != 1 {
 				t.Errorf("batch_size = %d, want 1", got.BatchSize)
+			}
+			// The plugin's configured precedence, which is what puts the chain
+			// back in order: batch_size cannot, since two plugins handed equal
+			// batches would sort arbitrarily.
+			if got.Precedence != 70 {
+				t.Errorf("precedence = %d, want 70", got.Precedence)
 			}
 			if got.Outcome != tc.wantOut {
 				t.Errorf("outcome = %q, want %q", got.Outcome, tc.wantOut)

--- a/server/service/ingestion/resolve.go
+++ b/server/service/ingestion/resolve.go
@@ -191,12 +191,13 @@ func runDescriptionPluginsBatch(ctx context.Context, deps ingestDeps, broker, so
 		started := time.Now()
 		res, err := p.ExtractBatch(ctx, c.Config, broker, source, filtered)
 		call := db.TelemetryDescriptionPluginCall{
-			RunID:     deps.RunID,
-			PluginID:  c.PluginID,
-			BatchSize: len(filtered),
-			Outcome:   string(res.Telemetry.Outcome),
-			Tokens:    descriptionTokens(res.Telemetry.Tokens),
-			Duration:  time.Since(started),
+			RunID:      deps.RunID,
+			PluginID:   c.PluginID,
+			Precedence: c.Precedence,
+			BatchSize:  len(filtered),
+			Outcome:    string(res.Telemetry.Outcome),
+			Tokens:     descriptionTokens(res.Telemetry.Tokens),
+			Duration:   time.Since(started),
 		}
 		if err != nil {
 			// A plugin that returned an error without saying how it went is not


### PR DESCRIPTION
Third of four in the 0117 stack. **Stacked on #455**, which is stacked on #454.

Opens issue 0120, because this changes what 0116 emits rather than what 0117
reads. It sits in the stack because the run dashboard's description-plugin panel
needs it.

## The problem

Description plugins run in precedence order and each sees only the items its
predecessors failed on. That is why `batch_size` is a different population per
plugin and their hit rates are not comparable -- a fact the schema already
documents. But nothing recorded the order, so the narrowing ("plugin 1 saw 40,
failed on 12; plugin 2 saw those 12") could not be reconstructed from the rows.

A panel's only alternative is `ORDER BY batch_size DESC`, which is a guess, and
an arbitrary one as soon as two plugins are handed equal batches.

## Precedence, not an ordinal

The plugin's configured precedence, not the position of the row among those
written. A plugin whose filtered batch is empty `continue`s before any row is
written, so an ordinal would silently renumber around it and claim a plugin ran
first that never ran at all.

Recording precedence instead means a gap in the sequence carries information:
that plugin was skipped. This is exactly how a filtered-out identifier plugin
already reads, where no call row is written because no call was made.

## Cost

`c.Precedence` was already in scope at the composition site --
`ListEnabledPluginConfigs` returns `PluginConfigRow` precedence-descending -- so
this is a column, a struct field, one INSERT column and one assignment.

## Verified

`make server-test` and `make db-test`, both green.

`TestWriteDescriptionPluginCallPrecedence` writes the shape a real chain
produces (a 40-item batch at precedence 100, then the 12 survivors at 50) and
reads it back through the view ordered by precedence, so the round trip and the
ordering are both pinned. The composition-site test now asserts the configured
precedence reaches the row rather than a default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)