### PR TITLE
Add the run and drift telemetry dashboards (0117)

### DIFF
--- a/docker/grafana/dashboards/drift.json
+++ b/docker/grafana/dashboards/drift.json
@@ -1,0 +1,1187 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "description": "The same tables bucketed over time, for noticing that something changed.",
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "type": "row",
+      "title": "Runs",
+      "collapsed": false,
+      "id": 1,
+      "panels": [],
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      }
+    },
+    {
+      "type": "text",
+      "title": "How to read this dashboard",
+      "datasource": null,
+      "options": {
+        "mode": "markdown",
+        "content": "Every panel reads one view and selects on judgements defined once in\n`server/migrations/005_telemetry.sql`. Child views carry no timestamp of their own, so\ntheir time axis is `run_started_at` -- the run's start -- and never `started_at`, which\nexists only on `v_run`.\n\nThe import-scoped panels filter `is_import` and honour the **Broker** picker; the run\npanels do not, because a price fetch cycle dying matters as much as an import doing so.\nNever join two child grains under one run: use `v_run`'s rollups."
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2
+    },
+    {
+      "type": "timeseries",
+      "title": "Runs by outcome",
+      "description": "All run kinds, deliberately: this is the 'is anything dying' panel. 'incomplete' is a run whose process died, stamped by the sweep at startup -- under the dev stack's pinned memswap_limit that is a diagnosis rather than an edge case.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  $__timeGroupAlias(started_at,$__interval),\n  coalesce(outcome, 'in flight') AS metric,\n  count(*) AS value\nFROM telemetry.v_run\nWHERE $__timeFilter(started_at)\nGROUP BY 1, 2\nORDER BY 1",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "bars",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "never",
+            "pointSize": 5,
+            "barAlignment": 0,
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "axisColorMode": "text",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "none",
+          "mappings": [],
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 6
+      },
+      "id": 3
+    },
+    {
+      "type": "timeseries",
+      "title": "Run duration by kind",
+      "description": "The IS NOT NULL is load-bearing and must not be tidied away. A run stamped incomplete has no ended_at, so it has no duration; letting it through drops it out of the average as a null, which reads as imports getting faster at exactly the moment one died. A quiet cycle and a large import share this panel, so expect the scales to differ by orders of magnitude.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  $__timeGroupAlias(started_at,$__interval),\n  kind AS metric,\n  round(avg(duration_ms)) AS value\nFROM telemetry.v_run\nWHERE $__timeFilter(started_at)\n  AND duration_ms IS NOT NULL\nGROUP BY 1, 2\nORDER BY 1",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "never",
+            "pointSize": 5,
+            "barAlignment": 0,
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "axisColorMode": "text",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "ms",
+          "mappings": [],
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 6
+      },
+      "id": 4
+    },
+    {
+      "type": "stat",
+      "title": "Runs with lost telemetry",
+      "description": "A telemetry write failed, so these runs' counts understate by an unknown amount. Unrelated to the 'incomplete' outcome: the work may have succeeded while its telemetry was lost. Read this before believing any other panel here.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT count(*) AS \"runs with lost telemetry\"\nFROM telemetry.v_run\nWHERE $__timeFilter(started_at)\n  AND telemetry_incomplete",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "text": {}
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 4,
+        "x": 0,
+        "y": 14
+      },
+      "id": 5
+    },
+    {
+      "type": "table",
+      "title": "Runs to look at",
+      "description": "IS DISTINCT FROM rather than <>, so a run with a null outcome -- in flight, or stuck -- is included rather than silently dropped. The run_id links through to the single-run dashboard.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  started_at,\n  kind,\n  broker,\n  source,\n  coalesce(outcome, 'in flight') AS outcome,\n  duration_ms,\n  telemetry_incomplete,\n  key_count,\n  key_tx_count,\n  id AS run_id\nFROM telemetry.v_run\nWHERE $__timeFilter(started_at)\n  AND (outcome IS DISTINCT FROM 'success' OR telemetry_incomplete)\nORDER BY started_at DESC\nLIMIT 100",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "fields": ""
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "duration_ms"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ms"
+              },
+              {
+                "id": "noValue",
+                "value": "n/a"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "run_id"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Open this run",
+                    "url": "/d/telemetry-run/telemetry-one-run?var-run=${__value.raw}&var-scope=all"
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 20,
+        "x": 4,
+        "y": 14
+      },
+      "id": 6
+    },
+    {
+      "type": "row",
+      "title": "Resolution",
+      "collapsed": false,
+      "id": 7,
+      "panels": [],
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 22
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Key outcome mix",
+      "description": "Stacked to 100%, because for drift the mix is the signal and the volume is not. Which path is carrying an import -- a stored (source, description), supplied hints, or a plugin -- is the thing that moves when a broker changes its export.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  $__timeGroupAlias(run_started_at,$__interval),\n  coalesce(outcome, '(not stamped)') AS metric,\n  count(*) AS value\nFROM telemetry.v_resolution_key\nWHERE $__timeFilter(run_started_at)\n  AND is_import\n  AND run_broker IN (${broker:sqlstring})\nGROUP BY 1, 2\nORDER BY 1",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "bars",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "never",
+            "pointSize": 5,
+            "barAlignment": 0,
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "axisColorMode": "text",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "percent"
+            }
+          },
+          "unit": "short",
+          "mappings": [],
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
+      "id": 8
+    },
+    {
+      "type": "timeseries",
+      "title": "Keys that did not resolve, by run kind",
+      "description": "Split by run kind rather than blended, because broker_description_only is a failure for a transaction import and the expected outcome for an archive. Blending them puts the archive's normal level into the transaction line and makes both unreadable; split, each drifts against itself.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  $__timeGroupAlias(run_started_at,$__interval),\n  run_kind AS metric,\n  count(*) FILTER (WHERE NOT resolved)::numeric / nullif(count(*), 0) AS value\nFROM telemetry.v_resolution_key\nWHERE $__timeFilter(run_started_at)\n  AND is_import\n  AND run_broker IN (${broker:sqlstring})\nGROUP BY 1, 2\nORDER BY 1",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "never",
+            "pointSize": 5,
+            "barAlignment": 0,
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "axisColorMode": "text",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "percentunit",
+          "mappings": [],
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "decimals": 1,
+          "max": 1,
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 23
+      },
+      "id": 9
+    },
+    {
+      "type": "row",
+      "title": "Identification",
+      "collapsed": false,
+      "id": 10,
+      "panels": [],
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Primary identification failure rate",
+      "description": "Not a duplicate of the panel above it, and the two are expected to diverge. That one is key-grain and improves as the instrument table fills, because more keys short-circuit in the database. This one is attempt-grain over attempts that actually reached a plugin, and does not move when the database gets fuller. The gap between the lines is the diagnostic, and is the whole reason reached_plugins exists.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  $__timeGroupAlias(run_started_at,$__interval),\n  count(*) FILTER (WHERE outcome <> 'identified')::numeric\n    / nullif(count(*), 0) AS \"primary failure rate\"\nFROM telemetry.v_identification_attempt\nWHERE $__timeFilter(run_started_at)\n  AND is_import\n  AND reached_plugins\n  AND purpose = 'primary'\n  AND run_broker IN (${broker:sqlstring})\nGROUP BY 1\nORDER BY 1",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "never",
+            "pointSize": 5,
+            "barAlignment": 0,
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "axisColorMode": "text",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "percentunit",
+          "mappings": [],
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "decimals": 1,
+          "max": 1,
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 11
+    },
+    {
+      "type": "timeseries",
+      "title": "Identifier plugin latency",
+      "description": "Comparable between plugins: identifier plugins run in parallel and every eligible one is called.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  $__timeGroupAlias(run_started_at,$__interval),\n  plugin_id AS metric,\n  round(avg(duration_ms)) AS value\nFROM telemetry.v_identifier_plugin_call\nWHERE $__timeFilter(run_started_at)\n  AND is_import\nGROUP BY 1, 2\nORDER BY 1",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "never",
+            "pointSize": 5,
+            "barAlignment": 0,
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "axisColorMode": "text",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "ms",
+          "mappings": [],
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 12
+    },
+    {
+      "type": "timeseries",
+      "title": "Identifier plugin transport failures",
+      "description": "Calls that did not complete -- rate limited, timed out, errored. Deliberately not not_identified, which is a completed call whose answer was no: the API being down and the API not knowing need different fixes. All run kinds, since a plugin failing in a worker cycle is the same problem.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  $__timeGroupAlias(run_started_at,$__interval),\n  plugin_id AS metric,\n  count(*) FILTER (WHERE transport_failed) AS value\nFROM telemetry.v_identifier_plugin_call\nWHERE $__timeFilter(run_started_at)\nGROUP BY 1, 2\nORDER BY 1",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "bars",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "never",
+            "pointSize": 5,
+            "barAlignment": 0,
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "axisColorMode": "text",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "none",
+          "mappings": [],
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 40
+      },
+      "id": 13
+    },
+    {
+      "type": "row",
+      "title": "Description extraction",
+      "collapsed": false,
+      "id": 14,
+      "panels": [],
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 48
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Hint yield per description plugin",
+      "description": "Not stacked, and it must stay that way. Each line is one plugin against its own past, which is valid. Two lines at the same instant are not comparable: description plugins run in precedence order and each sees only the items its predecessors failed on, so every line has a different denominator.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  $__timeGroupAlias(run_started_at,$__interval),\n  plugin_id AS metric,\n  sum(items_with_hints)::numeric / nullif(sum(batch_size), 0) AS value\nFROM telemetry.v_description_plugin_call\nWHERE $__timeFilter(run_started_at)\n  AND is_import\n  AND run_broker IN (${broker:sqlstring})\nGROUP BY 1, 2\nORDER BY 1",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "never",
+            "pointSize": 5,
+            "barAlignment": 0,
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "axisColorMode": "text",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "percentunit",
+          "mappings": [],
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "decimals": 1,
+          "max": 1,
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 49
+      },
+      "id": 15
+    },
+    {
+      "type": "timeseries",
+      "title": "Description plugin call failures",
+      "description": "call_failed excludes no_hints, which is an answer rather than a fault. Plugin and outcome are concatenated into the series name only because failures are rare enough for the legend to stay short; if that stops being true, split the panel. All run kinds: a quota_exceeded in a worker cycle is the same problem.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  $__timeGroupAlias(run_started_at,$__interval),\n  plugin_id || ' / ' || outcome AS metric,\n  count(*) AS value\nFROM telemetry.v_description_plugin_call\nWHERE $__timeFilter(run_started_at)\n  AND call_failed\nGROUP BY 1, 2\nORDER BY 1",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "bars",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "never",
+            "pointSize": 5,
+            "barAlignment": 0,
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "axisColorMode": "text",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "none",
+          "mappings": [],
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 49
+      },
+      "id": 16
+    },
+    {
+      "type": "timeseries",
+      "title": "Tokens",
+      "description": "Stacking is legitimate here, unlike the yield panel: one grain, an additive quantity, no cross-population rate. Plugins with no token cost write null and contribute nothing rather than a zero.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  $__timeGroupAlias(run_started_at,$__interval),\n  plugin_id AS metric,\n  sum(total_tokens) AS value\nFROM telemetry.v_description_plugin_call\nWHERE $__timeFilter(run_started_at)\nGROUP BY 1, 2\nORDER BY 1",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "bars",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "never",
+            "pointSize": 5,
+            "barAlignment": 0,
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "axisColorMode": "text",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "short",
+          "mappings": [],
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 57
+      },
+      "id": 17
+    }
+  ],
+  "preload": false,
+  "refresh": "",
+  "schemaVersion": 41,
+  "tags": [
+    "telemetry",
+    "portfoliodb"
+  ],
+  "templating": {
+    "list": [
+      {
+        "type": "query",
+        "name": "broker",
+        "label": "Broker",
+        "description": "Applied to the import-scoped panels only. A broker changing its export format is the drift these panels exist to catch. A system archive import has no broker and drops out when one is selected, which is correct.",
+        "datasource": {
+          "type": "grafana-postgresql-datasource",
+          "uid": "portfoliodb-telemetry"
+        },
+        "definition": "SELECT DISTINCT broker\nFROM telemetry.v_run\nWHERE is_import AND broker IS NOT NULL AND broker <> ''\nORDER BY 1",
+        "query": {
+          "rawQuery": true,
+          "rawSql": "SELECT DISTINCT broker\nFROM telemetry.v_run\nWHERE is_import AND broker IS NOT NULL AND broker <> ''\nORDER BY 1",
+          "editorMode": "code",
+          "format": "table"
+        },
+        "multi": true,
+        "includeAll": true,
+        "allValue": null,
+        "refresh": 2,
+        "regex": "",
+        "sort": 1,
+        "options": [],
+        "current": {},
+        "hide": 0,
+        "skipUrlSync": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-7d",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Telemetry: drift",
+  "uid": "telemetry-drift",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docker/grafana/dashboards/run.json
+++ b/docker/grafana/dashboards/run.json
@@ -1,0 +1,1098 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "description": "One ingestion job or worker cycle, end to end. For reading a single import during manual testing.",
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "links": [],
+  "panels": [
+    {
+      "type": "row",
+      "title": "Run",
+      "collapsed": false,
+      "id": 1,
+      "panels": [],
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      }
+    },
+    {
+      "type": "text",
+      "title": "How to read this dashboard",
+      "datasource": null,
+      "options": {
+        "mode": "markdown",
+        "content": "Every panel here reads one view, and every judgement it selects on\n(`resolved`, `had_attempt`, `reached_plugins`, `transport_failed`, `call_failed`,\n`is_import`) is a column defined once in `server/migrations/005_telemetry.sql`. Adding a\npanel that spells out a list of outcomes instead means the views are missing a judgement;\nadd it there.\n\nTwo rules the grains impose. **Never join two child grains under one run** -- a run joined\nto both resolution keys and description plugin calls repeats itself once per pair and\nreports both counts as multiples of themselves; `v_run` carries `key_count`,\n`key_tx_count` and `description_call_count` for that reason. **Counts of one grain are\nnever added to counts of another**: a key is not a transaction, an attempt is not a key,\nand `tx_count` is the only fan-out any of them records."
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 1
+      },
+      "id": 2
+    },
+    {
+      "type": "table",
+      "title": "This run",
+      "description": "duration_ms is null both while a run is in flight and for one stamped incomplete: the startup sweep knows the process died but not when, so there is no end to measure to. key_tx_count is transactions that needed resolution, not rows in the file -- a row naming no instrument never becomes a key.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  kind,\n  broker,\n  source,\n  started_at,\n  ended_at,\n  outcome,\n  duration_ms,\n  telemetry_incomplete,\n  key_count,\n  key_tx_count,\n  description_call_count\nFROM telemetry.v_run\nWHERE id = '${run}'::uuid",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "fields": ""
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "duration_ms"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ms"
+              },
+              {
+                "id": "noValue",
+                "value": "n/a (run did not end)"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "telemetry_incomplete"
+            },
+            "properties": [
+              {
+                "id": "mappings",
+                "value": [
+                  {
+                    "type": "value",
+                    "options": {
+                      "true": {
+                        "text": "COUNTS UNDERSTATE",
+                        "color": "red",
+                        "index": 0
+                      },
+                      "false": {
+                        "text": "ok",
+                        "color": "text",
+                        "index": 1
+                      }
+                    }
+                  }
+                ]
+              },
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "color-text"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 7
+      },
+      "id": 3
+    },
+    {
+      "type": "row",
+      "title": "Resolution keys",
+      "collapsed": false,
+      "id": 4,
+      "panels": [],
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 13
+      }
+    },
+    {
+      "type": "table",
+      "title": "Key outcomes",
+      "description": "Both measures, because one key failing 300 transactions and 300 keys failing one each are different bugs and a single count hides which happened. '(not stamped)' is a key whose run died before it resolved.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  coalesce(outcome, '(not stamped)') AS outcome,\n  count(*)      AS keys,\n  sum(tx_count) AS txs\nFROM telemetry.v_resolution_key\nWHERE run_id = '${run}'::uuid\nGROUP BY 1\nORDER BY txs DESC",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "fields": ""
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "txs"
+            },
+            "properties": [
+              {
+                "id": "custom.cellOptions",
+                "value": {
+                  "type": "gauge",
+                  "mode": "gradient"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 0,
+        "y": 14
+      },
+      "id": 5
+    },
+    {
+      "type": "bargauge",
+      "title": "Extraction outcomes",
+      "description": "Whether the paid extraction call was made, and if not which skip fired. Extraction is skipped for a description already resolved in the database and for one whose every posting names an identifier, because it exists to find an identifier.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  coalesce(extraction_outcome, '(not stamped)') AS extraction_outcome,\n  count(*) AS keys\nFROM telemetry.v_resolution_key\nWHERE run_id = '${run}'::uuid\nGROUP BY 1\nORDER BY 2 DESC",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": true
+        },
+        "showUnfilled": true,
+        "valueMode": "color",
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "maxVizHeight": 300,
+        "namePlacement": "auto",
+        "sizing": "auto",
+        "legend": {
+          "showLegend": false
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "color": {
+            "mode": "continuous-BlPu"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 9,
+        "y": 14
+      },
+      "id": 6
+    },
+    {
+      "type": "stat",
+      "title": "Keys with a hint mismatch",
+      "description": "MIC_TICKER and OPENFIGI_SHARE_CLASS resolved differently. These keys resolve successfully via MIC_TICKER, so they never appear in the two tables below and need a tile of their own.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT count(*) AS \"hint mismatches\"\nFROM telemetry.v_resolution_key\nWHERE run_id = '${run}'::uuid\n  AND mismatch_detected",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "text": {}
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 18,
+        "y": 14
+      },
+      "id": 7
+    },
+    {
+      "type": "stat",
+      "title": "Keys that did not resolve",
+      "description": "Counts the table below. broker_description_only is included: an instrument exists but nothing identified it, which is a failure for a transaction import and the expected outcome for an archive.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT count(*) AS \"unresolved keys\"\nFROM telemetry.v_resolution_key\nWHERE run_id = '${run}'::uuid\n  AND NOT resolved",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "text": {}
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 6,
+        "x": 0,
+        "y": 22
+      },
+      "id": 8
+    },
+    {
+      "type": "table",
+      "title": "Keys that did not resolve",
+      "description": "The panel to read after an import. Ordered by fan-out, so the description costing the most transactions is first. had_attempt tells a key that never reached identification from one that asked and was told nothing.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  k.description,\n  k.source,\n  k.tx_count,\n  k.outcome,\n  k.extraction_outcome,\n  k.had_attempt,\n  k.had_identifier_hints,\n  k.security_type_hint,\n  k.instrument_kind,\n  k.mismatch_detected\nFROM telemetry.v_resolution_key k\nWHERE k.run_id = '${run}'::uuid\n  AND NOT k.resolved\nORDER BY k.tx_count DESC, k.description",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "fields": ""
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 26
+      },
+      "id": 9
+    },
+    {
+      "type": "table",
+      "title": "Keys that did resolve, and to what",
+      "description": "A description resolving to the wrong listing looks exactly like one resolving to the right listing in a bare UUID, so this is where that gets checked. The join is to a lookup view, not to a recorded fact: renaming an instrument changes what this says about an old run.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  k.description,\n  k.source,\n  k.tx_count,\n  k.outcome,\n  i.label AS instrument,\n  i.exchange,\n  i.asset_class,\n  i.currency\nFROM telemetry.v_resolution_key k\nLEFT JOIN telemetry.v_instrument_label i ON i.id = k.instrument_id\nWHERE k.run_id = '${run}'::uuid\n  AND k.resolved\nORDER BY k.tx_count DESC, k.description",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "fields": ""
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 35
+      },
+      "id": 10
+    },
+    {
+      "type": "row",
+      "title": "Identification",
+      "collapsed": false,
+      "id": 11,
+      "panels": [],
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 44
+      }
+    },
+    {
+      "type": "stat",
+      "title": "Primary identification failure rate",
+      "description": "Both denominator rules. reached_plugins excludes attempts that short-circuited in the database, which would otherwise make this fall as the instrument table fills and read as improving identification when nothing changed. purpose = 'primary' excludes the mismatch-check and underlying attempts, which an import carrying more dual-hint descriptions would otherwise inflate the denominator with.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  count(*) FILTER (WHERE outcome <> 'identified')::numeric\n    / nullif(count(*), 0) AS \"primary failure rate\"\nFROM telemetry.v_identification_attempt\nWHERE run_id = '${run}'::uuid\n  AND reached_plugins\n  AND purpose = 'primary'",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "text": {}
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.05
+              },
+              {
+                "color": "red",
+                "value": 0.2
+              }
+            ]
+          },
+          "decimals": 1
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 0,
+        "y": 45
+      },
+      "id": 12
+    },
+    {
+      "type": "table",
+      "title": "Attempts by purpose and outcome",
+      "description": "The shape of the run: whether the mismatch check ran, whether underlying recursion fired. One key produces several attempts, so these do not sum to the key count and were never meant to.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  purpose,\n  outcome,\n  count(*) AS attempts\nFROM telemetry.v_identification_attempt\nWHERE run_id = '${run}'::uuid\nGROUP BY 1, 2\nORDER BY 1, 3 DESC",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "fields": ""
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 9,
+        "x": 6,
+        "y": 45
+      },
+      "id": 13
+    },
+    {
+      "type": "barchart",
+      "title": "Identifier plugin calls",
+      "description": "Comparing plugins side by side is valid here and only here: identifier plugins run in parallel and every eligible one is called, so they see the same population. won, superseded and discarded_inconsistent are all successes, decided by the orchestrator after every plugin returned.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  plugin_id,\n  outcome,\n  count(*) AS calls\nFROM telemetry.v_identifier_plugin_call\nWHERE run_id = '${run}'::uuid\nGROUP BY 1, 2\nORDER BY 1, 3 DESC",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "orientation": "auto",
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0,
+        "showValue": "auto",
+        "stacking": "normal",
+        "groupWidth": 0.7,
+        "barWidth": 0.8,
+        "barRadius": 0,
+        "fullHighlight": false,
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "lineWidth": 1,
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 9,
+        "x": 15,
+        "y": 45
+      },
+      "id": 14
+    },
+    {
+      "type": "table",
+      "title": "Identifier plugin latency and retries",
+      "description": "avg and max rather than percentiles: at a handful of calls per run a p95 is noise. failed counts calls that did not complete, which is not the same as calls that completed and found nothing.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  plugin_id,\n  count(*)                             AS calls,\n  count(*) FILTER (WHERE transport_failed) AS failed,\n  round(avg(duration_ms))              AS avg_ms,\n  max(duration_ms)                     AS max_ms,\n  sum(retries)                         AS retries\nFROM telemetry.v_identifier_plugin_call\nWHERE run_id = '${run}'::uuid\nGROUP BY 1\nORDER BY 2 DESC",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "fields": ""
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*_ms"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ms"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 52
+      },
+      "id": 15
+    },
+    {
+      "type": "row",
+      "title": "Description extraction",
+      "collapsed": false,
+      "id": 16,
+      "panels": [],
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 59
+      }
+    },
+    {
+      "type": "table",
+      "title": "Description plugin batches",
+      "description": "In the order the chain ran, highest precedence first. hit_pct is valid down a row and NOT across them: each plugin sees only the items its predecessors failed on, so batch_size is a different population per row -- which is why it sits next to hit_pct. A precedence with no row is a plugin whose filtered batch was empty, so it was never called.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  precedence,\n  plugin_id,\n  outcome,\n  batch_size,\n  items_with_hints,\n  round(100.0 * items_with_hints / nullif(batch_size, 0), 1) AS hit_pct,\n  duration_ms,\n  prompt_tokens,\n  completion_tokens,\n  total_tokens\nFROM telemetry.v_description_plugin_call\nWHERE run_id = '${run}'::uuid\nORDER BY precedence DESC",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "fields": ""
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "hit_pct"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "percent"
+              }
+            ]
+          },
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "duration_ms"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ms"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 18,
+        "x": 0,
+        "y": 60
+      },
+      "id": 17
+    },
+    {
+      "type": "stat",
+      "title": "Tokens this run",
+      "description": "Summing across plugins is fine: one grain, an additive quantity. Plugins with no token cost write null rather than zero and are skipped rather than counted as free.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  sum(prompt_tokens)     AS prompt,\n  sum(completion_tokens) AS completion,\n  sum(total_tokens)      AS total\nFROM telemetry.v_description_plugin_call\nWHERE run_id = '${run}'::uuid",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "text": {}
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 18,
+        "y": 60
+      },
+      "id": 18
+    }
+  ],
+  "preload": false,
+  "refresh": "",
+  "schemaVersion": 41,
+  "tags": [
+    "telemetry",
+    "portfoliodb"
+  ],
+  "templating": {
+    "list": [
+      {
+        "type": "custom",
+        "name": "scope",
+        "label": "Scope",
+        "description": "Which runs the picker offers. 'imports' uses the is_import judgement the views carry; 'all' adds the five worker cycles, which are frequent and usually quiet.",
+        "query": "imports,all",
+        "options": [
+          {
+            "selected": true,
+            "text": "imports",
+            "value": "imports"
+          },
+          {
+            "selected": false,
+            "text": "all",
+            "value": "all"
+          }
+        ],
+        "current": {
+          "selected": true,
+          "text": "imports",
+          "value": "imports"
+        },
+        "multi": false,
+        "includeAll": false,
+        "hide": 0,
+        "skipUrlSync": false
+      },
+      {
+        "type": "query",
+        "name": "run",
+        "label": "Run",
+        "description": "Newest first, so the run you just triggered is the default. The label carries the telemetry_incomplete marker, so a run whose counts understate says so before you read a number off it.",
+        "datasource": {
+          "type": "grafana-postgresql-datasource",
+          "uid": "portfoliodb-telemetry"
+        },
+        "definition": "SELECT\n  to_char(started_at, 'MM-DD HH24:MI') || '  ' || kind\n    || coalesce('  ' || broker, '')\n    || coalesce('  ' || source, '')\n    || '  [' || coalesce(outcome, 'in flight') || ']'\n    || CASE WHEN telemetry_incomplete THEN '  !! TELEMETRY INCOMPLETE' ELSE '' END\n    AS __text,\n  id::text AS __value\nFROM telemetry.v_run\nWHERE '${scope}' = 'all' OR is_import\nORDER BY started_at DESC\nLIMIT 200",
+        "query": {
+          "rawQuery": true,
+          "rawSql": "SELECT\n  to_char(started_at, 'MM-DD HH24:MI') || '  ' || kind\n    || coalesce('  ' || broker, '')\n    || coalesce('  ' || source, '')\n    || '  [' || coalesce(outcome, 'in flight') || ']'\n    || CASE WHEN telemetry_incomplete THEN '  !! TELEMETRY INCOMPLETE' ELSE '' END\n    AS __text,\n  id::text AS __value\nFROM telemetry.v_run\nWHERE '${scope}' = 'all' OR is_import\nORDER BY started_at DESC\nLIMIT 200",
+          "editorMode": "code",
+          "format": "table"
+        },
+        "multi": false,
+        "includeAll": false,
+        "allValue": null,
+        "refresh": 2,
+        "regex": "",
+        "sort": 0,
+        "options": [],
+        "current": {},
+        "hide": 0,
+        "skipUrlSync": false
+      }
+    ]
+  },
+  "time": {
+    "from": "now-24h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Telemetry: one run",
+  "uid": "telemetry-run",
+  "version": 1,
+  "weekStart": ""
+}

--- a/docs/issues/0117-grafana-container.md
+++ b/docs/issues/0117-grafana-container.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Grafana container reading the telemetry schema
 milestone: M20
 dependencies: [0115]

--- a/docs/issues/0120-description-plugin-call-precedence.md
+++ b/docs/issues/0120-description-plugin-call-precedence.md
@@ -1,5 +1,5 @@
 ---
-status: open
+status: closed
 title: Record which description plugin ran first
 milestone: M20
 dependencies: [0116]

--- a/docs/spec/telemetry.md
+++ b/docs/spec/telemetry.md
@@ -318,11 +318,25 @@ its dashboards provisioned from files under `docker/grafana`. Dashboards are rea
 the browser: an edit saved there would live in the container volume and drift from the
 repository unnoticed.
 
-There are two, over the same tables. One is scoped by a run picker, for reading a single
-import during manual testing; the other buckets over time, for drift. Panels select from
-the views and carry no definitions of their own -- `where is_import and reached_plugins`,
-never a repeated list of excluded outcomes. A judgement a panel needs and the views do not
-carry is a gap in the views.
+There are two, over the same tables. **Telemetry: one run** is scoped by a run picker,
+for reading a single import during manual testing; **Telemetry: drift** buckets over
+time, for noticing that something changed. The drift dashboard's run table links each row
+through to the run dashboard, which is what makes the pair a workflow rather than two
+pictures.
+
+Panels select from the views and carry no definitions of their own -- `where is_import
+and reached_plugins`, never a repeated list of excluded outcomes. A judgement a panel
+needs and the views do not carry is a gap in the views.
+
+Two consequences of the grains bind every panel. A view spanning two sibling child grains
+duplicates the parent, so a panel wanting per-run child counts reads `v_run`'s rollups and
+never a join. And a child view has no timestamp of its own, so a panel bucketing one over
+time uses `run_started_at`, the run's start; `started_at` exists only on `v_run`.
+
+The dashboards are SQL in files no compiler reads, so a renamed column would break them
+silently until somebody opened a browser. Every panel query and every template variable
+query is therefore planned against the real schema by a test in the database layer, which
+also refuses a panel that reads a table instead of a view.
 
 ## 3. Logger
 

--- a/server/db/postgres/telemetry_dashboard_test.go
+++ b/server/db/postgres/telemetry_dashboard_test.go
@@ -1,0 +1,199 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// The dashboards are SQL against the telemetry views, held in files no compiler
+// reads and no test would otherwise touch. Rename a column in 005_telemetry.sql
+// and every panel selecting it keeps working until somebody opens a browser --
+// which, for a dashboard read a few times a month, could be a long time.
+//
+// So each panel's query is pulled out of the JSON and planned against the real
+// schema. EXPLAIN resolves every column and function without running anything,
+// which is the whole of what is being asked: does this query still make sense
+// against these views.
+//
+// It cannot check that a panel means what its title says. It can check that a
+// panel which no longer parses fails here rather than in front of a person
+// trying to diagnose an import.
+
+// dashboardDir is docker/grafana/dashboards relative to this package.
+const dashboardDir = "../../../docker/grafana/dashboards"
+
+var (
+	// $__timeGroupAlias(col,$__interval) -> col AS "time". Grafana's own
+	// expansion buckets the column; for planning, the column alone type checks
+	// the same way and keeps the alias the panel's ORDER BY refers to.
+	reTimeGroup = regexp.MustCompile(`\$__timeGroupAlias\(\s*([A-Za-z_][A-Za-z0-9_.]*)\s*,\s*\$__interval\s*\)`)
+	// $__timeFilter(col) is a BETWEEN over the dashboard's time range.
+	reTimeFilter = regexp.MustCompile(`\$__timeFilter\(\s*[A-Za-z_][A-Za-z0-9_.]*\s*\)`)
+)
+
+// expand turns a panel's rawSql into something the planner will accept, standing
+// in for what Grafana substitutes at query time. Every replacement keeps the
+// column references and the result types the panel depends on, because those are
+// what this test exists to check.
+func expand(sql string) string {
+	sql = reTimeGroup.ReplaceAllString(sql, `$1 AS "time"`)
+	sql = reTimeFilter.ReplaceAllString(sql, "true")
+	// A single-value variable arrives already quoted by the panel: '${run}'::uuid.
+	sql = strings.ReplaceAll(sql, "${run}", "00000000-0000-0000-0000-000000000000")
+	sql = strings.ReplaceAll(sql, "${scope}", "all")
+	// :sqlstring quotes and comma-joins a multi-value variable. One empty string
+	// keeps the IN list valid and matches nothing.
+	sql = strings.ReplaceAll(sql, "${broker:sqlstring}", "''")
+	return sql
+}
+
+// query is one rawSql found in a dashboard, with enough context to name it in a
+// failure.
+type query struct {
+	dashboard string
+	panel     string
+	sql       string
+}
+
+// collect walks a dashboard file for every rawSql it holds: panel targets, the
+// targets of panels nested inside a row, and the template variable queries,
+// which are as capable of naming a dropped column as any panel.
+func collect(t *testing.T, path string) []query {
+	t.Helper()
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	var d struct {
+		Title  string `json:"title"`
+		Panels []struct {
+			Title   string `json:"title"`
+			Targets []struct {
+				RawSQL string `json:"rawSql"`
+			} `json:"targets"`
+			Panels []struct {
+				Title   string `json:"title"`
+				Targets []struct {
+					RawSQL string `json:"rawSql"`
+				} `json:"targets"`
+			} `json:"panels"`
+		} `json:"panels"`
+		Templating struct {
+			List []struct {
+				Name string `json:"name"`
+				Type string `json:"type"`
+				// A query variable holds an object here; a custom variable holds
+				// its comma-joined options as a bare string. Decoding late keeps
+				// both readable by one struct.
+				Query json.RawMessage `json:"query"`
+			} `json:"list"`
+		} `json:"templating"`
+	}
+	if err := json.Unmarshal(raw, &d); err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+
+	var out []query
+	for _, p := range d.Panels {
+		for _, tg := range p.Targets {
+			if tg.RawSQL != "" {
+				out = append(out, query{d.Title, p.Title, tg.RawSQL})
+			}
+		}
+		for _, n := range p.Panels {
+			for _, tg := range n.Targets {
+				if tg.RawSQL != "" {
+					out = append(out, query{d.Title, n.Title, tg.RawSQL})
+				}
+			}
+		}
+	}
+	for _, v := range d.Templating.List {
+		if v.Type != "query" {
+			continue
+		}
+		var q struct {
+			RawSQL string `json:"rawSql"`
+		}
+		if err := json.Unmarshal(v.Query, &q); err != nil {
+			t.Fatalf("parse variable %s in %s: %v", v.Name, path, err)
+		}
+		if q.RawSQL != "" {
+			out = append(out, query{d.Title, "variable " + v.Name, q.RawSQL})
+		}
+	}
+	return out
+}
+
+// TestDashboardQueriesStillPlan is the test that fails when a view moves under a
+// dashboard.
+func TestDashboardQueriesStillPlan(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+
+	files, err := filepath.Glob(filepath.Join(dashboardDir, "*.json"))
+	if err != nil {
+		t.Fatalf("glob dashboards: %v", err)
+	}
+	if len(files) == 0 {
+		t.Fatalf("no dashboards found under %s", dashboardDir)
+	}
+
+	var queries []query
+	for _, f := range files {
+		queries = append(queries, collect(t, f)...)
+	}
+	// A dashboard whose panels stopped being extracted would otherwise pass this
+	// test by checking nothing at all.
+	if len(queries) < 20 {
+		t.Fatalf("found only %d dashboard queries, which is too few to be right", len(queries))
+	}
+
+	for _, q := range queries {
+		t.Run(q.dashboard+"/"+q.panel, func(t *testing.T) {
+			if _, err := p.q.ExecContext(ctx, "EXPLAIN "+expand(q.sql)); err != nil {
+				t.Errorf("panel query no longer plans against the schema: %v\n\n%s",
+					err, expand(q.sql))
+			}
+		})
+	}
+}
+
+// TestDashboardsSelectOnlyFromViews pins the rule the issue is built on: a panel
+// reads a view, so a judgement it needs is stated once in reviewed SQL rather
+// than retyped into a dashboard nobody diffs. Reading a table directly would let
+// a panel recompute is_import or resolved for itself and drift from the
+// definition every other panel uses.
+func TestDashboardsSelectOnlyFromViews(t *testing.T) {
+	files, err := filepath.Glob(filepath.Join(dashboardDir, "*.json"))
+	if err != nil {
+		t.Fatalf("glob dashboards: %v", err)
+	}
+	// Every relation in the telemetry schema that is not a view.
+	tables := []string{
+		"telemetry.run",
+		"telemetry.resolution_key",
+		"telemetry.identification_attempt",
+		"telemetry.identifier_plugin_call",
+		"telemetry.description_plugin_call",
+	}
+	for _, f := range files {
+		for _, q := range collect(t, f) {
+			for _, tbl := range tables {
+				// The view names share these prefixes, so match the table only
+				// where a view name cannot also match.
+				for _, kw := range []string{"FROM " + tbl, "JOIN " + tbl} {
+					if strings.Contains(q.sql, kw) {
+						t.Errorf("%s / %s reads %s directly; panels read the views",
+							q.dashboard, q.panel, tbl)
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
Last of four. **Stacked on #456 → #455 → #454.** Closes 0117 and 0120.

## The two dashboards

**Telemetry: one run** (14 panels) -- a run picker, then the run end to end.
The panels that get read in practice are *Keys that did not resolve* (ordered by
fan-out, so the description costing 300 transactions is first, with `had_attempt`
separating "never asked" from "asked and was told nothing") and *Keys that did
resolve, and to what*, which joins `v_instrument_label` because a description
landing on the wrong listing looks identical to one landing on the right listing
in a bare UUID.

**Telemetry: drift** (13 panels) -- the same views bucketed over time, with a
broker picker on the import-scoped panels. Its *Runs to look at* table links each
row through to the run dashboard.

## Panel descriptions carry the reasoning

Several panels have conditions that look like clutter to anyone tidying up, so
each says what removing it would break:

- **Run duration** filters `duration_ms IS NOT NULL`. A run stamped `incomplete`
  has no `ended_at`; letting it through drops it out of the average as a null,
  which reads as imports getting *faster* at the moment one died.
- **The two failure rates are not duplicates.** The key-grain one improves as the
  instrument table fills, because more keys short-circuit in the database. The
  attempt-grain one filters `reached_plugins` and does not move when the database
  gets fuller. The gap between them is the diagnostic, and is the whole reason
  `reached_plugins` exists.
- **Hint yield must not be stacked; tokens may be.** Each description plugin sees
  only what its predecessors failed on, so two yield lines at the same instant
  have different denominators -- valid against a plugin's own past, invalid across
  plugins. Tokens are one grain and additive.
- **Keys not resolved splits by run kind**, because `broker_description_only` is a
  failure for a transaction import and the expected outcome for an archive.

## The drift test

The dashboards are SQL in files no compiler reads. Rename a column in
`005_telemetry.sql` and every panel selecting it keeps "working" until somebody
opens a browser -- which for a dashboard read a few times a month could be
months.

`TestDashboardQueriesStillPlan` pulls every `rawSql` out of both files (panel
targets, nested row panels, template variables), substitutes the Grafana macros
and runs `EXPLAIN`. 27 queries covered. It also refuses to pass if it extracts
implausibly few, so a decoder that silently stopped finding panels cannot make it
vacuous. `TestDashboardsSelectOnlyFromViews` fails any panel reading a table
directly, which is the rule the whole arrangement rests on.

## Verified

Beyond `make db-test` (0 failures), against a throwaway stack with seeded data --
no existing dev database touched:

- both dashboards provision with a **clean** Grafana log
- all 27 queries **execute as the `telemetry` reader role**, not just as the
  owner, so the grants are exercised too -- including the `v_instrument_label`
  join, which is the one reaching outside the schema
- the rollups are right on real rows: 5 keys, `key_tx_count` 438, 2 description
  calls, **one** run row -- i.e. not multiplied by either sibling grain, which is
  the failure a join would have produced
- `broker_description_only` lands in "did not resolve" with `had_attempt = false`,
  and the timed-out key lands there with `had_attempt = true`
- description batches come back ordered by precedence showing the chain narrowing
  5 → 4, tokens null for the plugin that costs none
- one panel run through Grafana's own `/api/ds/query` to confirm **Grafana's**
  macro expansion works, which the Go test substitutes and so cannot prove

## Note on the JSON

Generated from a script rather than hand-written, then verified as above. The
JSON is the committed artifact, since it is what Grafana reads and what the UI
exports; the generator was scaffolding and is not in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)