### PR TITLE
Add the price gap and price plugin call grains (0121)

### DIFF
--- a/docs/issues/0121-price-fetch-cycles-emit-telemetry.md
+++ b/docs/issues/0121-price-fetch-cycles-emit-telemetry.md
@@ -1,0 +1,17 @@
+---
+status: open
+title: Price fetch cycles emit run-scoped telemetry
+milestone: M20
+dependencies: [0116, 0117]
+---
+
+A price fetch cycle opens a run and stamps it, and records nothing else. It is the
+longest running of the cycles and the only subsystem with no child telemetry at all,
+so its run duration is the whole of what can be said about it: when a cycle takes
+twenty minutes instead of two, nothing says which plugin, which instrument, or how
+much was asked for.
+
+Record the two grains the orchestrator already works in -- one instrument's outstanding
+gap, and one range put to one plugin -- so that a slow cycle can be attributed, an
+instrument that will never price can be found, and the coverage recording that stops a
+range being asked about forever can be seen working.

--- a/docs/spec/telemetry.md
+++ b/docs/spec/telemetry.md
@@ -222,7 +222,6 @@ One outstanding range put to one plugin, which is one `FetchPrices` call in ever
 | `price_gap_id`, `plugin_id` | |
 | `precedence` | where this plugin sat in the order, higher first |
 | `range_from`, `range_before` | half-open, as the orchestrator's ranges are |
-| `days` | |
 | `bars` | rows the plugin returned; 0 for every outcome but `bars_returned` |
 | `outcome` | `bars_returned`, `no_data`, `history_limit`, `permanent_block`, `timeout`, `error`, `upsert_failed` |
 | `duration_ms` | null for `history_limit`, which called nothing |
@@ -243,6 +242,11 @@ absence of work would make the table grow with the catalogue rather than with wh
 done, and the same (instrument, plugin, range) recurring across cycles is the better signal
 that coverage recording has stopped working -- it is positive evidence rather than an
 absence.
+
+The span in days is not a column. `v_price_plugin_call` derives it by subtracting the two
+dates, so it cannot disagree with the range it came from. `days_outstanding` on the gap is
+a different matter and is stored: it sums ranges the gap no longer holds by the time
+anything is written.
 
 `no_data` is an answer and not a failure to answer: the range is settled for that plugin
 and never asked again. `upsert_failed` is our database rather than the provider's API, and

--- a/docs/spec/telemetry.md
+++ b/docs/spec/telemetry.md
@@ -23,7 +23,9 @@ run
 ├── resolution_key                     one distinct (source, description, hints)
 │     └── identification_attempt       one ResolveWithPlugins call
 │           └── identifier_plugin_call one plugin invocation
-└── description_plugin_call            one plugin invocation over a batch
+├── description_plugin_call            one plugin invocation over a batch
+└── price_gap                          one instrument a cycle set out to fill
+      └── price_plugin_call            one outstanding range put to one plugin
 ```
 
 `description_plugin_call` hangs off the run rather than off a resolution key: one
@@ -172,6 +174,80 @@ configured precedence rather than an ordinal of the rows written, because a plug
 filtered batch is empty writes no row at all -- so a gap in the sequence means that
 plugin was skipped, which is how a filtered-out identifier plugin already reads.
 
+### price_gap
+
+One instrument a price fetch cycle set out to fill, which is one entry in the gap list
+`PriceGaps` and `FXGaps` produce between them. Created before its children and stamped
+when the instrument is done with.
+
+| column | notes |
+| --- | --- |
+| `run_id` | |
+| `instrument_id` | not a foreign key, for the reason `run.job_id` is not one |
+| `is_fx` | the gap came from `FXGaps` rather than `PriceGaps` |
+| `asset_class`, `currency`, `exchange` | the three fields plugin filtering reads |
+| `days_outstanding` | days the gap covered when the cycle picked it up, summed over its ranges |
+| `outcome` | `filled`, `settled_empty`, `no_eligible_plugin`, `all_plugins_failed`, `instrument_missing`; null while in flight |
+
+Not one price row and not one provider call: a single instrument's outstanding history is
+put to several plugins over several ranges. `days_outstanding` is the size of that ask and
+the denominator every rate here wants -- without it a cycle that got slower cannot be told
+from one that was asked for more, which is the first question about a cycle whose duration
+moved. It is also what shrinks cycle over cycle while coverage recording is working, and
+what stops shrinking when it is not.
+
+Rows are written for the whole gap list up front, so a cycle that died part way leaves the
+instruments it never reached unstamped and where it stopped stays readable. A null outcome
+therefore means what a null run outcome means.
+
+`settled_empty` is a success. Every outstanding range was closed by coverage without bars,
+because the instrument did not trade then or no plugin reaches that far back, and the gap
+will not be asked about again -- which is the whole purpose of recording empty coverage. A
+`settled_empty` gap with no `price_plugin_call` rows beneath it is the shape worth hunting:
+every plugin had already covered every range, so the gap recurs in the gap list every cycle
+while no plugin will ever fill it.
+
+`asset_class`, `currency` and `exchange` are recorded rather than read live through
+`v_instrument_label`, because they are the inputs to the decision this row explains. An
+instrument whose asset class is corrected later would otherwise rewrite the reason a plugin
+was skipped a year ago.
+
+### price_plugin_call
+
+One outstanding range put to one plugin, which is one `FetchPrices` call in every case but
+`history_limit`.
+
+| column | notes |
+| --- | --- |
+| `price_gap_id`, `plugin_id` | |
+| `precedence` | where this plugin sat in the order, higher first |
+| `range_from`, `range_before` | half-open, as the orchestrator's ranges are |
+| `days` | |
+| `bars` | rows the plugin returned; 0 for every outcome but `bars_returned` |
+| `outcome` | `bars_returned`, `no_data`, `history_limit`, `permanent_block`, `timeout`, `error`, `upsert_failed` |
+| `duration_ms` | null for `history_limit`, which called nothing |
+
+The range rather than the plugin is the grain because one plugin is asked separately for
+each range a gap leaves outstanding, and those calls can end differently -- a head the
+plugin cannot reach, a middle it answers, a tail that times out. One row per (gap, plugin)
+would force one outcome onto three answers.
+
+Plugins are tried in order until one covers the gap, so a gap normally has rows from fewer
+plugins than are configured. `precedence` makes that readable for the reason it does on
+`description_plugin_call`: a plugin filtered out by asset class, exchange or currency,
+blocked for this instrument, or holding no identifier it supports writes no row at all, so
+a gap in the sequence means skipped.
+
+There is deliberately no row for a range a plugin had already covered. Recording the
+absence of work would make the table grow with the catalogue rather than with what was
+done, and the same (instrument, plugin, range) recurring across cycles is the better signal
+that coverage recording has stopped working -- it is positive evidence rather than an
+absence.
+
+`no_data` is an answer and not a failure to answer: the range is settled for that plugin
+and never asked again. `upsert_failed` is our database rather than the provider's API, and
+is a separate member for the reason transport failure is separate from `not_identified`.
+
 ### Views
 
 One view per table, each flattening its parents in and never fanning out into its
@@ -190,6 +266,10 @@ outcome list into a dashboard. They are:
 | `had_attempt` | key | the key produced at least one identification attempt |
 | `transport_failed` | identifier call | the call did not complete |
 | `call_failed` | description call | the call produced no answer |
+| `settled` (`gap_settled` on the call) | price gap, price call | the gap is dealt with and will not recur |
+| `had_call` | price gap | the gap reached at least one `FetchPrices` call |
+| `transport_failed` | price call | the call did not complete |
+| `write_failed` | price call | our own upsert failed, not the provider |
 
 `reached_plugins` is the denominator for identification failure rate. Using all attempts
 instead makes the rate fall as the instrument table fills, because more resolutions
@@ -213,11 +293,23 @@ Four of the five paths that stamp a key return before `ResolveWithPlugins` is ca
 no attempt is ordinary rather than a fault.
 
 `transport_failed` and `call_failed` both draw the line at the call completing.
-`not_identified` and `no_hints` stay outside them: an empty answer is an answer, and
-counting it as a fault makes a plugin that correctly knew nothing read as a plugin that
-is down.
+`not_identified`, `no_hints` and a price call's `no_data` stay outside them: an empty
+answer is an answer, and counting it as a fault makes a plugin that correctly knew nothing
+read as a plugin that is down. A price call's `history_limit` is outside it because nothing
+was called, and `permanent_block` because it is a durable fact about the (instrument,
+plugin) pair rather than an incident -- it creates a fetch block, so it happens once and
+never again. `write_failed` is separate so a panel watching provider health is not moved by
+our own write failing.
 
-`v_run` also carries `key_count`, `key_tx_count` and `description_call_count`. These are
+`settled` and `had_call` are the price-gap parallels of `resolved` and `had_attempt`, and
+the reasoning is the same. `settled` includes `settled_empty`, because a range no plugin can
+fill is dealt with once that is recorded and counting it as a failure would make an untraded
+week look like an outage; the complement is the column a panel wants, being the gaps that
+come back every cycle. `had_call` separates a gap that never asked from one that asked and
+was told nothing -- filters, fetch blocks, missing identifiers and existing coverage each
+return before `FetchPrices`, so no call is ordinary rather than a fault.
+
+`v_run` also carries `key_count`, `key_tx_count`, `description_call_count` and `gap_count`. These are
 scalar subqueries, one per child table, and they are the only sanctioned way for a view
 to reach into a second child. The rule above forbids a view *fanning out* into two
 sibling grains, because that repeats the parent once per child and makes counting it
@@ -233,6 +325,11 @@ null for every cycle, which is a column meaning a different thing per row and th
 confusion this schema exists to end. The imported file's own row count is not available
 at all: `run.job_id` is not a foreign key and `ingestion_jobs` is outside the reading
 role, both by design.
+
+`gap_count` is how big a price fetch cycle was, counted in instruments rather than days
+because the instrument is what a hole in a valuation is traced back to;
+`v_price_gap.days_outstanding` carries the other measure at the grain that owns it. It is
+zero for every other run kind, as `key_count` is for a cycle.
 
 ### Naming an instrument
 

--- a/server/db/postgres/telemetry_schema_test.go
+++ b/server/db/postgres/telemetry_schema_test.go
@@ -343,9 +343,9 @@ func TestTelemetryVocabulariesAreClosed(t *testing.T) {
 		gapID := seedPriceGap(t, p, seedRun(t, p, "price_fetch_cycle", time.Now()), "filled", 10)
 		if _, err := p.q.ExecContext(context.Background(), `
 			INSERT INTO telemetry.price_plugin_call
-				(price_gap_id, plugin_id, precedence, range_from, range_before, days,
+				(price_gap_id, plugin_id, precedence, range_from, range_before,
 				 bars, outcome, duration_ms)
-			VALUES ($1::uuid, 'eodhd', 100, DATE '2026-01-01', DATE '2026-01-11', 10,
+			VALUES ($1::uuid, 'eodhd', 100, DATE '2026-01-01', DATE '2026-01-11',
 			        0, 'already_covered', 12)
 		`, gapID); err == nil {
 			t.Error("price plugin call accepted an outcome outside its vocabulary")
@@ -381,9 +381,9 @@ func seedPriceCall(t *testing.T, p *Postgres, gapID, pluginID, outcome string) s
 	var id string
 	err := p.q.QueryRowContext(context.Background(), `
 		INSERT INTO telemetry.price_plugin_call
-			(price_gap_id, plugin_id, precedence, range_from, range_before, days,
+			(price_gap_id, plugin_id, precedence, range_from, range_before,
 			 bars, outcome, duration_ms)
-		VALUES ($1::uuid, $2, 100, DATE '2026-01-01', DATE '2026-01-11', 10, 0, $3, 40)
+		VALUES ($1::uuid, $2, 100, DATE '2026-01-01', DATE '2026-01-11', 0, $3, 40)
 		RETURNING id
 	`, gapID, pluginID, outcome).Scan(&id)
 	if err != nil {
@@ -896,9 +896,9 @@ func TestTelemetryPriceCallDurationIsNullable(t *testing.T) {
 	var id string
 	if err := p.q.QueryRowContext(ctx, `
 		INSERT INTO telemetry.price_plugin_call
-			(price_gap_id, plugin_id, precedence, range_from, range_before, days,
+			(price_gap_id, plugin_id, precedence, range_from, range_before,
 			 bars, outcome, duration_ms)
-		VALUES ($1::uuid, 'eodhd', 100, DATE '2026-01-01', DATE '2026-01-11', 10,
+		VALUES ($1::uuid, 'eodhd', 100, DATE '2026-01-01', DATE '2026-01-11',
 		        0, 'history_limit', NULL)
 		RETURNING id
 	`, gapID).Scan(&id); err != nil {
@@ -913,5 +913,26 @@ func TestTelemetryPriceCallDurationIsNullable(t *testing.T) {
 	}
 	if duration != nil {
 		t.Errorf("duration_ms = %d, want null", *duration)
+	}
+}
+
+// TestTelemetryViews_PriceCallDaysAreDerived pins that the span of a fetch range
+// is the subtraction of its own two dates rather than a stored number that could
+// drift from them.
+func TestTelemetryViews_PriceCallDaysAreDerived(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	gapID := seedPriceGap(t, p, seedRun(t, p, "price_fetch_cycle", time.Now()), "filled", 10)
+	id := seedPriceCall(t, p, gapID, "eodhd", "bars_returned")
+
+	var days int
+	if err := p.q.QueryRowContext(ctx,
+		`SELECT days FROM telemetry.v_price_plugin_call WHERE id = $1::uuid`, id,
+	).Scan(&days); err != nil {
+		t.Fatalf("select v_price_plugin_call: %v", err)
+	}
+	// The seed's half-open [2026-01-01, 2026-01-11).
+	if days != 10 {
+		t.Errorf("days = %d, want 10", days)
 	}
 }

--- a/server/db/postgres/telemetry_schema_test.go
+++ b/server/db/postgres/telemetry_schema_test.go
@@ -322,6 +322,74 @@ func TestTelemetryVocabulariesAreClosed(t *testing.T) {
 			t.Error("identifier plugin call accepted an outcome outside its vocabulary")
 		}
 	})
+
+	t.Run("price gap outcome", func(t *testing.T) {
+		p := testDBTx(t)
+		runID := seedRun(t, p, "price_fetch_cycle", time.Now())
+		// 'skipped' is the tempting member and is deliberately absent: a gap no
+		// plugin was eligible for and one every plugin failed on need different
+		// fixes, so the vocabulary names which.
+		if _, err := p.q.ExecContext(context.Background(), `
+			INSERT INTO telemetry.price_gap
+				(run_id, instrument_id, is_fx, days_outstanding, outcome)
+			VALUES ($1::uuid, gen_random_uuid(), FALSE, 10, 'skipped')
+		`, runID); err == nil {
+			t.Error("price gap accepted an outcome outside its vocabulary")
+		}
+	})
+
+	t.Run("price plugin call outcome", func(t *testing.T) {
+		p := testDBTx(t)
+		gapID := seedPriceGap(t, p, seedRun(t, p, "price_fetch_cycle", time.Now()), "filled", 10)
+		if _, err := p.q.ExecContext(context.Background(), `
+			INSERT INTO telemetry.price_plugin_call
+				(price_gap_id, plugin_id, precedence, range_from, range_before, days,
+				 bars, outcome, duration_ms)
+			VALUES ($1::uuid, 'eodhd', 100, DATE '2026-01-01', DATE '2026-01-11', 10,
+			        0, 'already_covered', 12)
+		`, gapID); err == nil {
+			t.Error("price plugin call accepted an outcome outside its vocabulary")
+		}
+	})
+}
+
+// seedPriceGap inserts a price gap under a run and returns its id. An empty
+// outcome is a gap the cycle never reached.
+func seedPriceGap(t *testing.T, p *Postgres, runID, outcome string, days int) string {
+	t.Helper()
+	var oc any
+	if outcome != "" {
+		oc = outcome
+	}
+	var id string
+	err := p.q.QueryRowContext(context.Background(), `
+		INSERT INTO telemetry.price_gap
+			(run_id, instrument_id, is_fx, asset_class, currency, exchange,
+			 days_outstanding, outcome)
+		VALUES ($1::uuid, gen_random_uuid(), FALSE, 'STOCK', 'USD', 'XNAS', $2, $3)
+		RETURNING id
+	`, runID, days, oc).Scan(&id)
+	if err != nil {
+		t.Fatalf("seed price gap %q: %v", outcome, err)
+	}
+	return id
+}
+
+// seedPriceCall inserts a price plugin call under a gap.
+func seedPriceCall(t *testing.T, p *Postgres, gapID, pluginID, outcome string) string {
+	t.Helper()
+	var id string
+	err := p.q.QueryRowContext(context.Background(), `
+		INSERT INTO telemetry.price_plugin_call
+			(price_gap_id, plugin_id, precedence, range_from, range_before, days,
+			 bars, outcome, duration_ms)
+		VALUES ($1::uuid, $2, 100, DATE '2026-01-01', DATE '2026-01-11', 10, 0, $3, 40)
+		RETURNING id
+	`, gapID, pluginID, outcome).Scan(&id)
+	if err != nil {
+		t.Fatalf("seed price call %q: %v", outcome, err)
+	}
+	return id
 }
 
 // seedKeyWithOutcome inserts a resolution key carrying a given stage 2 outcome,
@@ -552,17 +620,28 @@ func TestTelemetryViews_RunRollupsDoNotMultiply(t *testing.T) {
 	seedAttempt(t, p, first, "mismatch_check", "identified", 0)
 	seedDescriptionCall(t, p, runID, "hints_returned")
 	seedDescriptionCall(t, p, runID, "no_hints")
+	// A fourth child grain under the same run. Two gaps, one carrying two calls,
+	// so a join rather than a scalar subquery would multiply the key counts by
+	// three and the gap count by two.
+	gapID := seedPriceGap(t, p, runID, "filled", 30)
+	seedPriceGap(t, p, runID, "settled_empty", 5)
+	seedPriceCall(t, p, gapID, "eodhd", "bars_returned")
+	seedPriceCall(t, p, gapID, "massive", "no_data")
 
-	var rows, keyCount, keyTxCount, descCount int
+	var rows, keyCount, keyTxCount, descCount, gapCount int
 	err := p.q.QueryRowContext(ctx, `
-		SELECT count(*), max(key_count), max(key_tx_count), max(description_call_count)
+		SELECT count(*), max(key_count), max(key_tx_count), max(description_call_count),
+		       max(gap_count)
 		FROM telemetry.v_run WHERE id = $1::uuid
-	`, runID).Scan(&rows, &keyCount, &keyTxCount, &descCount)
+	`, runID).Scan(&rows, &keyCount, &keyTxCount, &descCount, &gapCount)
 	if err != nil {
 		t.Fatalf("select v_run: %v", err)
 	}
 	if rows != 1 {
 		t.Errorf("v_run rows = %d, want 1", rows)
+	}
+	if gapCount != 2 {
+		t.Errorf("gap_count = %d, want 2", gapCount)
 	}
 	if keyCount != 2 {
 		t.Errorf("key_count = %d, want 2", keyCount)
@@ -583,17 +662,17 @@ func TestTelemetryViews_RunRollupsAreZeroNotNull(t *testing.T) {
 	p := testDBTx(t)
 	runID := seedRun(t, p, "grouping_cycle", time.Now())
 
-	var keyCount, keyTxCount, descCount int
+	var keyCount, keyTxCount, descCount, gapCount int
 	err := p.q.QueryRowContext(context.Background(), `
-		SELECT key_count, key_tx_count, description_call_count
+		SELECT key_count, key_tx_count, description_call_count, gap_count
 		FROM telemetry.v_run WHERE id = $1::uuid
-	`, runID).Scan(&keyCount, &keyTxCount, &descCount)
+	`, runID).Scan(&keyCount, &keyTxCount, &descCount, &gapCount)
 	if err != nil {
 		t.Fatalf("select v_run: %v", err)
 	}
-	if keyCount != 0 || keyTxCount != 0 || descCount != 0 {
-		t.Errorf("rollups for an empty run = (%d, %d, %d), want all 0",
-			keyCount, keyTxCount, descCount)
+	if keyCount != 0 || keyTxCount != 0 || descCount != 0 || gapCount != 0 {
+		t.Errorf("rollups for an empty run = (%d, %d, %d, %d), want all 0",
+			keyCount, keyTxCount, descCount, gapCount)
 	}
 }
 
@@ -625,5 +704,214 @@ func TestTelemetryReaderReadsLabelsWithoutReachingPublic(t *testing.T) {
 		`SELECT count(*) FROM instruments`,
 	).Scan(&n); err == nil {
 		t.Error("telemetry_reader can read instruments directly; the view indirection is not what is granting access")
+	}
+}
+
+// TestTelemetryViews_Settled pins which gap outcomes mean the gap is dealt with.
+// settled_empty is the member worth staring at, and is the mirror image of
+// broker_description_only above: no prices were stored, and the gap is
+// nonetheless finished with. Reading it as a failure would put every untraded
+// week and every pre-IPO range into a panel meant to show outages.
+func TestTelemetryViews_Settled(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	runID := seedRun(t, p, "price_fetch_cycle", time.Now())
+
+	cases := []struct {
+		outcome string
+		settled bool
+	}{
+		{"filled", true},
+		{"settled_empty", true},
+		{"no_eligible_plugin", false},
+		{"all_plugins_failed", false},
+		{"instrument_missing", false},
+		// A gap the cycle died before reaching. Not settled, and it must not
+		// vanish from both the column and its negation.
+		{"", false},
+	}
+	for _, c := range cases {
+		name := c.outcome
+		if name == "" {
+			name = "unstamped"
+		}
+		t.Run(name, func(t *testing.T) {
+			id := seedPriceGap(t, p, runID, c.outcome, 10)
+			var got bool
+			if err := p.q.QueryRowContext(ctx,
+				`SELECT settled FROM telemetry.v_price_gap WHERE id = $1::uuid`, id,
+			).Scan(&got); err != nil {
+				t.Fatalf("select v_price_gap: %v", err)
+			}
+			if got != c.settled {
+				t.Errorf("settled for %q = %v, want %v", c.outcome, got, c.settled)
+			}
+		})
+	}
+}
+
+// TestTelemetryViews_HadCall separates a gap that never asked a plugin from one
+// that asked and got nothing. Four paths -- the plugin filter, a fetch block, no
+// supported identifier, and a range already covered -- return before FetchPrices,
+// so no call is the ordinary case and not a fault.
+func TestTelemetryViews_HadCall(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	runID := seedRun(t, p, "price_fetch_cycle", time.Now())
+
+	asked := seedPriceGap(t, p, runID, "all_plugins_failed", 10)
+	seedPriceCall(t, p, asked, "eodhd", "error")
+	never := seedPriceGap(t, p, runID, "no_eligible_plugin", 10)
+
+	for _, c := range []struct {
+		name string
+		id   string
+		want bool
+	}{
+		{"asked", asked, true},
+		{"never asked", never, false},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			var got bool
+			if err := p.q.QueryRowContext(ctx,
+				`SELECT had_call FROM telemetry.v_price_gap WHERE id = $1::uuid`, c.id,
+			).Scan(&got); err != nil {
+				t.Fatalf("select v_price_gap: %v", err)
+			}
+			if got != c.want {
+				t.Errorf("had_call = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestTelemetryViews_PriceTransportFailed pins where the line falls between the
+// provider being unreachable and the provider having nothing. no_data is the
+// member a panel most easily gets wrong: it is the expected answer for a range an
+// instrument did not trade in, and counting it as a transport failure would make
+// every delisted holding look like an outage.
+//
+// upsert_failed sits outside transport_failed and alone in write_failed, because
+// it is our database and not the provider's API.
+func TestTelemetryViews_PriceTransportFailed(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	gapID := seedPriceGap(t, p, seedRun(t, p, "price_fetch_cycle", time.Now()), "filled", 10)
+
+	cases := []struct {
+		outcome   string
+		transport bool
+		write     bool
+	}{
+		{"timeout", true, false},
+		{"error", true, false},
+		{"bars_returned", false, false},
+		{"no_data", false, false},
+		{"history_limit", false, false},
+		{"permanent_block", false, false},
+		{"upsert_failed", false, true},
+	}
+	for _, c := range cases {
+		t.Run(c.outcome, func(t *testing.T) {
+			id := seedPriceCall(t, p, gapID, "eodhd", c.outcome)
+			var transport, write bool
+			if err := p.q.QueryRowContext(ctx, `
+				SELECT transport_failed, write_failed
+				FROM telemetry.v_price_plugin_call WHERE id = $1::uuid
+			`, id).Scan(&transport, &write); err != nil {
+				t.Fatalf("select v_price_plugin_call: %v", err)
+			}
+			if transport != c.transport {
+				t.Errorf("transport_failed for %q = %v, want %v", c.outcome, transport, c.transport)
+			}
+			if write != c.write {
+				t.Errorf("write_failed for %q = %v, want %v", c.outcome, write, c.write)
+			}
+		})
+	}
+}
+
+// TestTelemetryViews_PriceGapDoesNotFanOut keeps the gap view one row per gap
+// however many plugins were put to it. A gap asked of three plugins is one gap,
+// and a view that returned it three times would make every count over
+// days_outstanding silently treble.
+func TestTelemetryViews_PriceGapDoesNotFanOut(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	gapID := seedPriceGap(t, p, seedRun(t, p, "price_fetch_cycle", time.Now()), "filled", 30)
+	seedPriceCall(t, p, gapID, "eodhd", "no_data")
+	seedPriceCall(t, p, gapID, "massive", "bars_returned")
+	seedPriceCall(t, p, gapID, "massive", "history_limit")
+
+	var rows, days int
+	if err := p.q.QueryRowContext(ctx, `
+		SELECT count(*), coalesce(sum(days_outstanding), 0)
+		FROM telemetry.v_price_gap WHERE id = $1::uuid
+	`, gapID).Scan(&rows, &days); err != nil {
+		t.Fatalf("select v_price_gap: %v", err)
+	}
+	if rows != 1 {
+		t.Errorf("v_price_gap rows = %d, want 1", rows)
+	}
+	if days != 30 {
+		t.Errorf("summed days_outstanding = %d, want 30", days)
+	}
+}
+
+// TestTelemetryPriceGapCascades pins that a gap and its calls go with their run,
+// so retention stays a delete from one table.
+func TestTelemetryPriceGapCascades(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	runID := seedRun(t, p, "price_fetch_cycle", time.Now())
+	gapID := seedPriceGap(t, p, runID, "filled", 10)
+	seedPriceCall(t, p, gapID, "eodhd", "bars_returned")
+
+	if _, err := p.q.ExecContext(ctx,
+		`DELETE FROM telemetry.run WHERE id = $1::uuid`, runID); err != nil {
+		t.Fatalf("delete run: %v", err)
+	}
+
+	for _, tbl := range []string{"price_gap", "price_plugin_call"} {
+		var n int
+		if err := p.q.QueryRowContext(ctx,
+			`SELECT count(*) FROM telemetry.`+tbl,
+		).Scan(&n); err != nil {
+			t.Fatalf("count %s: %v", tbl, err)
+		}
+		if n != 0 {
+			t.Errorf("%s still holds %d rows after its run went", tbl, n)
+		}
+	}
+}
+
+// TestTelemetryPriceCallDurationIsNullable pins that history_limit can record no
+// duration. It made no call, and a zero would average into the latency panel as a
+// plugin that answered instantly.
+func TestTelemetryPriceCallDurationIsNullable(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	gapID := seedPriceGap(t, p, seedRun(t, p, "price_fetch_cycle", time.Now()), "settled_empty", 10)
+
+	var id string
+	if err := p.q.QueryRowContext(ctx, `
+		INSERT INTO telemetry.price_plugin_call
+			(price_gap_id, plugin_id, precedence, range_from, range_before, days,
+			 bars, outcome, duration_ms)
+		VALUES ($1::uuid, 'eodhd', 100, DATE '2026-01-01', DATE '2026-01-11', 10,
+		        0, 'history_limit', NULL)
+		RETURNING id
+	`, gapID).Scan(&id); err != nil {
+		t.Fatalf("insert history_limit call with a null duration: %v", err)
+	}
+
+	var duration *int
+	if err := p.q.QueryRowContext(ctx,
+		`SELECT duration_ms FROM telemetry.v_price_plugin_call WHERE id = $1::uuid`, id,
+	).Scan(&duration); err != nil {
+		t.Fatalf("select v_price_plugin_call: %v", err)
+	}
+	if duration != nil {
+		t.Errorf("duration_ms = %d, want null", *duration)
 	}
 }

--- a/server/migrations/005_telemetry.sql
+++ b/server/migrations/005_telemetry.sql
@@ -221,6 +221,111 @@ CREATE TABLE telemetry.description_plugin_call (
 CREATE INDEX idx_telemetry_description_plugin_call_run
   ON telemetry.description_plugin_call (run_id);
 
+-- One instrument a price fetch cycle set out to fill, which is one entry in the gap
+-- list PriceGaps and FXGaps produce between them.
+--
+-- Not one price row and not one provider call: a single instrument's outstanding
+-- history is put to several plugins over several ranges. days_outstanding is the size
+-- of that ask, and is the denominator every rate here wants -- without it a cycle that
+-- got slower cannot be told from one that was asked for more, which is the first
+-- question about a cycle whose duration moved.
+--
+-- Like run and resolution_key the row is created before its children and stamped when
+-- the instrument is done with, so a null outcome means the same thing it means there:
+-- not stamped. Rows are written for the whole gap list up front, so a cycle that died
+-- part way leaves the instruments it never reached unstamped, and where it stopped is
+-- readable rather than lost.
+--
+-- asset_class, currency and exchange are the three fields the orchestrator filters
+-- plugins on. They are recorded rather than looked up through v_instrument_label
+-- because they are the inputs to a decision this row explains: an instrument whose
+-- asset class is corrected later would otherwise rewrite the reason a plugin was
+-- skipped a year ago.
+CREATE TABLE telemetry.price_gap (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_id        UUID NOT NULL REFERENCES telemetry.run (id) ON DELETE CASCADE,
+  -- Not a foreign key, for the reason run.job_id is not one: telemetry outlives the
+  -- work it describes, and a deleted instrument must not take the diagnostics
+  -- explaining it. v_instrument_label is where a panel turns this into a name.
+  instrument_id UUID NOT NULL,
+  -- Price gaps and FX gaps are fetched by one loop over a concatenated list, and are
+  -- indistinguishable from there on. The flag is what keeps them apart, and they are
+  -- not the same size of problem: a missing rate breaks valuation for every instrument
+  -- denominated in that currency, not for one.
+  is_fx         BOOLEAN NOT NULL,
+  asset_class   TEXT,
+  currency      TEXT,
+  exchange      TEXT,
+  -- Days outstanding when the cycle picked the gap up, summed over its ranges. This is
+  -- what shrinks cycle over cycle while coverage recording is working, and what stops
+  -- shrinking when it is not.
+  days_outstanding INT NOT NULL,
+  -- settled_empty is a success and must not be read as a failure: every outstanding
+  -- range was closed by coverage without bars, because the instrument did not trade
+  -- then or no plugin reaches that far back. The gap is settled and will not be asked
+  -- about again, which is the whole purpose of recording empty coverage.
+  --
+  -- A settled_empty gap with no price_plugin_call rows under it is the one shape worth
+  -- hunting: every plugin had already covered every range, so the gap recurs in the
+  -- gap list every cycle forever while no plugin will ever fill it.
+  outcome       TEXT CHECK (outcome IN ('filled', 'settled_empty', 'no_eligible_plugin',
+                                        'all_plugins_failed', 'instrument_missing'))
+);
+
+CREATE INDEX idx_telemetry_price_gap_run ON telemetry.price_gap (run_id);
+-- The panel asking whether one instrument ever prices reads this way, and it is the
+-- question a hole in a portfolio valuation turns into.
+CREATE INDEX idx_telemetry_price_gap_instrument ON telemetry.price_gap (instrument_id);
+
+-- One outstanding range put to one plugin, which is one FetchPrices call in every case
+-- but history_limit.
+--
+-- The range rather than the plugin is the grain because one plugin is asked separately
+-- for each range a gap leaves outstanding, and those calls can end differently: a head
+-- the plugin cannot reach, a middle it answers, a tail that times out. Collapsing them
+-- to one row per (gap, plugin) would force one outcome onto three answers, which is the
+-- rule at the top of this file broken.
+--
+-- Plugins are tried in precedence order until one covers the gap, so a gap normally has
+-- rows from fewer plugins than are configured. precedence is what makes that readable,
+-- for the reason it is recorded on description_plugin_call: a plugin filtered out by
+-- asset class, exchange or currency, blocked for this instrument, or holding no
+-- identifier it supports, writes no row at all, so a gap in the sequence means skipped.
+--
+-- There is deliberately no row for a range a plugin had already covered. Recording the
+-- absence of work would make the table grow with the catalogue rather than with what
+-- was done; the same (instrument, plugin, range) recurring across cycles is the better
+-- signal that coverage recording has stopped working, and it is positive evidence.
+CREATE TABLE telemetry.price_plugin_call (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  price_gap_id UUID NOT NULL REFERENCES telemetry.price_gap (id) ON DELETE CASCADE,
+  plugin_id    TEXT NOT NULL,
+  precedence   INT NOT NULL,
+  -- Half-open [range_from, range_before), as the orchestrator's ranges are.
+  range_from   DATE NOT NULL,
+  range_before DATE NOT NULL,
+  days         INT NOT NULL,
+  -- Bars the plugin returned, 0 for every outcome but bars_returned. A plugin that
+  -- answered with an empty series records no_data instead, so this is never the way to
+  -- tell an empty answer from a failed one.
+  bars         INT NOT NULL,
+  -- no_data is an answer, not a failure to answer: the range is settled for this plugin
+  -- and never asked again. history_limit is the one member that made no call -- the
+  -- plugin's configured reach does not extend that far back, so the range is settled
+  -- without asking. upsert_failed is our database rather than the provider's API, and
+  -- is separate for the reason transport failure is separate from not_identified: the
+  -- two need different fixes.
+  outcome      TEXT NOT NULL CHECK (outcome IN ('bars_returned', 'no_data', 'history_limit',
+                                                'permanent_block', 'timeout', 'error',
+                                                'upsert_failed')),
+  -- Null for history_limit, which called nothing and so has no clock, for the reason a
+  -- plugin costing no tokens writes null rather than zero.
+  duration_ms  INT
+);
+
+CREATE INDEX idx_telemetry_price_plugin_call_gap
+  ON telemetry.price_plugin_call (price_gap_id);
+
 -- Views.
 --
 -- One per table, each flattening its parents in and never fanning out into its
@@ -270,7 +375,14 @@ SELECT
   (SELECT coalesce(sum(k.tx_count), 0) FROM telemetry.resolution_key k
      WHERE k.run_id = r.id) AS key_tx_count,
   (SELECT count(*) FROM telemetry.description_plugin_call c
-     WHERE c.run_id = r.id) AS description_call_count
+     WHERE c.run_id = r.id) AS description_call_count,
+  -- How big a price fetch cycle was. Instruments rather than days, because the
+  -- instrument is what the run dashboard drills into and what a hole in a
+  -- valuation is traced back to; v_price_gap.days_outstanding carries the other
+  -- measure at the grain that owns it. Zero for every other run kind, as
+  -- key_count is for this one.
+  (SELECT count(*) FROM telemetry.price_gap g
+     WHERE g.run_id = r.id) AS gap_count
 FROM telemetry.run r;
 
 CREATE VIEW telemetry.v_resolution_key AS
@@ -435,6 +547,85 @@ SELECT
   r.kind IN ('tx_import', 'user_archive_import', 'system_archive_import') AS is_import
 FROM telemetry.description_plugin_call c
 JOIN telemetry.run r ON r.id = c.run_id;
+
+CREATE VIEW telemetry.v_price_gap AS
+SELECT
+  g.id,
+  g.run_id,
+  g.instrument_id,
+  g.is_fx,
+  g.asset_class,
+  g.currency,
+  g.exchange,
+  g.days_outstanding,
+  g.outcome,
+  -- The gap is dealt with and will not be back. settled_empty is deliberately
+  -- inside it: a range no plugin can fill is settled once that is recorded, and
+  -- counting it as a failure would make an untraded week look like an outage.
+  --
+  -- The complement is the column a panel wants -- a gap that recurs every cycle,
+  -- costing discovery work and leaving a hole in valuation. A null outcome is not
+  -- settled either, hence the explicit null handling rather than a bare IN, which
+  -- would yield null and drop the row out of both this column and its negation.
+  g.outcome IS NOT NULL AND g.outcome IN ('filled', 'settled_empty') AS settled,
+  -- Whether any plugin was asked at all. Filters, fetch blocks, missing identifiers
+  -- and existing coverage each return before FetchPrices is called, so no call is an
+  -- ordinary case rather than a fault, and telling "never asked" from "asked and
+  -- failed" is the first question about a gap that did not fill. EXISTS rather than a
+  -- join: this view stays one row per gap.
+  EXISTS (SELECT 1 FROM telemetry.price_plugin_call c
+            WHERE c.price_gap_id = g.id) AS had_call,
+  r.kind       AS run_kind,
+  r.started_at AS run_started_at,
+  r.outcome    AS run_outcome,
+  r.telemetry_incomplete AS run_telemetry_incomplete,
+  -- Constant false while price_fetch_cycle is the only kind that fills gaps. Carried
+  -- because every view here carries it, so a panel written against one grain does not
+  -- have to remember which grains are the exception.
+  r.kind IN ('tx_import', 'user_archive_import', 'system_archive_import') AS is_import
+FROM telemetry.price_gap g
+JOIN telemetry.run r ON r.id = g.run_id;
+
+CREATE VIEW telemetry.v_price_plugin_call AS
+SELECT
+  c.id,
+  c.price_gap_id,
+  c.plugin_id,
+  c.precedence,
+  c.range_from,
+  c.range_before,
+  c.days,
+  c.bars,
+  c.outcome,
+  c.duration_ms,
+  -- The call did not complete. no_data is deliberately outside it, for the reason
+  -- not_identified is outside the identifier plugin's transport_failed: the provider
+  -- having nothing and the provider being unreachable are different events with
+  -- different fixes. history_limit is outside it because nothing was called, and
+  -- permanent_block because it is a durable fact about the pair rather than an
+  -- incident -- it creates a fetch block, so it happens once and never again.
+  c.outcome IN ('timeout', 'error') AS transport_failed,
+  -- Ours rather than theirs. Separate from transport_failed so a panel watching
+  -- provider health is not moved by our own write failing, and so that a burst of
+  -- these reads as what it is.
+  c.outcome = 'upsert_failed' AS write_failed,
+  g.instrument_id AS gap_instrument_id,
+  g.is_fx         AS gap_is_fx,
+  g.asset_class   AS gap_asset_class,
+  g.currency      AS gap_currency,
+  g.exchange      AS gap_exchange,
+  g.days_outstanding AS gap_days_outstanding,
+  g.outcome       AS gap_outcome,
+  g.outcome IS NOT NULL AND g.outcome IN ('filled', 'settled_empty') AS gap_settled,
+  r.id         AS run_id,
+  r.kind       AS run_kind,
+  r.started_at AS run_started_at,
+  r.outcome    AS run_outcome,
+  r.telemetry_incomplete AS run_telemetry_incomplete,
+  r.kind IN ('tx_import', 'user_archive_import', 'system_archive_import') AS is_import
+FROM telemetry.price_plugin_call c
+JOIN telemetry.price_gap g ON g.id = c.price_gap_id
+JOIN telemetry.run r ON r.id = g.run_id;
 
 -- The one thing here that reads outside the telemetry schema.
 --

--- a/server/migrations/005_telemetry.sql
+++ b/server/migrations/005_telemetry.sql
@@ -301,10 +301,11 @@ CREATE TABLE telemetry.price_plugin_call (
   price_gap_id UUID NOT NULL REFERENCES telemetry.price_gap (id) ON DELETE CASCADE,
   plugin_id    TEXT NOT NULL,
   precedence   INT NOT NULL,
-  -- Half-open [range_from, range_before), as the orchestrator's ranges are.
+  -- Half-open [range_from, range_before), as the orchestrator's ranges are. The
+  -- span in days is not stored: it is the subtraction of these two, and a column
+  -- holding it could disagree with the range it came from.
   range_from   DATE NOT NULL,
   range_before DATE NOT NULL,
-  days         INT NOT NULL,
   -- Bars the plugin returned, 0 for every outcome but bars_returned. A plugin that
   -- answered with an empty series records no_data instead, so this is never the way to
   -- tell an empty answer from a failed one.
@@ -594,7 +595,10 @@ SELECT
   c.precedence,
   c.range_from,
   c.range_before,
-  c.days,
+  -- Derived rather than stored, so it cannot disagree with the range above it.
+  -- DATE minus DATE is a whole number of days in postgres, which is the
+  -- resolution a fetch range has.
+  (c.range_before - c.range_from) AS days,
   c.bars,
   c.outcome,
   c.duration_ms,


### PR DESCRIPTION
A price fetch cycle opens a run and stamps it and records nothing else. It is the longest-running of the cycles and the only subsystem with no child telemetry, so its run duration is the whole of what can be said about it.

This is the schema half: two tables, two views, the `gap_count` rollup on `v_run`, and the spec. The writer and the orchestrator instrumentation follow in a dependent PR, and the panels after that -- nothing reads these rows yet.

## The grains

```
run
└── price_gap                one instrument a cycle set out to fill
      └── price_plugin_call  one outstanding range put to one plugin
```

Two levels rather than three. Identification's middle grain exists to carry `purpose` and `depth`, and price fetching has no analogue -- nothing recursive, no mismatch check -- so a third table would carry nothing.

**The range rather than the plugin is the call grain.** One plugin is asked separately for each range a gap leaves outstanding, and those calls can end differently: a head it cannot reach, a middle it answers, a tail that times out. One row per (gap, plugin) would force one outcome onto three answers.

**No row for a range a plugin had already covered.** Recording the absence of work would make the table grow with the catalogue rather than with what was done. The same (instrument, plugin, range) recurring across cycles is the better signal that coverage recording has broken, and it is positive evidence rather than an absence.

**`settled_empty` is a success**, and is the mirror of `broker_description_only`: no prices stored, gap nonetheless finished with, because the instrument did not trade then or no plugin reaches that far back. Reading it as a failure would put every untraded week into a panel meant to show outages. A `settled_empty` gap with no calls beneath it is the shape worth hunting -- it recurs every cycle and no plugin will ever fill it.

**`is_fx`** keeps FX gaps apart from price gaps, which one loop over a concatenated list otherwise blends. They are not the same size of problem: a missing rate breaks valuation for every instrument in that currency, not for one.

`duration_ms` is nullable for `history_limit`, the one outcome that made no call -- a zero would average into a latency panel as a plugin answering instantly.

## Tests

Schema tests pin `settled`, `had_call`, `transport_failed`/`write_failed`, that `v_price_gap` does not fan out over its calls, that both vocabularies are closed, that the cascade reaches both tables, and that a null duration survives the view. The `v_run` rollup tests gain `gap_count` and a second child grain, so a join instead of a scalar subquery would now treble the key counts.

`make db-test`, `make fmt-check vet lint-go` clean.

Closes #0121 partially -- see the dependent PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)