### PR TITLE
Show what a price fetch cycle did (0121)

### DIFF
--- a/docker/grafana/dashboards/drift.json
+++ b/docker/grafana/dashboards/drift.json
@@ -27,7 +27,7 @@
       "datasource": null,
       "options": {
         "mode": "markdown",
-        "content": "Every panel reads one view and selects on judgements defined once in\n`server/migrations/005_telemetry.sql`. Child views carry no timestamp of their own, so\ntheir time axis is `run_started_at` -- the run's start -- and never `started_at`, which\nexists only on `v_run`.\n\nThe import-scoped panels filter `is_import` and honour the **Broker** picker; the run\npanels do not, because a price fetch cycle dying matters as much as an import doing so.\nNever join two child grains under one run: use `v_run`'s rollups."
+        "content": "Every panel reads one view and selects on judgements defined once in\n`server/migrations/005_telemetry.sql`. Child views carry no timestamp of their own, so\ntheir time axis is `run_started_at` -- the run's start -- and never `started_at`, which\nexists only on `v_run`.\n\nThe import-scoped panels filter `is_import` and honour the **Broker** picker; the run\nand price panels do not, because a price fetch cycle dying matters as much as an\nimport doing so, and a cycle names no broker to filter on in the first place.\nNever join two child grains under one run: use `v_run`'s rollups."
       },
       "gridPos": {
         "h": 5,
@@ -1134,6 +1134,378 @@
         "y": 57
       },
       "id": 17
+    },
+    {
+      "type": "row",
+      "title": "Price fetching",
+      "collapsed": false,
+      "id": 18,
+      "panels": [],
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 65
+      }
+    },
+    {
+      "type": "timeseries",
+      "title": "Gap outcome mix",
+      "description": "Stacked to 100%, because the mix is the signal and the volume is not: how many instruments needed prices is a fact about the portfolio, and which way they ended is a fact about the fetching. settled_empty is a success and sits with filled -- a range no plugin can supply is dealt with once that is recorded. Every run kind, and no Broker picker: a price fetch cycle runs on nobody's behalf and names no broker, so filtering by one would empty this panel.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  $__timeGroupAlias(run_started_at,$__interval),\n  coalesce(outcome, '(not stamped)') AS metric,\n  count(*) AS value\nFROM telemetry.v_price_gap\nWHERE $__timeFilter(run_started_at)\nGROUP BY 1, 2\nORDER BY 1",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "bars",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "never",
+            "pointSize": 5,
+            "barAlignment": 0,
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "axisColorMode": "text",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "percent"
+            }
+          },
+          "unit": "short",
+          "mappings": [],
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 66
+      },
+      "id": 19
+    },
+    {
+      "type": "timeseries",
+      "title": "Gaps that did not settle, by kind",
+      "description": "The gaps that will be back next cycle, costing discovery work and leaving a hole in valuation. Split on is_fx rather than blended, because the two are not the same size of problem: a missing rate breaks valuation for every instrument denominated in that currency, while a missing quote breaks one. Blended, a single stuck FX pair disappears into the instrument line.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  $__timeGroupAlias(run_started_at,$__interval),\n  CASE WHEN is_fx THEN 'fx' ELSE 'instrument' END AS metric,\n  count(*) FILTER (WHERE NOT settled)::numeric / nullif(count(*), 0) AS value\nFROM telemetry.v_price_gap\nWHERE $__timeFilter(run_started_at)\nGROUP BY 1, 2\nORDER BY 1",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "line",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "never",
+            "pointSize": 5,
+            "barAlignment": 0,
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "axisColorMode": "text",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            }
+          },
+          "unit": "percentunit",
+          "mappings": [],
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          },
+          "decimals": 1,
+          "max": 1,
+          "min": 0
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 66
+      },
+      "id": 20
+    },
+    {
+      "type": "timeseries",
+      "title": "Time spent by plugin",
+      "description": "Where a cycle's duration went, which the run duration panel above can only say has moved. Stacking is legitimate here for the reason it is on Tokens: one grain, an additive quantity, no cross-population rate. A history_limit call writes a null duration and contributes nothing rather than a zero, which is correct -- it made no call.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  $__timeGroupAlias(run_started_at,$__interval),\n  plugin_id AS metric,\n  sum(duration_ms) AS value\nFROM telemetry.v_price_plugin_call\nWHERE $__timeFilter(run_started_at)\nGROUP BY 1, 2\nORDER BY 1",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "bars",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "never",
+            "pointSize": 5,
+            "barAlignment": 0,
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "axisColorMode": "text",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "ms",
+          "mappings": [],
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 74
+      },
+      "id": 21
+    },
+    {
+      "type": "timeseries",
+      "title": "Price plugin transport failures",
+      "description": "Calls that did not complete -- timed out or errored. Deliberately not no_data, which is a completed call whose answer was that the instrument did not trade then: the provider being down and the provider having nothing need different fixes, and counting the second here would make every delisted holding look like an outage. permanent_block is outside it too, being a durable fact about the pair that happens once.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "time_series",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  $__timeGroupAlias(run_started_at,$__interval),\n  plugin_id AS metric,\n  count(*) FILTER (WHERE transport_failed) AS value\nFROM telemetry.v_price_plugin_call\nWHERE $__timeFilter(run_started_at)\nGROUP BY 1, 2\nORDER BY 1",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        },
+        "legend": {
+          "showLegend": true,
+          "displayMode": "list",
+          "placement": "bottom",
+          "calcs": []
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "drawStyle": "bars",
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "spanNulls": false,
+            "showPoints": "never",
+            "pointSize": 5,
+            "barAlignment": 0,
+            "axisPlacement": "auto",
+            "axisLabel": "",
+            "axisColorMode": "text",
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            },
+            "stacking": {
+              "group": "A",
+              "mode": "normal"
+            }
+          },
+          "unit": "none",
+          "mappings": [],
+          "color": {
+            "mode": "palette-classic"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 74
+      },
+      "id": 22
     }
   ],
   "preload": false,

--- a/docker/grafana/dashboards/run.json
+++ b/docker/grafana/dashboards/run.json
@@ -27,7 +27,7 @@
       "datasource": null,
       "options": {
         "mode": "markdown",
-        "content": "Every panel here reads one view, and every judgement it selects on\n(`resolved`, `had_attempt`, `reached_plugins`, `transport_failed`, `call_failed`,\n`is_import`) is a column defined once in `server/migrations/005_telemetry.sql`. Adding a\npanel that spells out a list of outcomes instead means the views are missing a judgement;\nadd it there.\n\nTwo rules the grains impose. **Never join two child grains under one run** -- a run joined\nto both resolution keys and description plugin calls repeats itself once per pair and\nreports both counts as multiples of themselves; `v_run` carries `key_count`,\n`key_tx_count` and `description_call_count` for that reason. **Counts of one grain are\nnever added to counts of another**: a key is not a transaction, an attempt is not a key,\nand `tx_count` is the only fan-out any of them records."
+        "content": "Every panel here reads one view, and every judgement it selects on\n(`resolved`, `had_attempt`, `reached_plugins`, `transport_failed`, `call_failed`,\n`settled`, `had_call`, `write_failed`, `is_import`) is a column defined once in `server/migrations/005_telemetry.sql`. Adding a\npanel that spells out a list of outcomes instead means the views are missing a judgement;\nadd it there.\n\nTwo rules the grains impose. **Never join two child grains under one run** -- a run joined\nto both resolution keys and description plugin calls repeats itself once per pair and\nreports both counts as multiples of themselves; `v_run` carries `key_count`,\n`key_tx_count`, `description_call_count` and `gap_count` for that reason. **Counts of one grain are\nnever added to counts of another**: a key is not a transaction, an attempt is not a key,\na price gap is not a plugin call, and `tx_count` is the only fan-out any of them\nrecords. `days_outstanding` is the price side's measure of size and belongs to the\ngap, never summed across the calls beneath it."
       },
       "gridPos": {
         "h": 6,
@@ -54,7 +54,7 @@
           "editorMode": "code",
           "format": "table",
           "rawQuery": true,
-          "rawSql": "SELECT\n  kind,\n  broker,\n  source,\n  started_at,\n  ended_at,\n  outcome,\n  duration_ms,\n  telemetry_incomplete,\n  key_count,\n  key_tx_count,\n  description_call_count\nFROM telemetry.v_run\nWHERE id = '${run}'::uuid",
+          "rawSql": "SELECT\n  kind,\n  broker,\n  source,\n  started_at,\n  ended_at,\n  outcome,\n  duration_ms,\n  telemetry_incomplete,\n  key_count,\n  key_tx_count,\n  description_call_count,\n  gap_count\nFROM telemetry.v_run\nWHERE id = '${run}'::uuid",
           "refId": "A"
         }
       ],
@@ -1017,6 +1017,352 @@
         "y": 60
       },
       "id": 18
+    },
+    {
+      "type": "row",
+      "title": "Price fetching",
+      "collapsed": false,
+      "id": 19,
+      "panels": [],
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 67
+      }
+    },
+    {
+      "type": "bargauge",
+      "title": "Gap outcomes",
+      "description": "What became of each instrument this cycle set out to price. settled_empty is a success sitting next to filled: the range was closed without bars because the instrument did not trade then or no plugin reaches that far back, and it will not be asked about again. '(not stamped)' is an instrument the cycle died before reaching.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  coalesce(outcome, '(not stamped)') AS outcome,\n  count(*) AS gaps\nFROM telemetry.v_price_gap\nWHERE run_id = '${run}'::uuid\nGROUP BY 1\nORDER BY 2 DESC",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": true
+        },
+        "showUnfilled": true,
+        "valueMode": "color",
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "maxVizHeight": 300,
+        "namePlacement": "auto",
+        "sizing": "auto",
+        "legend": {
+          "showLegend": false
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "mappings": [],
+          "color": {
+            "mode": "continuous-BlPu"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 9,
+        "x": 0,
+        "y": 68
+      },
+      "id": 20
+    },
+    {
+      "type": "stat",
+      "title": "Days of history asked for",
+      "description": "Summed over the gaps, which is the size of the ask this cycle was handed. Read the cycle's duration against this before calling it slow: a cycle asked for ten years of a new holding is not the same cycle as one topping up yesterday.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT coalesce(sum(days_outstanding), 0) AS \"days outstanding\"\nFROM telemetry.v_price_gap\nWHERE run_id = '${run}'::uuid",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "text": {}
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 6,
+        "x": 9,
+        "y": 68
+      },
+      "id": 21
+    },
+    {
+      "type": "stat",
+      "title": "Gaps that did not settle",
+      "description": "Counts the table below, and is the number that should be zero on a healthy cycle. These recur every cycle until something changes.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT count(*) AS \"unsettled gaps\"\nFROM telemetry.v_price_gap\nWHERE run_id = '${run}'::uuid\n  AND NOT settled",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "auto",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "text": {}
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "none",
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 9,
+        "x": 15,
+        "y": 68
+      },
+      "id": 22
+    },
+    {
+      "type": "table",
+      "title": "Gaps that did not settle",
+      "description": "The panel to read when a valuation has a hole in it. Ordered by the size of the ask, so the instrument missing the most history is first. had_call separates a gap no plugin would take -- filtered out, blocked, or holding no identifier any of them supports -- from one that was asked and got nothing back, and those two have different fixes.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  i.label AS instrument,\n  g.is_fx,\n  g.asset_class,\n  g.currency,\n  g.exchange,\n  g.days_outstanding,\n  coalesce(g.outcome, '(not reached)') AS outcome,\n  g.had_call\nFROM telemetry.v_price_gap g\nLEFT JOIN telemetry.v_instrument_label i ON i.id = g.instrument_id\nWHERE g.run_id = '${run}'::uuid\n  AND NOT g.settled\nORDER BY g.days_outstanding DESC, i.label",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "fields": ""
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 9,
+        "w": 24,
+        "x": 0,
+        "y": 75
+      },
+      "id": 23
+    },
+    {
+      "type": "table",
+      "title": "Price plugin calls",
+      "description": "Where this cycle's time went, which is the question its duration cannot answer. One row per (plugin, outcome), because a plugin's fast no_data and its slow fetch averaged together describe neither. history_limit calls contribute no duration: they made no call, so they are counted and not timed.",
+      "datasource": {
+        "type": "grafana-postgresql-datasource",
+        "uid": "portfoliodb-telemetry"
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "grafana-postgresql-datasource",
+            "uid": "portfoliodb-telemetry"
+          },
+          "editorMode": "code",
+          "format": "table",
+          "rawQuery": true,
+          "rawSql": "SELECT\n  plugin_id,\n  outcome,\n  count(*)                  AS calls,\n  sum(days)                 AS days,\n  sum(bars)                 AS bars,\n  round(avg(duration_ms))   AS avg_ms,\n  max(duration_ms)          AS max_ms,\n  sum(duration_ms)          AS total_ms\nFROM telemetry.v_price_plugin_call\nWHERE run_id = '${run}'::uuid\nGROUP BY 1, 2\nORDER BY total_ms DESC NULLS LAST, plugin_id",
+          "refId": "A"
+        }
+      ],
+      "options": {
+        "showHeader": true,
+        "cellHeight": "sm",
+        "footer": {
+          "show": false,
+          "reducer": [
+            "sum"
+          ],
+          "fields": ""
+        }
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": "auto",
+            "cellOptions": {
+              "type": "auto"
+            },
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "text",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byRegexp",
+              "options": ".*_ms"
+            },
+            "properties": [
+              {
+                "id": "unit",
+                "value": "ms"
+              },
+              {
+                "id": "noValue",
+                "value": "n/a"
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 84
+      },
+      "id": 24
     }
   ],
   "preload": false,

--- a/docs/issues/0121-price-fetch-cycles-emit-telemetry.md
+++ b/docs/issues/0121-price-fetch-cycles-emit-telemetry.md
@@ -1,0 +1,17 @@
+---
+status: open
+title: Price fetch cycles emit run-scoped telemetry
+milestone: M20
+dependencies: [0116, 0117]
+---
+
+A price fetch cycle opens a run and stamps it, and records nothing else. It is the
+longest running of the cycles and the only subsystem with no child telemetry at all,
+so its run duration is the whole of what can be said about it: when a cycle takes
+twenty minutes instead of two, nothing says which plugin, which instrument, or how
+much was asked for.
+
+Record the two grains the orchestrator already works in -- one instrument's outstanding
+gap, and one range put to one plugin -- so that a slow cycle can be attributed, an
+instrument that will never price can be found, and the coverage recording that stops a
+range being asked about forever can be seen working.

--- a/docs/spec/telemetry.md
+++ b/docs/spec/telemetry.md
@@ -222,7 +222,6 @@ One outstanding range put to one plugin, which is one `FetchPrices` call in ever
 | `price_gap_id`, `plugin_id` | |
 | `precedence` | where this plugin sat in the order, higher first |
 | `range_from`, `range_before` | half-open, as the orchestrator's ranges are |
-| `days` | |
 | `bars` | rows the plugin returned; 0 for every outcome but `bars_returned` |
 | `outcome` | `bars_returned`, `no_data`, `history_limit`, `permanent_block`, `timeout`, `error`, `upsert_failed` |
 | `duration_ms` | null for `history_limit`, which called nothing |
@@ -243,6 +242,11 @@ absence of work would make the table grow with the catalogue rather than with wh
 done, and the same (instrument, plugin, range) recurring across cycles is the better signal
 that coverage recording has stopped working -- it is positive evidence rather than an
 absence.
+
+The span in days is not a column. `v_price_plugin_call` derives it by subtracting the two
+dates, so it cannot disagree with the range it came from. `days_outstanding` on the gap is
+a different matter and is stored: it sums ranges the gap no longer holds by the time
+anything is written.
 
 `no_data` is an answer and not a failure to answer: the range is settled for that plugin
 and never asked again. `upsert_failed` is our database rather than the provider's API, and

--- a/docs/spec/telemetry.md
+++ b/docs/spec/telemetry.md
@@ -23,7 +23,9 @@ run
 ├── resolution_key                     one distinct (source, description, hints)
 │     └── identification_attempt       one ResolveWithPlugins call
 │           └── identifier_plugin_call one plugin invocation
-└── description_plugin_call            one plugin invocation over a batch
+├── description_plugin_call            one plugin invocation over a batch
+└── price_gap                          one instrument a cycle set out to fill
+      └── price_plugin_call            one outstanding range put to one plugin
 ```
 
 `description_plugin_call` hangs off the run rather than off a resolution key: one
@@ -172,6 +174,80 @@ configured precedence rather than an ordinal of the rows written, because a plug
 filtered batch is empty writes no row at all -- so a gap in the sequence means that
 plugin was skipped, which is how a filtered-out identifier plugin already reads.
 
+### price_gap
+
+One instrument a price fetch cycle set out to fill, which is one entry in the gap list
+`PriceGaps` and `FXGaps` produce between them. Created before its children and stamped
+when the instrument is done with.
+
+| column | notes |
+| --- | --- |
+| `run_id` | |
+| `instrument_id` | not a foreign key, for the reason `run.job_id` is not one |
+| `is_fx` | the gap came from `FXGaps` rather than `PriceGaps` |
+| `asset_class`, `currency`, `exchange` | the three fields plugin filtering reads |
+| `days_outstanding` | days the gap covered when the cycle picked it up, summed over its ranges |
+| `outcome` | `filled`, `settled_empty`, `no_eligible_plugin`, `all_plugins_failed`, `instrument_missing`; null while in flight |
+
+Not one price row and not one provider call: a single instrument's outstanding history is
+put to several plugins over several ranges. `days_outstanding` is the size of that ask and
+the denominator every rate here wants -- without it a cycle that got slower cannot be told
+from one that was asked for more, which is the first question about a cycle whose duration
+moved. It is also what shrinks cycle over cycle while coverage recording is working, and
+what stops shrinking when it is not.
+
+Rows are written for the whole gap list up front, so a cycle that died part way leaves the
+instruments it never reached unstamped and where it stopped stays readable. A null outcome
+therefore means what a null run outcome means.
+
+`settled_empty` is a success. Every outstanding range was closed by coverage without bars,
+because the instrument did not trade then or no plugin reaches that far back, and the gap
+will not be asked about again -- which is the whole purpose of recording empty coverage. A
+`settled_empty` gap with no `price_plugin_call` rows beneath it is the shape worth hunting:
+every plugin had already covered every range, so the gap recurs in the gap list every cycle
+while no plugin will ever fill it.
+
+`asset_class`, `currency` and `exchange` are recorded rather than read live through
+`v_instrument_label`, because they are the inputs to the decision this row explains. An
+instrument whose asset class is corrected later would otherwise rewrite the reason a plugin
+was skipped a year ago.
+
+### price_plugin_call
+
+One outstanding range put to one plugin, which is one `FetchPrices` call in every case but
+`history_limit`.
+
+| column | notes |
+| --- | --- |
+| `price_gap_id`, `plugin_id` | |
+| `precedence` | where this plugin sat in the order, higher first |
+| `range_from`, `range_before` | half-open, as the orchestrator's ranges are |
+| `days` | |
+| `bars` | rows the plugin returned; 0 for every outcome but `bars_returned` |
+| `outcome` | `bars_returned`, `no_data`, `history_limit`, `permanent_block`, `timeout`, `error`, `upsert_failed` |
+| `duration_ms` | null for `history_limit`, which called nothing |
+
+The range rather than the plugin is the grain because one plugin is asked separately for
+each range a gap leaves outstanding, and those calls can end differently -- a head the
+plugin cannot reach, a middle it answers, a tail that times out. One row per (gap, plugin)
+would force one outcome onto three answers.
+
+Plugins are tried in order until one covers the gap, so a gap normally has rows from fewer
+plugins than are configured. `precedence` makes that readable for the reason it does on
+`description_plugin_call`: a plugin filtered out by asset class, exchange or currency,
+blocked for this instrument, or holding no identifier it supports writes no row at all, so
+a gap in the sequence means skipped.
+
+There is deliberately no row for a range a plugin had already covered. Recording the
+absence of work would make the table grow with the catalogue rather than with what was
+done, and the same (instrument, plugin, range) recurring across cycles is the better signal
+that coverage recording has stopped working -- it is positive evidence rather than an
+absence.
+
+`no_data` is an answer and not a failure to answer: the range is settled for that plugin
+and never asked again. `upsert_failed` is our database rather than the provider's API, and
+is a separate member for the reason transport failure is separate from `not_identified`.
+
 ### Views
 
 One view per table, each flattening its parents in and never fanning out into its
@@ -190,6 +266,10 @@ outcome list into a dashboard. They are:
 | `had_attempt` | key | the key produced at least one identification attempt |
 | `transport_failed` | identifier call | the call did not complete |
 | `call_failed` | description call | the call produced no answer |
+| `settled` (`gap_settled` on the call) | price gap, price call | the gap is dealt with and will not recur |
+| `had_call` | price gap | the gap reached at least one `FetchPrices` call |
+| `transport_failed` | price call | the call did not complete |
+| `write_failed` | price call | our own upsert failed, not the provider |
 
 `reached_plugins` is the denominator for identification failure rate. Using all attempts
 instead makes the rate fall as the instrument table fills, because more resolutions
@@ -213,11 +293,23 @@ Four of the five paths that stamp a key return before `ResolveWithPlugins` is ca
 no attempt is ordinary rather than a fault.
 
 `transport_failed` and `call_failed` both draw the line at the call completing.
-`not_identified` and `no_hints` stay outside them: an empty answer is an answer, and
-counting it as a fault makes a plugin that correctly knew nothing read as a plugin that
-is down.
+`not_identified`, `no_hints` and a price call's `no_data` stay outside them: an empty
+answer is an answer, and counting it as a fault makes a plugin that correctly knew nothing
+read as a plugin that is down. A price call's `history_limit` is outside it because nothing
+was called, and `permanent_block` because it is a durable fact about the (instrument,
+plugin) pair rather than an incident -- it creates a fetch block, so it happens once and
+never again. `write_failed` is separate so a panel watching provider health is not moved by
+our own write failing.
 
-`v_run` also carries `key_count`, `key_tx_count` and `description_call_count`. These are
+`settled` and `had_call` are the price-gap parallels of `resolved` and `had_attempt`, and
+the reasoning is the same. `settled` includes `settled_empty`, because a range no plugin can
+fill is dealt with once that is recorded and counting it as a failure would make an untraded
+week look like an outage; the complement is the column a panel wants, being the gaps that
+come back every cycle. `had_call` separates a gap that never asked from one that asked and
+was told nothing -- filters, fetch blocks, missing identifiers and existing coverage each
+return before `FetchPrices`, so no call is ordinary rather than a fault.
+
+`v_run` also carries `key_count`, `key_tx_count`, `description_call_count` and `gap_count`. These are
 scalar subqueries, one per child table, and they are the only sanctioned way for a view
 to reach into a second child. The rule above forbids a view *fanning out* into two
 sibling grains, because that repeats the parent once per child and makes counting it
@@ -233,6 +325,11 @@ null for every cycle, which is a column meaning a different thing per row and th
 confusion this schema exists to end. The imported file's own row count is not available
 at all: `run.job_id` is not a foreign key and `ingestion_jobs` is outside the reading
 role, both by design.
+
+`gap_count` is how big a price fetch cycle was, counted in instruments rather than days
+because the instrument is what a hole in a valuation is traced back to;
+`v_price_gap.days_outstanding` carries the other measure at the grain that owns it. It is
+zero for every other run kind, as `key_count` is for a cycle.
 
 ### Naming an instrument
 

--- a/docs/spec/telemetry.md
+++ b/docs/spec/telemetry.md
@@ -425,6 +425,11 @@ time, for noticing that something changed. The drift dashboard's run table links
 through to the run dashboard, which is what makes the pair a workflow rather than two
 pictures.
 
+The **Broker** picker is import scoped and applies to the resolution and description
+panels alone. The run panels ignore it because a price fetch cycle dying matters as much
+as an import doing so, and the price panels because a cycle runs on nobody's behalf and
+names no broker to filter on.
+
 Panels select from the views and carry no definitions of their own -- `where is_import
 and reached_plugins`, never a repeated list of excluded outcomes. A judgement a panel
 needs and the views do not carry is a gap in the views.
@@ -433,6 +438,14 @@ Two consequences of the grains bind every panel. A view spanning two sibling chi
 duplicates the parent, so a panel wanting per-run child counts reads `v_run`'s rollups and
 never a join. And a child view has no timestamp of its own, so a panel bucketing one over
 time uses `run_started_at`, the run's start; `started_at` exists only on `v_run`.
+
+The price panels answer the question a cycle's duration cannot. Both dashboards carry a
+**Price fetching** section: on the drift dashboard the gap outcome mix, the unsettled rate
+split on `is_fx`, time spent per plugin and transport failures; on the run dashboard the
+gap outcomes, the days of history the cycle was handed, and a table of the gaps that did
+not settle joined to `v_instrument_label` so a hole in a valuation names an instrument
+rather than a UUID. Time per plugin is summed rather than averaged, because attributing a
+cycle's duration is what it is for.
 
 The dashboards are SQL in files no compiler reads, so a renamed column would break them
 silently until somebody opened a browser. Every panel query and every template variable

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -2068,6 +2068,34 @@ const (
 	TelemetryPluginCallDiscardedInconsistent = "discarded_inconsistent"
 )
 
+// Price gap outcomes. TelemetryGapSettledEmpty is a success and the mirror of
+// broker_description_only: no prices were stored and the gap is nonetheless
+// finished with, because the instrument did not trade over the range or no plugin
+// reaches that far back. Reading it as a failure would put every untraded week
+// into a panel meant to show outages.
+const (
+	TelemetryGapFilled            = "filled"
+	TelemetryGapSettledEmpty      = "settled_empty"
+	TelemetryGapNoEligiblePlugin  = "no_eligible_plugin"
+	TelemetryGapAllPluginsFailed  = "all_plugins_failed"
+	TelemetryGapInstrumentMissing = "instrument_missing"
+)
+
+// Price plugin call outcomes. TelemetryPriceCallNoData is an answer rather than a
+// failure to answer and settles the range for that plugin;
+// TelemetryPriceCallHistoryLimit made no call at all, the plugin's configured
+// reach not extending that far back; and TelemetryPriceCallUpsertFailed is our
+// database rather than the provider's API.
+const (
+	TelemetryPriceCallBarsReturned   = "bars_returned"
+	TelemetryPriceCallNoData         = "no_data"
+	TelemetryPriceCallHistoryLimit   = "history_limit"
+	TelemetryPriceCallPermanentBlock = "permanent_block"
+	TelemetryPriceCallTimeout        = "timeout"
+	TelemetryPriceCallError          = "error"
+	TelemetryPriceCallUpsertFailed   = "upsert_failed"
+)
+
 // TelemetryRun is one activation of one subsystem, as it stands when it starts.
 // JobID is empty for a cycle, as are UserID, Broker and Source, which cycles run
 // without.
@@ -2159,6 +2187,51 @@ type TelemetryDescriptionPluginCall struct {
 	Duration       time.Duration
 }
 
+// TelemetryPriceGap is one instrument a price fetch cycle set out to fill, as it
+// stands before any plugin is put to it. Not one price row and not one provider
+// call: an instrument's outstanding history is put to several plugins over several
+// ranges, and DaysOutstanding records the size of that ask so a cycle that got
+// slower can be told from one that was asked for more.
+//
+// AssetClass, Currency and Exchange are the three fields plugin filtering reads.
+// They are recorded rather than looked up later because they are the inputs to the
+// decision the row explains, and any of them may be empty on an instrument that
+// carries none -- which is itself why a plugin accepted it.
+type TelemetryPriceGap struct {
+	RunID           string
+	InstrumentID    string
+	IsFX            bool
+	AssetClass      string
+	Currency        string
+	Exchange        string
+	DaysOutstanding int
+}
+
+// TelemetryPricePluginCall is one outstanding range put to one plugin, which is
+// one FetchPrices call in every case but history_limit.
+//
+// The range rather than the plugin is the grain: one plugin is asked separately
+// for each range a gap leaves outstanding, and those calls can end differently.
+// Precedence is the plugin's position in the configured order, which is what makes
+// a skipped plugin readable as a gap in the sequence.
+//
+// RunID is not stored on the row -- a call reaches its run through its gap -- and
+// is carried only so a failed write can mark the run.
+type TelemetryPricePluginCall struct {
+	RunID      string
+	GapID      string
+	PluginID   string
+	Precedence int
+	// Half-open [From, Before), as the orchestrator's ranges are. The span in days
+	// is derived by the view rather than carried here.
+	From    time.Time
+	Before  time.Time
+	Bars    int
+	Outcome string
+	// Duration is nil for history_limit, which called nothing and so has no clock.
+	Duration *time.Duration
+}
+
 // TelemetryDB writes the event rows in the telemetry schema.
 //
 // It is deliberately not part of DB. It holds its own connection pool and never
@@ -2189,6 +2262,15 @@ type TelemetryDB interface {
 	WriteIdentificationAttempt(ctx context.Context, a TelemetryIdentificationAttempt) string
 	WriteIdentifierPluginCall(ctx context.Context, c TelemetryIdentifierPluginCall)
 	WriteDescriptionPluginCall(ctx context.Context, c TelemetryDescriptionPluginCall)
+
+	// StartPriceGap creates a price gap and returns its id, for the reason
+	// StartResolutionKey does: its plugin calls reference it, so it must exist
+	// before its own outcome is known.
+	StartPriceGap(ctx context.Context, g TelemetryPriceGap) string
+	// EndPriceGap stamps what became of a gap. A gap left unstamped is a cycle
+	// that died before reaching it, which is what makes where it stopped readable.
+	EndPriceGap(ctx context.Context, runID, gapID, outcome string)
+	WritePricePluginCall(ctx context.Context, c TelemetryPricePluginCall)
 
 	// SweepIncompleteRuns stamps every run left without a terminal outcome as
 	// incomplete, and returns how many it stamped. Called once at startup, before
@@ -2230,6 +2312,12 @@ func (NopTelemetry) WriteIdentificationAttempt(context.Context, TelemetryIdentif
 func (NopTelemetry) WriteIdentifierPluginCall(context.Context, TelemetryIdentifierPluginCall) {}
 
 func (NopTelemetry) WriteDescriptionPluginCall(context.Context, TelemetryDescriptionPluginCall) {}
+
+func (NopTelemetry) StartPriceGap(context.Context, TelemetryPriceGap) string { return "" }
+
+func (NopTelemetry) EndPriceGap(context.Context, string, string, string) {}
+
+func (NopTelemetry) WritePricePluginCall(context.Context, TelemetryPricePluginCall) {}
 
 func (NopTelemetry) SweepIncompleteRuns(context.Context) (int64, error) { return 0, nil }
 

--- a/server/db/postgres/telemetry.go
+++ b/server/db/postgres/telemetry.go
@@ -234,3 +234,62 @@ func (t *Telemetry) PurgeRunsBefore(ctx context.Context, cutoff time.Time) (int6
 	}
 	return res.RowsAffected()
 }
+
+// StartPriceGap implements db.TelemetryDB.
+func (t *Telemetry) StartPriceGap(ctx context.Context, g db.TelemetryPriceGap) string {
+	runID, ok := t.parent(ctx, g.RunID, g.RunID, "start price gap")
+	if !ok {
+		return ""
+	}
+	var id uuid.UUID
+	err := t.db.QueryRowContext(ctx, `
+		INSERT INTO telemetry.price_gap
+			(run_id, instrument_id, is_fx, asset_class, currency, exchange,
+			 days_outstanding)
+		VALUES ($1, $2, $3, $4, $5, $6, $7)
+		RETURNING id
+	`, runID, t.optUUID(g.InstrumentID, "start price gap"), g.IsFX,
+		nullStr(g.AssetClass), nullStr(g.Currency), nullStr(g.Exchange),
+		g.DaysOutstanding).Scan(&id)
+	if err != nil {
+		t.fail(ctx, g.RunID, "start price gap", err)
+		return ""
+	}
+	return id.String()
+}
+
+// EndPriceGap implements db.TelemetryDB.
+func (t *Telemetry) EndPriceGap(ctx context.Context, runID, gapID, outcome string) {
+	id, ok := t.parent(ctx, runID, gapID, "end price gap")
+	if !ok {
+		return
+	}
+	if _, err := t.db.ExecContext(ctx, `
+		UPDATE telemetry.price_gap SET outcome = $2 WHERE id = $1
+	`, id, outcome); err != nil {
+		t.fail(ctx, runID, "end price gap", err)
+	}
+}
+
+// WritePricePluginCall implements db.TelemetryDB.
+func (t *Telemetry) WritePricePluginCall(ctx context.Context, c db.TelemetryPricePluginCall) {
+	gapID, ok := t.parent(ctx, c.RunID, c.GapID, "write price plugin call")
+	if !ok {
+		return
+	}
+	// Null rather than zero for a call that never happened, so a history-limited
+	// range does not average into the latency panel as an instant answer.
+	var duration any
+	if c.Duration != nil {
+		duration = ms(*c.Duration)
+	}
+	if _, err := t.db.ExecContext(ctx, `
+		INSERT INTO telemetry.price_plugin_call
+			(price_gap_id, plugin_id, precedence, range_from, range_before, bars,
+			 outcome, duration_ms)
+		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+	`, gapID, c.PluginID, c.Precedence, c.From, c.Before, c.Bars, c.Outcome,
+		duration); err != nil {
+		t.fail(ctx, c.RunID, "write price plugin call", err)
+	}
+}

--- a/server/db/postgres/telemetry_schema_test.go
+++ b/server/db/postgres/telemetry_schema_test.go
@@ -343,9 +343,9 @@ func TestTelemetryVocabulariesAreClosed(t *testing.T) {
 		gapID := seedPriceGap(t, p, seedRun(t, p, "price_fetch_cycle", time.Now()), "filled", 10)
 		if _, err := p.q.ExecContext(context.Background(), `
 			INSERT INTO telemetry.price_plugin_call
-				(price_gap_id, plugin_id, precedence, range_from, range_before, days,
+				(price_gap_id, plugin_id, precedence, range_from, range_before,
 				 bars, outcome, duration_ms)
-			VALUES ($1::uuid, 'eodhd', 100, DATE '2026-01-01', DATE '2026-01-11', 10,
+			VALUES ($1::uuid, 'eodhd', 100, DATE '2026-01-01', DATE '2026-01-11',
 			        0, 'already_covered', 12)
 		`, gapID); err == nil {
 			t.Error("price plugin call accepted an outcome outside its vocabulary")
@@ -381,9 +381,9 @@ func seedPriceCall(t *testing.T, p *Postgres, gapID, pluginID, outcome string) s
 	var id string
 	err := p.q.QueryRowContext(context.Background(), `
 		INSERT INTO telemetry.price_plugin_call
-			(price_gap_id, plugin_id, precedence, range_from, range_before, days,
+			(price_gap_id, plugin_id, precedence, range_from, range_before,
 			 bars, outcome, duration_ms)
-		VALUES ($1::uuid, $2, 100, DATE '2026-01-01', DATE '2026-01-11', 10, 0, $3, 40)
+		VALUES ($1::uuid, $2, 100, DATE '2026-01-01', DATE '2026-01-11', 0, $3, 40)
 		RETURNING id
 	`, gapID, pluginID, outcome).Scan(&id)
 	if err != nil {
@@ -896,9 +896,9 @@ func TestTelemetryPriceCallDurationIsNullable(t *testing.T) {
 	var id string
 	if err := p.q.QueryRowContext(ctx, `
 		INSERT INTO telemetry.price_plugin_call
-			(price_gap_id, plugin_id, precedence, range_from, range_before, days,
+			(price_gap_id, plugin_id, precedence, range_from, range_before,
 			 bars, outcome, duration_ms)
-		VALUES ($1::uuid, 'eodhd', 100, DATE '2026-01-01', DATE '2026-01-11', 10,
+		VALUES ($1::uuid, 'eodhd', 100, DATE '2026-01-01', DATE '2026-01-11',
 		        0, 'history_limit', NULL)
 		RETURNING id
 	`, gapID).Scan(&id); err != nil {
@@ -913,5 +913,26 @@ func TestTelemetryPriceCallDurationIsNullable(t *testing.T) {
 	}
 	if duration != nil {
 		t.Errorf("duration_ms = %d, want null", *duration)
+	}
+}
+
+// TestTelemetryViews_PriceCallDaysAreDerived pins that the span of a fetch range
+// is the subtraction of its own two dates rather than a stored number that could
+// drift from them.
+func TestTelemetryViews_PriceCallDaysAreDerived(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	gapID := seedPriceGap(t, p, seedRun(t, p, "price_fetch_cycle", time.Now()), "filled", 10)
+	id := seedPriceCall(t, p, gapID, "eodhd", "bars_returned")
+
+	var days int
+	if err := p.q.QueryRowContext(ctx,
+		`SELECT days FROM telemetry.v_price_plugin_call WHERE id = $1::uuid`, id,
+	).Scan(&days); err != nil {
+		t.Fatalf("select v_price_plugin_call: %v", err)
+	}
+	// The seed's half-open [2026-01-01, 2026-01-11).
+	if days != 10 {
+		t.Errorf("days = %d, want 10", days)
 	}
 }

--- a/server/db/postgres/telemetry_schema_test.go
+++ b/server/db/postgres/telemetry_schema_test.go
@@ -322,6 +322,74 @@ func TestTelemetryVocabulariesAreClosed(t *testing.T) {
 			t.Error("identifier plugin call accepted an outcome outside its vocabulary")
 		}
 	})
+
+	t.Run("price gap outcome", func(t *testing.T) {
+		p := testDBTx(t)
+		runID := seedRun(t, p, "price_fetch_cycle", time.Now())
+		// 'skipped' is the tempting member and is deliberately absent: a gap no
+		// plugin was eligible for and one every plugin failed on need different
+		// fixes, so the vocabulary names which.
+		if _, err := p.q.ExecContext(context.Background(), `
+			INSERT INTO telemetry.price_gap
+				(run_id, instrument_id, is_fx, days_outstanding, outcome)
+			VALUES ($1::uuid, gen_random_uuid(), FALSE, 10, 'skipped')
+		`, runID); err == nil {
+			t.Error("price gap accepted an outcome outside its vocabulary")
+		}
+	})
+
+	t.Run("price plugin call outcome", func(t *testing.T) {
+		p := testDBTx(t)
+		gapID := seedPriceGap(t, p, seedRun(t, p, "price_fetch_cycle", time.Now()), "filled", 10)
+		if _, err := p.q.ExecContext(context.Background(), `
+			INSERT INTO telemetry.price_plugin_call
+				(price_gap_id, plugin_id, precedence, range_from, range_before, days,
+				 bars, outcome, duration_ms)
+			VALUES ($1::uuid, 'eodhd', 100, DATE '2026-01-01', DATE '2026-01-11', 10,
+			        0, 'already_covered', 12)
+		`, gapID); err == nil {
+			t.Error("price plugin call accepted an outcome outside its vocabulary")
+		}
+	})
+}
+
+// seedPriceGap inserts a price gap under a run and returns its id. An empty
+// outcome is a gap the cycle never reached.
+func seedPriceGap(t *testing.T, p *Postgres, runID, outcome string, days int) string {
+	t.Helper()
+	var oc any
+	if outcome != "" {
+		oc = outcome
+	}
+	var id string
+	err := p.q.QueryRowContext(context.Background(), `
+		INSERT INTO telemetry.price_gap
+			(run_id, instrument_id, is_fx, asset_class, currency, exchange,
+			 days_outstanding, outcome)
+		VALUES ($1::uuid, gen_random_uuid(), FALSE, 'STOCK', 'USD', 'XNAS', $2, $3)
+		RETURNING id
+	`, runID, days, oc).Scan(&id)
+	if err != nil {
+		t.Fatalf("seed price gap %q: %v", outcome, err)
+	}
+	return id
+}
+
+// seedPriceCall inserts a price plugin call under a gap.
+func seedPriceCall(t *testing.T, p *Postgres, gapID, pluginID, outcome string) string {
+	t.Helper()
+	var id string
+	err := p.q.QueryRowContext(context.Background(), `
+		INSERT INTO telemetry.price_plugin_call
+			(price_gap_id, plugin_id, precedence, range_from, range_before, days,
+			 bars, outcome, duration_ms)
+		VALUES ($1::uuid, $2, 100, DATE '2026-01-01', DATE '2026-01-11', 10, 0, $3, 40)
+		RETURNING id
+	`, gapID, pluginID, outcome).Scan(&id)
+	if err != nil {
+		t.Fatalf("seed price call %q: %v", outcome, err)
+	}
+	return id
 }
 
 // seedKeyWithOutcome inserts a resolution key carrying a given stage 2 outcome,
@@ -552,17 +620,28 @@ func TestTelemetryViews_RunRollupsDoNotMultiply(t *testing.T) {
 	seedAttempt(t, p, first, "mismatch_check", "identified", 0)
 	seedDescriptionCall(t, p, runID, "hints_returned")
 	seedDescriptionCall(t, p, runID, "no_hints")
+	// A fourth child grain under the same run. Two gaps, one carrying two calls,
+	// so a join rather than a scalar subquery would multiply the key counts by
+	// three and the gap count by two.
+	gapID := seedPriceGap(t, p, runID, "filled", 30)
+	seedPriceGap(t, p, runID, "settled_empty", 5)
+	seedPriceCall(t, p, gapID, "eodhd", "bars_returned")
+	seedPriceCall(t, p, gapID, "massive", "no_data")
 
-	var rows, keyCount, keyTxCount, descCount int
+	var rows, keyCount, keyTxCount, descCount, gapCount int
 	err := p.q.QueryRowContext(ctx, `
-		SELECT count(*), max(key_count), max(key_tx_count), max(description_call_count)
+		SELECT count(*), max(key_count), max(key_tx_count), max(description_call_count),
+		       max(gap_count)
 		FROM telemetry.v_run WHERE id = $1::uuid
-	`, runID).Scan(&rows, &keyCount, &keyTxCount, &descCount)
+	`, runID).Scan(&rows, &keyCount, &keyTxCount, &descCount, &gapCount)
 	if err != nil {
 		t.Fatalf("select v_run: %v", err)
 	}
 	if rows != 1 {
 		t.Errorf("v_run rows = %d, want 1", rows)
+	}
+	if gapCount != 2 {
+		t.Errorf("gap_count = %d, want 2", gapCount)
 	}
 	if keyCount != 2 {
 		t.Errorf("key_count = %d, want 2", keyCount)
@@ -583,17 +662,17 @@ func TestTelemetryViews_RunRollupsAreZeroNotNull(t *testing.T) {
 	p := testDBTx(t)
 	runID := seedRun(t, p, "grouping_cycle", time.Now())
 
-	var keyCount, keyTxCount, descCount int
+	var keyCount, keyTxCount, descCount, gapCount int
 	err := p.q.QueryRowContext(context.Background(), `
-		SELECT key_count, key_tx_count, description_call_count
+		SELECT key_count, key_tx_count, description_call_count, gap_count
 		FROM telemetry.v_run WHERE id = $1::uuid
-	`, runID).Scan(&keyCount, &keyTxCount, &descCount)
+	`, runID).Scan(&keyCount, &keyTxCount, &descCount, &gapCount)
 	if err != nil {
 		t.Fatalf("select v_run: %v", err)
 	}
-	if keyCount != 0 || keyTxCount != 0 || descCount != 0 {
-		t.Errorf("rollups for an empty run = (%d, %d, %d), want all 0",
-			keyCount, keyTxCount, descCount)
+	if keyCount != 0 || keyTxCount != 0 || descCount != 0 || gapCount != 0 {
+		t.Errorf("rollups for an empty run = (%d, %d, %d, %d), want all 0",
+			keyCount, keyTxCount, descCount, gapCount)
 	}
 }
 
@@ -625,5 +704,214 @@ func TestTelemetryReaderReadsLabelsWithoutReachingPublic(t *testing.T) {
 		`SELECT count(*) FROM instruments`,
 	).Scan(&n); err == nil {
 		t.Error("telemetry_reader can read instruments directly; the view indirection is not what is granting access")
+	}
+}
+
+// TestTelemetryViews_Settled pins which gap outcomes mean the gap is dealt with.
+// settled_empty is the member worth staring at, and is the mirror image of
+// broker_description_only above: no prices were stored, and the gap is
+// nonetheless finished with. Reading it as a failure would put every untraded
+// week and every pre-IPO range into a panel meant to show outages.
+func TestTelemetryViews_Settled(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	runID := seedRun(t, p, "price_fetch_cycle", time.Now())
+
+	cases := []struct {
+		outcome string
+		settled bool
+	}{
+		{"filled", true},
+		{"settled_empty", true},
+		{"no_eligible_plugin", false},
+		{"all_plugins_failed", false},
+		{"instrument_missing", false},
+		// A gap the cycle died before reaching. Not settled, and it must not
+		// vanish from both the column and its negation.
+		{"", false},
+	}
+	for _, c := range cases {
+		name := c.outcome
+		if name == "" {
+			name = "unstamped"
+		}
+		t.Run(name, func(t *testing.T) {
+			id := seedPriceGap(t, p, runID, c.outcome, 10)
+			var got bool
+			if err := p.q.QueryRowContext(ctx,
+				`SELECT settled FROM telemetry.v_price_gap WHERE id = $1::uuid`, id,
+			).Scan(&got); err != nil {
+				t.Fatalf("select v_price_gap: %v", err)
+			}
+			if got != c.settled {
+				t.Errorf("settled for %q = %v, want %v", c.outcome, got, c.settled)
+			}
+		})
+	}
+}
+
+// TestTelemetryViews_HadCall separates a gap that never asked a plugin from one
+// that asked and got nothing. Four paths -- the plugin filter, a fetch block, no
+// supported identifier, and a range already covered -- return before FetchPrices,
+// so no call is the ordinary case and not a fault.
+func TestTelemetryViews_HadCall(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	runID := seedRun(t, p, "price_fetch_cycle", time.Now())
+
+	asked := seedPriceGap(t, p, runID, "all_plugins_failed", 10)
+	seedPriceCall(t, p, asked, "eodhd", "error")
+	never := seedPriceGap(t, p, runID, "no_eligible_plugin", 10)
+
+	for _, c := range []struct {
+		name string
+		id   string
+		want bool
+	}{
+		{"asked", asked, true},
+		{"never asked", never, false},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			var got bool
+			if err := p.q.QueryRowContext(ctx,
+				`SELECT had_call FROM telemetry.v_price_gap WHERE id = $1::uuid`, c.id,
+			).Scan(&got); err != nil {
+				t.Fatalf("select v_price_gap: %v", err)
+			}
+			if got != c.want {
+				t.Errorf("had_call = %v, want %v", got, c.want)
+			}
+		})
+	}
+}
+
+// TestTelemetryViews_PriceTransportFailed pins where the line falls between the
+// provider being unreachable and the provider having nothing. no_data is the
+// member a panel most easily gets wrong: it is the expected answer for a range an
+// instrument did not trade in, and counting it as a transport failure would make
+// every delisted holding look like an outage.
+//
+// upsert_failed sits outside transport_failed and alone in write_failed, because
+// it is our database and not the provider's API.
+func TestTelemetryViews_PriceTransportFailed(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	gapID := seedPriceGap(t, p, seedRun(t, p, "price_fetch_cycle", time.Now()), "filled", 10)
+
+	cases := []struct {
+		outcome   string
+		transport bool
+		write     bool
+	}{
+		{"timeout", true, false},
+		{"error", true, false},
+		{"bars_returned", false, false},
+		{"no_data", false, false},
+		{"history_limit", false, false},
+		{"permanent_block", false, false},
+		{"upsert_failed", false, true},
+	}
+	for _, c := range cases {
+		t.Run(c.outcome, func(t *testing.T) {
+			id := seedPriceCall(t, p, gapID, "eodhd", c.outcome)
+			var transport, write bool
+			if err := p.q.QueryRowContext(ctx, `
+				SELECT transport_failed, write_failed
+				FROM telemetry.v_price_plugin_call WHERE id = $1::uuid
+			`, id).Scan(&transport, &write); err != nil {
+				t.Fatalf("select v_price_plugin_call: %v", err)
+			}
+			if transport != c.transport {
+				t.Errorf("transport_failed for %q = %v, want %v", c.outcome, transport, c.transport)
+			}
+			if write != c.write {
+				t.Errorf("write_failed for %q = %v, want %v", c.outcome, write, c.write)
+			}
+		})
+	}
+}
+
+// TestTelemetryViews_PriceGapDoesNotFanOut keeps the gap view one row per gap
+// however many plugins were put to it. A gap asked of three plugins is one gap,
+// and a view that returned it three times would make every count over
+// days_outstanding silently treble.
+func TestTelemetryViews_PriceGapDoesNotFanOut(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	gapID := seedPriceGap(t, p, seedRun(t, p, "price_fetch_cycle", time.Now()), "filled", 30)
+	seedPriceCall(t, p, gapID, "eodhd", "no_data")
+	seedPriceCall(t, p, gapID, "massive", "bars_returned")
+	seedPriceCall(t, p, gapID, "massive", "history_limit")
+
+	var rows, days int
+	if err := p.q.QueryRowContext(ctx, `
+		SELECT count(*), coalesce(sum(days_outstanding), 0)
+		FROM telemetry.v_price_gap WHERE id = $1::uuid
+	`, gapID).Scan(&rows, &days); err != nil {
+		t.Fatalf("select v_price_gap: %v", err)
+	}
+	if rows != 1 {
+		t.Errorf("v_price_gap rows = %d, want 1", rows)
+	}
+	if days != 30 {
+		t.Errorf("summed days_outstanding = %d, want 30", days)
+	}
+}
+
+// TestTelemetryPriceGapCascades pins that a gap and its calls go with their run,
+// so retention stays a delete from one table.
+func TestTelemetryPriceGapCascades(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	runID := seedRun(t, p, "price_fetch_cycle", time.Now())
+	gapID := seedPriceGap(t, p, runID, "filled", 10)
+	seedPriceCall(t, p, gapID, "eodhd", "bars_returned")
+
+	if _, err := p.q.ExecContext(ctx,
+		`DELETE FROM telemetry.run WHERE id = $1::uuid`, runID); err != nil {
+		t.Fatalf("delete run: %v", err)
+	}
+
+	for _, tbl := range []string{"price_gap", "price_plugin_call"} {
+		var n int
+		if err := p.q.QueryRowContext(ctx,
+			`SELECT count(*) FROM telemetry.`+tbl,
+		).Scan(&n); err != nil {
+			t.Fatalf("count %s: %v", tbl, err)
+		}
+		if n != 0 {
+			t.Errorf("%s still holds %d rows after its run went", tbl, n)
+		}
+	}
+}
+
+// TestTelemetryPriceCallDurationIsNullable pins that history_limit can record no
+// duration. It made no call, and a zero would average into the latency panel as a
+// plugin that answered instantly.
+func TestTelemetryPriceCallDurationIsNullable(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+	gapID := seedPriceGap(t, p, seedRun(t, p, "price_fetch_cycle", time.Now()), "settled_empty", 10)
+
+	var id string
+	if err := p.q.QueryRowContext(ctx, `
+		INSERT INTO telemetry.price_plugin_call
+			(price_gap_id, plugin_id, precedence, range_from, range_before, days,
+			 bars, outcome, duration_ms)
+		VALUES ($1::uuid, 'eodhd', 100, DATE '2026-01-01', DATE '2026-01-11', 10,
+		        0, 'history_limit', NULL)
+		RETURNING id
+	`, gapID).Scan(&id); err != nil {
+		t.Fatalf("insert history_limit call with a null duration: %v", err)
+	}
+
+	var duration *int
+	if err := p.q.QueryRowContext(ctx,
+		`SELECT duration_ms FROM telemetry.v_price_plugin_call WHERE id = $1::uuid`, id,
+	).Scan(&duration); err != nil {
+		t.Fatalf("select v_price_plugin_call: %v", err)
+	}
+	if duration != nil {
+		t.Errorf("duration_ms = %d, want null", *duration)
 	}
 }

--- a/server/db/postgres/telemetry_test.go
+++ b/server/db/postgres/telemetry_test.go
@@ -459,3 +459,157 @@ func TestWriteDescriptionPluginCallPrecedence(t *testing.T) {
 		}
 	}
 }
+
+// TestWritePriceGapNest walks the price grains end to end, so that a column
+// renamed under the writer fails here rather than in front of someone reading a
+// dashboard. The call view flattens both parents in, which is what lets one row
+// answer what a plugin was asked, about which instrument, in which run.
+func TestWritePriceGapNest(t *testing.T) {
+	tel := testTelemetry(t)
+	ctx := context.Background()
+
+	runID := tel.StartRun(ctx, db.TelemetryRun{Kind: db.TelemetryRunPriceFetchCycle})
+	instID := "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+	gapID := tel.StartPriceGap(ctx, db.TelemetryPriceGap{
+		RunID:           runID,
+		InstrumentID:    instID,
+		AssetClass:      "STOCK",
+		Currency:        "USD",
+		Exchange:        "XNAS",
+		DaysOutstanding: 420,
+	})
+	if gapID == "" {
+		t.Fatal("StartPriceGap returned no id")
+	}
+	took := 1500 * time.Millisecond
+	tel.WritePricePluginCall(ctx, db.TelemetryPricePluginCall{
+		RunID:      runID,
+		GapID:      gapID,
+		PluginID:   "eodhd",
+		Precedence: 70,
+		From:       time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC),
+		Before:     time.Date(2024, 1, 11, 0, 0, 0, 0, time.UTC),
+		Bars:       7,
+		Outcome:    db.TelemetryPriceCallBarsReturned,
+		Duration:   &took,
+	})
+	tel.EndPriceGap(ctx, runID, gapID, db.TelemetryGapFilled)
+	tel.EndRun(ctx, runID, db.TelemetryOutcomeSuccess)
+
+	var (
+		pluginID, callOutcome, gapOutcome, runKind, assetClass, currency, exchange string
+		precedence, days, bars, durationMS, daysOutstanding                        int
+		transportFailed, writeFailed, gapSettled, isFX                             bool
+	)
+	err := tel.db.QueryRow(`
+		SELECT plugin_id, precedence, days, bars, outcome, duration_ms,
+		       transport_failed, write_failed,
+		       gap_outcome, gap_settled, gap_is_fx, gap_asset_class, gap_currency,
+		       gap_exchange, gap_days_outstanding, run_kind
+		FROM telemetry.v_price_plugin_call WHERE run_id = $1::uuid
+	`, runID).Scan(&pluginID, &precedence, &days, &bars, &callOutcome, &durationMS,
+		&transportFailed, &writeFailed, &gapOutcome, &gapSettled, &isFX,
+		&assetClass, &currency, &exchange, &daysOutstanding, &runKind)
+	if err != nil {
+		t.Fatalf("read v_price_plugin_call: %v", err)
+	}
+	if pluginID != "eodhd" || callOutcome != db.TelemetryPriceCallBarsReturned {
+		t.Errorf("call = (%s, %s), want (eodhd, bars_returned)", pluginID, callOutcome)
+	}
+	if precedence != 70 || bars != 7 || durationMS != 1500 {
+		t.Errorf("precedence, bars, duration_ms = (%d, %d, %d), want (70, 7, 1500)",
+			precedence, bars, durationMS)
+	}
+	// Derived from the range rather than stored, so it cannot disagree with it.
+	if days != 10 {
+		t.Errorf("days = %d, want the 10 the range spans", days)
+	}
+	if transportFailed || writeFailed {
+		t.Errorf("a call that returned bars is marked failed (transport=%v, write=%v)",
+			transportFailed, writeFailed)
+	}
+	if gapOutcome != db.TelemetryGapFilled || !gapSettled || isFX {
+		t.Errorf("gap = (%s, settled=%v, fx=%v), want (filled, true, false)",
+			gapOutcome, gapSettled, isFX)
+	}
+	if assetClass != "STOCK" || currency != "USD" || exchange != "XNAS" {
+		t.Errorf("gap attributes = (%s, %s, %s), want (STOCK, USD, XNAS)",
+			assetClass, currency, exchange)
+	}
+	if daysOutstanding != 420 || runKind != db.TelemetryRunPriceFetchCycle {
+		t.Errorf("gap days_outstanding, run kind = (%d, %s), want (420, price_fetch_cycle)",
+			daysOutstanding, runKind)
+	}
+
+	// The instrument is readable through the label view rather than joined into
+	// the grain views, and the gap holds the id that reaches it.
+	var storedInst string
+	if err := tel.db.QueryRow(
+		`SELECT instrument_id::text FROM telemetry.v_price_gap WHERE id = $1::uuid`, gapID,
+	).Scan(&storedInst); err != nil {
+		t.Fatalf("read v_price_gap: %v", err)
+	}
+	if storedInst != instID {
+		t.Errorf("instrument_id = %s, want %s", storedInst, instID)
+	}
+}
+
+// TestWritePricePluginCallNullDuration pins the one outcome that made no call.
+// Zero would average into a latency panel as a plugin answering instantly, which
+// is the same reason a plugin costing no tokens writes null rather than zero.
+func TestWritePricePluginCallNullDuration(t *testing.T) {
+	tel := testTelemetry(t)
+	ctx := context.Background()
+	runID := tel.StartRun(ctx, db.TelemetryRun{Kind: db.TelemetryRunPriceFetchCycle})
+	gapID := tel.StartPriceGap(ctx, db.TelemetryPriceGap{
+		RunID:           runID,
+		InstrumentID:    "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+		DaysOutstanding: 30,
+	})
+	tel.WritePricePluginCall(ctx, db.TelemetryPricePluginCall{
+		RunID:    runID,
+		GapID:    gapID,
+		PluginID: "eodhd",
+		From:     time.Date(2019, 1, 1, 0, 0, 0, 0, time.UTC),
+		Before:   time.Date(2019, 2, 1, 0, 0, 0, 0, time.UTC),
+		Outcome:  db.TelemetryPriceCallHistoryLimit,
+	})
+
+	var duration sql.NullInt64
+	if err := tel.db.QueryRow(
+		`SELECT duration_ms FROM telemetry.v_price_plugin_call WHERE run_id = $1::uuid`, runID,
+	).Scan(&duration); err != nil {
+		t.Fatalf("read v_price_plugin_call: %v", err)
+	}
+	if duration.Valid {
+		t.Errorf("duration_ms = %d, want null for a call that never happened", duration.Int64)
+	}
+}
+
+// TestUnstampedPriceGapIsNotSettled pins that a gap the cycle never reached does
+// not read as dealt with. It must appear in the complement of settled, or a cycle
+// killed part way would look like one that finished.
+func TestUnstampedPriceGapIsNotSettled(t *testing.T) {
+	tel := testTelemetry(t)
+	ctx := context.Background()
+	runID := tel.StartRun(ctx, db.TelemetryRun{Kind: db.TelemetryRunPriceFetchCycle})
+	gapID := tel.StartPriceGap(ctx, db.TelemetryPriceGap{
+		RunID:           runID,
+		InstrumentID:    "6ba7b810-9dad-11d1-80b4-00c04fd430c8",
+		DaysOutstanding: 30,
+	})
+
+	var settled, hadCall bool
+	var outcome sql.NullString
+	if err := tel.db.QueryRow(
+		`SELECT outcome, settled, had_call FROM telemetry.v_price_gap WHERE id = $1::uuid`, gapID,
+	).Scan(&outcome, &settled, &hadCall); err != nil {
+		t.Fatalf("read v_price_gap: %v", err)
+	}
+	if outcome.Valid {
+		t.Errorf("outcome = %q, want null on a gap that was never stamped", outcome.String)
+	}
+	if settled || hadCall {
+		t.Errorf("settled, had_call = (%v, %v), want both false", settled, hadCall)
+	}
+}

--- a/server/migrations/005_telemetry.sql
+++ b/server/migrations/005_telemetry.sql
@@ -221,6 +221,111 @@ CREATE TABLE telemetry.description_plugin_call (
 CREATE INDEX idx_telemetry_description_plugin_call_run
   ON telemetry.description_plugin_call (run_id);
 
+-- One instrument a price fetch cycle set out to fill, which is one entry in the gap
+-- list PriceGaps and FXGaps produce between them.
+--
+-- Not one price row and not one provider call: a single instrument's outstanding
+-- history is put to several plugins over several ranges. days_outstanding is the size
+-- of that ask, and is the denominator every rate here wants -- without it a cycle that
+-- got slower cannot be told from one that was asked for more, which is the first
+-- question about a cycle whose duration moved.
+--
+-- Like run and resolution_key the row is created before its children and stamped when
+-- the instrument is done with, so a null outcome means the same thing it means there:
+-- not stamped. Rows are written for the whole gap list up front, so a cycle that died
+-- part way leaves the instruments it never reached unstamped, and where it stopped is
+-- readable rather than lost.
+--
+-- asset_class, currency and exchange are the three fields the orchestrator filters
+-- plugins on. They are recorded rather than looked up through v_instrument_label
+-- because they are the inputs to a decision this row explains: an instrument whose
+-- asset class is corrected later would otherwise rewrite the reason a plugin was
+-- skipped a year ago.
+CREATE TABLE telemetry.price_gap (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_id        UUID NOT NULL REFERENCES telemetry.run (id) ON DELETE CASCADE,
+  -- Not a foreign key, for the reason run.job_id is not one: telemetry outlives the
+  -- work it describes, and a deleted instrument must not take the diagnostics
+  -- explaining it. v_instrument_label is where a panel turns this into a name.
+  instrument_id UUID NOT NULL,
+  -- Price gaps and FX gaps are fetched by one loop over a concatenated list, and are
+  -- indistinguishable from there on. The flag is what keeps them apart, and they are
+  -- not the same size of problem: a missing rate breaks valuation for every instrument
+  -- denominated in that currency, not for one.
+  is_fx         BOOLEAN NOT NULL,
+  asset_class   TEXT,
+  currency      TEXT,
+  exchange      TEXT,
+  -- Days outstanding when the cycle picked the gap up, summed over its ranges. This is
+  -- what shrinks cycle over cycle while coverage recording is working, and what stops
+  -- shrinking when it is not.
+  days_outstanding INT NOT NULL,
+  -- settled_empty is a success and must not be read as a failure: every outstanding
+  -- range was closed by coverage without bars, because the instrument did not trade
+  -- then or no plugin reaches that far back. The gap is settled and will not be asked
+  -- about again, which is the whole purpose of recording empty coverage.
+  --
+  -- A settled_empty gap with no price_plugin_call rows under it is the one shape worth
+  -- hunting: every plugin had already covered every range, so the gap recurs in the
+  -- gap list every cycle forever while no plugin will ever fill it.
+  outcome       TEXT CHECK (outcome IN ('filled', 'settled_empty', 'no_eligible_plugin',
+                                        'all_plugins_failed', 'instrument_missing'))
+);
+
+CREATE INDEX idx_telemetry_price_gap_run ON telemetry.price_gap (run_id);
+-- The panel asking whether one instrument ever prices reads this way, and it is the
+-- question a hole in a portfolio valuation turns into.
+CREATE INDEX idx_telemetry_price_gap_instrument ON telemetry.price_gap (instrument_id);
+
+-- One outstanding range put to one plugin, which is one FetchPrices call in every case
+-- but history_limit.
+--
+-- The range rather than the plugin is the grain because one plugin is asked separately
+-- for each range a gap leaves outstanding, and those calls can end differently: a head
+-- the plugin cannot reach, a middle it answers, a tail that times out. Collapsing them
+-- to one row per (gap, plugin) would force one outcome onto three answers, which is the
+-- rule at the top of this file broken.
+--
+-- Plugins are tried in precedence order until one covers the gap, so a gap normally has
+-- rows from fewer plugins than are configured. precedence is what makes that readable,
+-- for the reason it is recorded on description_plugin_call: a plugin filtered out by
+-- asset class, exchange or currency, blocked for this instrument, or holding no
+-- identifier it supports, writes no row at all, so a gap in the sequence means skipped.
+--
+-- There is deliberately no row for a range a plugin had already covered. Recording the
+-- absence of work would make the table grow with the catalogue rather than with what
+-- was done; the same (instrument, plugin, range) recurring across cycles is the better
+-- signal that coverage recording has stopped working, and it is positive evidence.
+CREATE TABLE telemetry.price_plugin_call (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  price_gap_id UUID NOT NULL REFERENCES telemetry.price_gap (id) ON DELETE CASCADE,
+  plugin_id    TEXT NOT NULL,
+  precedence   INT NOT NULL,
+  -- Half-open [range_from, range_before), as the orchestrator's ranges are.
+  range_from   DATE NOT NULL,
+  range_before DATE NOT NULL,
+  days         INT NOT NULL,
+  -- Bars the plugin returned, 0 for every outcome but bars_returned. A plugin that
+  -- answered with an empty series records no_data instead, so this is never the way to
+  -- tell an empty answer from a failed one.
+  bars         INT NOT NULL,
+  -- no_data is an answer, not a failure to answer: the range is settled for this plugin
+  -- and never asked again. history_limit is the one member that made no call -- the
+  -- plugin's configured reach does not extend that far back, so the range is settled
+  -- without asking. upsert_failed is our database rather than the provider's API, and
+  -- is separate for the reason transport failure is separate from not_identified: the
+  -- two need different fixes.
+  outcome      TEXT NOT NULL CHECK (outcome IN ('bars_returned', 'no_data', 'history_limit',
+                                                'permanent_block', 'timeout', 'error',
+                                                'upsert_failed')),
+  -- Null for history_limit, which called nothing and so has no clock, for the reason a
+  -- plugin costing no tokens writes null rather than zero.
+  duration_ms  INT
+);
+
+CREATE INDEX idx_telemetry_price_plugin_call_gap
+  ON telemetry.price_plugin_call (price_gap_id);
+
 -- Views.
 --
 -- One per table, each flattening its parents in and never fanning out into its
@@ -270,7 +375,14 @@ SELECT
   (SELECT coalesce(sum(k.tx_count), 0) FROM telemetry.resolution_key k
      WHERE k.run_id = r.id) AS key_tx_count,
   (SELECT count(*) FROM telemetry.description_plugin_call c
-     WHERE c.run_id = r.id) AS description_call_count
+     WHERE c.run_id = r.id) AS description_call_count,
+  -- How big a price fetch cycle was. Instruments rather than days, because the
+  -- instrument is what the run dashboard drills into and what a hole in a
+  -- valuation is traced back to; v_price_gap.days_outstanding carries the other
+  -- measure at the grain that owns it. Zero for every other run kind, as
+  -- key_count is for this one.
+  (SELECT count(*) FROM telemetry.price_gap g
+     WHERE g.run_id = r.id) AS gap_count
 FROM telemetry.run r;
 
 CREATE VIEW telemetry.v_resolution_key AS
@@ -435,6 +547,85 @@ SELECT
   r.kind IN ('tx_import', 'user_archive_import', 'system_archive_import') AS is_import
 FROM telemetry.description_plugin_call c
 JOIN telemetry.run r ON r.id = c.run_id;
+
+CREATE VIEW telemetry.v_price_gap AS
+SELECT
+  g.id,
+  g.run_id,
+  g.instrument_id,
+  g.is_fx,
+  g.asset_class,
+  g.currency,
+  g.exchange,
+  g.days_outstanding,
+  g.outcome,
+  -- The gap is dealt with and will not be back. settled_empty is deliberately
+  -- inside it: a range no plugin can fill is settled once that is recorded, and
+  -- counting it as a failure would make an untraded week look like an outage.
+  --
+  -- The complement is the column a panel wants -- a gap that recurs every cycle,
+  -- costing discovery work and leaving a hole in valuation. A null outcome is not
+  -- settled either, hence the explicit null handling rather than a bare IN, which
+  -- would yield null and drop the row out of both this column and its negation.
+  g.outcome IS NOT NULL AND g.outcome IN ('filled', 'settled_empty') AS settled,
+  -- Whether any plugin was asked at all. Filters, fetch blocks, missing identifiers
+  -- and existing coverage each return before FetchPrices is called, so no call is an
+  -- ordinary case rather than a fault, and telling "never asked" from "asked and
+  -- failed" is the first question about a gap that did not fill. EXISTS rather than a
+  -- join: this view stays one row per gap.
+  EXISTS (SELECT 1 FROM telemetry.price_plugin_call c
+            WHERE c.price_gap_id = g.id) AS had_call,
+  r.kind       AS run_kind,
+  r.started_at AS run_started_at,
+  r.outcome    AS run_outcome,
+  r.telemetry_incomplete AS run_telemetry_incomplete,
+  -- Constant false while price_fetch_cycle is the only kind that fills gaps. Carried
+  -- because every view here carries it, so a panel written against one grain does not
+  -- have to remember which grains are the exception.
+  r.kind IN ('tx_import', 'user_archive_import', 'system_archive_import') AS is_import
+FROM telemetry.price_gap g
+JOIN telemetry.run r ON r.id = g.run_id;
+
+CREATE VIEW telemetry.v_price_plugin_call AS
+SELECT
+  c.id,
+  c.price_gap_id,
+  c.plugin_id,
+  c.precedence,
+  c.range_from,
+  c.range_before,
+  c.days,
+  c.bars,
+  c.outcome,
+  c.duration_ms,
+  -- The call did not complete. no_data is deliberately outside it, for the reason
+  -- not_identified is outside the identifier plugin's transport_failed: the provider
+  -- having nothing and the provider being unreachable are different events with
+  -- different fixes. history_limit is outside it because nothing was called, and
+  -- permanent_block because it is a durable fact about the pair rather than an
+  -- incident -- it creates a fetch block, so it happens once and never again.
+  c.outcome IN ('timeout', 'error') AS transport_failed,
+  -- Ours rather than theirs. Separate from transport_failed so a panel watching
+  -- provider health is not moved by our own write failing, and so that a burst of
+  -- these reads as what it is.
+  c.outcome = 'upsert_failed' AS write_failed,
+  g.instrument_id AS gap_instrument_id,
+  g.is_fx         AS gap_is_fx,
+  g.asset_class   AS gap_asset_class,
+  g.currency      AS gap_currency,
+  g.exchange      AS gap_exchange,
+  g.days_outstanding AS gap_days_outstanding,
+  g.outcome       AS gap_outcome,
+  g.outcome IS NOT NULL AND g.outcome IN ('filled', 'settled_empty') AS gap_settled,
+  r.id         AS run_id,
+  r.kind       AS run_kind,
+  r.started_at AS run_started_at,
+  r.outcome    AS run_outcome,
+  r.telemetry_incomplete AS run_telemetry_incomplete,
+  r.kind IN ('tx_import', 'user_archive_import', 'system_archive_import') AS is_import
+FROM telemetry.price_plugin_call c
+JOIN telemetry.price_gap g ON g.id = c.price_gap_id
+JOIN telemetry.run r ON r.id = g.run_id;
 
 -- The one thing here that reads outside the telemetry schema.
 --

--- a/server/migrations/005_telemetry.sql
+++ b/server/migrations/005_telemetry.sql
@@ -301,10 +301,11 @@ CREATE TABLE telemetry.price_plugin_call (
   price_gap_id UUID NOT NULL REFERENCES telemetry.price_gap (id) ON DELETE CASCADE,
   plugin_id    TEXT NOT NULL,
   precedence   INT NOT NULL,
-  -- Half-open [range_from, range_before), as the orchestrator's ranges are.
+  -- Half-open [range_from, range_before), as the orchestrator's ranges are. The
+  -- span in days is not stored: it is the subtraction of these two, and a column
+  -- holding it could disagree with the range it came from.
   range_from   DATE NOT NULL,
   range_before DATE NOT NULL,
-  days         INT NOT NULL,
   -- Bars the plugin returned, 0 for every outcome but bars_returned. A plugin that
   -- answered with an empty series records no_data instead, so this is never the way to
   -- tell an empty answer from a failed one.
@@ -594,7 +595,10 @@ SELECT
   c.precedence,
   c.range_from,
   c.range_before,
-  c.days,
+  -- Derived rather than stored, so it cannot disagree with the range above it.
+  -- DATE minus DATE is a whole number of days in postgres, which is the
+  -- resolution a fetch range has.
+  (c.range_before - c.range_from) AS days,
   c.bars,
   c.outcome,
   c.duration_ms,

--- a/server/pricefetcher/gap_telemetry_test.go
+++ b/server/pricefetcher/gap_telemetry_test.go
@@ -1,0 +1,484 @@
+package pricefetcher
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/leedenison/portfoliodb/server/db"
+	"github.com/leedenison/portfoliodb/server/db/mock"
+	"github.com/shopspring/decimal"
+	"go.uber.org/mock/gomock"
+)
+
+// TestGapOutcome pins what a cycle concludes about one instrument. The two
+// settled_empty rows are the point of the table: a plugin that covered every range
+// and returned nothing has settled the gap, and so has a gap every eligible plugin
+// had covered on an earlier cycle. Reading either as a failure would fill a panel
+// meant to show outages with untraded weeks.
+func TestGapOutcome(t *testing.T) {
+	tests := []struct {
+		name    string
+		fetched bool
+		bars    int
+		reached bool
+		called  bool
+		want    string
+	}{
+		{"prices arrived", true, 40, true, true, db.TelemetryGapFilled},
+		{"covered, nothing to give", true, 0, true, true, db.TelemetryGapSettledEmpty},
+		{"already covered by every plugin", false, 0, true, false, db.TelemetryGapSettledEmpty},
+		{"no plugin took it", false, 0, false, false, db.TelemetryGapNoEligiblePlugin},
+		{"every plugin failed", false, 0, true, true, db.TelemetryGapAllPluginsFailed},
+		// A plugin returned bars and a later range then failed, so the gap is not
+		// covered. The bars that did arrive do not make it filled.
+		{"partly fetched then failed", false, 12, true, true, db.TelemetryGapAllPluginsFailed},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := gapOutcome(tc.fetched, tc.bars, tc.reached, tc.called)
+			if got != tc.want {
+				t.Errorf("gapOutcome = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRangesDays sums the ask a gap represents. The ranges are half-open and
+// UTC-truncated, so this is a subtraction and not calendar arithmetic.
+func TestRangesDays(t *testing.T) {
+	tests := []struct {
+		name   string
+		ranges []db.DateRange
+		want   int
+	}{
+		{"none", nil, 0},
+		{"one week", []db.DateRange{{From: d(2024, 1, 1), Before: d(2024, 1, 8)}}, 7},
+		{
+			name: "two disjoint",
+			ranges: []db.DateRange{
+				{From: d(2024, 1, 1), Before: d(2024, 1, 8)},
+				{From: d(2024, 3, 1), Before: d(2024, 3, 4)},
+			},
+			want: 10,
+		},
+		// A range whose end is not after its start asks for nothing and must not
+		// subtract from the total.
+		{"empty range", []db.DateRange{{From: d(2024, 1, 8), Before: d(2024, 1, 8)}}, 0},
+		// A leap day is a day. The subtraction gets this right and a month-based
+		// calculation would not.
+		{"across a leap day", []db.DateRange{{From: d(2024, 2, 28), Before: d(2024, 3, 1)}}, 2},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := rangesDays(tc.ranges); got != tc.want {
+				t.Errorf("rangesDays = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+// telRecorder collects what a cycle wrote, so a test can assert on the rows rather
+// than on the order the writer was called in.
+type telRecorder struct {
+	gaps     []db.TelemetryPriceGap
+	outcomes map[string]string
+	calls    map[string][]db.TelemetryPricePluginCall
+}
+
+// gapID is the id the recorder hands back for the nth gap written, counting from 1.
+func gapID(n int) string { return fmt.Sprintf("gap-%d", n) }
+
+func newTelRecorder(ctrl *gomock.Controller) (*mock.MockTelemetryDB, *telRecorder) {
+	tel := mock.NewMockTelemetryDB(ctrl)
+	r := &telRecorder{
+		outcomes: make(map[string]string),
+		calls:    make(map[string][]db.TelemetryPricePluginCall),
+	}
+	tel.EXPECT().StartPriceGap(gomock.Any(), gomock.Any()).AnyTimes().
+		DoAndReturn(func(_ context.Context, g db.TelemetryPriceGap) string {
+			r.gaps = append(r.gaps, g)
+			return gapID(len(r.gaps))
+		})
+	tel.EXPECT().EndPriceGap(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().
+		Do(func(_ context.Context, _, id, outcome string) { r.outcomes[id] = outcome })
+	tel.EXPECT().WritePricePluginCall(gomock.Any(), gomock.Any()).AnyTimes().
+		Do(func(_ context.Context, c db.TelemetryPricePluginCall) {
+			r.calls[c.GapID] = append(r.calls[c.GapID], c)
+		})
+	return tel, r
+}
+
+// gapCycle wires the reads a cycle makes so a test states only what it is about.
+// The instrument list is derived from the gaps, so a caller supplying an
+// instrument row for every gap gets a cycle that reaches the plugins.
+type gapCycle struct {
+	priceGaps []db.InstrumentDateRanges
+	fxGaps    []db.InstrumentDateRanges
+	configs   []db.PluginConfigRow
+	insts     []*db.InstrumentRow
+	coverage  map[string]map[string][]db.DateRange
+}
+
+func (c gapCycle) expect(m *mock.MockDB) {
+	m.EXPECT().PriceGaps(gomock.Any(), gomock.Any()).Return(c.priceGaps, nil)
+	m.EXPECT().FXGaps(gomock.Any(), gomock.Any()).Return(c.fxGaps, nil)
+	m.EXPECT().ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryPrice).
+		Return(c.configs, nil).AnyTimes()
+	m.EXPECT().BlockedPluginsForInstruments(gomock.Any(), gomock.Any()).Return(nil, nil).AnyTimes()
+	m.EXPECT().ListInstrumentsByIDs(gomock.Any(), gomock.Any()).Return(c.insts, nil).AnyTimes()
+	m.EXPECT().PriceCoverageByPlugin(gomock.Any(), gomock.Any()).Return(c.coverage, nil).AnyTimes()
+	m.EXPECT().UpsertPricesForRange(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(),
+		gomock.Any(), gomock.Any(), gomock.Any()).Return(nil).AnyTimes()
+	m.EXPECT().CreatePriceFetchBlock(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).
+		Return(nil).AnyTimes()
+}
+
+// TestCycleRecordsWhatItWasAskedFor pins the gap row's inputs. The FX flag is what
+// keeps a missing rate apart from a missing quote once the two lists are one, and
+// the three attributes are the ones plugin filtering reads -- the MIC rather than
+// the denormalised display exchange.
+func TestCycleRecordsWhatItWasAskedFor(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	mockDB := mock.NewMockDB(ctrl)
+	tel, rec := newTelRecorder(ctrl)
+
+	gapCycle{
+		priceGaps: []db.InstrumentDateRanges{
+			{InstrumentID: "inst-1", Ranges: []db.DateRange{{From: d(2024, 1, 1), Before: d(2024, 1, 11)}}},
+		},
+		fxGaps: []db.InstrumentDateRanges{
+			{InstrumentID: "fx-1", Ranges: []db.DateRange{{From: d(2024, 1, 1), Before: d(2024, 1, 4)}}},
+		},
+		configs: []db.PluginConfigRow{{PluginID: "eodhd", Precedence: 10, Config: []byte("{}")}},
+		insts: []*db.InstrumentRow{
+			{ID: "inst-1", AssetClass: strPtr("STOCK"), Currency: strPtr("USD"),
+				ExchangeMIC: strPtr("XNAS"), Exchange: "NASDAQ"},
+			{ID: "fx-1", AssetClass: strPtr("FX"), Currency: strPtr("USD")},
+		},
+	}.expect(mockDB)
+
+	// A registered plugin that supports an identifier type neither instrument
+	// carries. Nothing is fetched, and unlike the no-plugin path the cycle still
+	// loads the instruments, which is what puts the attributes on the rows.
+	reg := NewRegistry()
+	reg.Register("eodhd", &fetchStub{idTypes: []string{"SEDOL"}})
+
+	if err := runCycle(context.Background(), mockDB, reg, nil, nil, nil, tel, "run-1"); err != nil {
+		t.Fatalf("runCycle: %v", err)
+	}
+
+	if len(rec.gaps) != 2 {
+		t.Fatalf("recorded %d gaps, want 2", len(rec.gaps))
+	}
+	price, fx := rec.gaps[0], rec.gaps[1]
+	if price.IsFX {
+		t.Error("a PriceGaps entry was recorded as FX")
+	}
+	if !fx.IsFX {
+		t.Error("an FXGaps entry was not recorded as FX")
+	}
+	if price.DaysOutstanding != 10 {
+		t.Errorf("days_outstanding = %d, want 10", price.DaysOutstanding)
+	}
+	if fx.DaysOutstanding != 3 {
+		t.Errorf("fx days_outstanding = %d, want 3", fx.DaysOutstanding)
+	}
+	if price.Exchange != "XNAS" {
+		t.Errorf("exchange = %q, want the MIC the plugin filter compares", price.Exchange)
+	}
+	if price.AssetClass != "STOCK" || price.Currency != "USD" {
+		t.Errorf("asset class / currency = %q / %q, want STOCK / USD",
+			price.AssetClass, price.Currency)
+	}
+	// The plugin held no identifier it could use, so it never became a candidate
+	// and wrote no row of its own.
+	if got := rec.outcomes[gapID(1)]; got != db.TelemetryGapNoEligiblePlugin {
+		t.Errorf("gap outcome = %q, want %q", got, db.TelemetryGapNoEligiblePlugin)
+	}
+	if n := len(rec.calls[gapID(1)]); n != 0 {
+		t.Errorf("recorded %d calls for a plugin that was never asked, want 0", n)
+	}
+}
+
+// TestCycleRecordsAFilledGap pins the ordinary success: one call carrying the bars
+// it returned and the range it was asked for, and a gap stamped filled.
+func TestCycleRecordsAFilledGap(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	mockDB := mock.NewMockDB(ctrl)
+	tel, rec := newTelRecorder(ctrl)
+
+	from, to := d(2024, 1, 1), d(2024, 1, 3)
+	stub := &fetchStub{
+		idTypes: []string{"MIC_TICKER"},
+		result: &FetchResult{Bars: []DailyBar{
+			{Date: from, Close: decimal.RequireFromString("100")},
+			{Date: d(2024, 1, 2), Close: decimal.RequireFromString("101")},
+		}},
+	}
+	reg := NewRegistry()
+	reg.Register("eodhd", stub)
+
+	gapCycle{
+		priceGaps: []db.InstrumentDateRanges{
+			{InstrumentID: "inst-1", Ranges: []db.DateRange{{From: from, Before: to}}},
+		},
+		configs: []db.PluginConfigRow{{PluginID: "eodhd", Precedence: 70, Config: []byte("{}")}},
+		insts: []*db.InstrumentRow{{
+			ID:          "inst-1",
+			Identifiers: []db.IdentifierInput{{Type: "MIC_TICKER", Value: "XNAS:AAPL"}},
+		}},
+	}.expect(mockDB)
+
+	if err := runCycle(context.Background(), mockDB, reg, nil, nil, nil, tel, "run-1"); err != nil {
+		t.Fatalf("runCycle: %v", err)
+	}
+
+	if got := rec.outcomes[gapID(1)]; got != db.TelemetryGapFilled {
+		t.Errorf("gap outcome = %q, want %q", got, db.TelemetryGapFilled)
+	}
+	calls := rec.calls[gapID(1)]
+	if len(calls) != 1 {
+		t.Fatalf("recorded %d calls, want 1", len(calls))
+	}
+	c := calls[0]
+	if c.Outcome != db.TelemetryPriceCallBarsReturned {
+		t.Errorf("call outcome = %q, want %q", c.Outcome, db.TelemetryPriceCallBarsReturned)
+	}
+	if c.Bars != 2 {
+		t.Errorf("bars = %d, want 2", c.Bars)
+	}
+	if !c.From.Equal(from) || !c.Before.Equal(to) {
+		t.Errorf("range = [%s, %s), want [%s, %s)", c.From, c.Before, from, to)
+	}
+	// The configured precedence, not a loop index, so a plugin skipped by a filter
+	// reads as a gap in the sequence.
+	if c.Precedence != 70 {
+		t.Errorf("precedence = %d, want the configured 70", c.Precedence)
+	}
+	if c.Duration == nil {
+		t.Error("a completed call recorded no duration")
+	}
+}
+
+// TestCycleRecordsAnEmptyAnswerAsSettled pins that a provider with nothing to say
+// is not a failure. The range is covered so it is never asked about again, and the
+// gap is settled rather than left looking like an outage.
+func TestCycleRecordsAnEmptyAnswerAsSettled(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	mockDB := mock.NewMockDB(ctrl)
+	tel, rec := newTelRecorder(ctrl)
+
+	stub := &fetchStub{idTypes: []string{"MIC_TICKER"}, err: ErrNoData}
+	reg := NewRegistry()
+	reg.Register("eodhd", stub)
+
+	gapCycle{
+		priceGaps: []db.InstrumentDateRanges{
+			{InstrumentID: "inst-1", Ranges: []db.DateRange{{From: d(2024, 1, 1), Before: d(2024, 1, 3)}}},
+		},
+		configs: []db.PluginConfigRow{{PluginID: "eodhd", Precedence: 70, Config: []byte("{}")}},
+		insts: []*db.InstrumentRow{{
+			ID:          "inst-1",
+			Identifiers: []db.IdentifierInput{{Type: "MIC_TICKER", Value: "XNAS:AAPL"}},
+		}},
+	}.expect(mockDB)
+
+	if err := runCycle(context.Background(), mockDB, reg, nil, nil, nil, tel, "run-1"); err != nil {
+		t.Fatalf("runCycle: %v", err)
+	}
+
+	if got := rec.outcomes[gapID(1)]; got != db.TelemetryGapSettledEmpty {
+		t.Errorf("gap outcome = %q, want %q", got, db.TelemetryGapSettledEmpty)
+	}
+	calls := rec.calls[gapID(1)]
+	if len(calls) != 1 || calls[0].Outcome != db.TelemetryPriceCallNoData {
+		t.Fatalf("calls = %+v, want one no_data", calls)
+	}
+	if calls[0].Bars != 0 {
+		t.Errorf("bars = %d, want 0", calls[0].Bars)
+	}
+}
+
+// TestCycleRecordsAHistoryLimitWithoutADuration pins the one outcome that made no
+// call. A zero duration would average into the latency panel as a plugin that
+// answered instantly, which is why the column is nullable.
+func TestCycleRecordsAHistoryLimitWithoutADuration(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	mockDB := mock.NewMockDB(ctrl)
+	tel, rec := newTelRecorder(ctrl)
+
+	stub := &fetchStub{idTypes: []string{"MIC_TICKER"}}
+	reg := NewRegistry()
+	reg.Register("eodhd", stub)
+
+	maxHist := 30
+	gapCycle{
+		// Long before any 30 day reach, so the whole range is settled without a call.
+		priceGaps: []db.InstrumentDateRanges{
+			{InstrumentID: "inst-1", Ranges: []db.DateRange{{From: d(2019, 1, 1), Before: d(2019, 2, 1)}}},
+		},
+		configs: []db.PluginConfigRow{
+			{PluginID: "eodhd", Precedence: 70, Config: []byte("{}"), MaxHistoryDays: &maxHist},
+		},
+		insts: []*db.InstrumentRow{{
+			ID:          "inst-1",
+			Identifiers: []db.IdentifierInput{{Type: "MIC_TICKER", Value: "XNAS:AAPL"}},
+		}},
+	}.expect(mockDB)
+
+	if err := runCycle(context.Background(), mockDB, reg, nil, nil, nil, tel, "run-1"); err != nil {
+		t.Fatalf("runCycle: %v", err)
+	}
+
+	if stub.calls != 0 {
+		t.Errorf("FetchPrices was called %d times for a range beyond the plugin's reach", stub.calls)
+	}
+	calls := rec.calls[gapID(1)]
+	if len(calls) != 1 || calls[0].Outcome != db.TelemetryPriceCallHistoryLimit {
+		t.Fatalf("calls = %+v, want one history_limit", calls)
+	}
+	if calls[0].Duration != nil {
+		t.Errorf("duration = %v, want none for a call that never happened", *calls[0].Duration)
+	}
+	if got := rec.outcomes[gapID(1)]; got != db.TelemetryGapSettledEmpty {
+		t.Errorf("gap outcome = %q, want %q", got, db.TelemetryGapSettledEmpty)
+	}
+}
+
+// TestCycleRecordsAPluginFailure pins that a provider error stamps the gap as one
+// nothing could fill, so it is visible as a recurring hole rather than as silence.
+func TestCycleRecordsAPluginFailure(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	mockDB := mock.NewMockDB(ctrl)
+	tel, rec := newTelRecorder(ctrl)
+
+	stub := &fetchStub{idTypes: []string{"MIC_TICKER"}, err: errors.New("502 bad gateway")}
+	reg := NewRegistry()
+	reg.Register("eodhd", stub)
+
+	gapCycle{
+		priceGaps: []db.InstrumentDateRanges{
+			{InstrumentID: "inst-1", Ranges: []db.DateRange{{From: d(2024, 1, 1), Before: d(2024, 1, 3)}}},
+		},
+		configs: []db.PluginConfigRow{{PluginID: "eodhd", Precedence: 70, Config: []byte("{}")}},
+		insts: []*db.InstrumentRow{{
+			ID:          "inst-1",
+			Identifiers: []db.IdentifierInput{{Type: "MIC_TICKER", Value: "XNAS:AAPL"}},
+		}},
+	}.expect(mockDB)
+
+	if err := runCycle(context.Background(), mockDB, reg, nil, nil, nil, tel, "run-1"); err != nil {
+		t.Fatalf("runCycle: %v", err)
+	}
+
+	calls := rec.calls[gapID(1)]
+	if len(calls) != 1 || calls[0].Outcome != db.TelemetryPriceCallError {
+		t.Fatalf("calls = %+v, want one error", calls)
+	}
+	if got := rec.outcomes[gapID(1)]; got != db.TelemetryGapAllPluginsFailed {
+		t.Errorf("gap outcome = %q, want %q", got, db.TelemetryGapAllPluginsFailed)
+	}
+}
+
+// TestCycleWithNoPluginRecordsEveryGap pins the misconfiguration that used to be
+// invisible. A cycle with work and nowhere to send it returned silently and
+// stamped its run success, which is indistinguishable from a cycle that found
+// nothing to do.
+func TestCycleWithNoPluginRecordsEveryGap(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	mockDB := mock.NewMockDB(ctrl)
+	tel, rec := newTelRecorder(ctrl)
+
+	gapCycle{
+		priceGaps: []db.InstrumentDateRanges{
+			{InstrumentID: "inst-1", Ranges: []db.DateRange{{From: d(2024, 1, 1), Before: d(2024, 1, 3)}}},
+			{InstrumentID: "inst-2", Ranges: []db.DateRange{{From: d(2024, 1, 1), Before: d(2024, 1, 3)}}},
+		},
+		configs: nil,
+	}.expect(mockDB)
+
+	if err := runCycle(context.Background(), mockDB, NewRegistry(), nil, nil, nil, tel, "run-1"); err != nil {
+		t.Fatalf("runCycle: %v", err)
+	}
+
+	if len(rec.gaps) != 2 {
+		t.Fatalf("recorded %d gaps, want 2", len(rec.gaps))
+	}
+	for i := 1; i <= 2; i++ {
+		if got := rec.outcomes[gapID(i)]; got != db.TelemetryGapNoEligiblePlugin {
+			t.Errorf("gap %d outcome = %q, want %q", i, got, db.TelemetryGapNoEligiblePlugin)
+		}
+	}
+}
+
+// TestCancelledCycleStopsAndLeavesTheRestUnstamped pins how far a killed cycle
+// got. The gaps it never reached keep a null outcome, which is what makes the
+// stopping point readable, and the error is what stops the run being stamped
+// success after covering one instrument of two.
+func TestCancelledCycleStopsAndLeavesTheRestUnstamped(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	t.Cleanup(ctrl.Finish)
+	mockDB := mock.NewMockDB(ctrl)
+	tel, rec := newTelRecorder(ctrl)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stub := &cancelStub{
+		fetchStub: fetchStub{idTypes: []string{"MIC_TICKER"},
+			result: &FetchResult{Bars: []DailyBar{{Date: d(2024, 1, 1), Close: decimal.RequireFromString("100")}}}},
+		cancel: cancel,
+	}
+	reg := NewRegistry()
+	reg.Register("eodhd", stub)
+
+	rng := []db.DateRange{{From: d(2024, 1, 1), Before: d(2024, 1, 3)}}
+	gapCycle{
+		priceGaps: []db.InstrumentDateRanges{
+			{InstrumentID: "inst-1", Ranges: rng},
+			{InstrumentID: "inst-2", Ranges: rng},
+		},
+		configs: []db.PluginConfigRow{{PluginID: "eodhd", Precedence: 70, Config: []byte("{}")}},
+		insts: []*db.InstrumentRow{
+			{ID: "inst-1", Identifiers: []db.IdentifierInput{{Type: "MIC_TICKER", Value: "XNAS:AAPL"}}},
+			{ID: "inst-2", Identifiers: []db.IdentifierInput{{Type: "MIC_TICKER", Value: "XNAS:MSFT"}}},
+		},
+	}.expect(mockDB)
+
+	err := runCycle(ctx, mockDB, reg, nil, nil, nil, tel, "run-1")
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("runCycle err = %v, want context.Canceled so the run is not stamped success", err)
+	}
+
+	// Both gap rows are written up front, which is what leaves a record of the
+	// instrument the cycle never got to.
+	if len(rec.gaps) != 2 {
+		t.Fatalf("recorded %d gaps, want 2", len(rec.gaps))
+	}
+	if got := rec.outcomes[gapID(1)]; got != db.TelemetryGapFilled {
+		t.Errorf("first gap outcome = %q, want %q", got, db.TelemetryGapFilled)
+	}
+	if got, ok := rec.outcomes[gapID(2)]; ok {
+		t.Errorf("second gap was stamped %q; a gap the cycle never reached stays unstamped", got)
+	}
+}
+
+// cancelStub cancels the cycle as its first fetch returns, standing in for a
+// container killed part way through.
+type cancelStub struct {
+	fetchStub
+	cancel context.CancelFunc
+}
+
+func (s *cancelStub) FetchPrices(ctx context.Context, cfg []byte, ids []Identifier, ac string, from, before time.Time) (*FetchResult, error) {
+	r, err := s.fetchStub.FetchPrices(ctx, cfg, ids, ac, from, before)
+	s.cancel()
+	return r, err
+}

--- a/server/pricefetcher/telemetry.go
+++ b/server/pricefetcher/telemetry.go
@@ -1,0 +1,153 @@
+package pricefetcher
+
+import (
+	"context"
+
+	"github.com/leedenison/portfoliodb/server/db"
+)
+
+// priceGaps owns the telemetry rows for one cycle's gap list.
+//
+// Rows are written for the whole list before any fetching starts, so a cycle that
+// dies part way leaves the instruments it never reached unstamped and where it
+// stopped stays readable. Writing each row as the loop arrived at it would leave
+// no trace of those at all, which is the question asked first when a cycle is
+// killed: how far did it get.
+//
+// A nil *priceGaps records nothing and every method is safe to call on one, which
+// is what a caller with no telemetry writer gets.
+type priceGaps struct {
+	tel   db.TelemetryDB
+	runID string
+	// ids is parallel to the gap list rather than keyed by instrument id, so two
+	// gaps naming one instrument cannot collide. An empty entry is a write that
+	// failed, which the writer already skips the children of.
+	ids []string
+	// calls counts the rows written under each gap, which is what separates a gap
+	// every eligible plugin had already covered from one no plugin would take.
+	calls []int
+}
+
+// newPriceGaps writes a row per gap and returns the ledger that stamps them.
+//
+// fxFrom is where FXGaps' entries start in the concatenated list. The two are
+// fetched by one loop and are indistinguishable from there on, and they are not
+// the same size of problem: a missing rate breaks valuation for every instrument
+// denominated in that currency rather than for one.
+//
+// instByID may be nil, for the caller that has established there is no plugin to
+// put any of these to and has not loaded the instruments. The three attributes it
+// supplies explain plugin filtering, and no filtering happens on that path.
+func newPriceGaps(ctx context.Context, tel db.TelemetryDB, runID string,
+	gaps []db.InstrumentDateRanges, fxFrom int, instByID map[string]*db.InstrumentRow) *priceGaps {
+	if tel == nil || runID == "" {
+		return nil
+	}
+	g := &priceGaps{
+		tel:   tel,
+		runID: runID,
+		ids:   make([]string, len(gaps)),
+		calls: make([]int, len(gaps)),
+	}
+	for i, ig := range gaps {
+		row := db.TelemetryPriceGap{
+			RunID:           runID,
+			InstrumentID:    ig.InstrumentID,
+			IsFX:            i >= fxFrom,
+			DaysOutstanding: rangesDays(ig.Ranges),
+		}
+		if inst := instByID[ig.InstrumentID]; inst != nil {
+			if inst.AssetClass != nil {
+				row.AssetClass = *inst.AssetClass
+			}
+			if inst.Currency != nil {
+				row.Currency = *inst.Currency
+			}
+			// The MIC rather than InstrumentRow.Exchange, which is a
+			// denormalised display form. PluginAccepts compares the MIC, and
+			// this column exists to explain that comparison.
+			if inst.ExchangeMIC != nil {
+				row.Exchange = *inst.ExchangeMIC
+			}
+		}
+		g.ids[i] = tel.StartPriceGap(ctx, row)
+	}
+	return g
+}
+
+// end stamps what became of the gap at i.
+func (g *priceGaps) end(ctx context.Context, i int, outcome string) {
+	if g == nil {
+		return
+	}
+	g.tel.EndPriceGap(ctx, g.runID, g.ids[i], outcome)
+}
+
+// endAll stamps every gap with one outcome, for the cycle that finds no plugin to
+// put any of them to.
+func (g *priceGaps) endAll(ctx context.Context, outcome string) {
+	if g == nil {
+		return
+	}
+	for i := range g.ids {
+		g.end(ctx, i, outcome)
+	}
+}
+
+// call records one range put to one plugin under the gap at i, filling in the ids
+// the caller does not hold.
+func (g *priceGaps) call(ctx context.Context, i int, c db.TelemetryPricePluginCall) {
+	if g == nil {
+		return
+	}
+	c.RunID, c.GapID = g.runID, g.ids[i]
+	g.calls[i]++
+	g.tel.WritePricePluginCall(ctx, c)
+}
+
+// called reports whether any plugin call was written under the gap at i.
+func (g *priceGaps) called(i int) bool {
+	if g == nil {
+		return false
+	}
+	return g.calls[i] > 0
+}
+
+// gapOutcome names what became of one instrument's gap.
+//
+// fetched is a plugin having covered every outstanding range without error, bars
+// the rows that arrived, reached whether any plugin passed the filters, and called
+// whether any of them was actually asked.
+//
+// The two settled_empty paths are the ones worth reading twice. A plugin that
+// covered every range and returned nothing has settled the gap -- the instrument
+// did not trade then, or no plugin reaches that far back -- and so has a gap every
+// eligible plugin had already covered on an earlier cycle. Neither is a failure,
+// and counting them as one would fill a panel meant to show outages with untraded
+// weeks.
+func gapOutcome(fetched bool, bars int, reached, called bool) string {
+	switch {
+	case fetched && bars > 0:
+		return db.TelemetryGapFilled
+	case fetched:
+		return db.TelemetryGapSettledEmpty
+	case !reached:
+		return db.TelemetryGapNoEligiblePlugin
+	case !called:
+		return db.TelemetryGapSettledEmpty
+	}
+	return db.TelemetryGapAllPluginsFailed
+}
+
+// rangesDays is how much history a gap was asking for, in whole days. The
+// orchestrator's ranges are half-open and UTC-truncated, so the subtraction is
+// exact and no calendar arithmetic is needed.
+func rangesDays(ranges []db.DateRange) int {
+	days := 0
+	for _, r := range ranges {
+		if r.Before.After(r.From) {
+			days += int(r.Before.Sub(r.From) / db.Day)
+		}
+	}
+	return days
+}

--- a/server/pricefetcher/worker.go
+++ b/server/pricefetcher/worker.go
@@ -36,7 +36,7 @@ func RunWorker(ctx context.Context, database db.DB, registry *Registry, counter 
 			}
 			runID := tel.StartRun(ctx, db.TelemetryRun{Kind: db.TelemetryRunPriceFetchCycle})
 			outcome := db.TelemetryOutcomeSuccess
-			if err := runCycle(ctx, database, registry, counter, log, workers); err != nil {
+			if err := runCycle(ctx, database, registry, counter, log, workers, tel, runID); err != nil {
 				outcome = db.TelemetryOutcomeFailed
 			}
 			tel.EndRun(ctx, runID, outcome)
@@ -46,13 +46,17 @@ func RunWorker(ctx context.Context, database db.DB, registry *Registry, counter 
 
 // pluginEntry pairs a registered plugin with its config row.
 type pluginEntry struct {
-	id          string
-	plugin      Plugin
-	config      []byte
+	id     string
+	plugin Plugin
+	config []byte
+	// precedence is the configured order the plugins are tried in, higher first.
+	// Carried for telemetry: a plugin skipped by a filter writes no row, so a gap
+	// in the recorded sequence is what says it was skipped.
+	precedence  int
 	maxHistDays *int
 }
 
-func runCycle(ctx context.Context, database db.DB, registry *Registry, counter telemetry.CounterIncrementer, log *slog.Logger, workers *worker.Registry) error {
+func runCycle(ctx context.Context, database db.DB, registry *Registry, counter telemetry.CounterIncrementer, log *slog.Logger, workers *worker.Registry, tel db.TelemetryDB, runID string) error {
 	const name = "price_fetcher"
 	if counter != nil {
 		counter.Incr(ctx, "price_fetcher.cycles")
@@ -87,6 +91,9 @@ func runCycle(ctx context.Context, database db.DB, registry *Registry, counter t
 	if len(allGaps) == 0 {
 		return nil
 	}
+	// Where the FX gaps start, which is the only thing that tells the two apart
+	// once they are one list.
+	fxFrom := len(gaps)
 
 	if workers != nil {
 		workers.SetRunning(name, fmt.Sprintf("Fetching prices for %d instruments", len(allGaps)))
@@ -100,6 +107,11 @@ func runCycle(ctx context.Context, database db.DB, registry *Registry, counter t
 		return err
 	}
 	if len(configs) == 0 {
+		// A cycle with work and nowhere to send it looks identical to a quiet one
+		// unless it says so. The instruments are deliberately not loaded for this:
+		// their attributes explain plugin filtering, and no filtering happened.
+		newPriceGaps(ctx, tel, runID, allGaps, fxFrom, nil).
+			endAll(ctx, db.TelemetryGapNoEligiblePlugin)
 		return nil
 	}
 
@@ -113,10 +125,13 @@ func runCycle(ctx context.Context, database db.DB, registry *Registry, counter t
 			id:          cfg.PluginID,
 			plugin:      p,
 			config:      cfg.Config,
+			precedence:  cfg.Precedence,
 			maxHistDays: cfg.MaxHistoryDays,
 		})
 	}
 	if len(plugins) == 0 {
+		newPriceGaps(ctx, tel, runID, allGaps, fxFrom, nil).
+			endAll(ctx, db.TelemetryGapNoEligiblePlugin)
 		return nil
 	}
 
@@ -153,28 +168,39 @@ func runCycle(ctx context.Context, database db.DB, registry *Registry, counter t
 		return err
 	}
 
-	processGaps(ctx, database, plugins, allGaps, instByID, blocked, coverage, log)
-	return nil
+	gapsTel := newPriceGaps(ctx, tel, runID, allGaps, fxFrom, instByID)
+	return processGaps(ctx, database, plugins, allGaps, instByID, blocked, coverage, log, gapsTel)
 }
 
 // processGaps iterates instrument gaps and fetches prices from matching plugins.
-func processGaps(ctx context.Context, database db.DB, plugins []pluginEntry, gaps []db.InstrumentDateRanges, instByID map[string]*db.InstrumentRow, blocked map[string]map[string]bool, coverage map[string]map[string][]db.DateRange, log *slog.Logger) {
+//
+// It returns ctx.Err() when the cycle is cancelled part way. The gaps it never
+// reached stay unstamped, so where it stopped is readable; returning nil instead
+// would stamp the run success and report a cycle that covered three instruments of
+// five hundred as a clean one.
+func processGaps(ctx context.Context, database db.DB, plugins []pluginEntry, gaps []db.InstrumentDateRanges, instByID map[string]*db.InstrumentRow, blocked map[string]map[string]bool, coverage map[string]map[string][]db.DateRange, log *slog.Logger, gapsTel *priceGaps) error {
 	// One fetch time for the whole cycle, so every row a back-adjusting plugin
 	// returns shares the same share count basis.
 	now := time.Now()
-	for _, ig := range gaps {
+	for i, ig := range gaps {
 		if ctx.Err() != nil {
-			return
+			return ctx.Err()
 		}
 		inst := instByID[ig.InstrumentID]
 		if inst == nil {
 			if log != nil {
 				log.WarnContext(ctx, "price fetch: instrument not found", "id", ig.InstrumentID)
 			}
+			gapsTel.end(ctx, i, db.TelemetryGapInstrumentMissing)
 			continue
 		}
 
 		fetchedByPlugin := false
+		// Whether any plugin got past the filters, and how many rows arrived.
+		// Together with whether anything was actually called they are what
+		// gapOutcome reads, and each distinguishes a case the others cannot.
+		reached := false
+		bars := 0
 		for _, pe := range plugins {
 			if !pluginutil.PluginAccepts(pe.plugin.AcceptableAssetClasses(), pe.plugin.AcceptableExchanges(), pe.plugin.AcceptableCurrencies(), inst) {
 				continue
@@ -193,6 +219,10 @@ func processGaps(ctx context.Context, database db.DB, plugins []pluginEntry, gap
 			if len(ids) == 0 {
 				continue
 			}
+			// Past every filter, so this plugin was a candidate whatever becomes
+			// of it below. None of the four skips above writes a row: no call was
+			// made, and a gap in the recorded precedence is how they read.
+			reached = true
 
 			// Ranges this plugin has already answered for are not put to it
 			// again, whether it returned a series or nothing at all.
@@ -215,13 +245,18 @@ func processGaps(ctx context.Context, database db.DB, plugins []pluginEntry, gap
 						// rediscovering the same gap every cycle. Other plugins
 						// keep their own coverage and are still offered it.
 						coverRange(ctx, database, ig.InstrumentID, pe.id, gap, "history limit", log)
+						gapsTel.call(ctx, i, priceCall(pe, gap, 0, db.TelemetryPriceCallHistoryLimit, nil))
 						continue
 					}
 					if gap.From.Before(cutoff) {
 						// The unreachable head is settled for this plugin even
 						// though the tail is about to be fetched.
-						coverRange(ctx, database, ig.InstrumentID, pe.id,
-							db.DateRange{From: gap.From, Before: cutoff}, "history limit", log)
+						head := db.DateRange{From: gap.From, Before: cutoff}
+						coverRange(ctx, database, ig.InstrumentID, pe.id, head, "history limit", log)
+						// Two rows for two ranges. The head was settled without
+						// asking and the tail is about to be fetched, and a grain
+						// of one range per row is what lets them differ.
+						gapsTel.call(ctx, i, priceCall(pe, head, 0, db.TelemetryPriceCallHistoryLimit, nil))
 						gap.From = cutoff
 					}
 				}
@@ -230,7 +265,9 @@ func processGaps(ctx context.Context, database db.DB, plugins []pluginEntry, gap
 					assetClass = *inst.AssetClass
 				}
 				callCtx, callCancel := context.WithTimeout(ctx, pluginutil.TimeoutFromConfig(pe.config, DefaultPricePluginTimeout))
+				started := time.Now()
 				result, err := pe.plugin.FetchPrices(callCtx, pe.config, pfIDs, assetClass, gap.From, gap.Before)
+				took := time.Since(started)
 				callCancel()
 				if err != nil {
 					var permErr *ErrPermanent
@@ -240,6 +277,7 @@ func processGaps(ctx context.Context, database db.DB, plugins []pluginEntry, gap
 							log.WarnContext(ctx, "price fetch: permanent block",
 								"plugin", pe.id, "instrument", ig.InstrumentID, "reason", permErr.Reason)
 						}
+						gapsTel.call(ctx, i, priceCall(pe, gap, 0, db.TelemetryPriceCallPermanentBlock, &took))
 						allOK = false
 						break // skip remaining ranges, try next plugin
 					}
@@ -249,12 +287,22 @@ func processGaps(ctx context.Context, database db.DB, plugins []pluginEntry, gap
 						// settled for this plugin instead of being asked about
 						// on every cycle forever.
 						coverRange(ctx, database, ig.InstrumentID, pe.id, gap, "no data", log)
+						gapsTel.call(ctx, i, priceCall(pe, gap, 0, db.TelemetryPriceCallNoData, &took))
 						continue
 					}
 					if log != nil {
 						log.WarnContext(ctx, "price fetch: plugin error",
 							"plugin", pe.id, "instrument", ig.InstrumentID, "err", err)
 					}
+					// The provider running out of time and the provider answering
+					// badly need different fixes, and only the deadline can say
+					// which this was. errors.Is rather than a comparison, since a
+					// plugin is free to wrap what its transport returned.
+					outcome := db.TelemetryPriceCallError
+					if errors.Is(err, context.DeadlineExceeded) {
+						outcome = db.TelemetryPriceCallTimeout
+					}
+					gapsTel.call(ctx, i, priceCall(pe, gap, 0, outcome, &took))
 					allOK = false
 					break
 				}
@@ -264,9 +312,15 @@ func processGaps(ctx context.Context, database db.DB, plugins []pluginEntry, gap
 					if log != nil {
 						log.ErrorContext(ctx, "price fetch: upsert", "instrument", ig.InstrumentID, "err", err)
 					}
+					// Ours rather than theirs. Recorded apart from the transport
+					// outcomes so a panel watching provider health is not moved by
+					// our own write failing.
+					gapsTel.call(ctx, i, priceCall(pe, gap, 0, db.TelemetryPriceCallUpsertFailed, &took))
 					allOK = false
 					break
 				}
+				bars += len(result.Bars)
+				gapsTel.call(ctx, i, priceCall(pe, gap, len(result.Bars), db.TelemetryPriceCallBarsReturned, &took))
 			}
 			if allOK {
 				fetchedByPlugin = true
@@ -274,7 +328,22 @@ func processGaps(ctx context.Context, database db.DB, plugins []pluginEntry, gap
 			}
 			// On error, try next plugin for this instrument.
 		}
-		_ = fetchedByPlugin
+		gapsTel.end(ctx, i, gapOutcome(fetchedByPlugin, bars, reached, gapsTel.called(i)))
+	}
+	return nil
+}
+
+// priceCall assembles the telemetry row for one range put to one plugin. The gap
+// and run ids are the ledger's to fill in, since the fetch loop does not hold them.
+func priceCall(pe pluginEntry, r db.DateRange, bars int, outcome string, took *time.Duration) db.TelemetryPricePluginCall {
+	return db.TelemetryPricePluginCall{
+		PluginID:   pe.id,
+		Precedence: pe.precedence,
+		From:       r.From,
+		Before:     r.Before,
+		Bars:       bars,
+		Outcome:    outcome,
+		Duration:   took,
 	}
 }
 

--- a/server/pricefetcher/worker_test.go
+++ b/server/pricefetcher/worker_test.go
@@ -163,7 +163,7 @@ func TestRunCycle_FXGapsProcessed(t *testing.T) {
 	}, nil)
 	mockDB.EXPECT().UpsertPricesForRange(gomock.Any(), fxInstID, pluginID, gomock.Any(), from, to, gomock.Any()).Return(nil)
 
-	_ = runCycle(ctx, mockDB, reg, nil, nil, nil)
+	_ = runCycle(ctx, mockDB, reg, nil, nil, nil, db.NopTelemetry{}, "")
 
 	if stub.calls != 1 {
 		t.Errorf("expected 1 FetchPrices call for FX gap, got %d", stub.calls)
@@ -245,7 +245,7 @@ func TestRunCycle_BlockedPluginSkipped(t *testing.T) {
 		},
 	}, nil)
 
-	_ = runCycle(ctx, mockDB, reg, nil, nil, nil)
+	_ = runCycle(ctx, mockDB, reg, nil, nil, nil, db.NopTelemetry{}, "")
 
 	if stub.calls != 0 {
 		t.Errorf("expected 0 FetchPrices calls for blocked plugin, got %d", stub.calls)
@@ -290,7 +290,7 @@ func TestRunCycle_ErrPermanentCreatesBlock(t *testing.T) {
 	}, nil)
 	mockDB.EXPECT().CreatePriceFetchBlock(gomock.Any(), instID, pluginID, "ticker not found").Return(nil)
 
-	_ = runCycle(ctx, mockDB, reg, nil, nil, nil)
+	_ = runCycle(ctx, mockDB, reg, nil, nil, nil, db.NopTelemetry{}, "")
 
 	if stub.calls != 1 {
 		t.Errorf("expected 1 FetchPrices call, got %d", stub.calls)
@@ -344,7 +344,7 @@ func TestRunCycle_MaxHistoryTruncation(t *testing.T) {
 	mockDB.EXPECT().UpsertPricesForRange(gomock.Any(), instID, pluginID, nil, from, cutoff, gomock.Any()).Return(nil)
 	mockDB.EXPECT().UpsertPricesForRange(gomock.Any(), instID, pluginID, gomock.Any(), cutoff, to, gomock.Any()).Return(nil)
 
-	_ = runCycle(ctx, mockDB, reg, nil, nil, nil)
+	_ = runCycle(ctx, mockDB, reg, nil, nil, nil, db.NopTelemetry{}, "")
 
 	if stub.calls != 1 {
 		t.Errorf("expected 1 FetchPrices call (truncated), got %d", stub.calls)
@@ -394,7 +394,7 @@ func TestRunCycle_MaxHistorySkipsOldGap(t *testing.T) {
 	// rather than being asked about again every cycle.
 	mockDB.EXPECT().UpsertPricesForRange(gomock.Any(), instID, pluginID, nil, from, to, gomock.Any()).Return(nil)
 
-	_ = runCycle(ctx, mockDB, reg, nil, nil, nil)
+	_ = runCycle(ctx, mockDB, reg, nil, nil, nil, db.NopTelemetry{}, "")
 
 	if stub.calls != 0 {
 		t.Errorf("expected 0 FetchPrices calls for gap older than max history, got %d", stub.calls)
@@ -430,7 +430,7 @@ func TestRunCycle_NoDataRecordsCoverage(t *testing.T) {
 	}, nil)
 	mockDB.EXPECT().UpsertPricesForRange(gomock.Any(), instID, pluginID, nil, from, to, gomock.Any()).Return(nil)
 
-	_ = runCycle(ctx, mockDB, reg, nil, nil, nil)
+	_ = runCycle(ctx, mockDB, reg, nil, nil, nil, db.NopTelemetry{}, "")
 
 	if stub.calls != 1 {
 		t.Errorf("expected 1 FetchPrices call, got %d", stub.calls)
@@ -466,7 +466,7 @@ func TestRunCycle_CoveredRangeNotRefetched(t *testing.T) {
 		{ID: instID, AssetClass: strPtr("STOCK"), Identifiers: []db.IdentifierInput{{Type: "MIC_TICKER", Value: "AAPL"}}},
 	}, nil)
 
-	_ = runCycle(ctx, mockDB, reg, nil, nil, nil)
+	_ = runCycle(ctx, mockDB, reg, nil, nil, nil, db.NopTelemetry{}, "")
 
 	if stub.calls != 0 {
 		t.Errorf("expected no FetchPrices call for an already covered range, got %d", stub.calls)
@@ -507,7 +507,7 @@ func TestRunCycle_OtherPluginStillAskedAfterCoverage(t *testing.T) {
 	}, nil)
 	mockDB.EXPECT().UpsertPricesForRange(gomock.Any(), instID, freshID, gomock.Any(), from, to, gomock.Any()).Return(nil)
 
-	_ = runCycle(ctx, mockDB, reg, nil, nil, nil)
+	_ = runCycle(ctx, mockDB, reg, nil, nil, nil, db.NopTelemetry{}, "")
 
 	if covered.calls != 0 {
 		t.Errorf("covered plugin should not be asked again, got %d calls", covered.calls)


### PR DESCRIPTION
Panels over the grains added in #458 and filled in #459. **Stacked on #459** -- review that one first.

Completes #0121. Nothing read the price rows before this.

## Drift dashboard -- new Price fetching row

- **Gap outcome mix** -- stacked to 100%, because the mix is the signal and the volume is not: how many instruments needed prices is a fact about the portfolio, which way they ended is a fact about the fetching.
- **Gaps that did not settle, by kind** -- the gaps that come back every cycle. Split on `is_fx` rather than blended, because a missing rate breaks valuation for every instrument denominated in that currency while a missing quote breaks one; blended, a single stuck FX pair disappears into the instrument line.
- **Time spent by plugin** -- summed, not averaged. This is the panel that answers where two minutes went, which "Run duration by kind" can only say has moved. Stacking is legitimate for the same reason it is on Tokens: one grain, additive quantity, no cross-population rate.
- **Price plugin transport failures** -- `transport_failed` only. `no_data` stays out: counting a completed call whose answer was "this did not trade then" as a failure would make every delisted holding look like an outage.

## Run dashboard -- new Price fetching row

- **Gap outcomes** bar gauge, **Days of history asked for**, **Gaps that did not settle** stat.
- **Gaps that did not settle** table, joined to `v_instrument_label` so a hole in a valuation names an instrument rather than a UUID. `had_call` separates a gap no plugin would take from one that was asked and got nothing -- different fixes.
- **Price plugin calls** table: one row per (plugin, outcome), because a plugin's fast `no_data` and its slow fetch averaged together describe neither.

`This run` gains `gap_count`. Both how-to-read texts gain the new judgements and the rule that `days_outstanding` belongs to the gap and is never summed across the calls beneath it.

**Days of history asked for** is there to be read against the cycle's duration before calling it slow: a cycle handed ten years of a new holding is not the same cycle as one topping up yesterday.

## Verification

The dashboard test plans every new panel and template query against the real schema -- all pass. The live dev Grafana has picked the files up via its bind mount, so both dashboards load and the panels render.

Note for whoever pulls this: the dev database will not have the new tables. Migration 005 was edited in place per the pre-release convention and `schema_migrations` tracks versions without checksums, so an existing dev database will not re-apply it and the price panels will error until it is recreated.

`make db-test`, `make fmt-check vet lint-go` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)