### PR TITLE
Give a template variable its query as a string (0117)

### DIFF
--- a/docker/grafana/dashboards/drift.json
+++ b/docker/grafana/dashboards/drift.json
@@ -1527,12 +1527,7 @@
           "uid": "portfoliodb-telemetry"
         },
         "definition": "SELECT DISTINCT broker\nFROM telemetry.v_run\nWHERE is_import AND broker IS NOT NULL AND broker <> ''\nORDER BY 1",
-        "query": {
-          "rawQuery": true,
-          "rawSql": "SELECT DISTINCT broker\nFROM telemetry.v_run\nWHERE is_import AND broker IS NOT NULL AND broker <> ''\nORDER BY 1",
-          "editorMode": "code",
-          "format": "table"
-        },
+        "query": "SELECT DISTINCT broker\nFROM telemetry.v_run\nWHERE is_import AND broker IS NOT NULL AND broker <> ''\nORDER BY 1",
         "multi": true,
         "includeAll": true,
         "allValue": null,

--- a/docker/grafana/dashboards/run.json
+++ b/docker/grafana/dashboards/run.json
@@ -1412,12 +1412,7 @@
           "uid": "portfoliodb-telemetry"
         },
         "definition": "SELECT\n  to_char(started_at, 'MM-DD HH24:MI') || '  ' || kind\n    || coalesce('  ' || broker, '')\n    || coalesce('  ' || source, '')\n    || '  [' || coalesce(outcome, 'in flight') || ']'\n    || CASE WHEN telemetry_incomplete THEN '  !! TELEMETRY INCOMPLETE' ELSE '' END\n    AS __text,\n  id::text AS __value\nFROM telemetry.v_run\nWHERE '${scope}' = 'all' OR is_import\nORDER BY started_at DESC\nLIMIT 200",
-        "query": {
-          "rawQuery": true,
-          "rawSql": "SELECT\n  to_char(started_at, 'MM-DD HH24:MI') || '  ' || kind\n    || coalesce('  ' || broker, '')\n    || coalesce('  ' || source, '')\n    || '  [' || coalesce(outcome, 'in flight') || ']'\n    || CASE WHEN telemetry_incomplete THEN '  !! TELEMETRY INCOMPLETE' ELSE '' END\n    AS __text,\n  id::text AS __value\nFROM telemetry.v_run\nWHERE '${scope}' = 'all' OR is_import\nORDER BY started_at DESC\nLIMIT 200",
-          "editorMode": "code",
-          "format": "table"
-        },
+        "query": "SELECT\n  to_char(started_at, 'MM-DD HH24:MI') || '  ' || kind\n    || coalesce('  ' || broker, '')\n    || coalesce('  ' || source, '')\n    || '  [' || coalesce(outcome, 'in flight') || ']'\n    || CASE WHEN telemetry_incomplete THEN '  !! TELEMETRY INCOMPLETE' ELSE '' END\n    AS __text,\n  id::text AS __value\nFROM telemetry.v_run\nWHERE '${scope}' = 'all' OR is_import\nORDER BY started_at DESC\nLIMIT 200",
         "multi": false,
         "includeAll": false,
         "allValue": null,

--- a/docs/spec/telemetry.md
+++ b/docs/spec/telemetry.md
@@ -452,6 +452,12 @@ silently until somebody opened a browser. Every panel query and every template v
 query is therefore planned against the real schema by a test in the database layer, which
 also refuses a panel that reads a table instead of a view.
 
+A template variable holds its SQL as a bare string, not the `{rawSql, format}` object a
+panel target holds. Grafana hands the string to the datasource and builds `rawSql` from it
+itself, so an object there arrives at postgres as an object, the query fails and the picker
+offers nothing while every panel around it still draws. The same test refuses the object
+form, because the symptom looks like an empty dashboard rather than a broken one.
+
 ## 3. Logger
 
 ### Overview

--- a/server/db/postgres/telemetry_dashboard_test.go
+++ b/server/db/postgres/telemetry_dashboard_test.go
@@ -87,9 +87,9 @@ func collect(t *testing.T, path string) []query {
 			List []struct {
 				Name string `json:"name"`
 				Type string `json:"type"`
-				// A query variable holds an object here; a custom variable holds
-				// its comma-joined options as a bare string. Decoding late keeps
-				// both readable by one struct.
+				// A bare string for either kind of variable: a custom variable
+				// holds its comma-joined options, a query variable its SQL.
+				// Decoding late keeps both readable by one struct.
 				Query json.RawMessage `json:"query"`
 			} `json:"list"`
 		} `json:"templating"`
@@ -117,14 +117,18 @@ func collect(t *testing.T, path string) []query {
 		if v.Type != "query" {
 			continue
 		}
-		var q struct {
-			RawSQL string `json:"rawSql"`
+		// A string, not the {rawSql, format} object a panel target uses.
+		// Grafana hands a query variable's query to metricFindQuery, which
+		// assigns it to rawSql itself; an object there reaches postgres as an
+		// object and the picker silently offers nothing. So the shape is part
+		// of what this test checks, not just the SQL inside it.
+		var sql string
+		if err := json.Unmarshal(v.Query, &sql); err != nil {
+			t.Fatalf("variable %s in %s: query must be a SQL string, not an object: %v",
+				v.Name, path, err)
 		}
-		if err := json.Unmarshal(v.Query, &q); err != nil {
-			t.Fatalf("parse variable %s in %s: %v", v.Name, path, err)
-		}
-		if q.RawSQL != "" {
-			out = append(out, query{d.Title, "variable " + v.Name, q.RawSQL})
+		if sql != "" {
+			out = append(out, query{d.Title, "variable " + v.Name, sql})
 		}
 	}
 	return out


### PR DESCRIPTION
Both dashboard pickers -- **Run** on `Telemetry: one run` and **Broker** on `Telemetry: drift` -- offered nothing. Found while looking at a test import on the dev stack.

## The bug

Each variable held its query as the `{rawQuery, rawSql, editorMode, format}` object a *panel target* holds. That is the wrong shape for a variable. Grafana hands a variable's `query` to the SQL datasource's `metricFindQuery`, which interpolates it and builds the request itself:

```js
metricFindQuery(v, m) { const g = this.templateSrv.replace(v, ...),
  h = { refId: "tempvar", datasource: this.getRef(), rawSql: g, format: QueryFormat.Table }
```

So the object arrived where a SQL string belonged and reached postgres as an object:

```
path=/api/ds/query status=500 referer=".../d/telemetry-run/...&var-run=&var-scope=all"
error="failed to query data: error unmarshal query json: json: cannot unmarshal
        object into Go struct field QueryJson.rawSql of type string"
```

The dropdown stayed empty while every panel around it drew normally, which is why it read as a run with no telemetry rather than as a broken query. The drift dashboard is legible with **Broker** stuck on `All`, so that half went unnoticed too.

## The fix

`query` is now the SQL string, identical to the `definition` beside it, in both dashboards. Verified through Grafana's own datasource proxy: the interpolated `scope = all` query returns all four runs on the dev stack, and the picker populates after a reload.

`server/db/postgres/telemetry_dashboard_test.go` plans every panel and variable query against the real schema, but it reached *inside* the object for `rawSql` -- validating the SQL text while never checking the shape Grafana requires, so it passed throughout. It now decodes a variable's query as a string and fails with that in the message.

`docs/spec/telemetry.md` records the string-versus-object rule and why the symptom is deceptive.

## Testing

- `make db-test` passes, including all 40 `TestDashboardQueriesStillPlan` subtests with `variable_run` and `variable_broker` among them
- `make fmt-check` and `make vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)