### PR TITLE
Constrain option underlying resolution to the venue OCC implies

### DIFF
--- a/docs/issues/0122-resolve-identity-as-of-a-date.md
+++ b/docs/issues/0122-resolve-identity-as-of-a-date.md
@@ -1,0 +1,32 @@
+---
+status: open
+title: Resolve instrument identity as of a date, not as of now
+---
+
+Identifier resolution asks providers what a ticker means today, but a portfolio
+holds instruments that have since stopped existing. `EA` resolved to a Thai
+company once Electronic Arts delisted on 2026-08-05: the live ticker lookup no
+longer found it, so the only answer left was another listing of the same symbol.
+`ATVI` has been unresolvable since its 2023 merger for the same reason, and both
+were held and priced long before either date.
+
+Resolution should be able to ask what a ticker denoted on a given date, and
+should prefer identifiers that are not reused over ones that are. A FIGI is
+retired and never reassigned; an ISIN is not to be re-used, with documented
+national exceptions; a CUSIP is cancelled and eventually reassigned; a ticker is
+reused constantly and across venues, which is the one the resolver leans on.
+
+`instruments.valid_from` and `valid_before` already model the interval an
+instrument was tradeable, and the archive carries them, but nothing writes
+either: every instrument in the dev database has both null. Populating them from
+the providers that report a delisting date is the first half; consulting them
+during resolution, alongside a provider lookup that can see a delisted security,
+is the second.
+
+Delisting is an instrument lifecycle fact rather than a corporate event, so it
+belongs in these columns and not in `unhandled_corporate_events`. A merger is
+both: the position terminates, which is a transaction, and the instrument stops
+being tradeable, which is these columns.
+
+See docs/adr/0016-bitemporal-time-model.md and docs/spec/bitemporality.md for the
+time model this has to fit.

--- a/docs/issues/0123-carry-broker-contract-identifiers.md
+++ b/docs/issues/0123-carry-broker-contract-identifiers.md
@@ -1,0 +1,26 @@
+---
+status: open
+title: Carry broker contract identifiers through ingestion
+---
+
+IBKR names every contract by a CONID that survives corporate actions: the same
+`678940680` appears on the trade that opened an NVDA option position, on the
+transfer that split it three days before the ex-date, and on the trade that
+closed it afterwards. The QFX carries one security record per CONID describing it
+in current terms, so the OCC symbol in the file is rendered from a current-state
+security master rather than stated per transaction.
+
+The converter drops it. What reaches the archive is that current symbol
+attributed to the trade date, so the resolver rebases for a split the symbol
+already reflects and looks up a strike that never existed -- a $790 put becomes a
+$79 put in the file and a $7.90 put in the query.
+
+`IdentifierType` has no broker-scoped contract identifier. Adding one means a new
+enum member, a domain naming the broker that issued it the way `MIC_TICKER` names
+a MIC, and extraction from the OFX/QFX `UNIQUEID` whose `UNIQUEIDTYPE` is
+`CONID`. The identifier is opaque and carries no strike, expiry or ticker, so
+nothing rebases it and nothing has to state what it is denominated in.
+
+0122 asks how to resolve identity as of a date. A stable broker identifier is the
+kind of identifier that question prefers, and it is the one already on offer from
+the source PortfolioDB has most trouble with.

--- a/server/db/db.go
+++ b/server/db/db.go
@@ -1253,6 +1253,13 @@ type InstrumentDB interface {
 	FindInstrumentWithMetaByIdentifier(ctx context.Context, identifierType, domain, value string) (instrumentID, assetClass, exchangeMIC, currency string, err error)
 	// FindInstrumentByTypeAndValue looks up instrument_id by (identifier_type, value) with any domain. Returns "" if not found or if multiple instruments match (ambiguous).
 	FindInstrumentByTypeAndValue(ctx context.Context, identifierType, value string) (string, error)
+	// FindInstrumentByTickerIgnoringSeparators looks up instrument_id by a
+	// MIC_TICKER value compared with split-ticker separators removed on both
+	// sides. An OCC root spells a multi-class ticker without its separator --
+	// BRKB for BRK.B -- and no substitution recovers one spelling from the
+	// other, because nothing in BRKB says where the separator was. Returns ""
+	// if not found or if several instruments match.
+	FindInstrumentByTickerIgnoringSeparators(ctx context.Context, value string) (string, error)
 	// FindInstrumentBySourceDescription looks up instrument_id by (source, NULL domain, instrument_description). Returns "" if not found.
 	FindInstrumentBySourceDescription(ctx context.Context, source, description string) (string, error)
 	// GetInstrument returns an instrument by ID with its identifiers, or nil if not found.
@@ -2105,7 +2112,10 @@ type TelemetryResolutionKeyOutcome struct {
 	ExtractionOutcome string
 	Outcome           string
 	MismatchDetected  bool
-	InstrumentID      string
+	// HintDiffs summarises what the resolved instrument contradicted about its
+	// hints, empty when it contradicted nothing.
+	HintDiffs    string
+	InstrumentID string
 }
 
 // TelemetryIdentificationAttempt is one ResolveWithPlugins call, written when it

--- a/server/db/postgres/instruments.go
+++ b/server/db/postgres/instruments.go
@@ -217,6 +217,42 @@ func (p *Postgres) FindInstrumentWithMetaByIdentifier(ctx context.Context, ident
 
 // FindInstrumentByTypeAndValue implements db.InstrumentDB.
 // Returns "" if no row matches or if more than one instrument has the same (type, value) with different domains (ambiguous).
+// FindInstrumentByTickerIgnoringSeparators implements db.InstrumentDB. The
+// separator set matches identifier.NormalizeSplitTicker, and both sides are
+// stripped rather than one being rewritten, because an OCC root has lost the
+// separator's position and cannot have it put back.
+func (p *Postgres) FindInstrumentByTickerIgnoringSeparators(ctx context.Context, value string) (string, error) {
+	rows, err := p.q.QueryContext(ctx, `
+		SELECT DISTINCT instrument_id FROM instrument_identifiers
+		WHERE identifier_type = 'MIC_TICKER'
+		  AND translate(value, './- ', '') = translate($1, './- ', '')
+	`, value)
+	if err != nil {
+		return "", fmt.Errorf("find instrument by ticker ignoring separators: %w", err)
+	}
+	defer rows.Close()
+	var id uuid.UUID
+	var count int
+	for rows.Next() {
+		var next uuid.UUID
+		if err := rows.Scan(&next); err != nil {
+			return "", err
+		}
+		count++
+		if count > 1 {
+			return "", nil
+		}
+		id = next
+	}
+	if err := rows.Err(); err != nil {
+		return "", err
+	}
+	if count == 0 {
+		return "", nil
+	}
+	return id.String(), nil
+}
+
 func (p *Postgres) FindInstrumentByTypeAndValue(ctx context.Context, identifierType, value string) (string, error) {
 	rows, err := p.q.QueryContext(ctx, `
 		SELECT instrument_id FROM instrument_identifiers

--- a/server/db/postgres/instruments_test.go
+++ b/server/db/postgres/instruments_test.go
@@ -1132,3 +1132,59 @@ func TestMergeInstrumentFromArchive_LeavesSeededReferenceDataAlone(t *testing.T)
 			len(before.Identifiers), len(after.Identifiers))
 	}
 }
+
+// The lookup exists so an OCC root reaches the equity ticker it names. It has to
+// match across the separator in both directions and stay silent when two
+// instruments collapse to the same spelling, because at that point the root does
+// not name one of them.
+func TestFindInstrumentByTickerIgnoringSeparators(t *testing.T) {
+	p := testDBTx(t)
+	ctx := context.Background()
+
+	brk, err := p.EnsureInstrument(ctx, "STOCK", "XNYS", "USD", "Berkshire", "", "", []db.IdentifierInput{
+		{Type: "MIC_TICKER", Domain: "XNYS", Value: "BRK.B", Canonical: true},
+	}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+
+	// An OCC root finds the dotted ticker.
+	got, err := p.FindInstrumentByTickerIgnoringSeparators(ctx, "BRKB")
+	if err != nil {
+		t.Fatalf("lookup: %v", err)
+	}
+	if got != brk {
+		t.Errorf("BRKB -> %q, want %q", got, brk)
+	}
+
+	// And the reverse, so the caller need not know which spelling was stored.
+	if got, err = p.FindInstrumentByTickerIgnoringSeparators(ctx, "BRK-B"); err != nil || got != brk {
+		t.Errorf("BRK-B -> %q, %v; want %q", got, err, brk)
+	}
+
+	// A ticker with no separator at all still matches itself.
+	aapl, err := p.EnsureInstrument(ctx, "STOCK", "XNAS", "USD", "Apple", "", "", []db.IdentifierInput{
+		{Type: "MIC_TICKER", Domain: "XNAS", Value: "AAPL", Canonical: true},
+	}, "", nil, nil, nil)
+	if err != nil {
+		t.Fatalf("ensure aapl: %v", err)
+	}
+	if got, err = p.FindInstrumentByTickerIgnoringSeparators(ctx, "AAPL"); err != nil || got != aapl {
+		t.Errorf("AAPL -> %q, %v; want %q", got, err, aapl)
+	}
+
+	// Nothing that collapses to this spelling.
+	if got, err = p.FindInstrumentByTickerIgnoringSeparators(ctx, "NOSUCH"); err != nil || got != "" {
+		t.Errorf("NOSUCH -> %q, %v; want empty", got, err)
+	}
+
+	// Two instruments collapsing to one spelling is ambiguous, not a match.
+	if _, err = p.EnsureInstrument(ctx, "STOCK", "XBUE", "ARS", "Berkshire CEDEAR", "", "", []db.IdentifierInput{
+		{Type: "MIC_TICKER", Domain: "XBUE", Value: "BRKB", Canonical: true},
+	}, "", nil, nil, nil); err != nil {
+		t.Fatalf("ensure cedear: %v", err)
+	}
+	if got, err = p.FindInstrumentByTickerIgnoringSeparators(ctx, "BRK.B"); err != nil || got != "" {
+		t.Errorf("ambiguous BRK.B -> %q, %v; want empty", got, err)
+	}
+}

--- a/server/db/postgres/telemetry.go
+++ b/server/db/postgres/telemetry.go
@@ -144,10 +144,11 @@ func (t *Telemetry) EndResolutionKey(ctx context.Context, keyID string, o db.Tel
 	}
 	if _, err := t.db.ExecContext(ctx, `
 		UPDATE telemetry.resolution_key
-		SET extraction_outcome = $2, outcome = $3, mismatch_detected = $4, instrument_id = $5
+		SET extraction_outcome = $2, outcome = $3, mismatch_detected = $4,
+		    hint_diffs = $5, instrument_id = $6
 		WHERE id = $1
 	`, id, nullStr(o.ExtractionOutcome), nullStr(o.Outcome), o.MismatchDetected,
-		t.optUUID(o.InstrumentID, "end resolution key")); err != nil {
+		nullStr(o.HintDiffs), t.optUUID(o.InstrumentID, "end resolution key")); err != nil {
 		t.fail(ctx, o.RunID, "end resolution key", err)
 	}
 }

--- a/server/identifier/hints.go
+++ b/server/identifier/hints.go
@@ -31,6 +31,14 @@ type Hints struct {
 	SecurityTypeHint string
 }
 
+// USComposite is the composite exchange code for US listings. OpenFIGI spells
+// it this way as exchCode and EODHD as its exchange filter, so one hint domain
+// constrains both. An OCC symbol names a US-listed underlying by construction,
+// so a hint derived from one carries this rather than leaving the venue open: a
+// bare root matches that ticker on every venue in the world, and which of them
+// is chosen is then arbitrary.
+const USComposite = "US"
+
 // UnderlyingSecTypeHint returns the inferred security type for a derivative's
 // underlying. Returns "" if the asset class is not a derivative.
 func UnderlyingSecTypeHint(derivativeAssetClass string) string {

--- a/server/migrations/005_telemetry.sql
+++ b/server/migrations/005_telemetry.sql
@@ -122,6 +122,15 @@ CREATE TABLE telemetry.resolution_key (
   -- outcome: resolution continues and succeeds using MIC_TICKER, so a mismatch is not
   -- a terminal state, and modelling it as one would make outcome non-exhaustive.
   mismatch_detected BOOLEAN NOT NULL DEFAULT FALSE,
+  -- What the resolved instrument contradicted about the hints it was given,
+  -- as the same summary the resolver logs ("Currency: USD->THB, Exchange:
+  -- XNAS->XBKK"), or NULL when it contradicted nothing. Free text rather than a
+  -- flag because which field disagreed is the whole content of the signal: a
+  -- currency that differs is a different listing of one security, and an
+  -- exchange that differs may be a different company. Hints do not currently
+  -- gate resolution, so this is the only record that the answer stored was one
+  -- the caller had already contradicted.
+  hint_diffs        TEXT,
   -- Null when unresolved.
   instrument_id     UUID
 );

--- a/server/plugins/massive/identifier/map.go
+++ b/server/plugins/massive/identifier/map.go
@@ -44,7 +44,12 @@ func optionFromContract(r *client.OptionsContractResult) (*identifier.Instrument
 			identifier.ProviderIdentifier{Provider: "massive", Type: "SEGMENT_MIC_TICKER", Domain: r.PrimaryExchange, Value: strings.TrimPrefix(r.Ticker, "O:")})
 	}
 	if r.UnderlyingTicker != "" {
+		// PrimaryExchange is the option's venue (BATO, XASE), never the
+		// underlying's, so it says nothing about where the underlying trades.
+		// What does is that the contract is an OCC one: the underlying is US
+		// listed.
 		inst.UnderlyingIdentifiers = []identifier.Identifier{
+			{Type: "OPENFIGI_TICKER", Domain: identifier.USComposite, Value: r.UnderlyingTicker},
 			{Type: "MIC_TICKER", Value: r.UnderlyingTicker},
 		}
 	}

--- a/server/plugins/massive/identifier/map_test.go
+++ b/server/plugins/massive/identifier/map_test.go
@@ -99,10 +99,14 @@ func TestOptionFromContract(t *testing.T) {
 	if inst.Exchange != "BATO" {
 		t.Errorf("Exchange = %q, want BATO", inst.Exchange)
 	}
-	if len(inst.UnderlyingIdentifiers) != 1 {
-		t.Fatalf("len(UnderlyingIdentifiers) = %d, want 1", len(inst.UnderlyingIdentifiers))
+	// The OCC contract says the underlying is US listed, so the hints say so
+	// too, and the venue-constrained one comes first because the plugins take
+	// the first hint that answers.
+	if len(inst.UnderlyingIdentifiers) != 2 {
+		t.Fatalf("len(UnderlyingIdentifiers) = %d, want 2", len(inst.UnderlyingIdentifiers))
 	}
-	assertID(t, inst.UnderlyingIdentifiers[0], "MIC_TICKER", "", "AAPL")
+	assertID(t, inst.UnderlyingIdentifiers[0], "OPENFIGI_TICKER", "US", "AAPL")
+	assertID(t, inst.UnderlyingIdentifiers[1], "MIC_TICKER", "", "AAPL")
 	if len(ids) != 2 {
 		t.Fatalf("len(ids) = %d, want 2", len(ids))
 	}

--- a/server/plugins/massive/identifier/plugin_test.go
+++ b/server/plugins/massive/identifier/plugin_test.go
@@ -201,8 +201,10 @@ func TestPlugin_Identify_Option_OCC(t *testing.T) {
 	if res.Instrument.AssetClass != db.AssetClassOption {
 		t.Errorf("AssetClass = %q, want OPTION", res.Instrument.AssetClass)
 	}
-	if len(res.Instrument.UnderlyingIdentifiers) != 1 || res.Instrument.UnderlyingIdentifiers[0].Value != "AAPL" {
-		t.Errorf("UnderlyingIdentifiers = %+v, want [{MIC_TICKER AAPL}]", res.Instrument.UnderlyingIdentifiers)
+	if len(res.Instrument.UnderlyingIdentifiers) != 2 ||
+		res.Instrument.UnderlyingIdentifiers[0] != (identifier.Identifier{Type: "OPENFIGI_TICKER", Domain: identifier.USComposite, Value: "AAPL"}) ||
+		res.Instrument.UnderlyingIdentifiers[1] != (identifier.Identifier{Type: "MIC_TICKER", Value: "AAPL"}) {
+		t.Errorf("UnderlyingIdentifiers = %+v, want [{OPENFIGI_TICKER US AAPL} {MIC_TICKER AAPL}]", res.Instrument.UnderlyingIdentifiers)
 	}
 	if len(res.Identifiers) != 2 {
 		t.Fatalf("len(res.Identifiers) = %d, want 2", len(res.Identifiers))
@@ -247,8 +249,10 @@ func TestPlugin_Identify_Option_OCC_SpacePadded(t *testing.T) {
 	if res.Instrument.AssetClass != db.AssetClassOption {
 		t.Errorf("AssetClass = %q, want OPTION", res.Instrument.AssetClass)
 	}
-	if len(res.Instrument.UnderlyingIdentifiers) != 1 || res.Instrument.UnderlyingIdentifiers[0].Value != "AAPL" {
-		t.Errorf("UnderlyingIdentifiers = %+v, want [{MIC_TICKER AAPL}]", res.Instrument.UnderlyingIdentifiers)
+	if len(res.Instrument.UnderlyingIdentifiers) != 2 ||
+		res.Instrument.UnderlyingIdentifiers[0] != (identifier.Identifier{Type: "OPENFIGI_TICKER", Domain: identifier.USComposite, Value: "AAPL"}) ||
+		res.Instrument.UnderlyingIdentifiers[1] != (identifier.Identifier{Type: "MIC_TICKER", Value: "AAPL"}) {
+		t.Errorf("UnderlyingIdentifiers = %+v, want [{OPENFIGI_TICKER US AAPL} {MIC_TICKER AAPL}]", res.Instrument.UnderlyingIdentifiers)
 	}
 }
 

--- a/server/plugins/openfigi/identifier/plugin.go
+++ b/server/plugins/openfigi/identifier/plugin.go
@@ -249,7 +249,11 @@ func (p *Plugin) resolveResults(results []OpenFIGIResult, hints identifier.Hints
 		if !ok || parsed.Symbol == "" {
 			return nil, nil, false
 		}
+		// The OPENFIGI_TICKER hint is first because tryOpenFIGIFromHints takes
+		// the first hint that returns anything: the venue-constrained query has
+		// to run before the worldwide one, not after it.
 		inst.UnderlyingIdentifiers = []identifier.Identifier{
+			{Type: "OPENFIGI_TICKER", Domain: identifier.USComposite, Value: parsed.Symbol},
 			{Type: "MIC_TICKER", Value: parsed.Symbol},
 		}
 		// Convert parsed option ticker to OCC and replace OPENFIGI_TICKER.

--- a/server/plugins/openfigi/identifier/plugin_test.go
+++ b/server/plugins/openfigi/identifier/plugin_test.go
@@ -516,8 +516,10 @@ func TestPlugin_Identify_Option_WithUnderlying(t *testing.T) {
 	if res.Instrument.AssetClass != "OPTION" {
 		t.Errorf("res.Instrument.AssetClass = %q, want OPTION", res.Instrument.AssetClass)
 	}
-	if len(res.Instrument.UnderlyingIdentifiers) != 1 || res.Instrument.UnderlyingIdentifiers[0].Value != "AAPL" {
-		t.Errorf("UnderlyingIdentifiers = %+v, want [{MIC_TICKER AAPL}]", res.Instrument.UnderlyingIdentifiers)
+	if len(res.Instrument.UnderlyingIdentifiers) != 2 ||
+		res.Instrument.UnderlyingIdentifiers[0] != (identifier.Identifier{Type: "OPENFIGI_TICKER", Domain: identifier.USComposite, Value: "AAPL"}) ||
+		res.Instrument.UnderlyingIdentifiers[1] != (identifier.Identifier{Type: "MIC_TICKER", Value: "AAPL"}) {
+		t.Errorf("UnderlyingIdentifiers = %+v, want [{OPENFIGI_TICKER US AAPL} {MIC_TICKER AAPL}]", res.Instrument.UnderlyingIdentifiers)
 	}
 	hasOCC := false
 	for _, id := range res.Identifiers {
@@ -584,8 +586,10 @@ func TestPlugin_Identify_Option_OCCSpacePadded(t *testing.T) {
 	if res.Instrument.AssetClass != "OPTION" {
 		t.Errorf("res.Instrument.AssetClass = %q, want OPTION", res.Instrument.AssetClass)
 	}
-	if len(res.Instrument.UnderlyingIdentifiers) != 1 || res.Instrument.UnderlyingIdentifiers[0].Value != "AAPL" {
-		t.Errorf("UnderlyingIdentifiers = %+v, want [{MIC_TICKER AAPL}]", res.Instrument.UnderlyingIdentifiers)
+	if len(res.Instrument.UnderlyingIdentifiers) != 2 ||
+		res.Instrument.UnderlyingIdentifiers[0] != (identifier.Identifier{Type: "OPENFIGI_TICKER", Domain: identifier.USComposite, Value: "AAPL"}) ||
+		res.Instrument.UnderlyingIdentifiers[1] != (identifier.Identifier{Type: "MIC_TICKER", Value: "AAPL"}) {
+		t.Errorf("UnderlyingIdentifiers = %+v, want [{OPENFIGI_TICKER US AAPL} {MIC_TICKER AAPL}]", res.Instrument.UnderlyingIdentifiers)
 	}
 }
 
@@ -630,8 +634,10 @@ func TestPlugin_Identify_Option_ClassicTickerConvertedToOCC(t *testing.T) {
 	if res.Instrument.AssetClass != "OPTION" {
 		t.Errorf("res.Instrument.AssetClass = %q, want OPTION", res.Instrument.AssetClass)
 	}
-	if len(res.Instrument.UnderlyingIdentifiers) != 1 || res.Instrument.UnderlyingIdentifiers[0].Value != "AAPL" {
-		t.Errorf("UnderlyingIdentifiers = %+v, want [{MIC_TICKER AAPL}]", res.Instrument.UnderlyingIdentifiers)
+	if len(res.Instrument.UnderlyingIdentifiers) != 2 ||
+		res.Instrument.UnderlyingIdentifiers[0] != (identifier.Identifier{Type: "OPENFIGI_TICKER", Domain: identifier.USComposite, Value: "AAPL"}) ||
+		res.Instrument.UnderlyingIdentifiers[1] != (identifier.Identifier{Type: "MIC_TICKER", Value: "AAPL"}) {
+		t.Errorf("UnderlyingIdentifiers = %+v, want [{OPENFIGI_TICKER US AAPL} {MIC_TICKER AAPL}]", res.Instrument.UnderlyingIdentifiers)
 	}
 	hasOCC := false
 	for _, id := range res.Identifiers {

--- a/server/service/identification/attempt_telemetry_test.go
+++ b/server/service/identification/attempt_telemetry_test.go
@@ -131,6 +131,7 @@ func TestAttemptNoEligiblePlugins(t *testing.T) {
 	database.EXPECT().FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "AAPL").
 		Return("", "", "", "", nil)
 	database.EXPECT().FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "AAPL").Return("", nil)
+	database.EXPECT().FindInstrumentByTickerIgnoringSeparators(gomock.Any(), "AAPL").Return("", nil).AnyTimes()
 	database.EXPECT().ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryIdentifier).
 		Return([]db.PluginConfigRow{{PluginID: "cash-only", Precedence: 10}}, nil)
 
@@ -193,6 +194,7 @@ func TestPluginCallOutcomesAreComposed(t *testing.T) {
 	database.EXPECT().FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "AAPL").
 		Return("", "", "", "", nil)
 	database.EXPECT().FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "AAPL").Return("", nil)
+	database.EXPECT().FindInstrumentByTickerIgnoringSeparators(gomock.Any(), "AAPL").Return("", nil).AnyTimes()
 	database.EXPECT().ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryIdentifier).
 		Return([]db.PluginConfigRow{
 			{PluginID: "high", Precedence: 30},
@@ -255,6 +257,7 @@ func TestPluginTransportOutcomePassesThrough(t *testing.T) {
 	database.EXPECT().FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "AAPL").
 		Return("", "", "", "", nil)
 	database.EXPECT().FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "AAPL").Return("", nil)
+	database.EXPECT().FindInstrumentByTickerIgnoringSeparators(gomock.Any(), "AAPL").Return("", nil).AnyTimes()
 	database.EXPECT().ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryIdentifier).
 		Return([]db.PluginConfigRow{{PluginID: "expired", Precedence: 10}}, nil)
 
@@ -302,6 +305,7 @@ func TestPluginCallCountsRetries(t *testing.T) {
 	database.EXPECT().FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "AAPL").
 		Return("", "", "", "", nil)
 	database.EXPECT().FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "AAPL").Return("", nil)
+	database.EXPECT().FindInstrumentByTickerIgnoringSeparators(gomock.Any(), "AAPL").Return("", nil).AnyTimes()
 	database.EXPECT().ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryIdentifier).
 		Return([]db.PluginConfigRow{{PluginID: "flaky", Precedence: 10}}, nil)
 

--- a/server/service/identification/resolve.go
+++ b/server/service/identification/resolve.go
@@ -81,6 +81,17 @@ func ResolveByHintsDBOnly(ctx context.Context, database db.InstrumentDB, hints [
 			if err != nil {
 				return nil, err
 			}
+			// An underlying hint built from an OCC root spells a multi-class
+			// ticker without its separator, so the exact lookups above miss the
+			// instrument that the same import resolved from its own posting
+			// minutes earlier. Compare with the separator dropped on both sides
+			// before concluding it is not there.
+			if id == "" && h.Type == "MIC_TICKER" {
+				id, err = database.FindInstrumentByTickerIgnoringSeparators(ctx, value)
+				if err != nil {
+					return nil, err
+				}
+			}
 			// TypeAndValue fallback doesn't return metadata. Empty fields
 			// cause CompareHints to skip currency/exchange/assetClass
 			// checks, so hint validation is not performed for instruments
@@ -120,6 +131,17 @@ func ResolveIDsByHintsDBOnly(ctx context.Context, database db.InstrumentDB, hint
 			id, err = database.FindInstrumentByTypeAndValue(ctx, h.Type, value)
 			if err != nil {
 				return nil, err
+			}
+			// An underlying hint built from an OCC root spells a multi-class
+			// ticker without its separator, so the exact lookups above miss the
+			// instrument that the same import resolved from its own posting
+			// minutes earlier. Compare with the separator dropped on both sides
+			// before concluding it is not there.
+			if id == "" && h.Type == "MIC_TICKER" {
+				id, err = database.FindInstrumentByTickerIgnoringSeparators(ctx, value)
+				if err != nil {
+					return nil, err
+				}
 			}
 		}
 		if id != "" && !seen[id] {

--- a/server/service/identification/resolve_test.go
+++ b/server/service/identification/resolve_test.go
@@ -208,6 +208,7 @@ func TestResolveWithPlugins_PluginSuccess(t *testing.T) {
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "AAPL").
 		Return("", nil)
+	database.EXPECT().FindInstrumentByTickerIgnoringSeparators(gomock.Any(), "AAPL").Return("", nil).AnyTimes()
 	database.EXPECT().
 		ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryIdentifier).
 		Return([]db.PluginConfigRow{{PluginID: "test", Precedence: 10}}, nil)
@@ -247,6 +248,7 @@ func TestResolveWithPlugins_StampsIdentityAsOfOnPluginSuccess(t *testing.T) {
 
 	database.EXPECT().FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "AAPL").Return("", "", "", "", nil)
 	database.EXPECT().FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "AAPL").Return("", nil)
+	database.EXPECT().FindInstrumentByTickerIgnoringSeparators(gomock.Any(), "AAPL").Return("", nil).AnyTimes()
 	database.EXPECT().ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryIdentifier).
 		Return([]db.PluginConfigRow{{PluginID: "test", Precedence: 10}}, nil)
 	database.EXPECT().EnsureInstrument(gomock.Any(), "STOCK", "XNAS", "USD", "Apple Inc.", "", "", gomock.Any(), "", nil, nil, nil).
@@ -276,6 +278,7 @@ func TestResolveWithPlugins_NoStampOnFallback(t *testing.T) {
 
 	database.EXPECT().FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "AAPL").Return("", "", "", "", nil)
 	database.EXPECT().FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "AAPL").Return("", nil)
+	database.EXPECT().FindInstrumentByTickerIgnoringSeparators(gomock.Any(), "AAPL").Return("", nil).AnyTimes()
 	database.EXPECT().ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryIdentifier).
 		Return([]db.PluginConfigRow{{PluginID: "test", Precedence: 10}}, nil)
 	// No UpdateIdentityAsOf expectation: the strict controller fails the test if
@@ -309,6 +312,7 @@ func TestResolveWithPlugins_AllPluginsFail_Fallback(t *testing.T) {
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "XYZ").
 		Return("", nil)
+	database.EXPECT().FindInstrumentByTickerIgnoringSeparators(gomock.Any(), "XYZ").Return("", nil).AnyTimes()
 	database.EXPECT().
 		ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryIdentifier).
 		Return([]db.PluginConfigRow{{PluginID: "test", Precedence: 10}}, nil)
@@ -356,6 +360,7 @@ func TestResolveWithPlugins_Timeout_SetsHadTimeout(t *testing.T) {
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "SLOW").
 		Return("", nil)
+	database.EXPECT().FindInstrumentByTickerIgnoringSeparators(gomock.Any(), "SLOW").Return("", nil).AnyTimes()
 	database.EXPECT().
 		ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryIdentifier).
 		Return([]db.PluginConfigRow{{PluginID: "slow", Precedence: 10}}, nil)
@@ -394,6 +399,7 @@ func TestResolveWithPlugins_NilFallback_ReturnsEmpty(t *testing.T) {
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "XYZ").
 		Return("", nil)
+	database.EXPECT().FindInstrumentByTickerIgnoringSeparators(gomock.Any(), "XYZ").Return("", nil).AnyTimes()
 	database.EXPECT().
 		ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryIdentifier).
 		Return([]db.PluginConfigRow{{PluginID: "test", Precedence: 10}}, nil)
@@ -431,6 +437,7 @@ func TestResolveWithPlugins_StoreSourceDescription(t *testing.T) {
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", desc).
 		Return("", nil)
+	database.EXPECT().FindInstrumentByTickerIgnoringSeparators(gomock.Any(), desc).Return("", nil).AnyTimes()
 	database.EXPECT().
 		ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryIdentifier).
 		Return([]db.PluginConfigRow{{PluginID: "test", Precedence: 10}}, nil)
@@ -477,6 +484,7 @@ func TestResolveWithPlugins_PluginError_SetsHadError(t *testing.T) {
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "BAD").
 		Return("", nil)
+	database.EXPECT().FindInstrumentByTickerIgnoringSeparators(gomock.Any(), "BAD").Return("", nil).AnyTimes()
 	database.EXPECT().
 		ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryIdentifier).
 		Return([]db.PluginConfigRow{{PluginID: "bad", Precedence: 10}}, nil)
@@ -759,6 +767,7 @@ func TestResolveWithPlugins_InconsistentPluginExcluded(t *testing.T) {
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "AAPL").
 		Return("", nil)
+	database.EXPECT().FindInstrumentByTickerIgnoringSeparators(gomock.Any(), "AAPL").Return("", nil).AnyTimes()
 	database.EXPECT().
 		ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryIdentifier).
 		Return([]db.PluginConfigRow{
@@ -979,6 +988,7 @@ func TestResolveWithPlugins_ConsistentPluginsMerged(t *testing.T) {
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "AAPL").
 		Return("", nil)
+	database.EXPECT().FindInstrumentByTickerIgnoringSeparators(gomock.Any(), "AAPL").Return("", nil).AnyTimes()
 	database.EXPECT().
 		ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryIdentifier).
 		Return([]db.PluginConfigRow{
@@ -1216,6 +1226,7 @@ func TestResolveWithPlugins_NoHintMatch_FallsBackToPrecedence(t *testing.T) {
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "AAPL").
 		Return("", nil)
+	database.EXPECT().FindInstrumentByTickerIgnoringSeparators(gomock.Any(), "AAPL").Return("", nil).AnyTimes()
 	database.EXPECT().
 		ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryIdentifier).
 		Return([]db.PluginConfigRow{
@@ -1263,6 +1274,7 @@ func TestResolveWithPlugins_NoHints_PurePrecedence(t *testing.T) {
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "AAPL").
 		Return("", nil)
+	database.EXPECT().FindInstrumentByTickerIgnoringSeparators(gomock.Any(), "AAPL").Return("", nil).AnyTimes()
 	database.EXPECT().
 		ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryIdentifier).
 		Return([]db.PluginConfigRow{
@@ -1375,5 +1387,58 @@ func TestResolveWithPlugins_SparseResultDoesNotVacuouslyMatch(t *testing.T) {
 	}
 	if result.InstrumentID != "id-apple" {
 		t.Errorf("expected id-apple (highest precedence), got %s", result.InstrumentID)
+	}
+}
+
+// An underlying hint built from an OCC root spells a multi-class ticker without
+// its separator, so BRKB has to reach the BRK.B the same import already
+// resolved. Without this the resolver falls through to the plugins, where a
+// bare root matches that ticker on every venue in the world.
+func TestResolveByHintsDBOnly_OCCRootReachesSplitTicker(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	database := mock.NewMockDB(ctrl)
+
+	database.EXPECT().
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "BRKB").
+		Return("", "", "", "", nil)
+	database.EXPECT().
+		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "BRKB").
+		Return("", nil)
+	database.EXPECT().
+		FindInstrumentByTickerIgnoringSeparators(gomock.Any(), "BRKB").
+		Return("inst-brk", nil)
+
+	ids, err := ResolveByHintsDBOnly(context.Background(), database, []identifier.Identifier{
+		{Type: "MIC_TICKER", Value: "BRKB"},
+	})
+	if err != nil {
+		t.Fatalf("ResolveByHintsDBOnly: %v", err)
+	}
+	if len(ids) != 1 || ids[0].ID != "inst-brk" {
+		t.Fatalf("got %+v, want one instrument inst-brk", ids)
+	}
+}
+
+// The separator-insensitive lookup is a last resort: an exact match must not
+// reach it, or a ticker that genuinely differs only by a separator would be
+// answered by whichever row the looser query happened to find first.
+func TestResolveByHintsDBOnly_ExactMatchSkipsSeparatorFallback(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	database := mock.NewMockDB(ctrl)
+
+	database.EXPECT().
+		FindInstrumentWithMetaByIdentifier(gomock.Any(), "MIC_TICKER", "", "AAPL").
+		Return("inst-aapl", "STOCK", "XNAS", "USD", nil)
+
+	ids, err := ResolveByHintsDBOnly(context.Background(), database, []identifier.Identifier{
+		{Type: "MIC_TICKER", Value: "AAPL"},
+	})
+	if err != nil {
+		t.Fatalf("ResolveByHintsDBOnly: %v", err)
+	}
+	if len(ids) != 1 || ids[0].ID != "inst-aapl" {
+		t.Fatalf("got %+v, want one instrument inst-aapl", ids)
 	}
 }

--- a/server/service/ingestion/resolution_telemetry.go
+++ b/server/service/ingestion/resolution_telemetry.go
@@ -34,7 +34,13 @@ type resolutionKeys struct {
 	// mismatched is the MIC_TICKER against OPENFIGI_SHARE_CLASS disagreement,
 	// detected between the two stages and likewise held.
 	mismatched map[string]bool
-	stamped    map[string]bool
+	// hintDiffs is what the resolved instrument contradicted about its hints.
+	// Recorded by the primary resolution and held until the key is stamped, the
+	// same way, because the resolution that decides the key is the one whose
+	// contradictions belong on it -- a mismatch-check probe answers a different
+	// question and its diffs would overwrite the answer with an aside.
+	hintDiffs map[string]string
+	stamped   map[string]bool
 }
 
 // newResolutionKeys writes a key row per distinct (source, description, hints)
@@ -59,6 +65,7 @@ func newResolutionKeys(ctx context.Context, tel db.TelemetryDB, runID, source st
 		ids:        make(map[string]string),
 		extraction: make(map[string]string),
 		mismatched: make(map[string]bool),
+		hintDiffs:  make(map[string]string),
 		stamped:    make(map[string]bool),
 	}
 	type seed struct {
@@ -110,6 +117,16 @@ func (k *resolutionKeys) mismatch(key string) {
 	k.mismatched[key] = true
 }
 
+// hintDiff records what the instrument this key resolved to contradicted about
+// the hints it was given. Empty summaries are dropped rather than stored, so the
+// column reads as "contradicted nothing" rather than "was not looked at".
+func (k *resolutionKeys) hintDiff(key, summary string) {
+	if k == nil || summary == "" {
+		return
+	}
+	k.hintDiffs[key] = summary
+}
+
 // end stamps a key with what became of it, filling stage 1 in from what the
 // pre-pass recorded.
 //
@@ -126,6 +143,7 @@ func (k *resolutionKeys) end(ctx context.Context, key, outcome, instrumentID str
 		ExtractionOutcome: k.extraction[key],
 		Outcome:           outcome,
 		MismatchDetected:  k.mismatched[key],
+		HintDiffs:         k.hintDiffs[key],
 		InstrumentID:      instrumentID,
 	})
 }
@@ -204,6 +222,7 @@ func newIdentifierResolutionKeys(ctx context.Context, tel db.TelemetryDB, runID 
 		ids:        make(map[string]string),
 		extraction: make(map[string]string),
 		mismatched: make(map[string]bool),
+		hintDiffs:  make(map[string]string),
 		stamped:    make(map[string]bool),
 	}
 	var order []identifierRef

--- a/server/service/ingestion/resolve.go
+++ b/server/service/ingestion/resolve.go
@@ -394,12 +394,16 @@ func resolveWithIdentifierPlugins(ctx context.Context, database db.DB, registry 
 		return resolveResult{}, err
 	}
 	if len(result.HintDiffs) > 0 {
+		summary := hintDiffsSummary(result.HintDiffs)
 		ingestionLogger().InfoContext(ctx, "instrument resolved with hint differences",
 			"source", source,
 			"instrument_description", instrumentDescription,
 			"instrument_id", result.InstrumentID,
-			"diffs", hintDiffsSummary(result.HintDiffs),
+			"diffs", summary,
 		)
+		if purpose == db.TelemetryPurposePrimary {
+			keys.hintDiff(key, summary)
+		}
 	}
 
 	r := resolveResult{InstrumentID: result.InstrumentID, FirstRowIndex: rowIndex}

--- a/server/service/ingestion/resolve_test.go
+++ b/server/service/ingestion/resolve_test.go
@@ -171,6 +171,7 @@ func TestResolve_AllPluginsErrNotIdentified_BrokerDescriptionOnly(t *testing.T) 
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "UNKNOWN").
 		Return("", nil)
+	database.EXPECT().FindInstrumentByTickerIgnoringSeparators(gomock.Any(), "UNKNOWN").Return("", nil).AnyTimes()
 	database.EXPECT().
 		ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryIdentifier).
 		Return([]db.PluginConfigRow{{PluginID: "p1", Precedence: 10, Config: nil}}, nil)
@@ -209,6 +210,7 @@ func TestResolve_OnePluginSuccess_EnsureInstrumentWithResult(t *testing.T) {
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "AAPL").
 		Return("", nil)
+	database.EXPECT().FindInstrumentByTickerIgnoringSeparators(gomock.Any(), "AAPL").Return("", nil).AnyTimes()
 	database.EXPECT().
 		ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryIdentifier).
 		Return([]db.PluginConfigRow{{PluginID: "local", Precedence: 10, Config: nil}}, nil)
@@ -260,6 +262,7 @@ func TestResolve_BrokerDescriptionAlwaysStored(t *testing.T) {
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", desc).
 		Return("", nil)
+	database.EXPECT().FindInstrumentByTickerIgnoringSeparators(gomock.Any(), desc).Return("", nil).AnyTimes()
 	database.EXPECT().
 		ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryIdentifier).
 		Return([]db.PluginConfigRow{{PluginID: "local", Precedence: 10, Config: nil}}, nil)
@@ -323,6 +326,7 @@ func TestResolve_PluginReturnsUnderlying_ResolvesUnderlyingThenDerivative(t *tes
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", desc).
 		Return("", nil)
+	database.EXPECT().FindInstrumentByTickerIgnoringSeparators(gomock.Any(), desc).Return("", nil).AnyTimes()
 	// Top-level: list plugins.
 	database.EXPECT().
 		ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryIdentifier).
@@ -376,6 +380,7 @@ func TestResolve_TwoPlugins_HigherPrecedenceWins(t *testing.T) {
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "X").
 		Return("", nil)
+	database.EXPECT().FindInstrumentByTickerIgnoringSeparators(gomock.Any(), "X").Return("", nil).AnyTimes()
 	// ListEnabledPluginConfigs returns precedence desc, so high (20) before low (10)
 	database.EXPECT().
 		ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryIdentifier).
@@ -425,6 +430,7 @@ func TestResolve_TwoPlugins_MergedIdentifiersByPrecedence(t *testing.T) {
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "Y").
 		Return("", nil)
+	database.EXPECT().FindInstrumentByTickerIgnoringSeparators(gomock.Any(), "Y").Return("", nil).AnyTimes()
 	database.EXPECT().
 		ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryIdentifier).
 		Return([]db.PluginConfigRow{
@@ -482,6 +488,7 @@ func TestResolve_TwoPlugins_SameType_HighPrecedenceWins(t *testing.T) {
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "Z").
 		Return("", nil)
+	database.EXPECT().FindInstrumentByTickerIgnoringSeparators(gomock.Any(), "Z").Return("", nil).AnyTimes()
 	database.EXPECT().
 		ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryIdentifier).
 		Return([]db.PluginConfigRow{
@@ -527,6 +534,7 @@ func TestResolve_PluginTimeout_FallbackAndMessage(t *testing.T) {
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "SLOW").
 		Return("", nil)
+	database.EXPECT().FindInstrumentByTickerIgnoringSeparators(gomock.Any(), "SLOW").Return("", nil).AnyTimes()
 	database.EXPECT().
 		ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryIdentifier).
 		Return([]db.PluginConfigRow{{PluginID: "slow", Precedence: 10, Config: nil}}, nil)
@@ -564,6 +572,7 @@ func TestResolve_PluginUnavailable_FallbackAndMessage(t *testing.T) {
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "BAD").
 		Return("", nil)
+	database.EXPECT().FindInstrumentByTickerIgnoringSeparators(gomock.Any(), "BAD").Return("", nil).AnyTimes()
 	database.EXPECT().
 		ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryIdentifier).
 		Return([]db.PluginConfigRow{{PluginID: "bad", Precedence: 10, Config: nil}}, nil)
@@ -892,6 +901,7 @@ func TestResolve_PluginFailsThenRetrySucceeds(t *testing.T) {
 	database.EXPECT().
 		FindInstrumentByTypeAndValue(gomock.Any(), "MIC_TICKER", "RETRY").
 		Return("", nil)
+	database.EXPECT().FindInstrumentByTickerIgnoringSeparators(gomock.Any(), "RETRY").Return("", nil).AnyTimes()
 	database.EXPECT().
 		ListEnabledPluginConfigs(gomock.Any(), db.PluginCategoryIdentifier).
 		Return([]db.PluginConfigRow{{PluginID: "retry", Precedence: 10, Config: nil}}, nil)


### PR DESCRIPTION
An OCC symbol names a US-listed underlying by construction, but the hint built
from one said only "this ticker", so the lookup ran worldwide. A bare root
matches that ticker on every venue there is, and which one is chosen is then
arbitrary: five Berkshire options resolved their underlying to the Buenos Aires
CEDEAR in Argentine pesos, alongside the correct NYSE listing the same import
had created twelve seconds earlier.

## What changes

**Underlying hints carry the venue.** `OPENFIGI_TICKER` with a US domain,
ordered ahead of the bare `MIC_TICKER` because both plugins take the first hint
that answers. The domain reaches OpenFIGI as `exchCode` and EODHD as its
exchange filter, so one hint constrains both. It also switches on ranking that
was dead for underlyings: `resolveResults` scores a result by the exchange a
hint names, and a hint that named none scored every candidate alike.

Verified against OpenFIGI directly:

```
BRKB  bare          -> 6 results (Vienna, Buenos Aires CEDEARs, ...)
BRK/B + exchCode US -> 1: BERKSHIRE HATHAWAY INC-CL B
QQQ   + exchCode US -> 1: INVESCO QQQ TRUST, securityType ETP
```

**The DB lookup compares tickers with the separator dropped.** That alone does
not find Berkshire, because an OCC root spells a multi-class ticker without its
separator and no substitution recovers `BRK.B` from `BRKB` -- nothing in `BRKB`
says where the separator was. So the lookup that runs before any plugin now
strips separators on both sides, which is what lets an underlying reach an
instrument the same import already resolved. Two instruments collapsing to one
spelling stay ambiguous rather than matching, since at that point the root names
neither.

**Hint contradictions are recorded, not just logged.** They do not gate
resolution -- a plugin that contradicts every hint still wins when it is the only
one that answered -- so the log line was the sole trace that a stored answer was
one the caller had already contradicted, and it was not queryable.
`mismatch_detected` is a different signal: MIC_TICKER against
OPENFIGI_SHARE_CLASS, not hints against the result.

## Not fixed here

Whether a hint contradiction should *reject* a result rather than be noted. On a
real import that fired once in 140 resolutions and that once was a genuine error
(a US stock resolving to a same-ticker listing in Bangkok), so it looks like a
high-precision signal -- but making it terminal converts currently-resolving
instruments into unidentified ones and deserves its own change.

## Issues opened

- 0122 -- resolve instrument identity as of a date, not as of now
- 0123 -- carry broker contract identifiers through ingestion

## Testing

`make test`, `make check` and `make e2e-test` (48 specs) all pass. New coverage:
two unit tests pinning the separator-insensitive lookup and the exact-match path
that must not reach it, and a db-layer integration test covering both spellings,
the no-separator case, and the ambiguity guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)